### PR TITLE
Move paircompare to DICT_ATTR

### DIFF
--- a/src/include/radiusd.h
+++ b/src/include/radiusd.h
@@ -620,10 +620,9 @@ int radius_exec_program(REQUEST *request, char const *cmd, bool exec_wait, bool 
 void exec_trigger(REQUEST *request, CONF_SECTION *cs, char const *name, int quench);
 
 /* valuepair.c */
-int		paircompare_register(unsigned int attr, int otherattr,
-				     RAD_COMPARE_FUNC func,
-				     void *instance);
-void		paircompare_unregister(unsigned int attr, RAD_COMPARE_FUNC func);
+int paircompare_register(DICT_ATTR const *attribute, DICT_ATTR const *from,
+          bool first_only, RAD_COMPARE_FUNC func, void *instance);
+void		paircompare_unregister(DICT_ATTR const *attr, RAD_COMPARE_FUNC func);
 void		paircompare_unregister_instance(void *instance);
 int		paircompare(REQUEST *request, VALUE_PAIR *req_list,
 			    VALUE_PAIR *check, VALUE_PAIR **rep_list);
@@ -633,7 +632,7 @@ int radius_compare_vps(REQUEST *request, VALUE_PAIR *check, VALUE_PAIR *vp);
 int radius_callback_compare(REQUEST *request, VALUE_PAIR *req,
 			    VALUE_PAIR *check, VALUE_PAIR *check_pairs,
 			    VALUE_PAIR **reply_pairs);
-int radius_find_compare(unsigned int attribute);
+int radius_find_compare(DICT_ATTR const *attribute);
 VALUE_PAIR	*radius_paircreate(REQUEST *request, VALUE_PAIR **vps,
 				   unsigned int attribute, unsigned int vendor);
 void module_failure_msg(REQUEST *request, char const *fmt, ...)

--- a/src/main/evaluate.c
+++ b/src/main/evaluate.c
@@ -436,7 +436,7 @@ int radius_evaluate_map(REQUEST *request, UNUSED int modreturn, UNUSED int depth
 			 */
 			if ((map->dst->type == VPT_TYPE_ATTR) &&
 			    (map->dst->da->vendor == 0) &&
-			    radius_find_compare(map->dst->da->attr)) {
+			    radius_find_compare(map->dst->da)) {
 				rhs_vp = pairalloc(request, map->dst->da);
 
 				if (!pairparsevalue(rhs_vp, rhs)) {

--- a/src/modules/rlm_counter/rlm_counter.c
+++ b/src/modules/rlm_counter/rlm_counter.c
@@ -540,8 +540,9 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 
 	/*
 	 *	Register the counter comparison operation.
+	 * FIXME: move all attributes to DA
 	 */
-	paircompare_register(inst->dict_attr, 0, counter_cmp, inst);
+	paircompare_register(dict_attrbyvalue(inst->dict_attr, 0), NULL, true, counter_cmp, inst);
 
 	/*
 	 * Init the mutex

--- a/src/modules/rlm_expiration/rlm_expiration.c
+++ b/src/modules/rlm_expiration/rlm_expiration.c
@@ -99,7 +99,7 @@ static int mod_instantiate(UNUSED CONF_SECTION *conf, UNUSED void *instance)
 	/*
 	 *	Register the expiration comparison operation.
 	 */
-	paircompare_register(PW_EXPIRATION, 0, expirecmp, instance);
+	paircompare_register(dict_attrbyvalue(PW_EXPIRATION, 0), NULL, false, expirecmp, instance);
 	return 0;
 }
 

--- a/src/modules/rlm_expr/paircmp.c
+++ b/src/modules/rlm_expr/paircmp.c
@@ -247,13 +247,14 @@ void pair_builtincompare_add(void *instance)
 {
 	int i;
 
-	paircompare_register(PW_PREFIX, PW_USER_NAME, presufcmp, instance);
-	paircompare_register(PW_SUFFIX, PW_USER_NAME, presufcmp, instance);
-	paircompare_register(PW_CONNECT_RATE, PW_CONNECT_INFO, connectcmp, instance);
-	paircompare_register(PW_PACKET_TYPE, 0, packetcmp, instance);
-	paircompare_register(PW_RESPONSE_PACKET_TYPE, 0, responsecmp, instance);
+	paircompare_register(dict_attrbyvalue(PW_PREFIX, 0), dict_attrbyvalue(PW_USER_NAME, 0), false, presufcmp, instance);
+	paircompare_register(dict_attrbyvalue(PW_SUFFIX, 0), dict_attrbyvalue(PW_USER_NAME, 0), false, presufcmp, instance);
+	paircompare_register(dict_attrbyvalue(PW_CONNECT_RATE, 0), dict_attrbyvalue(PW_CONNECT_INFO, 0),
+				false, connectcmp, instance);
+	paircompare_register(dict_attrbyvalue(PW_PACKET_TYPE, 0), NULL, true, packetcmp, instance);
+	paircompare_register(dict_attrbyvalue(PW_RESPONSE_PACKET_TYPE, 0), NULL, true, responsecmp, instance);
 
 	for (i = 0; generic_attrs[i] != 0; i++) {
-		paircompare_register(generic_attrs[i], -1, genericcmp, instance);
+		paircompare_register(dict_attrbyvalue(generic_attrs[i], 0), NULL, true, genericcmp, instance);
 	}
 }

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -666,13 +666,14 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 			goto error;
 		}
 
-		paircompare_register(inst->group_da->attr, PW_USER_NAME, rlm_ldap_groupcmp, inst);
+		paircompare_register(inst->group_da, dict_attrbyvalue(PW_USER_NAME, 0), false, rlm_ldap_groupcmp, inst);
 	/*
 	 *	Were the default instance
 	 */
 	} else {
 		inst->group_da = dict_attrbyvalue(PW_LDAP_GROUP, 0);
-		paircompare_register(PW_LDAP_GROUP, PW_USER_NAME, rlm_ldap_groupcmp, inst);
+		paircompare_register(dict_attrbyvalue(PW_LDAP_GROUP, 0), dict_attrbyvalue(PW_USER_NAME, 0),
+				false, rlm_ldap_groupcmp, inst);
 	}
 
 	xlat_register(inst->xlat_name, ldap_xlat, rlm_ldap_escape_func, inst);

--- a/src/modules/rlm_logintime/rlm_logintime.c
+++ b/src/modules/rlm_logintime/rlm_logintime.c
@@ -230,16 +230,16 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 	/*
 	 * Register a Current-Time comparison function
 	 */
-	paircompare_register(PW_CURRENT_TIME, 0, timecmp, inst);
-	paircompare_register(PW_TIME_OF_DAY, 0, time_of_day, inst);
+	paircompare_register(dict_attrbyvalue(PW_CURRENT_TIME, 0), NULL, true, timecmp, inst);
+	paircompare_register(dict_attrbyvalue(PW_TIME_OF_DAY, 0), NULL, true, time_of_day, inst);
 
 	return 0;
 }
 
 static int mod_detach(UNUSED void *instance)
 {
-	paircompare_unregister(PW_CURRENT_TIME, timecmp);
-	paircompare_unregister(PW_TIME_OF_DAY, time_of_day);
+	paircompare_unregister(dict_attrbyvalue(PW_CURRENT_TIME, 0), timecmp);
+	paircompare_unregister(dict_attrbyvalue(PW_TIME_OF_DAY, 0), time_of_day);
 	return 0;
 }
 

--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -762,8 +762,8 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 		    inst->config->groupmemb_query[0]) {
 			DEBUG("rlm_sql (%s): Registering sql_groupcmp for %s",
 			      inst->config->xlat_name, group_name);
-			paircompare_register(dattr->attr, PW_USER_NAME,
-					     sql_groupcmp, inst);
+			paircompare_register(dattr, dict_attrbyvalue(PW_USER_NAME, 0),
+					     false, sql_groupcmp, inst);
 		}
 	}
 
@@ -879,7 +879,8 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 
 	if (inst->config->groupmemb_query &&
 	    inst->config->groupmemb_query[0]) {
-		paircompare_register(PW_SQL_GROUP, PW_USER_NAME, sql_groupcmp, inst);
+		paircompare_register(dict_attrbyvalue(PW_SQL_GROUP, 0),
+				dict_attrbyvalue(PW_USER_NAME, 0), false, sql_groupcmp, inst);
 	}
 
 	if (inst->config->do_clients) {

--- a/src/modules/rlm_sqlcounter/rlm_sqlcounter.c
+++ b/src/modules/rlm_sqlcounter/rlm_sqlcounter.c
@@ -473,7 +473,7 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 	/*
 	 *	Register the counter comparison operation.
 	 */
-	paircompare_register(inst->dict_attr->attr, 0, sqlcounter_cmp, inst);
+	paircompare_register(inst->dict_attr, NULL, true, sqlcounter_cmp, inst);
 
 	return 0;
 }

--- a/src/modules/rlm_unix/rlm_unix.c
+++ b/src/modules/rlm_unix/rlm_unix.c
@@ -116,9 +116,10 @@ static int mod_instantiate(UNUSED CONF_SECTION *conf, void *instance)
 
 	/* FIXME - delay these until a group file has been read so we know
 	 * groupcmp can actually do something */
-	paircompare_register(PW_GROUP, PW_USER_NAME, groupcmp, inst);
+	paircompare_register(dict_attrbyvalue(PW_GROUP, 0), dict_attrbyvalue(PW_USER_NAME, 0), false, groupcmp, inst);
 #ifdef PW_GROUP_NAME /* compat */
-	paircompare_register(PW_GROUP_NAME, PW_USER_NAME, groupcmp, inst);
+	paircompare_register(dict_attrbyvalue(PW_GROUP_NAME, 0), dict_attrbyvalue(PW_USER_NAME, 0),
+			true, groupcmp, inst);
 #endif
 
 	return 0;


### PR DESCRIPTION
All modules registering paircompare callback have been updated.
For every callback which didn't use the *req list, the first_only has been set to true
