### PR TITLE
add the ability to persist SSL session cache to disk across server restarts

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -604,6 +604,7 @@ AC_CHECK_HEADERS( \
 	sys/types.h \
 	sys/socket.h \
 	winsock.h \
+	utime.h \
 	sys/time.h \
 	sys/wait.h \
 	sys/security.h \

--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -388,6 +388,34 @@ eap {
 		      #  who are logged in... which can be a LOT.
 		      #
 		      max_entries = 255
+
+		      #
+		      #  Internal "name" of the session cache.
+		      #  Used to distinguish which TLS context
+		      #  sessions belong to.
+		      #
+		      #  The server will generate a random value
+		      #  if unset. This will change across server
+		      #  restart so you MUST set the "name" if you
+		      #  want to persist sessions (see below).
+		      #
+		      #name = "EAP module"
+
+		      #
+		      #  Simple directory-based storage of sessions.
+		      #  Two files per session will be written, the SSL
+		      #  state and the cached VPs. This will persist session
+		      #  across server restarts.
+		      #
+		      #  The server will need write perms, and the directory
+		      #  should be secured from anyone else. You might want
+		      #  a script to remove old files from here periodically:
+		      #
+		      #    find ${logdir}/tlscache -mtime +2 -exec rm -f {} \;
+		      #
+		      #  This feature REQUIRES "name" option be set above.
+		      #
+		      #persist_dir = "${logdir}/tlscache"
 		}
 
 		#

--- a/src/include/tls.h
+++ b/src/include/tls.h
@@ -359,6 +359,7 @@ struct fr_tls_server_conf_t {
         int     	session_timeout;
         int     	session_cache_size;
 	char		*session_id_name;
+	char		*session_cache_path;
 	char		session_context_id[SSL_MAX_SSL_SESSION_ID_LENGTH];
 	time_t		session_last_flushed;
 


### PR DESCRIPTION
This is a pretty simple disk-based cache, that writes the OpenSSL blob and the server cached VPs to disk. The files are touched with "utime" on each use, so can be cleaned with a simple "find +mtime".

It relies on the SSL context name being consistent across server restarts.
