### PR TITLE
don't count status server requests in internal stats

### DIFF
--- a/src/main/stats.c
+++ b/src/main/stats.c
@@ -127,6 +127,10 @@ void request_stats_final(REQUEST *request)
 #endif
 	    (request->listener->type != RAD_LISTEN_AUTH)) return;
 
+	/* don't count statistic requests */
+	if (request->packet->code == PW_STATUS_SERVER)
+		return;
+
 #undef INC_AUTH
 #define INC_AUTH(_x) radius_auth_stats._x++;request->listener->stats._x++;request->client->auth._x++;
 


### PR DESCRIPTION
Requests to to status server should not be added to the internal counters,
notably the Access-Accept replies. See also the thread in
http://lists.freeradius.org/pipermail/freeradius-devel/2013-March/007801.html
