### PR TITLE
Building debian package. Fixed some errors

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,10 @@ Build-Depends: debhelper (>= 6.0.7),
  libreadline-dev,
  libsnmp-dev,
  libpq-dev,
- libssl-dev
+ libssl-dev,
+ libtalloc-dev,
+ libyubikey-dev,
+ libsqlite3-dev
 Section: net
 Priority: optional
 Maintainer: Josip Rodin <joy-packages@debian.org>


### PR DESCRIPTION
Got clean Debian 6 stable.

```
aptitude install devscripts git
git clone ...
cd ...
debuild -us -uc
```

Got depends error

```
aptitude install quilt libpam0g-dev libmysqlclient-dev libldap2-dev libsasl2-dev libiodbc2-dev libkrb5-dev libperl-dev libpcap-dev python-dev libreadline-dev libsnmp-dev libpq-dev autotools-dev libltdl3-dev
debuild -us -uc
```

got 

```
configure: WARNING: talloc headers not found. Use --with-talloc-include-dir=<path>.
configure: error: FreeRADIUS requires libtalloc
```

and the same error with libyubikey-dev, libsqlite3-dev
after adding them to control file and into system 
'configure' script successfully finished.

Then i got other errors, but i can't fix it myself :-(

the first one is

```
dh_install --sourcedir=/root/github/freeradius-server/debian/tmp -p freeradius-utils
    install -d debian/freeradius-utils//usr/bin
    cp -a /root/github/freeradius-server/debian/tmp/usr/bin/rlm_dbm_cat debian/freeradius-utils//usr/bin/
cp: cannot stat `/root/github/freeradius-server/debian/tmp/usr/bin/rlm_dbm_cat': No such file or directory
dh_install: cp -a /root/github/freeradius-server/debian/tmp/usr/bin/rlm_dbm_cat debian/freeradius-utils//usr/bin/ returned exit code 1
make: *** [install-arch] Error 2
dpkg-buildpackage: error: fakeroot debian/rules binary gave error exit status 2
debuild: fatal error at line 1325:
dpkg-buildpackage -rfakeroot -D -us -uc failed
```

i fixed that in
debian/freeradius-utils.install
removed
usr/bin/rlm_dbm_cat 
line
and two more errors like this
