### PR TITLE
moved cui in post-auth section

### DIFF
--- a/raddb/sites-available/default
+++ b/raddb/sites-available/default
@@ -618,6 +618,11 @@ post-auth {
 	#  Get an address from the IP Pool.
 #	main_pool
 
+
+        #  Create the CUI value and add the attribute to Access-Accept.
+        #  Uncomment the line below if *returning* the CUI.
+#       cui
+
 	#
 	#  If you want to have a log of authentication replies,
 	#  un-comment the following line, and enable the
@@ -670,9 +675,6 @@ post-auth {
 	#
 #	wimax
 
-        #  Create the CUI value and add the attribute to Access-Accept.
-        #  Uncomment the line below if *returning* the CUI.
-#       cui
 
 	#  If there is a client certificate (EAP-TLS, sometimes PEAP
 	#  and TTLS), then some attributes are filled out after the

--- a/raddb/sites-available/inner-tunnel
+++ b/raddb/sites-available/inner-tunnel
@@ -254,6 +254,11 @@ session {
 #  Once we KNOW that the user has been authenticated, there are
 #  additional steps we can take.
 post-auth {
+        #  If you want privacy to remain, see the
+        #  Chargeable-User-Identity attribute from RFC 4372.
+        #  If you want to use it just uncomment the line below.
+#       cui
+
 	#
 	#  If you want to have a log of authentication replies,
 	#  un-comment the following line, and enable the
@@ -322,10 +327,6 @@ post-auth {
         #  User-Name = "%{request:User-Name}"
         #}
         #
-        #  If you want privacy to remain, see the
-        #  Chargeable-User-Identity attribute from RFC 4372.
-        #  If you want to use it just uncomment the line below.
-#       cui
 }
 
 #


### PR DESCRIPTION
moved cui in post-auth section (default and inner-tunnel) before logging.  This is to ensure that the cui value is generated before the logging occurs.
