### PR TITLE
fix JSON upload in rlm_rest

### DIFF
--- a/src/lib/print.c
+++ b/src/lib/print.c
@@ -685,7 +685,7 @@ size_t vp_prints_value_json(char *out, size_t outlen, VALUE_PAIR const *vp)
 
 	if (freespace < 2) return outlen;
 	*out++ = '"';
-	*out++ = '\0';
+	*out = '\0'; // We don't increment out, because the nul byte should not be included in the length
 
 	return out - start;
 }


### PR DESCRIPTION
Previously the POSTED json would be invalid - it would truncate at the
end of the first tuple (because of accidentally including a \0 in the
string).  This change ensures that the returned length from
vp_prints_value_json does not include the nul terminator (which is
conventional and I assme the intent)
