### PR TITLE
removed 2 compilation warnings in rlm_python

### DIFF
--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -545,8 +545,12 @@ static rlm_rcode_t do_python(rlm_python_t *inst, REQUEST *request, PyObject *pFu
 	}
 
 finish:
-	if (pArgs) Py_DECREF(pArgs);
-	if (pRet) Py_DECREF(pRet);
+	if (pArgs) {
+		Py_DECREF(pArgs);
+	}
+	if (pRet) {
+		Py_DECREF(pRet);
+	}
 
 #ifdef HAVE_PTHREAD_H
 	if (worker) {


### PR DESCRIPTION
warning: suggest explicit braces to avoid ambiguous ‘else’ - used
braces to remove these warnings.
