### PR TITLE
change to cui policy

### DIFF
--- a/raddb/policy.d/cui
+++ b/raddb/policy.d/cui
@@ -66,7 +66,7 @@ cui.pre-proxy {
 #  use_tunneled_reply parameter MUST be set to yes
 #
 cui.post-auth {
-	if (outer.request:EAP-Message) {
+	if (outer.request) {
 		if (outer.request:Chargeable-User-Identity && \
 		    (outer.request:Operator-Name || ('${policy.cui_require_operator_name}' != 'yes'))) {
 			update reply {


### PR DESCRIPTION
outer.request:EAP-Message gives a warning when outer context is undefined, outer.request allows to check if we are in the inner-tunnel (see developers mailing list 28th Feb 2013)
