### PR TITLE
Allow EAP-Message APVs > 253 octets in EAP-TTLS module

### DIFF
--- a/src/modules/rlm_eap/types/rlm_eap_ttls/ttls.c
+++ b/src/modules/rlm_eap/types/rlm_eap_ttls/ttls.c
@@ -201,8 +201,11 @@ static VALUE_PAIR *diameter2vp(REQUEST *request, SSL *ssl,
 			goto next_attr;
 		}
 
-		if (size > 253) {
-			RDEBUG2("WARNING: diameter2vp skipping long attribute %u, attr");
+		/*
+		 * EAP-Message AVPs can be larger than 253 octets.
+		 */
+		if ((size > 253) && !((vendor == 0) && (attr == PW_EAP_MESSAGE))) {
+			RDEBUG2("WARNING: diameter2vp skipping long attribute %u", attr);
 			goto next_attr;
 		}
 


### PR DESCRIPTION
According to [RFC 5281, section 11.2.1](http://tools.ietf.org/html/rfc5281#section-11.2.1) tunneled EAP packets that are larger than 253 octets MUST be contained in a single EAP-Message AVP.
