### PR TITLE
Add option to be able to disable nonce in OCSP request (master branch)

### DIFF
--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -443,6 +443,22 @@
 			      #  Responder is running as a vhost.
 			      #
 			      url = "http://127.0.0.1/ocsp/"
+
+			      #
+			      # If the OCSP Responder can not cope with nonce
+			      # in the request, then it can be disabled here.
+			      #
+			      # For security reasons, disabling this option
+			      # is not recommended as nonce protects against
+			      # replay attacks.
+			      #
+			      # Note that Microsoft AD Certificate Services OCSP
+			      # Responder does not enable nonce by default. It is
+			      # more secure to enable nonce on the responder than
+			      # to disable it in the query here.
+			      # See http://technet.microsoft.com/en-us/library/cc770413%28WS.10%29.aspx
+			      #
+			      # use_nonce = yes
 			}
 		}
 

--- a/src/include/tls.h
+++ b/src/include/tls.h
@@ -374,6 +374,7 @@ struct fr_tls_server_conf_t {
 	int		ocsp_enable;
 	int		ocsp_override_url;
 	char		*ocsp_url;
+	int		ocsp_use_nonce;
 	X509_STORE	*ocsp_store;
 #endif
 


### PR DESCRIPTION
Some OCSP responders cannot cope with an OCSP request if nonce
is used so this gives a way to allow freeradius to work with them.
