### PR TITLE
windows phone doesn't accept vert for validation if it doesn't contain CRLCP

### DIFF
--- a/raddb/certs/README
+++ b/raddb/certs/README
@@ -13,6 +13,16 @@ EAP-TTLS.
 server certificate.  Without those extensions Windows clients will
 refuse to authenticate to FreeRADIUS.
 
+  The root CA and the "XP Extensions" file also contain a crlDistributionPoints
+attribute. The latest release of Windows Phone needs this to be present
+for the handset to validate the RADIUS server certificate. The RADIUS
+server must have the URI defined but the CA need not have...however it
+is best practice for a CA to have a recovation URI. Note that whilst
+the Windows Mobile client cannot actually use the CRL when doing 802.1X
+it is recommended that the URI be an actual working URL and contain a
+recovation format file as there may be other OS behaviour at play and 
+future OSes that may do something with that URI.
+
   In general, you should use self-signed certificates for 802.1x (EAP)
 authentication.  When you list root CAs from other organizations in
 the "CA_file", you permit them to masquerade as you, to authenticate

--- a/raddb/certs/ca.cnf
+++ b/raddb/certs/ca.cnf
@@ -19,6 +19,7 @@ default_crl_days	= 30
 default_md		= sha1
 preserve		= no
 policy			= policy_match
+crlDistributionPoints	= URI:http://www.example.com/example_ca.crl
 
 [ policy_match ]
 countryName		= match
@@ -57,3 +58,5 @@ commonName		= "Example Certificate Authority"
 subjectKeyIdentifier	= hash
 authorityKeyIdentifier	= keyid:always,issuer:always
 basicConstraints	= CA:true
+crlDistributionPoints	= URI:http://www.example.com/example_ca.crl
+

--- a/raddb/certs/xpextensions
+++ b/raddb/certs/xpextensions
@@ -5,9 +5,11 @@
 #
 [ xpclient_ext]
 extendedKeyUsage = 1.3.6.1.5.5.7.3.2
+crlDistributionPoints = URI:http://www.example.com/example_ca.crl
 
 [ xpserver_ext]
 extendedKeyUsage = 1.3.6.1.5.5.7.3.1
+crlDistributionPoints = URI:http://www.example.com/example_ca.crl
 
 #
 #  Add this to the PKCS#7 keybag attributes holding the client's private key


### PR DESCRIPTION
CRLDP attribute needs to be present in CA/RADIUS vert or Windows Phone
won't validate the cert. as found by eduroam people struggling with
windows phone (same fix in 3.x)
