### PR TITLE
all IPv4 examples should now be using RFC5737 documentation space

### DIFF
--- a/doc/vendor/cisco.rst
+++ b/doc/vendor/cisco.rst
@@ -145,7 +145,7 @@ and configure the loopback interface on your router as follows:
 ::
 
   interface Loopback0
-   ip address 192.168.0.250 255.255.255.255
+   ip address 192.0.2.250 255.255.255.255
 
 Use a real world IP address and check the Cisco documentation for why
 it is a good idea to have working loopback interface configured on

--- a/man/man1/radclient.1
+++ b/man/man1/radclient.1
@@ -158,9 +158,9 @@ configurable support for it).
 .sp
 .nf
 .ne 3
-$ echo "Message-Authenticator = 0x00" | radclient 192.168.1.42 status s3cr3t
-Sending request to server 192.168.1.42, port 1812.
-radrecv: Packet from host 192.168.1.42 code=2, id=140, length=54
+$ echo "Message-Authenticator = 0x00" | radclient 192.0.2.42 status s3cr3t
+Sending request to server 192.0.2.42, port 1812.
+radrecv: Packet from host 192.0.2.42 code=2, id=140, length=54
     Reply-Message = "FreeRADIUS up 21 days, 02:05"
 .fi
 .sp

--- a/man/man5/clients.conf.5
+++ b/man/man5/clients.conf.5
@@ -88,14 +88,14 @@ server locally, for example with
 .IP
 .nf
 client private-network-1 {
-        ipaddr          = 192.168.0.0
+        ipaddr          = 192.0.2.0
         netmask         = 24
         secret          = testing123-1
         shortname       = private-network-1
 }
 .fi
 .LP
-This entry represents any client from the 192.168.0.0/24 network. 
+This entry represents any client from the 192.0.2.0/24 network. 
 
 The old-style format from 1.x is still accepted by the server, but
 that form is deprecated.

--- a/man/man5/dictionary.5
+++ b/man/man5/dictionary.5
@@ -102,7 +102,7 @@ the Ascend-Send-Secret attribute.
 
 The "has_tag" flag marks the attribute as being permitted to have a
 tag, as defined in \fIRFC2868\fP.  The purpose of the tag is to allow
-grouping of attributes for tunnelled users.  See \fIRFC2868\fP for
+grouping of attributes for tunneled users.  See \fIRFC2868\fP for
 more details.
 
 When the server receives an encoded attribute in a RADIUS packet, it

--- a/raddb/clients.conf
+++ b/raddb/clients.conf
@@ -237,18 +237,18 @@ client localhost {
 #  When a client request comes in, the BEST match is chosen.
 #  i.e. The entry from the smallest possible network.
 #
-#client 192.168.0.0/24 {
+#client 192.0.2.0/24 {
 #	secret		= testing123-1
 #	shortname	= private-network-1
 #}
 #
-#client 192.168.0.0/16 {
+#client 198.51.100.0/24 {
 #	secret		= testing123-2
 #	shortname	= private-network-2
 #}
 
 
-#client 10.10.10.10 {
+#client 203.0.113.1 {
 #	# secret and password are mapped through the "secrets" file.
 #	secret		= testing123
 #	shortname	= liv1
@@ -274,7 +274,7 @@ client localhost {
 #  will then accept ONLY the clients listed in this section.
 #
 #clients per_socket_clients {
-#	client 192.168.3.4 {
+#	client 192.0.2.4 {
 #		secret = testing123
 #	}
 #}

--- a/raddb/mods-available/dynamic_clients
+++ b/raddb/mods-available/dynamic_clients
@@ -20,8 +20,8 @@
 #	   does this.
 #
 #	5) put files into the above directory, one per IP.
-#	   e.g. file "192.168.1.1" should contain a normal client definition
-#	   for a client with IP address 192.168.1.1.
+#	   e.g. file "192.0.2.1" should contain a normal client definition
+#	   for a client with IP address 192.0.2.1.
 #
 #  For more documentation, see the file:
 #

--- a/raddb/mods-available/inner-eap
+++ b/raddb/mods-available/inner-eap
@@ -4,7 +4,7 @@
 
 #
 #  Sample configuration for an EAP module that occurs *inside*
-#  of a tunnelled method.  It is used to limit the EAP types that
+#  of a tunneled method.  It is used to limit the EAP types that
 #  can occur inside of the inner tunnel.
 #
 #  See also raddb/sites-available/inner-tunnel

--- a/raddb/mods-available/ippool
+++ b/raddb/mods-available/ippool
@@ -29,8 +29,8 @@ ippool main_pool {
 
 	#  range-start,range-stop:
 	#	The start and end ip addresses for this pool.
-	range_start = 192.168.1.1
-	range_stop = 192.168.3.254
+	range_start = 192.0.2.1
+	range_stop = 192.0.2.254
 
 	#  netmask:
 	#	The network mask used for this pool.

--- a/raddb/mods-available/mac2ip
+++ b/raddb/mods-available/mac2ip
@@ -9,9 +9,9 @@
 #
 #  The file is in the format <mac>,<ip>
 #
-#	00:01:02:03:04:05,192.168.1.100
-#	01:01:02:03:04:05,192.168.1.101
-#	02:01:02:03:04:05,192.168.1.102
+#	00:01:02:03:04:05,192.0.2.100
+#	01:01:02:03:04:05,192.0.2.101
+#	02:01:02:03:04:05,192.0.2.102
 #
 #  This lets you perform simple static IP assignments from a flat-text
 #  file.  You will have to define lease times yourself.

--- a/raddb/mods-config/attr_filter/post-proxy
+++ b/raddb/mods-config/attr_filter/post-proxy
@@ -58,14 +58,14 @@
 # These rules allow:
 #       o Only Login-User Service-Type ( no framed/ppp sessions )
 #       o Telnet sessions only ( no rlogin, tcp-clear )
-#       o Login hosts of either 192.168.1.1 or 192.168.1.2
+#       o Login hosts of either 192.0.2.1 or 192.0.2.2
 #
 #tisp
 #	Service-Type == Login-User,
 #	Login-Service == Telnet,
 #	Login-TCP-Port == 23,
-#	Login-IP-Host == 192.168.1.1,
-#	Login-IP-Host == 192.168.1.2
+#	Login-IP-Host == 192.0.2.1,
+#	Login-IP-Host == 192.0.2.2
 
 #
 # The following example can be used for a home server which is only

--- a/raddb/mods-config/files/authorize
+++ b/raddb/mods-config/files/authorize
@@ -116,7 +116,7 @@
 # the following DEFAULT entries
 #
 #swilson	Service-Type == Framed-User, Huntgroup-Name == "alphen"
-#		Framed-IP-Address = 192.168.1.65,
+#		Framed-IP-Address = 192.0.2.65,
 #		Fall-Through = Yes
 
 #
@@ -144,11 +144,11 @@
 # IP address. The Port-Id (S0, S1 etc) will be added to it.
 #
 #DEFAULT	Service-Type == Framed-User, Huntgroup-Name == "alphen"
-#		Framed-IP-Address = 192.168.1.32+,
+#		Framed-IP-Address = 192.0.2.32+,
 #		Fall-Through = Yes
 
 #DEFAULT	Service-Type == Framed-User, Huntgroup-Name == "delft"
-#		Framed-IP-Address = 192.168.2.32+,
+#		Framed-IP-Address = 198.51.100.32+,
 #		Fall-Through = Yes
 
 #

--- a/raddb/mods-config/preprocess/huntgroups
+++ b/raddb/mods-config/preprocess/huntgroups
@@ -22,14 +22,14 @@
 # Our POP in Alphen a/d Rijn has 3 terminal servers. Create a Huntgroup-Name
 # called Alphen that matches on all three terminal servers.
 #
-#alphen		NAS-IP-Address == 192.168.2.5
-#alphen		NAS-IP-Address == 192.168.2.6
-#alphen		NAS-IP-Address == 192.168.2.7
+#alphen		NAS-IP-Address == 192.0.2.5
+#alphen		NAS-IP-Address == 192.0.2.6
+#alphen		NAS-IP-Address == 192.0.2.7
 
 #
 # The POP in Delft consists of only one terminal server.
 #
-#delft		NAS-IP-Address == 192.168.3.5
+#delft		NAS-IP-Address == 198.51.100.5
 
 #
 # Ports 0-7 on the first terminal server in Alphen are connected to
@@ -38,7 +38,7 @@
 #
 # Note that this huntgroup is a subset of the "alphen" huntgroup.
 #
-#business	NAS-IP-Address == 192.168.2.5, NAS-Port-Id == 0-7
+#business	NAS-IP-Address == 198.51.100.5, NAS-Port-Id == 0-7
 #		User-Name = rogerl,
 #		User-Name = henks,
 #		Group = business,

--- a/raddb/radrelay.conf.in
+++ b/raddb/radrelay.conf.in
@@ -103,7 +103,7 @@ home_server home1 {
 	#  This directive replaces the "-r" command-line option
 	#  in radrelay
 	#
-	ipaddr = 192.168.10.20
+	ipaddr = 192.0.2.20
 
 	port = 1812
 
@@ -111,7 +111,7 @@ home_server home1 {
 	#  This directive replaces the "-i" command-line option
 	#  in radrelay
 	#
-#	src_ipaddr = 192.168.1.1
+#	src_ipaddr = 192.0.2.1
 
 	#
 	#  This directive replaces the "-s", "-S", and "-n" command-line

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -129,9 +129,9 @@ dhcp DHCP-Discover {
 		DHCP-Domain-Name-Server = 127.0.0.1
 		DHCP-Domain-Name-Server = 127.0.0.2
 		DHCP-Subnet-Mask = 255.255.255.0
-		DHCP-Router-Address = 192.168.1.1
+		DHCP-Router-Address = 192.0.2.1
 		DHCP-IP-Address-Lease-Time = 86400
-		DHCP-DHCP-Server-Identifier = 192.168.1.1
+		DHCP-DHCP-Server-Identifier = 192.0.2.1
 	}
 
 	#  Do a simple mapping of MAC to assigned IP.
@@ -164,9 +164,9 @@ dhcp DHCP-Request {
 		DHCP-Domain-Name-Server = 127.0.0.1
 		DHCP-Domain-Name-Server = 127.0.0.2
 		DHCP-Subnet-Mask = 255.255.255.0
-		DHCP-Router-Address = 192.168.1.1
+		DHCP-Router-Address = 192.0.2.1
 		DHCP-IP-Address-Lease-Time = 86400
-		DHCP-DHCP-Server-Identifier = 192.168.1.1
+		DHCP-DHCP-Server-Identifier = 192.0.2.1
 	}
 
 	#  Do a simple mapping of MAC to assigned IP.
@@ -207,9 +207,9 @@ dhcp {
 #
 #  The file is in the format <mac>,<ip>
 #
-#	00:01:02:03:04:05,192.168.1.100
-#	01:01:02:03:04:05,192.168.1.101
-#	02:01:02:03:04:05,192.168.1.102
+#	00:01:02:03:04:05,192.0.2.100
+#	01:01:02:03:04:05,192.0.2.101
+#	02:01:02:03:04:05,192.0.2.102
 #
 #  This lets you perform simple static IP assignment.
 #

--- a/raddb/sites-available/dynamic-clients
+++ b/raddb/sites-available/dynamic-clients
@@ -4,7 +4,7 @@
 #	Sample configuration file for dynamically updating the list
 #	of RADIUS clients at run time.
 #
-#	Everything is keyed off of a client "network".  (e.g. 192.168/16)
+#	Everything is keyed off of a client "network".  (e.g. 192.0.2/24)
 #	This configuration lets the server know that clients within
 #	that network are defined dynamically.
 #
@@ -34,12 +34,12 @@
 #
 #  Define a network where clients may be dynamically defined.
 client dynamic {
-	ipaddr = 192.168.0.0
+	ipaddr = 192.0.2.0
 
 	#
 	#  You MUST specify a netmask!
 	#  IPv4 /32 or IPv6 /128 are NOT allowed!
-	netmask = 16
+	netmask = 24
 
 	#
 	#  Any other configuration normally found in a "client"

--- a/raddb/sites-available/status
+++ b/raddb/sites-available/status
@@ -84,11 +84,11 @@ server status {
 #
 #	All packets for a particular client (globally defined)
 #		FreeRADIUS-Statistics-Type = 35
-#		FreeRADIUS-Stats-Client-IP-Address = 192.168.1.1
+#		FreeRADIUS-Stats-Client-IP-Address = 192.0.2.1
 #
 #	All packets for a client attached to a "listen" ip/port
 #		FreeRADIUS-Statistics-Type = 35
-#		FreeRADIUS-Stats-Client-IP-Address = 192.168.1.1
+#		FreeRADIUS-Stats-Client-IP-Address = 192.0.2.1
 #		FreeRADIUS-Stats-Server-IP-Address = 127.0.0.1
 #		FreeRADIUS-Stats-Server-Port = 1812
 #
@@ -99,7 +99,7 @@ server status {
 #
 #	All packets for a home server IP / port
 #		FreeRADIUS-Statistics-Type = 131
-#		FreeRADIUS-Stats-Server-IP-Address = 192.168.1.2
+#		FreeRADIUS-Stats-Server-IP-Address = 192.0.2.2
 #		FreeRADIUS-Stats-Server-Port = 1812
 
 #

--- a/src/lib/valuepair.c
+++ b/src/lib/valuepair.c
@@ -1736,7 +1736,7 @@ int pairparsevalue(VALUE_PAIR *vp, char const *value)
 		p = strchr(value, '/');
 
 		/*
-		 *	192.168.1.2 is parsed as if it was /32
+		 *	192.0.2.2 is parsed as if it was /32
 		 */
 		if (!p) {
 			vp->vp_ipv4prefix[1] = 32;

--- a/src/main/checkrad.in
+++ b/src/main/checkrad.in
@@ -1150,13 +1150,13 @@ sub versanet_snmp {
 # Check Bay8000 NAS (aka: Annex) using finger.
 # Returns from "finger @bay" like:
 #   Port  What User         Location         When          Idle  Address
-#   asy2  PPP  bill         ---              9:33am         :08  192.168.1.194
-#   asy4  PPP  hillary      ---              9:36am         :04  192.168.1.195
+#   asy2  PPP  bill         ---              9:33am         :08  192.0.2.194
+#   asy4  PPP  hillary      ---              9:36am         :04  192.0.2.195
 #   [...]
 # But also returns partial-match users if you say like "finger g@bay":
 #   Port  What User         Location         When          Idle  Address
-#   asy2  PPP  gore         ---              9:33am         :09  192.168.1.194
-#   asy22 PPP  gwbush       ---              Mon  9:19am    :07  192.168.1.80
+#   asy2  PPP  gore         ---              9:33am         :09  192.0.2.194
+#   asy22 PPP  gwbush       ---              Mon  9:19am    :07  192.0.2.80
 # So check exact match of username!
 
 sub bay_finger {		# ARGV: 1=nas_ip, 2=nas_port, 3=login, 4=sessid

--- a/src/modules/rlm_ippool/rlm_ippool_tool.8
+++ b/src/modules/rlm_ippool/rlm_ippool_tool.8
@@ -56,8 +56,8 @@ Given the syntax in the FreeRadius radiusd.conf:
 .IP
 .nf
  ippool myippool {
-	range-start = 192.168.1.0
-	range-stop = 192.168.1.255
+	range-start = 192.0.2.0
+	range-stop = 192.0.2.255
 	[...]
 	session-db = ${raddbdir}/ip-pool.db
 	ip-index = ${raddbdir}/ip-index.db
@@ -75,12 +75,12 @@ To see all active entries in this pool, use:
 .IP
 .nf
  $ rlm_ippool_tool -a ip-pool.db ip-index.db
- 192.168.1.5
- 192.168.1.82
- 192.168.1.244
- 192.168.1.57
- 192.168.1.120
- 192.168.1.27
+ 192.0.2.5
+ 192.0.2.82
+ 192.0.2.244
+ 192.0.2.57
+ 192.0.2.120
+ 192.0.2.27
  [...]
 .fi
 .P
@@ -88,29 +88,29 @@ To see all information about the active entries in the use, use:
 .IP
 .nf
  $ rlm_ippool_tool -av ip-pool.db ip-index.db
- NAS:172.16.1.1 port:0x2e8 - ipaddr:192.168.1.5 active:1 cli:0 num:1
- NAS:172.16.1.1 port:0x17c - ipaddr:192.168.1.82 active:1 cli:0 num:1
- NAS:172.16.1.1 port:0x106 - ipaddr:192.168.1.244 active:1 cli:0 num:1
- NAS:172.16.1.1 port:0x157 - ipaddr:192.168.1.57 active:1 cli:0 num:1
- NAS:172.16.1.1 port:0x2d8 - ipaddr:192.168.1.120 active:1 cli:0 num:1
- NAS:172.16.1.1 port:0x162 - ipaddr:192.168.1.27 active:1 cli:0 num:1
+ NAS:172.16.1.1 port:0x2e8 - ipaddr:192.0.2.5 active:1 cli:0 num:1
+ NAS:172.16.1.1 port:0x17c - ipaddr:192.0.2.82 active:1 cli:0 num:1
+ NAS:172.16.1.1 port:0x106 - ipaddr:192.0.2.244 active:1 cli:0 num:1
+ NAS:172.16.1.1 port:0x157 - ipaddr:192.0.2.57 active:1 cli:0 num:1
+ NAS:172.16.1.1 port:0x2d8 - ipaddr:192.0.2.120 active:1 cli:0 num:1
+ NAS:172.16.1.1 port:0x162 - ipaddr:192.0.2.27 active:1 cli:0 num:1
  [...]
 .fi
 .P
 To see only information of one entry, use:
 .IP
 .nf
- $ rlm_ippool_tool -v ip-pool.db ip-index.db 192.168.1.1
- NAS:172.16.1.1 port:0x90 - ipaddr:192.168.1.1 active:0 cli:0 num:0
+ $ rlm_ippool_tool -v ip-pool.db ip-index.db 192.0.2.1
+ NAS:172.16.1.1 port:0x90 - ipaddr:192.0.2.1 active:0 cli:0 num:0
 .fi
 .P
 To add an IP address usage entry, use:
 .IP
 .nf
- $ rlm_ippool_tool -n ip-pool.db ip-index.db 192.168.1.1 172.16.1.1 0x90
+ $ rlm_ippool_tool -n ip-pool.db ip-index.db 192.0.0.1 172.16.1.1 0x90
  rlm_ippool_tool: Allocating ip to nas/port: 172.16.1.1/144
  rlm_ippool_tool: num: 1
- rlm_ippool_tool: Allocated ip 192.168.1.1 to client on nas 172.16.1.1,port 144
+ rlm_ippool_tool: Allocated ip 192.0.2.1 to client on nas 172.16.1.1,port 144
 .fi
 
 .SH SEE ALSO

--- a/src/tests/eapsim-03/radiusd-example.txt
+++ b/src/tests/eapsim-03/radiusd-example.txt
@@ -1204,8 +1204,8 @@ modules {
 
 		#  range-start,range-stop: The start and end ip
 		#  addresses for the ip pool
-		range-start = 192.168.1.1
-		range-stop = 192.168.3.254
+		range-start = 192.0.2.1
+		range-stop = 192.0.2.254
 
 		#  netmask: The network mask used for the ip's
 		netmask = 255.255.255.0


### PR DESCRIPTION
also fixed 2 'tunnelled' - we now have tunneled as standard
(code/config options have that spelling)
