### PR TITLE
Fixed typo in calculation of size of available buffer.

### DIFF
--- a/src/main/files.c
+++ b/src/main/files.c
@@ -157,7 +157,7 @@ parse_again:
 						*p = FR_DIR_SEP;
 					}
 					getword(&ptr, p + 1,
-						sizeof(newfile) - 1 - (p - buffer));
+						sizeof(newfile) - 1 - (p - newfile));
 				} else {
 					getword(&ptr, newfile,
 						sizeof(newfile));


### PR DESCRIPTION
Hi.

I have got a same issue as described in this topic:
http://www.mail-archive.com/freeradius-users@lists.freeradius.org/msg78571.html
It seems that $INCLUDE directive ignores files with relative path.
Due to a typo at line 160 of src/main/files.c, calculed buffer size becomes negative (as gdb shows) and only \0 is copied and newfile contains only path of base directory of file.
Proposed patch fixed this bug.
