### PR TITLE
rlm_sql_post_proxy function for v2.1.x

### DIFF
--- a/raddb/sites-available/default
+++ b/raddb/sites-available/default
@@ -625,6 +625,15 @@ post-proxy {
 	eap
 
 	#
+	# If you want to add user-specific reply-attributes to the reply
+	# after the home server has processed the request, you can enable
+	# this function. You can choose to re-use the radreply table
+	# or have a separate table with a similar structure
+	# the post_proxy_query must be defined in sql.conf for this to work
+	#
+	# sql
+
+	#
 	#  If the server tries to proxy a request and fails, then the
 	#  request is processed through the modules in this section.
 	#

--- a/raddb/sql.conf
+++ b/raddb/sql.conf
@@ -59,6 +59,9 @@ sql {
 	groupcheck_table = "radgroupcheck"
 	groupreply_table = "radgroupreply"
 
+	# A table to get per-user reply items in the post-proxy stage
+	post_proxy_reply_table = "radreply"
+
 	# Table to keep group info
 	usergroup_table = "radusergroup"
 

--- a/raddb/sql/mssql/dialup.conf
+++ b/raddb/sql/mssql/dialup.conf
@@ -56,6 +56,8 @@
           WHERE username = '%{SQL-User-Name}' \
           ORDER BY priority"
 
+	post_proxy_reply_query = "SELECT id,UserName,Attribute,Value,op FROM ${post_proxy_reply_table} WHERE Username = '%{SQL-User-Name}' ORDER BY id"
+
 	#######################################################################
 	#  Accounting Queries
 	#######################################################################

--- a/raddb/sql/mysql/dialup.conf
+++ b/raddb/sql/mysql/dialup.conf
@@ -133,6 +133,12 @@
           WHERE groupname = '%{Sql-Group}' \
           ORDER BY id"
 
+	post_proxy_reply_query = "\
+          SELECT id, username, attribute, value, op \
+          FROM ${post_proxy_reply_table} \
+          WHERE username = '%{SQL-User-Name}' \
+          ORDER BY id"
+
 	#######################################################################
 	#  Accounting Queries
 	#######################################################################

--- a/raddb/sql/oracle/dialup.conf
+++ b/raddb/sql/oracle/dialup.conf
@@ -95,6 +95,8 @@
 	authorize_group_check_query = "SELECT ${groupcheck_table}.id,${groupcheck_table}.GroupName,${groupcheck_table}.Attribute,${groupcheck_table}.Value,${groupcheck_table}.op  FROM ${groupcheck_table},${usergroup_table} WHERE ${usergroup_table}.Username = '%{SQL-User-Name}' AND ${usergroup_table}.GroupName = ${groupcheck_table}.GroupName ORDER BY ${groupcheck_table}.id"
 	authorize_group_reply_query = "SELECT ${groupreply_table}.id,${groupreply_table}.GroupName,${groupreply_table}.Attribute,${groupreply_table}.Value,${groupreply_table}.op  FROM ${groupreply_table},${usergroup_table} WHERE ${usergroup_table}.Username = '%{SQL-User-Name}' AND ${usergroup_table}.GroupName = ${groupreply_table}.GroupName ORDER BY ${groupreply_table}.id"
 
+	post_proxy_reply_query = "SELECT id,UserName,Attribute,Value,op FROM ${post_proxy_reply_table} WHERE Username = '%{SQL-User-Name}' ORDER BY id"
+
 	#######################################################################
 	#  Accounting Queries
 	#######################################################################

--- a/raddb/sql/postgresql/dialup.conf
+++ b/raddb/sql/postgresql/dialup.conf
@@ -123,6 +123,12 @@ authorize_group_reply_query = "SELECT id, GroupName, Attribute, Value, op \
   WHERE GroupName = '%{Sql-Group}' \
   ORDER BY id"
 
+post_proxy_reply_query =  "SELECT id, UserName, Attribute, Value, Op \
+  FROM ${post_proxy_reply_table} \
+  WHERE Username = '%{SQL-User-Name}' \
+  ORDER BY id"
+
+
 #######################################################################
 # Simultaneous Use Checking Queries
 #######################################################################

--- a/src/modules/rlm_sql/conf.h
+++ b/src/modules/rlm_sql/conf.h
@@ -47,6 +47,7 @@ typedef struct sql_config {
 	int     max_queries;
 	int     connect_failure_retry_delay;
 	char   *postauth_query;
+	char   *post_proxy_reply_query;
 	char   *allowed_chars;
 	int	query_timeout;
 


### PR DESCRIPTION
Hi,
please look at this and give me your comments. We intend to use it in a project.
- modified:   src/modules/rlm_sql/conf.h
- modified:   src/modules/rlm_sql/rlm_sql.c

Added rlm_sql_post_proxy() function, so that one can use the rlm_sql module
to look up additional attributes for a user, and add it to the reply
after the request has been handled by the home-server. The table may be
the same as the authreply_table or a similar one.
- modified:   raddb/sites-available/default
- modified:   raddb/sql.conf
- modified:   raddb/sql/mssql/dialup.conf
- modified:   raddb/sql/mysql/dialup.conf
- modified:   raddb/sql/oracle/dialup.conf
- modified:   raddb/sql/postgresql/dialup.conf

Configuration samples for rlm_sql_post_proxy
## 

Nils Ronhovde
