### PR TITLE
Decode encrypted VSAs in requests

### DIFF
--- a/src/lib/radius.c
+++ b/src/lib/radius.c
@@ -67,7 +67,9 @@ typedef struct radius_packet_t {
 static fr_randctx fr_rand_pool;	/* across multiple calls */
 static int fr_rand_initialized = 0;
 static unsigned int salt_offset = 0;
-static uint8_t nullvector[AUTH_VECTOR_LEN]; /* for CoA decode */
+static uint8_t nullvector[AUTH_VECTOR_LEN] = { /* for CoA decode */
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
 
 const char *fr_packet_codes[FR_MAX_PACKET_CODE] = {
   "",


### PR DESCRIPTION
We're trying to do proxy CoA with Juniper ERXes as targets (NAS having a home server role for CoA). Some of the VSAs are encrypted.  These show up still encrypted in the debug log:

```
 # Executing section pre-proxy from file /etc/freeradius/sites-enabled/coatest
 +- entering group pre-proxy {...}
 ++[proxy-request] returns noop
 Sending CoA-Request of id 234 to 192.168.3.1 port 3799
          ERX-Attr-58 = 0x87cebf5f40d1848842769089371a0e708dca
          Proxy-State = 0x3636
 Proxying request 2 to home server 192.168.3.1 port 3799
 Sending CoA-Request of id 234 to 192.168.3.1 port 3799
          ERX-Attr-58 = 0x87cebf5f40d1848842769089371a0e708dca
          Proxy-State = 0x3636
 Going to the next request
```

Which isn't really much of a problem.  The real problem is that the proxied packets contain the VSAs still encrypted using the client secret instead of the appropriate home server secret.  That will of course not work.

The problem is the same as the one I previously pushed a radsniff workaround for, but this time the solution is a bit more generic:  Just attempt to decode any tunnel encrypted attribute in a request using a static null vector.  This should not affect most requests, as they cannot contain any encrypted attributes, and it does fix the problem for CoA requests.  I've verified that the proxied requests are re-encrypted using the appropriate secret as expected, and the debug log now shows the more user-friendly:

```
 # Executing section pre-proxy from file /etc/freeradius/sites-enabled/coatest
 +- entering group pre-proxy {...}
 ++[proxy-request] returns noop
 Sending CoA-Request of id 35 to 192.168.3.1 port 3799
          ERX-LI-Action = noop
          Proxy-State = 0x323236
 Proxying request 1 to home server 192.168.3.1 port 3799
 Sending CoA-Request of id 35 to 192.168.3.1 port 3799
          ERX-LI-Action = noop
          Proxy-State = 0x323236
 Going to the next request
```

I've made this change against the v2.1.x branch for now, as I really need it in 2.2.  But I'm prepared to forward port it to the master branch if the solution is accepted.

Thanks for reviewing
