### PR TITLE
radmin: make "del client ipaddr" command behave as documented

### DIFF
--- a/src/main/command.c
+++ b/src/main/command.c
@@ -1814,7 +1814,7 @@ static int command_del_client(rad_listen_t *listener, int argc, char *argv[])
 #ifdef WITH_DYNAMIC_CLIENTS
 	RADCLIENT *client;
 
-	client = get_client(listener, argc - 1, argv + 1);
+	client = get_client(listener, argc, argv);
 	if (!client) return 0;
 
 	if (!client->dynamic) {


### PR DESCRIPTION
Fixes this error:

 radmin> del client ipaddr 192.168.168.111
 ERROR: Must specify <ipaddr>

Signed-off-by: Bjørn Mork bjorn@mork.no
