### PR TITLE
better default interop with eduroam

### DIFF
--- a/raddb/attrs
+++ b/raddb/attrs
@@ -124,4 +124,6 @@ DEFAULT
 	State =* ANY,
 	Session-Timeout <= 28800,
 	Idle-Timeout <= 600,
+	Calling-Station-Id =* ANY,
+	Operator-Name =* ANY,
 	Port-Limit <= 2


### PR DESCRIPTION
eduroam use these 2 attributes…by adding them to the default
configuration we should not cause other usage issues but we will make
FreeRADIUS more 'out of the box' ready for eduroam
