### PR TITLE
DHCP valuepair API updates.

### DIFF
--- a/src/include/dhcp.h
+++ b/src/include/dhcp.h
@@ -55,9 +55,6 @@ int fr_dhcp_decode(RADIUS_PACKET *packet);
 #define PW_DHCP_INFORM		(1024 + 8)
 
 #define DHCP_MAGIC_VENDOR (54)
-#define DHCP2ATTR(x) ((DHCP_MAGIC_VENDOR << 16) | (x))
-#define ATTR2DHCP(x) ((x) & 0xff)
-#define IS_DHCP_ATTR(x) (VENDOR((x)->attribute) == DHCP_MAGIC_VENDOR)
 
 #define PW_DHCP_OPTION_82 (82)
 #define DHCP_PACK_OPTION1(x,y) ((x) | ((y) << 8))

--- a/src/main/dhcpd.c
+++ b/src/main/dhcpd.c
@@ -47,9 +47,9 @@ static int dhcp_process(REQUEST *request)
 	int rcode;
 	VALUE_PAIR *vp;
 
-	vp = pairfind(request->packet->vps, DHCP2ATTR(53)); /* DHCP-Message-Type */
+	vp = pairfind(request->packet->vps, 53, DHCP_MAGIC_VENDOR); /* DHCP-Message-Type */
 	if (vp) {
-		DICT_VALUE *dv = dict_valbyattr(DHCP2ATTR(53), vp->vp_integer);
+		DICT_VALUE *dv = dict_valbyattr(53, DHCP_MAGIC_VENDOR, vp->vp_integer);
 		DEBUG("Trying sub-section dhcp %s {...}",
 		      dv->name ? dv->name : "<unknown>");
 		rcode = module_post_auth(vp->vp_integer, request);
@@ -61,7 +61,7 @@ static int dhcp_process(REQUEST *request)
 	/*
 	 *	Look for Relay attribute, and forward it if necessary.
 	 */
-	vp = pairfind(request->config_items, DHCP2ATTR(270));
+	vp = pairfind(request->config_items, 270, DHCP_MAGIC_VENDOR);
 	if (vp) {
 		VALUE_PAIR *giaddr;
 		RADIUS_PACKET relayed;
@@ -74,9 +74,9 @@ static int dhcp_process(REQUEST *request)
 		 *
 		 *	It's invalid to have giaddr=0 AND a relay option
 		 */
-		giaddr = pairfind(request->packet->vps, 266);
+		giaddr = pairfind(request->packet->vps, 266, DHCP_MAGIC_VENDOR);
 		if (giaddr && (giaddr->vp_ipaddr == htonl(INADDR_ANY))) {
-			if (pairfind(request->packet->vps, DHCP2ATTR(82))) {
+			if (pairfind(request->packet->vps, 82, DHCP_MAGIC_VENDOR)) {
 				RDEBUG("DHCP: Received packet with giaddr = 0 and containing relay option: Discarding packet");
 				return 1;
 			}
@@ -125,7 +125,7 @@ static int dhcp_process(REQUEST *request)
 		return 1;
 	}
 
-	vp = pairfind(request->reply->vps, DHCP2ATTR(53)); /* DHCP-Message-Type */
+	vp = pairfind(request->reply->vps, 53, DHCP_MAGIC_VENDOR); /* DHCP-Message-Type */
 	if (vp) {
 		request->reply->code = vp->vp_integer;
 		if ((request->reply->code != 0) &&

--- a/src/modules/rlm_soh/rlm_soh.c
+++ b/src/modules/rlm_soh/rlm_soh.c
@@ -143,7 +143,7 @@ static int soh_postauth(UNUSED void * instance, REQUEST *request)
 	int rcode;
 	VALUE_PAIR *vp;
 
-	vp = pairfind(request->packet->vps, DHCP2ATTR(43));
+	vp = pairfind(request->packet->vps, 43, DHCP_MAGIC_VENDOR);
 	if (vp) {
 		/*
 		 * vendor-specific options contain
@@ -164,7 +164,7 @@ static int soh_postauth(UNUSED void * instance, REQUEST *request)
 					if (vlen <= 1) {
 						RDEBUG("SoH adding NAP marker to DHCP reply");
 						/* client probe; send "NAP" in the reply */
-						vp = paircreate(DHCP2ATTR(43), PW_TYPE_OCTETS);
+						vp = paircreate(43, DHCP_MAGIC_VENDOR, PW_TYPE_OCTETS);
 						vp->vp_octets[0] = 220;
 						vp->vp_octets[1] = 3;
 						vp->vp_octets[4] = 'N';


### PR DESCRIPTION
The DHCP code in master was still using the old valuepair (pre vp->vendor) API. I think I've found and fixed all of those, so master now compiles when configured "--with-dhcp".
