### PR TITLE
Fix --with-system-libltdl and --with-system-libtool

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -81,15 +81,20 @@ fi
 
 AC_ARG_WITH(system-libltdl,
 [  --with-system-libltdl   Use the libltdl installed in your system (default=use dlopen)],
-[
-LIBLTDL="-lltdl"
-INCLTDL=-DWITH_SYSTEM_LTDL
-],
-)
+[],
+[with_system_libltdl=no])
+
+AS_IF([test "x$with_system_libltdl" = "xyes" ],
+[ LIBLTDL="-lltdl"
+INCLTDL=-DWITH_SYSTEM_LTDL])
 
 dnl use system-wide libtool, if it exists
 AC_ARG_WITH(system-libtool,
 [  --with-system-libtool   Use the libtool installed in your system (default=use our own)],
+[],
+[with_system_libtool=no])
+
+AS_IF([test "x$with_system_libtool" = "xyes" ],
 [ AC_PATH_PROG(LIBTOOL, libtool,,$PATH:/usr/local/bin) AC_LIBTOOL_DLOPEN
  AC_PROG_LIBTOOL],
 [


### PR DESCRIPTION
The use of AC_ARG_WITH in configure.in is incorrect because its third argument is a block of code to be run whenever --with-<foo> is present(regardless of the argument is receives), not when is enabled
