### PR TITLE
Don't rotate Red Hat radutmp. Fix #174

### DIFF
--- a/redhat/freeradius-logrotate
+++ b/redhat/freeradius-logrotate
@@ -32,14 +32,6 @@
 	compress
 }
 
-/var/log/radius/radutmp {
-	monthly
-	rotate 4
-	create
-	compress
-	missingok
-}
-
 /var/log/radius/radwtmp {
 	monthly
 	rotate 4


### PR DESCRIPTION
Eventually to apply on both master and v2.x.x branch.
