### PR TITLE
Load Python with RTLD_GLOBAL to ensure symbols are accessible by dynload libraries / C extensions

### DIFF
--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -30,6 +30,7 @@ RCSID("$Id$")
 #include <freeradius-devel/modules.h>
 
 #include <Python.h>
+#include <dlfcn.h>
 
 #ifdef HAVE_PTHREAD_H
 #define Pyx_BLOCK_THREADS    {PyGILState_STATE __gstate = PyGILState_Ensure();
@@ -202,6 +203,13 @@ static int mod_init(rlm_python_t *inst)
 	static char name[] = "radiusd";
 
 	if (radiusd_module) return 0;
+
+	// Explicitly load libpython, so symbols will be available to lib-dynload modules
+	#define STR(c) #c
+	#define XSTR(c) STR(c)
+	dlopen("libpython" XSTR(PY_MAJOR_VERSION) "." XSTR(PY_MINOR_VERSION) ".so", RTLD_NOW | RTLD_GLOBAL);
+	#undef STR
+	#undef XSTR
 
 	Py_SetProgramName(name);
 #ifdef HAVE_PTHREAD_H


### PR DESCRIPTION
It seems by default, implicit link loading of libpython does not allow its symbols to be used by libraries loaded later. So I was getting errors like this:

```
rlm_python:EXCEPT:<type 'exceptions.ImportError'>: /usr/lib/python2.7/lib-dynload/_io.so: undefined symbol: _Py_ZeroStruct
```

The solution is to explicitly load libpython with `dlopen` and the `RTLD_GLOBAL` flag (though, in a [previous project](https://github.com/theY4Kman/viper/blob/2f7a4c5d460d06c8bd1b0e16906af01cc23b438d/src/extension.cpp#L164) I only needed `RTLD_NOW`. Hmm... I'll have to revisit this). All was well after this. 

However, because multiple versions of Python are supported by rlm_python, I can't be hardcoding the version number in there. I've been trying to figure out autoconf to send the version number as a preprocessor define, but I keep fucking up :P I'm sure there's a define in Python.h which has it, but I've been using PY_VERSION, which includes the micro version. All I want is "2.7".

The Python.h approach is likely the way to go. It's certainly cleaner and requires less dependencies. I shall figure it out and update the pull request.
