### PR TITLE
Add support for conf.d directory for site specific configuration directives

### DIFF
--- a/debian/freeradius.install
+++ b/debian/freeradius.install
@@ -8,6 +8,7 @@ etc/freeradius/mods-available/*
 etc/freeradius/mods-enabled/*
 etc/freeradius/policy.d/*
 etc/freeradius/certs/*
+etc/freeradius/conf.d/*
 etc/freeradius/preproxy_users
 etc/freeradius/proxy.conf
 etc/freeradius/sites-available/*

--- a/raddb/all.mk
+++ b/raddb/all.mk
@@ -21,7 +21,7 @@ LOCAL_CERT_FILES := Makefile README xpextensions \
 		    ca.cnf server.cnf client.cnf bootstrap
 
 RADDB_DIRS := sites-available sites-enabled mods-available mods-enabled \
-		filter policy.d certs
+		filter policy.d certs conf.d
 
 # Installed directories
 INSTALL_RADDB_DIRS := $(R)$(raddbdir)/ $(addprefix $(R)$(raddbdir)/, \

--- a/raddb/radiusd.conf.in
+++ b/raddb/radiusd.conf.in
@@ -436,6 +436,19 @@ security {
 	status_server = yes
 }
 
+# SITE SPECIFIC CONFIGURATION
+#
+#	Load site specific configuration directives
+#
+#	This next $INCLUDE line loads files in the directory that
+#	match the regular expression: /[a-zA-Z0-9_.]+/
+#
+#	It allows you to define configuration values used it other files
+#  like clients.conf, proxy.conf and any virtual server
+
+$INCLUDE conf.d/
+
+
 # PROXY CONFIGURATION
 #
 #  proxy_requests: Turns proxying of RADIUS requests on or off.

--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -310,6 +310,7 @@ fi
 %attr(640,root,radiusd) %config(noreplace) /etc/raddb/mods-enabled/*
 %attr(640,root,radiusd) %config(noreplace) /etc/raddb/modules/*
 %dir %attr(755,radiusd,radiusd) /var/run/radiusd/
+%dir %attr(750,root,radiusd) /etc/raddb/conf.d
 # binaries
 %defattr(-,root,root)
 /usr/sbin/checkrad


### PR DESCRIPTION
Just an idea I had today which will make it easier to create custom configuration (often used in eduroam deployments of freeradius)
