### PR TITLE
Fix (and change) Foreach-Variable xlat.  Add tests.

### DIFF
--- a/man/man5/unlang.5
+++ b/man/man5/unlang.5
@@ -107,15 +107,19 @@ none of the usual variable referenced %{...}.  This is because it is a
 reference to the attribute, and not an expansion of the attribute.
 
 Inside of the "foreach" block, the attribute which is being looped
-over can be referenced as "Foreach-Variable-#".  Where "#" is the
-depth of the loop, starting at "0".  e.g. "Foreach-Variable-0".  The
-loops can be nested up to eight (8) deep, though this is not
+over can be referenced as "Foreach-Variable:#".  Where "#" is the
+depth of the loop, starting at "0".  e.g. "Foreach-Variable:0".  The
+loops can be nested up to ten (10) deep, though this is not
 recommended.
 
 .DS
 	foreach Attribute-Name {
 .br
-		...
+		if ("%{Foreach-Variable:0}") {
+.br
+			...
+.br
+		}
 .br
 	}
 .DE

--- a/src/main/modcall.c
+++ b/src/main/modcall.c
@@ -522,7 +522,7 @@ int modcall(int component, modcallable *c, REQUEST *request)
 				copy_p = request_data_get(request,
 							  radius_get_vp, i);
 				if (copy_p) {
-						RDEBUG2("%.*s #  BREAK Foreach-Variable-%d", stack.pointer + 1, modcall_spaces, i);
+						RDEBUG2("%.*s #  BREAK Foreach-Variable:%d", stack.pointer + 1, modcall_spaces, i);
 					pairfree(copy_p);
 					break;
 				}
@@ -568,7 +568,7 @@ int modcall(int component, modcallable *c, REQUEST *request)
 						char buffer[1024];
 
 						vp_prints_value(buffer, sizeof(buffer), vp, 1);
-						RDEBUG2("%.*s #  Foreach-Variable-%d = %s", stack.pointer + 1, modcall_spaces, depth, buffer);
+						RDEBUG2("%.*s #  Foreach-Variable:%d = %s", stack.pointer + 1, modcall_spaces, depth, buffer);
 					}
 #endif
 

--- a/src/main/xlat.c
+++ b/src/main/xlat.c
@@ -80,20 +80,6 @@ typedef struct xlat_out {
 
 static rbtree_t *xlat_root = NULL;
 
-#ifdef WITH_UNLANG
-static char const * const xlat_foreach_names[] = {"Foreach-Variable-0",
-						  "Foreach-Variable-1",
-						  "Foreach-Variable-2",
-						  "Foreach-Variable-3",
-						  "Foreach-Variable-4",
-						  "Foreach-Variable-5",
-						  "Foreach-Variable-6",
-						  "Foreach-Variable-7",
-						  "Foreach-Variable-8",
-						  "Foreach-Variable-9",
-						  NULL};
-#endif
-
 #if REQUEST_MAX_REGEX > 8
 #error Please fix the following line
 #endif
@@ -254,20 +240,29 @@ static size_t xlat_module(UNUSED void *instance, REQUEST *request,
 }
 
 #ifdef WITH_UNLANG
-/** Implements the Foreach-Variable-X
+
+/** Implements the Foreach-Variable:X
  *
  * @see modcall()
  */
-static size_t xlat_foreach(void *instance, REQUEST *request,
-			   UNUSED char const *fmt, char *out, size_t outlen)
+static size_t xlat_foreach(UNUSED void *instance, REQUEST *request,
+			   char const *fmt, char *out, size_t outlen)
 {
 	VALUE_PAIR	**pvp;
+	int level;
+
+	while (isspace((int) *fmt)) fmt++;
+
+	if (*fmt > '9' || *fmt < '0' || (level = atoi(fmt)) < 0 || level > 9) {
+		*out = '\0';
+		return 0;
+	}
 
 	/*
 	 *	See modcall, "FOREACH" for how this works.
 	 */
 	pvp = (VALUE_PAIR **) request_data_reference(request, radius_get_vp,
-						     *(int*) instance);
+						     level);
 	if (!pvp || !*pvp) {
 		*out = '\0';
 		return 0;
@@ -418,7 +413,6 @@ int xlat_register(char const *name, RAD_XLAT_FUNC func, RADIUS_ESCAPE_STRING esc
 	 *	and into a global "initialization".  But it isn't critical...
 	 */
 	if (!xlat_root) {
-		int i;
 
 		xlat_root = rbtree_create(xlat_cmp, free, 0);
 		if (!xlat_root) {
@@ -427,13 +421,10 @@ int xlat_register(char const *name, RAD_XLAT_FUNC func, RADIUS_ESCAPE_STRING esc
 		}
 
 #ifdef WITH_UNLANG
-		for (i = 0; xlat_foreach_names[i] != NULL; i++) {
-			xlat_register(xlat_foreach_names[i],
-				      xlat_foreach, NULL, &xlat_inst[i]);
-			c = xlat_find(xlat_foreach_names[i]);
-			rad_assert(c != NULL);
-			c->internal = true;
-		}
+		xlat_register("Foreach-Variable", xlat_foreach, NULL, NULL);
+		c = xlat_find("Foreach-Variable");
+		rad_assert(c != NULL);
+		c->internal = true;
 #endif
 
 #define XLAT_REGISTER(_x) xlat_register(Stringify(_x), xlat_ ## _x, NULL, NULL); \

--- a/src/tests/config/test.conf
+++ b/src/tests/config/test.conf
@@ -45,7 +45,7 @@ authorize {
 		}
 		foreach control:Reply-Message {
 			update reply {
-				Reply-Message += Foreach-Variable-0
+				Reply-Message += "%{Foreach-Variable:0}"
 			}
 			update request {
 				Reply-Message := "%{Reply-Message}L"
@@ -55,6 +55,23 @@ authorize {
 			}
 		}
 		if (Reply-Message != "LLL") {
+			reject
+		}
+		if ("one" != "%{reply:Reply-Message}") {
+			reject
+		}
+# Attribute indexing is currently broken
+#		if ("two" != "%{reply:Reply-Message[2]}") {
+#			reject
+#		}
+		foreach control:Reply-Message {
+			foreach Reply-Message {
+				update reply {
+					Reply-Message := "%{Foreach-Variable:0}%{Foreach-Variable:1}"
+				}
+			}
+		}
+		if ("twoLLL" != "%{reply:Reply-Message}") {
 			reject
 		}
 	}


### PR DESCRIPTION
This is a user-visible change.

  It was broken, you had to do %{Foreach-Variable-0:foo} rather than manpage.
     Probably the result of streamlining syntax.

  This changes it to %{Foreach-Variable:0} but some trickery in the parse
     might be able to preserve old behavior while depricating it.

  Since it already was an xlat and not a virtual attribute, nothing
     changes on that level.

On a related topic, Attribute[N], Attribute[#] and Attribute[*] are broken right now, and I can't even find the code for their expansion in the current repo.  If that's not something that will be landing with more of the xlat refactor, I could work on that and add some more to this branch before the pull.  Please advise.
