### PR TITLE
remove debug output from main server

### DIFF
--- a/src/main/parser.c
+++ b/src/main/parser.c
@@ -145,8 +145,6 @@ static int cast_vpt(value_pair_tmpl_t *vpt, DICT_ATTR const *da)
 	vpt->type = VPT_TYPE_DATA;
 	vpt->da = da;
 
-	debug_pair(vp);
-
 	if (vp->da->flags.is_pointer) {
 		data->ptr = talloc_steal(vpt, vp->data.ptr);
 		vp->data.ptr = NULL;


### PR DESCRIPTION
this took a while to chase through, but starting the server (e.g. build/bin/local/radiusd -CX -d raddb) with default config you get a Chargeable-User-Identity = '' printed out while reading in the config files (pipe the above radiusd command through cat and it will appear at the bottom, so it's going to a different file descriptor).

The "cause" is from raddb/policy.d/cui:124 -
if (Chargeable-User-Identity && (Chargeable-User-Identity != '')) {

if this is changed to Chargeable-User-Identity != "" then it doesn't print out. In fact, any "if" using single quotes seems to cause it to be printed, but double quotes, not.

The debug pair removed here is what's generating it. I can't see why it should be there, unless it's used for debugging elsewhere? In any case, a random VP appearing on the console with no context is no help at all.
