### PR TITLE
trivial fix for list qualifier error

### DIFF
--- a/raddb/sites-available/dynamic-clients
+++ b/raddb/sites-available/dynamic-clients
@@ -113,7 +113,7 @@ server dynamic_client_server {
 			FreeRADIUS-Client-IP-Address = "%{Packet-Src-IP-Address}"
 
 			# require_message_authenticator
-			FreeRADIUS-Client-Require-MA = no
+			FreeRADIUS-Client-Require-MA = "no"
 
 			# secret
 			FreeRADIUS-Client-Secret = "testing123"


### PR DESCRIPTION
default config causes this error message when dynamic-clients VS is
enabled)

server dynamic_client_server { # from file
/etc/raddb/sites-enabled/dynamic-clients
 # Loading authorize {...}
Invalid list qualifier "no"
} # server
