### PR TITLE
Configurable file permissions in rlm_linelog

### DIFF
--- a/raddb/modules/linelog
+++ b/raddb/modules/linelog
@@ -18,6 +18,14 @@ linelog {
 	filename = ${logdir}/linelog
 
 	#
+	#  The Unix-style permissions on the log file.
+	#
+	#  Depending on format string, the log file may contain secret or
+	#  private information about users.  Keep the file permissions as
+	#  restrictive as possible.
+	permissions = 0600
+
+	#
 	#  The default format string.
 	format = "This is a log message for %{User-Name}"
 

--- a/src/modules/rlm_linelog/rlm_linelog.c
+++ b/src/modules/rlm_linelog/rlm_linelog.c
@@ -45,6 +45,7 @@ RCSID("$Id$")
 typedef struct rlm_linelog_t {
 	CONF_SECTION	*cs;
 	char		*filename;
+	int		permissions;
 	char		*line;
 	char		*reference;
 } rlm_linelog_t;
@@ -61,6 +62,8 @@ typedef struct rlm_linelog_t {
 static const CONF_PARSER module_config[] = {
 	{ "filename",  PW_TYPE_STRING_PTR,
 	  offsetof(rlm_linelog_t,filename), NULL,  NULL},
+	{ "permissions",  PW_TYPE_INTEGER,
+	  offsetof(rlm_linelog_t,permissions), NULL,  "0600"},
 	{ "format",  PW_TYPE_STRING_PTR,
 	  offsetof(rlm_linelog_t,line), NULL,  NULL},
 	{ "reference",  PW_TYPE_STRING_PTR,
@@ -240,7 +243,7 @@ static int do_linelog(void *instance, REQUEST *request)
 		radius_xlat(buffer, sizeof(buffer), inst->filename, request,
 			    NULL);
 		
-		fd = open(buffer, O_WRONLY | O_APPEND | O_CREAT, 0600);
+		fd = open(buffer, O_WRONLY | O_APPEND | O_CREAT, inst->permissions);
 		if (fd == -1) {
 			radlog(L_ERR, "rlm_linelog: Failed to open %s: %s",
 			       buffer, strerror(errno));


### PR DESCRIPTION
Allows rlm_linelog to set permissions on the created files, in the same way as rlm_detail does.

With this patch, it's possible to set up a restricted non-priviledged user to pull linelog files from a Radius server. For example, you could make such user a member of the radiusd group and set permissions to 0640 instead of the default 0600.
