### PR TITLE
Made NT password hashing functions compliant to RFC 2759 sec 8.3

### DIFF
--- a/src/include/libradius.h
+++ b/src/include/libradius.h
@@ -603,6 +603,9 @@ int fr_ipaddr2sockaddr(fr_ipaddr_t const *ipaddr, int port,
 		       struct sockaddr_storage *sa, socklen_t *salen);
 int fr_sockaddr2ipaddr(struct sockaddr_storage const *sa, socklen_t salen,
 		       fr_ipaddr_t *ipaddr, int * port);
+int utf8_to_ucs2(const uint8_t *utf8_string, size_t utf8_string_len,
+				 uint8_t *ucs2_buffer, size_t ucs2_buffer_size,
+				size_t *ucs2_string_size);
 
 
 #ifdef WITH_ASCEND_BINARY

--- a/src/modules/rlm_mschap/mschap.c
+++ b/src/modules/rlm_mschap/mschap.c
@@ -47,22 +47,13 @@ RCSID("$Id$")
  */
 void mschap_ntpwdhash (uint8_t *szHash, char const *szPassword)
 {
-	char szUnicodePass[513];
-	int nPasswordLen;
-	int i;
-
-	/*
-	 *	NT passwords are unicode.  Convert plain text password
-	 *	to unicode by inserting a zero every other byte
-	 */
-	nPasswordLen = strlen(szPassword);
-	for (i = 0; i < nPasswordLen; i++) {
-		szUnicodePass[i << 1] = szPassword[i];
-		szUnicodePass[(i << 1) + 1] = 0;
-	}
+	unsigned char unicodePass[512];
+    size_t nPasswordLen;
+    utf8_to_ucs2(szPassword, strlen(szPassword), unicodePass, sizeof(unicodePass), &nPasswordLen);
 
 	/* Encrypt Unicode password to a 16-byte MD4 hash */
-	fr_md4_calc(szHash, (uint8_t *) szUnicodePass, (nPasswordLen<<1) );
+    nPasswordLen *= 2;
+	fr_md4_calc(szHash, (uint8_t *) unicodePass, nPasswordLen);
 }
 
 

--- a/src/modules/rlm_mschap/smbencrypt.c
+++ b/src/modules/rlm_mschap/smbencrypt.c
@@ -48,22 +48,13 @@ static void tohex (unsigned char const  *src, size_t len, char *dst)
 
 static void ntpwdhash (uint8_t *szHash, char const *szPassword)
 {
-	char szUnicodePass[513];
-	char nPasswordLen;
-	int i;
-
-	/*
-	 *	NT passwords are unicode.  Convert plain text password
-	 *	to unicode by inserting a zero every other byte
-	 */
-	nPasswordLen = strlen(szPassword);
-	for (i = 0; i < nPasswordLen; i++) {
-		szUnicodePass[i << 1] = szPassword[i];
-		szUnicodePass[(i << 1) + 1] = 0;
-	}
+	unsigned char unicodePass[512];
+    size_t nPasswordLen;
+    utf8_to_ucs2(szPassword, strlen(szPassword), unicodePass, sizeof(unicodePass), &nPasswordLen);
 
 	/* Encrypt Unicode password to a 16-byte MD4 hash */
-	fr_md4_calc(szHash, (uint8_t *) szUnicodePass, (nPasswordLen<<1) );
+    nPasswordLen *= 2;
+	fr_md4_calc(szHash, (uint8_t *) unicodePass, nPasswordLen);
 }
 
 


### PR DESCRIPTION
Implemented proper password conversion from utf-8 to ucs-2 in EAP-LEAP and MSCHAP modules which was originally implemented for ASCII only. This conversion is a part of NtPasswordHash() function (RFC 2759).
