### PR TITLE
rlm_sql acct noop Accounting-Start fix

### DIFF
--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -1321,12 +1321,12 @@ static int rlm_sql_accounting(void *instance, REQUEST * request) {
 							radlog_request(L_ERR, 0, request, "Couldn't update SQL accounting START record - %s",
 							       (inst->module->sql_error)(sqlsocket, inst->config));
 							ret = RLM_MODULE_FAIL;
-						} else {
-							numaffected = (inst->module->sql_affected_rows)(sqlsocket, inst->config);
-							if (numaffected < 1) {
-								ret = RLM_MODULE_NOOP;
-							}
 						}
+					}
+				} else {
+					numaffected = (inst->module->sql_affected_rows)(sqlsocket, inst->config);
+					if (numaffected < 1) {
+						ret = RLM_MODULE_NOOP;
 					}
 				}
 				(inst->module->sql_finish_query)(sqlsocket, inst->config);


### PR DESCRIPTION
When 6ed9727 was merged, else{} in the START case got placed against the wrong if(). Unlike STOP and ALIVE cases, in START insert comes first, and we only care if that affects 0 rows. If insert fails and we have to go for an update, we don't have to check for NOOP because we can assume the insert failed due to a conflicting row already in the database.

I've separated this commit out of pull request #14 into it's own branch. I agree that the redundant section fix is more controversial and needs more thought, but the Accounting-Start fix is more straight-forward, I still think it should be applied.
