### PR TITLE
fixed error in dialup.conf for PSQL

### DIFF
--- a/raddb/sql/postgresql/dialup.conf
+++ b/raddb/sql/postgresql/dialup.conf
@@ -349,7 +349,7 @@
 	
 	post-auth {
 		query = "\
-			INSERT INTO ${postauth_table} \
+			INSERT INTO ${..postauth_table} \
 				(username, pass, reply, authdate) \
 	  		VALUES(\
 	  			'%{User-Name}', \


### PR DESCRIPTION
fixed variable definition in new dialup.conf file - without this the
server blows up on startup with 'unknown variable' message as soon as
someone tries to use postgres
