### PR TITLE
Add all autoconf-enabled modules to the list of build subdirectories

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1148,28 +1148,6 @@ AC_SUBST(INCLTDL)
 
 dnl import libtool stuff
 
-dnl #############################################################
-dnl #
-dnl #  Configure in any module directories.
-dnl #
-dnl #############################################################
-
-mysubdirs="$LIBLTDLPATH"
-if test "x$EXPERIMENTAL" = "xyes"; then
-  bar=`ls -1 "${srcdir}"/src/modules/rlm_*/configure | sed 's%/configure%%'`
-  dnl # get rid of LF's.
-  mysubdirs=`echo $mysubdirs $bar`
-else
-  dnl #
-  dnl # Find 'configure' in ONLY the stable modules
-  dnl #
-  for bar in `cat "${srcdir}"/src/modules/stable`; do
-    if test -f "${srcdir}"/src/modules/$bar/configure; then
-      mysubdirs="$mysubdirs src/modules/$bar"
-    fi
-  done
-fi
-
 dnl ############################################################
 dnl # make modules by list
 dnl #############################################################
@@ -1185,6 +1163,19 @@ else
     MODULES="$MODULES $foo"
    done
 fi
+
+dnl #############################################################
+dnl #
+dnl #  Configure in any module directories.
+dnl #
+dnl #############################################################
+
+mysubdirs="$LIBLTDLPATH"
+for bar in $MODULES; do
+  if test -f "${srcdir}"/src/modules/$bar/configure; then
+    mysubdirs="$mysubdirs src/modules/$bar"
+  fi
+done
 
 dnl #
 dnl #  Don't change the variable name here.  Autoconf goes bonkers


### PR DESCRIPTION
Previous code was ignoring modules specified using --with-modules
