### PR TITLE
V2.1.x debian build fix

### DIFF
--- a/debian/patches/rlm_sql.libs.diff
+++ b/debian/patches/rlm_sql.libs.diff
@@ -23,7 +23,7 @@
 @@ -8,7 +8,7 @@
  SRCS        = rlm_sqlippool.c
  HEADERS     = $(top_builddir)/src/modules/rlm_sql/rlm_sql.h
- RLM_CFLAGS  = -I$(top_builddir)/src/modules/rlm_sql $(INCLTDL)
+ RLM_CFLAGS  = -I$(top_builddir)/src/modules/rlm_sql
 -RLM_LIBS    =
 +RLM_LIBS    += $(top_builddir)/src/modules/rlm_sql/.libs/rlm_sql.la
  RLM_INSTALL =


### PR DESCRIPTION
Commit 2e71dd9 can be applied cleanly to v2.1.x branch to fix debian package build issue. Only the commit message is different, refers to libltdl fix in their respective branch.

Commit 5c82368d changed src/modules/rlm_sqlippool/Makefile.in to
fix libltdl issue. This commit adjust
debian/patches/rlm_sql.libs.diff to match that.
