### PR TITLE
Print abinary values without delimiters, unless requested by caller.

### DIFF
--- a/src/include/libradius.h
+++ b/src/include/libradius.h
@@ -484,7 +484,7 @@ int fr_sockaddr2ipaddr(const struct sockaddr_storage *sa, socklen_t salen,
 #ifdef ASCEND_BINARY
 /* filters.c */
 int		ascend_parse_filter(VALUE_PAIR *pair);
-void		print_abinary(const VALUE_PAIR *vp, char *buffer, size_t len);
+void		print_abinary(const VALUE_PAIR *vp, char *buffer, size_t len, int delimitst);
 #endif /*ASCEND_BINARY*/
 
 /* random numbers in isaac.c */

--- a/src/lib/filters.c
+++ b/src/lib/filters.c
@@ -1142,7 +1142,7 @@ ascend_parse_filter(VALUE_PAIR *pair)
  *	Note we don't bother checking 'len' after the snprintf's.
  *	This function should ONLY be called with a large (~1k) buffer.
  */
-void print_abinary(const VALUE_PAIR *vp, char *buffer, size_t len)
+void print_abinary(const VALUE_PAIR *vp, char *buffer, size_t len, int delimitst)
 {
   size_t 		i;
   char			*p;
@@ -1168,8 +1168,10 @@ void print_abinary(const VALUE_PAIR *vp, char *buffer, size_t len)
 	  return;
   }
 
-  *(p++) = '"';
-  len -= 3;			/* account for leading & trailing quotes */
+  if (delimitst) {
+  	*(p++) = '"';
+  	len -= 3;			/* account for leading & trailing quotes */
+  }
 
   filter = (ascend_filter_t *) &(vp->vp_filter);
   i = snprintf(p, len, "%s %s %s",
@@ -1313,7 +1315,7 @@ void print_abinary(const VALUE_PAIR *vp, char *buffer, size_t len)
     }
   }
 
-  *(p++) = '"';
+  if (delimitst) *(p++) = '"';
   *p = '\0';
 }
 #endif

--- a/src/lib/print.c
+++ b/src/lib/print.c
@@ -292,7 +292,7 @@ int vp_prints_value(char * out, size_t outlen, const VALUE_PAIR *vp, int delimit
 		case PW_TYPE_ABINARY:
 #ifdef ASCEND_BINARY
 			a = buf;
-			print_abinary(vp, buf, sizeof(buf));
+			print_abinary(vp, buf, sizeof(buf), delimitst);
 			break;
 #else
 		  /* FALL THROUGH */


### PR DESCRIPTION
This commit fixes Bug #191, submitted this morning.
