### PR TITLE
Create threads as joinable, not detached.

### DIFF
--- a/src/include/radiusd.h
+++ b/src/include/radiusd.h
@@ -593,6 +593,7 @@ void		xlat_free(void);
 
 /* threads.c */
 extern		int thread_pool_init(CONF_SECTION *cs, int *spawn_flag);
+extern		void thread_pool_stop(void);
 extern		int thread_pool_addrequest(REQUEST *, RAD_REQUEST_FUNP);
 extern		pid_t rad_fork(void);
 extern		pid_t rad_waitpid(pid_t pid, int *status);

--- a/src/main/event.c
+++ b/src/main/event.c
@@ -3738,10 +3738,11 @@ static int proxy_hash_cb(UNUSED void *ctx, void *data)
 void radius_event_free(void)
 {
 	/*
-	 *	FIXME: Stop all threads, or at least check that
-	 *	they're all waiting on the semaphore, and the queues
-	 *	are empty.
+	 *	Stop and join all threads.
 	 */
+#ifdef HAVE_PTHREAD_H
+	thread_pool_stop();
+#endif
 
 #ifdef WITH_PROXY
 	/*

--- a/src/main/threads.c
+++ b/src/main/threads.c
@@ -131,6 +131,7 @@ typedef struct THREAD_POOL {
 	unsigned long request_count;
 	time_t time_last_spawned;
 	int cleanup_delay;
+	int stop_flag;
 	int spawn_flag;
 
 #ifdef WNOHANG
@@ -358,7 +359,8 @@ static int request_enqueue(REQUEST *request, RAD_REQUEST_FUNP fun)
 /*
  *	Remove a request from the queue.
  */
-static int request_dequeue(REQUEST **request, RAD_REQUEST_FUNP *fun)
+static int request_dequeue(REQUEST **request, RAD_REQUEST_FUNP *fun,
+                           int *stop_flag)
 {
 	int blocked;
 	RAD_LISTEN_TYPE i, start;
@@ -367,6 +369,17 @@ static int request_dequeue(REQUEST **request, RAD_REQUEST_FUNP *fun)
 	reap_children();
 
 	pthread_mutex_lock(&thread_pool.queue_mutex);
+
+	/*
+	 *	Check if queue is stopped.
+	 */
+	*stop_flag = thread_pool.stop_flag;
+	if (*stop_flag) {
+		pthread_mutex_unlock(&thread_pool.queue_mutex);
+		*request = NULL;
+		*fun = NULL;
+		return 0;
+	}
 
 	/*
 	 *	Clear old requests from all queues.
@@ -483,6 +496,7 @@ static int request_dequeue(REQUEST **request, RAD_REQUEST_FUNP *fun)
 static void *request_handler_thread(void *arg)
 {
 	RAD_REQUEST_FUNP  fun;
+	int stop_flag;
 	THREAD_HANDLE	  *self = (THREAD_HANDLE *) arg;
 
 	/*
@@ -520,12 +534,21 @@ static void *request_handler_thread(void *arg)
 #endif
 
 		/*
+		 *	The server is exiting.  Don't dequeue any
+		 *	requests.
+		 */
+		if (thread_pool.stop_flag) break;
+
+		/*
 		 *	Try to grab a request from the queue.
 		 *
 		 *	It may be empty, in which case we fail
 		 *	gracefully.
 		 */
-		if (!request_dequeue(&self->request, &fun)) continue;
+		if (!request_dequeue(&self->request, &fun, &stop_flag)) {
+			if (stop_flag) break;
+			continue;
+		}
 
 		self->request->child_pid = self->pthread_id;
 		self->request_count++;
@@ -621,7 +644,6 @@ static THREAD_HANDLE *spawn_thread(time_t now)
 {
 	int rcode;
 	THREAD_HANDLE *handle;
-	pthread_attr_t attr;
 
 	/*
 	 *	Ensure that we don't spawn too many threads.
@@ -644,30 +666,19 @@ static THREAD_HANDLE *spawn_thread(time_t now)
 	handle->timestamp = time(NULL);
 
 	/*
-	 *	Initialize the thread's attributes to detached.
-	 *
-	 *	We could call pthread_detach() later, but if the thread
-	 *	exits between the create & detach calls, it will need to
-	 *	be joined, which will never happen.
-	 */
-	pthread_attr_init(&attr);
-	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
-
-	/*
-	 *	Create the thread detached, so that it cleans up it's
-	 *	own memory when it exits.
+	 *	Create the thread joinable, so that it can be cleaned up
+	 *	using pthread_join().
 	 *
 	 *	Note that the function returns non-zero on error, NOT
 	 *	-1.  The return code is the error, and errno isn't set.
 	 */
-	rcode = pthread_create(&handle->pthread_id, &attr,
+	rcode = pthread_create(&handle->pthread_id, 0,
 			request_handler_thread, handle);
 	if (rcode != 0) {
 		radlog(L_ERR, "Thread create failed: %s",
 		       strerror(rcode));
 		return NULL;
 	}
-	pthread_attr_destroy(&attr);
 
 	/*
 	 *	One more thread to go into the list.
@@ -763,6 +774,7 @@ int thread_pool_init(CONF_SECTION *cs, int *spawn_flag)
 	thread_pool.total_threads = 0;
 	thread_pool.max_thread_num = 1;
 	thread_pool.cleanup_delay = 5;
+	thread_pool.stop_flag = 0;
 	thread_pool.spawn_flag = *spawn_flag;
 	
 	/*
@@ -777,7 +789,7 @@ int thread_pool_init(CONF_SECTION *cs, int *spawn_flag)
 		       strerror(errno));
 		return -1;
 	}
-	
+
 	/*
 	 *	Create the hash table of child PID's
 	 */
@@ -871,6 +883,40 @@ int thread_pool_init(CONF_SECTION *cs, int *spawn_flag)
 	DEBUG2("Thread pool initialized");
 	pool_initialized = TRUE;
 	return 0;
+}
+
+
+/*
+ *	Stop all threads in the pool.
+ */
+void thread_pool_stop(void)
+{
+	int i;
+	int total_threads;
+	THREAD_HANDLE *handle;
+	THREAD_HANDLE *next;
+
+	/*
+	 *	Set pool stop flag.
+	 */
+	thread_pool.stop_flag = 1;
+
+	/*
+	 *	Wakeup all threads to make them see stop flag.
+	 */
+	total_threads = thread_pool.total_threads;
+	for (i = 0; i != total_threads; i++) {
+		sem_post(&thread_pool.semaphore);
+	}
+
+	/*
+	 *	Join and free all threads.
+	 */
+	for (handle = thread_pool.head; handle; handle = next) {
+		next = handle->next;
+		pthread_join(handle->pthread_id, NULL);
+		delete_thread(handle);
+	}
 }
 
 
@@ -999,6 +1045,7 @@ static void thread_pool_manage(time_t now)
 		 *	has agreed.
 		 */
 		if (handle->status == THREAD_EXITED) {
+			pthread_join(handle->pthread_id, NULL);
 			delete_thread(handle);
 		}
 	}


### PR DESCRIPTION
Stop and join all threads before detaching modules.

This prevents a crash on exit where the modules are free'd before
the threads stop using them.
