### PR TITLE
additional interoperability in default configuration for eduroam

### DIFF
--- a/raddb/attrs
+++ b/raddb/attrs
@@ -124,4 +124,6 @@ DEFAULT
 	State =* ANY,
 	Session-Timeout <= 28800,
 	Idle-Timeout <= 600,
+        Calling-Station-Id =* ANY,
+        Operator-Name =* ANY,
 	Port-Limit <= 2


### PR DESCRIPTION
eduroam federation use these 2 attributes…by adding them to the default
configuration we shouldnt cause any issues for other usage but will
enable FreeRADIUS to be more ready for eduroam 'out of the box'
