### PR TITLE
Create threads as joinable, not detached.

### DIFF
--- a/src/include/radiusd.h
+++ b/src/include/radiusd.h
@@ -593,6 +593,7 @@ void		xlat_free(void);
 
 /* threads.c */
 extern		int thread_pool_init(CONF_SECTION *cs, int *spawn_flag);
+extern		void thread_pool_stop(void);
 extern		int thread_pool_addrequest(REQUEST *, RAD_REQUEST_FUNP);
 extern		pid_t rad_fork(void);
 extern		pid_t rad_waitpid(pid_t pid, int *status);

--- a/src/main/event.c
+++ b/src/main/event.c
@@ -3738,10 +3738,9 @@ static int proxy_hash_cb(UNUSED void *ctx, void *data)
 void radius_event_free(void)
 {
 	/*
-	 *	FIXME: Stop all threads, or at least check that
-	 *	they're all waiting on the semaphore, and the queues
-	 *	are empty.
+	 *	Stop and join all threads.
 	 */
+	thread_pool_stop();
 
 #ifdef WITH_PROXY
 	/*


### PR DESCRIPTION
Stop and join all threads before detaching modules.
