### PR TITLE
DANTE VSA dictionary

### DIFF
--- a/share/dictionary
+++ b/share/dictionary
@@ -154,6 +154,7 @@ $INCLUDE dictionary.cisco.bbsm
 $INCLUDE dictionary.clavister
 $INCLUDE dictionary.colubris
 $INCLUDE dictionary.cosine
+$INCLUDE dictionary.dante
 $INCLUDE dictionary.dlink
 $INCLUDE dictionary.digium
 $INCLUDE dictionary.eltex

--- a/share/dictionary.dante
+++ b/share/dictionary.dante
@@ -1,0 +1,18 @@
+# -*- text -*-
+# Copyright (C) 2013 The FreeRADIUS Server project and contributors
+##############################################################################
+#
+#   DANTE Vendor Specific Attributes Dictionary
+#
+#   Created by Alan Buxey <a.l.m.buxey@lboro.ac.uk>
+#
+##############################################################################
+
+VENDOR	DANTE				27262
+
+BEGIN-VENDOR DANTE
+
+ATTRIBUTE	Default-TTL			1	integer
+
+END-VENDOR DANTE
+


### PR DESCRIPTION
DANTE IANA attribute space 27262 - first attribute is for RADSEC TTL to
stop loops (like TCP TTL)
