### PR TITLE
radmin: fixup error message when attemting to delete non-dynamic client

### DIFF
--- a/src/main/command.c
+++ b/src/main/command.c
@@ -1818,7 +1818,7 @@ static int command_del_client(rad_listen_t *listener, int argc, char *argv[])
 	if (!client) return 0;
 
 	if (!client->dynamic) {
-		cprintf(listener, "ERROR: Client %s was not dynamically defined.\n", argv[1]);
+		cprintf(listener, "ERROR: Client %s was not dynamically defined.\n", argv[0]);
 		return 0;
 	}
 


### PR DESCRIPTION
commit b9e5dd2c changed the command syntax in line with docs, but failed
to update the error message accordingly.

Signed-off-by: Bjørn Mork bjorn@mork.no
