### PR TITLE
Additional note to doc/Acct-Type.rst

### DIFF
--- a/doc/Acct-Type.rst
+++ b/doc/Acct-Type.rst
@@ -70,15 +70,15 @@ And in radiusd.conf::
         sql0
   }
 
-Note:
--------
+Important note
+--------------------
 
-Any Acct-Type value should be declared in a known dictionary. For example, if you want to use:
+Any Acct-Type value should be declared in a known dictionary. For example, if you want to use::
 
   DEFAULT Acct-Status-Type == Stop, Acct-Type := Stop
 
-Then you have to specify
+Then you have to specify::
 
   VALUE Acct-Type Stop 2
 
-in 'dictionary' file. Otherwise you will have 'Unknown value' errors. 
+in 'dictionary' file. Otherwise you will have 'Unknown value' errors.


### PR DESCRIPTION
I've made an additional note to be included in doc/Acct-Type.rst file. It's about Acct-Type values declaration in an available dictionary. Absense of this note costed me a couple-hours thinking. Hope this would be helpful.
