### PR TITLE
Add require_client_cert options to EAP-PEAP/TTLS

### DIFF
--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -532,13 +532,6 @@ eap {
 	#
 	#  Surprisingly, it works quite well.
 	#
-	#  EAP-TTLS does not normally require a client certificate,
-	#  but you can make it require one by setting
-	#
-	#	EAP-TLS-Require-Client-Cert = Yes
-	#
-	#  in the control items for a request.
-	#
 	ttls {
 		#  Which tls-config section the TLS negotiation parameters
 		#  are in - see EAP-TLS above for an explanation.
@@ -605,6 +598,18 @@ eap {
 		#  The default value here is "yes".
 		#
 	#	include_length = yes
+
+		#
+		# Unlike EAP-TLS, EAP-TTLS does not require a client
+		# certificate. However, you can require one by setting the
+		# following option. You can also override this option by
+		# setting
+		#
+		#	EAP-TLS-Require-Client-Cert = Yes
+		#
+		# in the control items for a request.
+		#
+	#	require_client_cert = yes
 	}
 
 
@@ -650,13 +655,6 @@ eap {
 	#  which is separate from the one for the non-tunneled
 	#  EAP module.  Inside of the TLS/PEAP tunnel, we
 	#  recommend using EAP-MS-CHAPv2.
-	#
-	#  Unlike EAP-TLS, PEAP does not require a client certificate.
-	#  However, you can require one by setting
-	#
-	#	EAP-TLS-Require-Client-Cert = Yes
-	#
-	#  in the control items for a request.
 	#
 	peap {
 		#  Which tls-config section the TLS negotiation parameters
@@ -715,6 +713,17 @@ eap {
 		# can be sent to a specific virtual server:
 		#
 	#	soh_virtual_server = "soh-server"
+
+		#
+		# Unlike EAP-TLS, PEAP does not require a client certificate.
+		# However, you can require one by setting the following
+		# option. You can also override this option by setting
+		#
+		#	EAP-TLS-Require-Client-Cert = Yes
+		#
+		# in the control items for a request.
+		#
+	#	require_client_cert = yes
 	}
 
 	#

--- a/src/modules/rlm_eap/types/rlm_eap_peap/rlm_eap_peap.c
+++ b/src/modules/rlm_eap/types/rlm_eap_peap/rlm_eap_peap.c
@@ -70,6 +70,11 @@ typedef struct rlm_eap_peap_t {
 	 */
 	int	soh;
   	char	*soh_virtual_server;
+
+	/*
+	 * 	Do we do require a client cert?
+	 */
+	int	req_client_cert;
 } rlm_eap_peap_t;
 
 
@@ -96,6 +101,9 @@ static CONF_PARSER module_config[] = {
 
 	{ "soh", PW_TYPE_BOOLEAN,
 	  offsetof(rlm_eap_peap_t, soh), NULL, "no" },
+
+	{ "require_client_cert", PW_TYPE_BOOLEAN,
+	  offsetof(rlm_eap_peap_t, req_client_cert), NULL, "no" },
 
 	{ "soh_virtual_server", PW_TYPE_STRING_PTR,
 	  offsetof(rlm_eap_peap_t, soh_virtual_server), NULL, NULL },
@@ -227,8 +235,12 @@ static int eappeap_initiate(void *type_arg, EAP_HANDLER *handler)
 
 	/*
 	 *	Check if we need a client certificate.
-	 *
-	 *	FIXME: This should be more configurable.
+	 */
+	client_cert = inst->req_client_cert;
+
+	/*
+	 * EAP-TLS-Require-Client-Cert attribute will override
+	 * the require_client_cert configuration option.
 	 */
 	vp = pairfind(handler->request->config_items,
 		      PW_EAP_TLS_REQUIRE_CLIENT_CERT, 0);

--- a/src/modules/rlm_eap/types/rlm_eap_ttls/rlm_eap_ttls.c
+++ b/src/modules/rlm_eap/types/rlm_eap_ttls/rlm_eap_ttls.c
@@ -68,6 +68,11 @@ typedef struct rlm_eap_ttls_t {
 	 *	Virtual server for inner tunnel session.
 	 */
 	char	*virtual_server;
+
+	/*
+	 * 	Do we do require a client cert?
+	 */
+	int	req_client_cert;
 } rlm_eap_ttls_t;
 
 
@@ -89,6 +94,9 @@ static CONF_PARSER module_config[] = {
 
 	{ "include_length", PW_TYPE_BOOLEAN,
 	  offsetof(rlm_eap_ttls_t, include_length), NULL, "yes" },
+
+	{ "require_client_cert", PW_TYPE_BOOLEAN,
+	  offsetof(rlm_eap_ttls_t, req_client_cert), NULL, "no" },
 
  	{ NULL, -1, 0, NULL, NULL }           /* end the list */
 };
@@ -214,8 +222,12 @@ static int eapttls_initiate(void *type_arg, EAP_HANDLER *handler)
 
 	/*
 	 *	Check if we need a client certificate.
-	 *
-	 *	FIXME: This should be more configurable.
+	 */
+	client_cert = inst->req_client_cert;
+
+	/*
+	 * EAP-TLS-Require-Client-Cert attribute will override
+	 * the require_client_cert configuration option.
 	 */
 	vp = pairfind(handler->request->config_items,
 		      PW_EAP_TLS_REQUIRE_CLIENT_CERT, 0);


### PR DESCRIPTION
Hi Alan,

As mentioned this morning - two new options for PEAP and TTLS to require a client certificate from the config, rather than having to set EAP-TLS-Require-Client-Cert. However, if that attribute exists it will override this setting in the config.

Cheers

Matthew
