### PR TITLE
Add option to disable ocsp nonce (patch for v2.1.x)

### DIFF
--- a/raddb/eap.conf
+++ b/raddb/eap.conf
@@ -425,6 +425,22 @@
 			      #  Responder is running as a vhost.
 			      #
 			      url = "http://127.0.0.1/ocsp/"
+
+			      #
+			      # If the OCSP Responder can not cope with nonce
+			      # in the request, then it can be disabled here.
+			      #
+			      # For security reasons, disabling this option
+			      # is not recommended as nonce protects against
+			      # replay attacks.
+			      #
+			      # Note that Microsoft AD Certificate Services OCSP
+			      # Responder does not enable nonce by default. It is
+			      # more secure to enable nonce on the responder than
+			      # to disable it in the query here.
+			      # See http://technet.microsoft.com/en-us/library/cc770413%28WS.10%29.aspx
+			      #
+			      # use_nonce = yes
 			}
 		}
 

--- a/src/modules/rlm_eap/types/rlm_eap_tls/rlm_eap_tls.c
+++ b/src/modules/rlm_eap/types/rlm_eap_tls/rlm_eap_tls.c
@@ -77,6 +77,8 @@ static CONF_PARSER ocsp_config[] = {
 	  offsetof(EAP_TLS_CONF, ocsp_override_url), NULL, "no"},
 	{ "url", PW_TYPE_STRING_PTR,
 	  offsetof(EAP_TLS_CONF, ocsp_url), NULL, NULL },
+	{ "use_nonce", PW_TYPE_BOOLEAN,
+	  offsetof(EAP_TLS_CONF, ocsp_use_nonce), NULL, "yes"},
  	{ NULL, -1, 0, NULL, NULL }           /* end the list */
 };
 #endif
@@ -312,7 +314,9 @@ static int ocsp_check(X509_STORE *store, X509 *issuer_cert, X509 *client_cert,
 	certid = OCSP_cert_to_id(NULL, client_cert, issuer_cert);
 	req = OCSP_REQUEST_new();
 	OCSP_request_add0_id(req, certid);
-	OCSP_request_add1_nonce(req, NULL, 8);
+	if(conf->ocsp_use_nonce){
+		OCSP_request_add1_nonce(req, NULL, 8);
+	}
 	
 	/* 
 	 * Send OCSP Request and get OCSP Response
@@ -351,7 +355,7 @@ static int ocsp_check(X509_STORE *store, X509 *issuer_cert, X509 *client_cert,
 		goto ocsp_end;
 	}
 	bresp = OCSP_response_get1_basic(resp);
-	if(OCSP_check_nonce(req, bresp)!=1) {
+	if(conf->ocsp_use_nonce && OCSP_check_nonce(req, bresp)!=1) {
 		radlog(L_ERR, "Error: OCSP response has wrong nonce value");
 		goto ocsp_end;
 	}

--- a/src/modules/rlm_eap/types/rlm_eap_tls/rlm_eap_tls.h
+++ b/src/modules/rlm_eap/types/rlm_eap_tls/rlm_eap_tls.h
@@ -78,6 +78,7 @@ typedef struct eap_tls_conf {
 	int		ocsp_enable;
 	int		ocsp_override_url;
 	char		*ocsp_url;
+	int		ocsp_use_nonce;
 #endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x0090800fL


### PR DESCRIPTION
Some OCSP responders cannot cope with an OCSP request if nonce
is used so this gives a way to allow freeradius to work with them.
