### PR TITLE
 added setting of dhcp broadcast address

### DIFF
--- a/src/include/dhcp.h
+++ b/src/include/dhcp.h
@@ -38,7 +38,7 @@ extern "C" {
 RADIUS_PACKET *fr_dhcp_recv(int sockfd);
 int fr_dhcp_send(RADIUS_PACKET *packet);
 
-int fr_dhcp_encode(RADIUS_PACKET *packet, RADIUS_PACKET *original);
+int fr_dhcp_encode(RADIUS_PACKET *packet, RADIUS_PACKET *original, fr_ipaddr_t* broadband_ipaddr);
 int fr_dhcp_decode(RADIUS_PACKET *packet);
 
 /*


### PR DESCRIPTION
Good day, freeradius-developers.

In this patch optional configuration parameter broadcast_addr is added to dhcp configuration file.  This is useful when you want to send dhcp broadcast only to some specific network.  Also note, that some platform, such as freebsd does not support using 255.255.255.255 as general broadcast.  

Regards !
