### PR TITLE
Decode encrypted VSAs in requests

### DIFF
--- a/src/lib/radius.c
+++ b/src/lib/radius.c
@@ -75,6 +75,9 @@ typedef struct radius_packet_t {
 static fr_randctx fr_rand_pool;	/* across multiple calls */
 static int fr_rand_initialized = 0;
 static unsigned int salt_offset = 0;
+static uint8_t nullvector[AUTH_VECTOR_LEN] = { /* for CoA decode */
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+};
 
 const char *fr_packet_codes[FR_MAX_PACKET_CODE] = {
   "",
@@ -2944,12 +2947,9 @@ static ssize_t data2vp_any(const RADIUS_PACKET *packet,
 		 *	in response packets.
 		 */
 	case FLAG_ENCRYPT_TUNNEL_PASSWORD:
-		if (!original) goto raw;
-
-		if (rad_tunnel_pwdecode(buffer, &vp->length,
-					secret, original->vector) < 0) {
+		if (rad_tunnel_pwdecode(buffer, &vp->length, secret,
+					original ? original->vector : nullvector) < 0)
 			goto raw;
-		}
 		break;
 
 		/*


### PR DESCRIPTION
Incoming CoA requests can contain encrypted VSAs.  At least one
vendor is known to use this. These VSAs must be decrypted before
being proxied to enable the server to re-encrypt them using
the correct home server secret.

Fix by attempting to decode any encrypted request attribute using
a static vector of \0 bytes.

This also fixes debug logging of encrypted request attributes.

Signed-off-by: Bjørn Mork bjorn@mork.no
