### PR TITLE
Prevent invalid config filenames from being loaded.

### DIFF
--- a/src/include/libradius.h
+++ b/src/include/libradius.h
@@ -413,6 +413,17 @@ int fr_ipaddr2sockaddr(const fr_ipaddr_t *ipaddr, int port,
 int fr_sockaddr2ipaddr(const struct sockaddr_storage *sa, socklen_t salen,
 		       fr_ipaddr_t *ipaddr, int * port);
 
+int
+str_starts_with(const char *subject, const char *pattern);
+int
+strn_starts_with(const char *subject, const char *pattern, size_t sbj_len, size_t pat_len);
+int
+str_ends_with(const char *subject, const char *pattern);
+int
+strn_ends_with(const char *subject, const char *pattern, size_t sbj_len, size_t pat_len);
+int
+fr_exclude_config_file(const char *basename);
+
 
 #ifdef ASCEND_BINARY
 /* filters.c */

--- a/src/main/conffile.c
+++ b/src/main/conffile.c
@@ -1443,12 +1443,23 @@ static int cf_section_read(const char *filename, int *lineno, FILE *fp,
 				}
 
 				/*
-				 *	Read the directory, ignoring "." files.
+				 *	Read the directory, ignoring invalid files.
 				 */
 				while ((dp = readdir(dir)) != NULL) {
 					const char *p;
 
-					if (dp->d_name[0] == '.') continue;
+					/*
+					 *	Check for invalid file names
+					 */
+					if (fr_exclude_config_file(dp->d_name)) {
+						if (!(strcmp(dp->d_name, ".")  == 0 ||
+						      strcmp(dp->d_name, "..") == 0)) {
+							radlog(L_INFO, "skipping config file, invalid name \"%s%s\"",
+							value, dp->d_name);
+						}
+						continue;
+					}
+
 
 					/*
 					 *	Check for valid characters
@@ -1461,7 +1472,11 @@ static int cf_section_read(const char *filename, int *lineno, FILE *fp,
 						    (*p == '.')) continue;
 						break;
 					}
-					if (*p != '\0') continue;
+					if (*p != '\0') {
+                                            radlog(L_INFO, "skipping config file, invalid characters in name \"%s%s\"",
+                                                   value, dp->d_name);
+                                            continue;
+                                        }
 
 					snprintf(buf2, sizeof(buf2), "%s%s",
 						 value, dp->d_name);

--- a/src/modules/rlm_policy/parse.c
+++ b/src/modules/rlm_policy/parse.c
@@ -1583,13 +1583,22 @@ static int parse_include(policy_lex_file_t *lexer)
 			}
 
 			/*
-			 *	Read the directory, ignoring "." files.
+			 *	Read the directory, ignoring invalid files.
 			 */
 			while ((dp = readdir(dir)) != NULL) {
 				struct stat buf;
 
-				if (dp->d_name[0] == '.') continue;
-				if (strchr(dp->d_name, '~') != NULL) continue;
+				/*
+				 *	Check for invalid file names
+				 */
+				if (fr_exclude_config_file(dp->d_name)) {
+					if (!(strcmp(dp->d_name, ".")  == 0 ||
+					      strcmp(dp->d_name, "..") == 0)) {
+	                                    fprintf(stderr, "skipping policy file, invalid name \"%s%s\"",
+						buffer, dp->d_name);
+					}
+					continue;
+				}
 
 				strlcpy(p, dp->d_name,
 					sizeof(buffer) - (p - buffer));


### PR DESCRIPTION
There are several places where configuration files are read by opening
a directory and loading every file found in that directory. However
sometimes files may be present which should not be loaded, instead
they should be excluded. We introduce a new utility function
fr_exclude_config_file() which takes a file basename and returns True
if it should be excluded from loading. We also log any files found in
a config directory which are excluded for any reason (there are other
checks for excluding a file, e.g. invalid characters in the basename
which are not part of fr_exclude_config_file()).

There are two approaches to identifying which basenames to exclude,
regular expession matching and specific checks (i.e. name begins with,
or name ends with). Regular expression matching is the most general
and likely more efficient than repeatedly testing a string for certain
substring conditions (the alternative approach). Unfortunately
regexp's are not always available (controlled by the config symbol
HAVE_REGEX_H). If regexps are available then fr_exclude_config_file()
is implemented with a single pre-compiled regexp match. If regexp's
are not available then fr_exclude_config_file() is implemented with
string utilities for testing the beginning and ending of a
string. Included are implementations of those string functions because
no such POSIX function exists nor were there any such functions
previously in FreeRADIUS.

In both cases files that are excluded are members of this hardcoded list:

Any basename beginning with a dot (.)
Any basename beginning with a hash (i.e. pound sign, octothorp) (#)
Any basename ending with a tilde (~)
Any basename ending with the substring ".rpmsave"
Any basename ending with the substring ".rpmnew"
Any basename ending with the substring ".dpkg-new"
Any basename ending with the substring ".dpkg-dist"
Any basename ending with the substring ".dpkg-old"
Any basename ending with the substring ".bak"

If the set of excluded files is updated then both implementations of
fr_exclude_config_file() should be adjusted.
