### PR TITLE
Fix debian package to work even without freeradius-mysql

### DIFF
--- a/debian/patches/dhcp_sqlippool-comment-out-mysql.diff
+++ b/debian/patches/dhcp_sqlippool-comment-out-mysql.diff
@@ -1,0 +1,18 @@
+diff --git a/raddb/modules/dhcp_sqlippool b/raddb/modules/dhcp_sqlippool
+index 39358b2..2a29daf 100644
+--- a/raddb/modules/dhcp_sqlippool
++++ b/raddb/modules/dhcp_sqlippool
+@@ -14,8 +14,11 @@ sqlippool dhcp_sqlippool {
+ 	# Client's MAC address is mapped to Calling-Station-Id in policy.conf
+ 	pool-key = "%{Calling-Station-Id}"
+ 
+-	# For now, it only works with MySQL.
+-	$INCLUDE ${confdir}/sql/mysql/ippool-dhcp.conf
++	# For now, it only works with MySQL. 
++	# This line is commented by default to enable clean startup when you
++	# don't have freeradius-mysql installed. Uncomment this line if you 
++	# use this module.
++	#$INCLUDE ${confdir}/sql/mysql/ippool-dhcp.conf
+  
+ 	sqlippool_log_exists = "DHCP: Existing IP: %{reply:Framed-IP-Address} (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,4 @@ radiusd-to-freeradius.diff
 dialupadmin-help.diff
 gitignore.diff
 rlm_sql.libs.diff
+dhcp_sqlippool-comment-out-mysql.diff


### PR DESCRIPTION
The default "freeradius" debian package includes "/etc/freeradius/modules/dhcp_sqlippool", which loads "/etc/freeradius/sql/mysql/ippool-dhcp.conf". This will cause the server fail to start if freeradius-mysql is not installed.

Added "debian/patches/dhcp_sqlippool-comment-out-mysql.diff" to comment-out that line in the default debian package so that by default users installing "freeradius" package can always start the server, even without
"freeeradius-mysql" package installed.
