### PR TITLE
Dictionary redback

### DIFF
--- a/share/dictionary.redback
+++ b/share/dictionary.redback
@@ -642,4 +642,15 @@ VALUE	Service-Action			DE-ACTIVATE		0
 VALUE	Service-Action			ACTIVATE-WITH-ACCT	1
 VALUE	Service-Action			ACTIVATE-WITHOUT-ACCT	2
 
+VALUE	Service-Error-Cause		Service-success		0
+VALUE	Service-Error-Cause		Unsupported-attribute	401
+VALUE	Service-Error-Cause		Missing-attribute	402
+VALUE	Service-Error-Cause		Invalid-request		404
+VALUE	Service-Error-Cause		Resource-unavailable	506
+VALUE	Service-Error-Cause		Generic-service-error	550
+VALUE	Service-Error-Cause		Service-not-found	551
+VALUE	Service-Error-Cause		Service-already-active	552
+VALUE	Service-Error-Cause		Service-accounting-disabled 553
+VALUE	Service-Error-Cause		Service-duplicate-parameter 554
+
 END-VENDOR	Redback


### PR DESCRIPTION
Hi Alan,

In dictionary of equipment Redback tagged attributes not used!
These attributes are necessary for proper operation of the Redback SE ( activation services, CoA)
We use equipment Redback SE100/400/600

The following patches implement:
add has_tag  to Tunnel-Hello-Timer, Service-Name, Service-Action, Service-Parameter, Service-Error-Cause, Deactivate-Service-Name, Reauth-Service-Name atributes, because redback receives and sends these attributes with a tag
add values of the attribute Service-Error-Cause who used in CoA queries

Thanks,

Robert
