### PR TITLE
enhancements to rlm_cache

### DIFF
--- a/raddb/mods-available/cache
+++ b/raddb/mods-available/cache
@@ -30,6 +30,7 @@ cache {
 	#  You can set the TTL per cache entry, but adding a control
 	#  variable "Cache-TTL".  The value there will over-ride this one.
 	#  Setting a Cache-TTL of 0 means "delete this entry".
+	#  Setting a Cache-TTL < 0 means "delete this entry and create a new one".
 	#
 	#  This value should be between 10 and 86400.
 	ttl = 10

--- a/share/dictionary.freeradius.internal
+++ b/share/dictionary.freeradius.internal
@@ -222,7 +222,7 @@ ATTRIBUTE	MS-CHAP-New-NT-Password			1137	octets
 
 ATTRIBUTE	Stripped-User-Domain			1138	string
 ATTRIBUTE	Called-Station-SSID			1139	string
-ATTRIBUTE	Cache-TTL				1140	integer
+ATTRIBUTE	Cache-TTL				1140	signed
 ATTRIBUTE	Cache-Status-Only			1141	integer
 ATTRIBUTE	Cache-Merge				1142	integer
 ATTRIBUTE	Cache-Entry-Hits			1143	integer

--- a/src/modules/rlm_cache/rlm_cache.c
+++ b/src/modules/rlm_cache/rlm_cache.c
@@ -221,12 +221,13 @@ static rlm_cache_entry_t *cache_find(rlm_cache_t *inst, REQUEST *request,
 	/*
 	 *	Update the expiry time based on the TTL.
 	 *	A TTL of 0 means "delete from the cache".
+	 *	A TTL < 0 means "delete from the cache and recreate the entry".
 	 */
 	vp = pairfind(request->config_items, PW_CACHE_TTL, 0, TAG_ANY);
 	if (vp) {
-		if (vp->vp_integer == 0) goto delete;
+		if (vp->vp_signed <= 0) goto delete;
 
-		ttl = vp->vp_integer;
+		ttl = vp->vp_signed;
 		c->expires = request->timestamp + ttl;
 		RDEBUG("Adding %d to the TTL", ttl);
 	}
@@ -263,17 +264,17 @@ static rlm_cache_entry_t *cache_add(rlm_cache_t *inst, REQUEST *request,
 	 *	TTL of 0 means "don't cache this entry"
 	 */
 	vp = pairfind(request->config_items, PW_CACHE_TTL, 0, TAG_ANY);
-	if (vp && (vp->vp_integer == 0)) return NULL;
+	if (vp && (vp->vp_signed == 0)) return NULL;
 
 	c = talloc_zero(inst, rlm_cache_entry_t);
 	c->key = talloc_strdup(c, key);
 	c->created = c->expires = request->timestamp;
 
 	/*
-	 *	Use per-entry TTL, or globally defined one.
+	 *	Use per-entry TTL if > 0, or globally defined one.
 	 */
-	if (vp) {
-		ttl = vp->vp_integer;
+	if (vp && (vp->vp_signed > 0)) {
+		ttl = vp->vp_signed;
 	} else {
 		ttl = inst->ttl;
 	}


### PR DESCRIPTION
allow to use Cache-TTL < 0 to clear and recreate the cache entry
