### PR TITLE
minor IPv6 accounting bugfix

### DIFF
--- a/raddb/mods-config/sql/main/postgresql/queries.conf
+++ b/raddb/mods-config/sql/main/postgresql/queries.conf
@@ -183,7 +183,7 @@
 						AcctTerminateCause = '%{Acct-Terminate-Cause}', \
 						AcctStopDelay = 0 \
 					WHERE AcctStopTime IS NULL \
-					AND NASIPAddress= '%{NAS-IP-Address}' \
+					AND NASIPAddress= '%{%{NAS-IPv6-Address}:-%{NAS-IP-Address}}' \
 					AND AcctStartTime <= '%S'::timestamp"
 			}
 			
@@ -205,7 +205,7 @@
 						'%{Acct-Unique-Session-Id}', \
 						'%{SQL-User-Name}', \
 						NULLIF('%{Realm}', ''), \
-						'%{NAS-IP-Address}', \
+						'%{%{NAS-IPv6-Address}:-%{NAS-IP-Address}}', \
 						%{%{NAS-Port}:-NULL}, \
 						'%{NAS-Port-Type}', \
 						('%S'::timestamp - '%{%{Acct-Delay-Time}:-0}'::interval), \
@@ -227,7 +227,7 @@
 						ConnectInfo_start = '%{Connect-Info}' \
 					WHERE AcctSessionId = '%{Acct-Session-Id}' \
 					AND UserName = '%{SQL-User-Name}' \
-					AND NASIPAddress = '%{NAS-IP-Address}' \
+					AND NASIPAddress = '%{%{NAS-IPv6-Address}:-%{NAS-IP-Address}}' \
 					AND AcctStopTime IS NULL"	
 			}
 			
@@ -243,7 +243,7 @@
 							'%{%{Acct-Output-Octets}:-0}'::bigint) \
 					WHERE AcctSessionId = '%{Acct-Session-Id}' \
 					AND UserName = '%{SQL-User-Name}' \
-					AND NASIPAddress= '%{NAS-IP-Address}' \
+					AND NASIPAddress= '%{%{NAS-IPv6-Address}:-%{NAS-IP-Address}}' \
 					AND AcctStopTime IS NULL"
 				
 				query = "\
@@ -259,7 +259,7 @@
 						'%{Acct-Unique-Session-Id}', \
 						'%{SQL-User-Name}', \
 						NULLIF('%{Realm}', ''), \
-						'%{NAS-IP-Address}', \
+						'%{%{NAS-IPv6-Address}:-%{NAS-IP-Address}}', \
 						%{%{NAS-Port}:-NULL}, \
 						'%{NAS-Port-Type}', \
 						('%S'::timestamp - '%{%{Acct-Delay-Time}:-0}'::interval - \
@@ -300,7 +300,7 @@
 						ConnectInfo_stop = '%{Connect-Info}' \
 					WHERE AcctSessionId = '%{Acct-Session-Id}' \
 					AND UserName = '%{SQL-User-Name}' \
-					AND NASIPAddress = '%{NAS-IP-Address}' \
+					AND NASIPAddress = '%{%{NAS-IPv6-Address}:-%{NAS-IP-Address}}' \
 					AND AcctStopTime IS NULL"
 					
 				query = "\
@@ -317,7 +317,7 @@
 						'%{Acct-Unique-Session-Id}', \
 						'%{SQL-User-Name}', \
 						NULLIF('%{Realm}', ''), \
-						'%{NAS-IP-Address}', \
+						'%{%{NAS-IPv6-Address}:-%{NAS-IP-Address}}', \
 						%{%{NAS-Port}:-NULL}, \
 						'%{NAS-Port-Type}', \
 						('%S'::timestamp - '%{%{Acct-Delay-Time}:-0}'::interval - \


### PR DESCRIPTION
Sorry about previous pull.  I wasn't paying attention to what was in the pull request.

Small bug with accounting when using postgres and IPv6 NAS:

Fri Jun 28 15:14:31 2013 : Debug: rlm_sql_postgresql: Status: PGRES_FATAL_ERROR
Fri Jun 28 15:14:31 2013 : Debug: rlm_sql_postgresql: Error invalid input syntax for type inet: "=3F.=3F.=3F.=3F"
Fri Jun 28 15:14:31 2013 : Debug: rlm_sql_postgresql: Postgresql Fatal Error: [22P02: INVALID TEXT REPRESENTATION] Occurred!!
Fri Jun 28 15:14:31 2013 : Error: rlm_sql (sql): Database query error: ERROR: invalid input syntax for type inet: "=3F.=3F.=3F.=3F" LINE 1: ...ame = 'ccspa@scottarmitage.eu' AND NASIPAddress = '=3F.=3F.=... ^

After adding support for IPv6 in the sql queries:

Fri Jun 28 15:18:35 2013 : Debug: rlm_sql (sql): Executing query: 'UPDATE radacct SET AcctStartTime = ('2013-06-28 15:18:35'::timestamp - '0'::interval), AcctStartDelay = 0, ConnectInfo_start = 'CONNECT 54Mbps 802.11a' WHERE AcctSessionId = '51C8B05E-0000002D' AND UserName = 'ccspa@scottarmitage.eu' AND NASIPAddress = '0:0:0:0:0:0:0:1' AND AcctStopTime IS NULL'
Fri Jun 28 15:18:35 2013 : Debug: rlm_sql_postgresql: Status: PGRES_COMMAND_OK
Fri Jun 28 15:18:35 2013 : Debug: rlm_sql_postgresql: query affected rows = 0
Fri Jun 28 15:18:35 2013 : Debug: (26) sql : No records updated
Fri Jun 28 15:18:35 2013 : Debug: (26) sql : No additional queries configured
