### PR TITLE
add group option to rlm_detail

### DIFF
--- a/raddb/modules/detail
+++ b/raddb/modules/detail
@@ -48,6 +48,13 @@ detail {
 	#  people from seeing that information.
 	detailperm = 0600
 
+	# The Unix group of the log file.
+	#
+	# The user that the server runs as must be in the specified
+	# system group otherwise this will fail to work.
+	#
+#	group = freerad
+
 	#
 	#  Every entry in the detail file has a header which
 	#  is a timestamp.  By default, we use the ctime

--- a/src/modules/rlm_detail/rlm_detail.c
+++ b/src/modules/rlm_detail/rlm_detail.c
@@ -36,6 +36,14 @@ RCSID("$Id$")
 #include	<fnmatch.h>
 #endif
 
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#ifdef HAVE_GRP_H
+#include <grp.h>
+#endif
+
 #define 	DIRLEN	8192
 
 struct detail_instance {
@@ -44,6 +52,9 @@ struct detail_instance {
 
 	/* detail file permissions */
 	int detailperm;
+
+	/* detail file group */
+	char *group;
 
 	/* directory permissions */
 	int dirperm;
@@ -67,6 +78,8 @@ static const CONF_PARSER module_config[] = {
 	  offsetof(struct detail_instance,header), NULL, "%t" },
 	{ "detailperm",    PW_TYPE_INTEGER,
 	  offsetof(struct detail_instance,detailperm), NULL, "0600" },
+	{ "group",         PW_TYPE_STRING_PTR,
+	  offsetof(struct detail_instance,group), NULL,  NULL},
 	{ "dirperm",       PW_TYPE_INTEGER,
 	  offsetof(struct detail_instance,dirperm),    NULL, "0755" },
 	{ "locking",       PW_TYPE_BOOLEAN,
@@ -184,6 +197,12 @@ static int do_detail(void *instance, REQUEST *request, RADIUS_PACKET *packet,
 	VALUE_PAIR	*pair;
 	off_t		fsize;
 	FILE		*fp;
+
+#ifdef HAVE_GRP_H
+	gid_t		gid;
+	struct group	*grp;
+	char		*endptr;
+#endif
 
 	struct detail_instance *inst = instance;
 
@@ -316,6 +335,27 @@ static int do_detail(void *instance, REQUEST *request, RADIUS_PACKET *packet,
 		       buffer);
 		return RLM_MODULE_FAIL;
 	}
+
+
+#ifdef HAVE_GRP_H
+	if (inst->group != NULL) {
+		gid = strtol(inst->group, &endptr, 10);
+		if (*endptr != '\0') {
+			grp = getgrnam(inst->group);
+			if (grp == NULL) {
+				RDEBUG2("rlm_detail: Unable to find system group \"%s\"", inst->group);
+				goto skip_group;
+			}
+			gid = grp->gr_gid;
+		}
+
+		if (chown(buffer, -1, gid) == -1) {
+			RDEBUG2("rlm_detail: Unable to change system group of \"%s\"", buffer);
+		}
+	}
+#endif
+
+ skip_group:
 
 	/*
 	 *	Post a timestamp


### PR DESCRIPTION
Hi Alan - Are you happy to pull this update? Should apply to both v2.1.x and master. Thanks, Matthew

Patch to allow the group to be set when updating detail logs, rather
than being limited to just the group of the running daemon.
