### PR TITLE
com_err.h include change

### DIFF
--- a/src/modules/rlm_krb5/rlm_krb5.c
+++ b/src/modules/rlm_krb5/rlm_krb5.c
@@ -33,7 +33,7 @@ RCSID("$Id$")
 
 /* krb5 includes */
 #include <krb5.h>
-#include <com_err.h>
+#include <et/com_err.h>
 
 /** Instance configuration for rlm_krb5
  *


### PR DESCRIPTION
path for com_err.h is in et/ subdirectory (however, this probably needs
a wrapper in the configuration stage as its a rehdatism i think)
