### PR TITLE
pool-key and lease-duration now have _

### DIFF
--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -9,10 +9,10 @@
 #  SET nasipaddress = '', pool_key = 0, \
 #  callingstationid = '', username = '', \
 #  expiry_time = NULL \
-#  WHERE pool_key = '${pool-key}'"
+#  WHERE pool_key = '${pool_key}'"
 
 ## This series of queries allocates an IP address
-## (Note: If your pool-key is set to Calling-Station-Id and not NAS-Port
+## (Note: If your pool_key is set to Calling-Station-Id and not NAS-Port
 ## then you may wish to delete the "AND nasipaddress = '%{Nas-IP-Address}'
 ## from the WHERE clause)
 
@@ -56,9 +56,9 @@ pool_check = "SELECT id FROM ${ippool_table} \
 
 ## This is the final IP Allocation query, which saves the allocated ip details
 allocate-update = "UPDATE ${ippool_table} \
- SET nasipaddress = '%{NAS-IP-Address}', pool_key = '${pool-key}', \
+ SET nasipaddress = '%{NAS-IP-Address}', pool_key = '${pool_key}', \
  callingstationid = '%{Calling-Station-Id}', username = '%{User-Name}', \
- expiry_time = NOW() + INTERVAL ${lease-duration} SECOND \
+ expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
  WHERE framedipaddress = '%I' AND expiry_time IS NULL"
 
 
@@ -66,8 +66,8 @@ allocate-update = "UPDATE ${ippool_table} \
 ## This series of queries frees an IP number when an accounting
 ## START record arrives
 start_update = "UPDATE ${ippool_table} \
- SET expiry_time = NOW() + INTERVAL ${lease-duration} SECOND \
- WHERE nasipaddress = '%{NAS-IP-Address}' AND  pool_key = '${pool-key}' \
+ SET expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
+ WHERE nasipaddress = '%{NAS-IP-Address}' AND  pool_key = '${pool_key}' \
  AND username = '%{User-Name}' \
  AND callingstationid = '%{Calling-Station-Id}' \
  AND framedipaddress = '%{Framed-IP-Address}'"
@@ -77,7 +77,7 @@ start_update = "UPDATE ${ippool_table} \
 stop_clear = "UPDATE ${ippool_table} \
  SET nasipaddress = '', pool_key = 0, callingstationid = '', username = '', \
  expiry_time = NULL \
- WHERE nasipaddress = '%{Nas-IP-Address}' AND pool_key = '${pool-key}' \
+ WHERE nasipaddress = '%{Nas-IP-Address}' AND pool_key = '${pool_key}' \
  AND username = '%{User-Name}' \
  AND callingstationid = '%{Calling-Station-Id}' \
  AND framedipaddress = '%{Framed-IP-Address}'"
@@ -87,8 +87,8 @@ stop_clear = "UPDATE ${ippool_table} \
 ## This series of queries frees an IP number when an accounting
 ## ALIVE record arrives
 alive_update = "UPDATE ${ippool_table} \
- SET expiry_time = NOW() + INTERVAL ${lease-duration} SECOND \
- WHERE nasipaddress = '%{Nas-IP-Address}' AND pool_key = '${pool-key}' \
+ SET expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
+ WHERE nasipaddress = '%{Nas-IP-Address}' AND pool_key = '${pool_key}' \
  AND username = '%{User-Name}' \
  AND callingstationid = '%{Calling-Station-Id}' \
  AND framedipaddress = '%{Framed-IP-Address}'"

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -9,10 +9,10 @@
 #  SET nasipaddress = '', pool_key = 0, \
 #  callingstationid = '', username = '', \
 #  expiry_time = NULL \
-#  WHERE pool_key = '${pool-key}'"
+#  WHERE pool_key = '${pool_key}'"
 
 ## This series of queries allocates an IP address
-## (Note: If your pool-key is set to Calling-Station-Id and not NAS-Port
+## (Note: If your pool_key is set to Calling-Station-Id and not NAS-Port
 ## then you may wish to delete the "AND nasipaddress = '%{Nas-IP-Address}'
 ## from the WHERE clause)
 
@@ -56,9 +56,9 @@ pool_check = "SELECT id FROM ${ippool_table} \
 
 ## This is the final IP Allocation query, which saves the allocated ip details
 allocate_update = "UPDATE ${ippool_table} \
- SET nasipaddress = '%{NAS-IP-Address}', pool_key = '${pool-key}', \
+ SET nasipaddress = '%{NAS-IP-Address}', pool_key = '${pool_key}', \
  callingstationid = '%{Calling-Station-Id}', username = '%{User-Name}', \
- expiry_time = NOW() + INTERVAL ${lease-duration} SECOND \
+ expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
  WHERE framedipaddress = '%I' AND expiry_time IS NULL"
 
 
@@ -66,8 +66,8 @@ allocate_update = "UPDATE ${ippool_table} \
 ## This series of queries frees an IP number when an accounting
 ## START record arrives
 start_update = "UPDATE ${ippool_table} \
- SET expiry_time = NOW() + INTERVAL ${lease-duration} SECOND \
- WHERE nasipaddress = '%{NAS-IP-Address}' AND  pool_key = '${pool-key}' \
+ SET expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
+ WHERE nasipaddress = '%{NAS-IP-Address}' AND  pool_key = '${pool_key}' \
  AND username = '%{User-Name}' \
  AND callingstationid = '%{Calling-Station-Id}' \
  AND framedipaddress = '%{Framed-IP-Address}'"
@@ -77,7 +77,7 @@ start_update = "UPDATE ${ippool_table} \
 stop_clear = "UPDATE ${ippool_table} \
  SET nasipaddress = '', pool_key = 0, callingstationid = '', username = '', \
  expiry_time = NULL \
- WHERE nasipaddress = '%{Nas-IP-Address}' AND pool_key = '${pool-key}' \
+ WHERE nasipaddress = '%{Nas-IP-Address}' AND pool_key = '${pool_key}' \
  AND username = '%{User-Name}' \
  AND callingstationid = '%{Calling-Station-Id}' \
  AND framedipaddress = '%{Framed-IP-Address}'"
@@ -87,8 +87,8 @@ stop_clear = "UPDATE ${ippool_table} \
 ## This series of queries frees an IP number when an accounting
 ## ALIVE record arrives
 alive_update = "UPDATE ${ippool_table} \
- SET expiry_time = NOW() + INTERVAL ${lease-duration} SECOND \
- WHERE nasipaddress = '%{Nas-IP-Address}' AND pool_key = '${pool-key}' \
+ SET expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
+ WHERE nasipaddress = '%{Nas-IP-Address}' AND pool_key = '${pool_key}' \
  AND username = '%{User-Name}' \
  AND callingstationid = '%{Calling-Station-Id}' \
  AND framedipaddress = '%{Framed-IP-Address}'"

--- a/raddb/mods-config/sql/ippool/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mysql/queries.conf
@@ -9,10 +9,10 @@
 #  SET nasipaddress = '', pool_key = 0, \
 #  callingstationid = '', username = '', \
 #  expiry_time = NULL \
-#  WHERE pool_key = '${pool-key}'"
+#  WHERE pool_key = '${pool_key}'"
 
 ## This series of queries allocates an IP address
-## (Note: If your pool-key is set to Calling-Station-Id and not NAS-Port
+## (Note: If your pool_key is set to Calling-Station-Id and not NAS-Port
 ## then you may wish to delete the "AND nasipaddress = '%{Nas-IP-Address}'
 ## from the WHERE clause)
 
@@ -56,9 +56,9 @@ pool_check = "SELECT id FROM ${ippool_table} \
 
 ## This is the final IP Allocation query, which saves the allocated ip details
 allocate_update = "UPDATE ${ippool_table} \
- SET nasipaddress = '%{NAS-IP-Address}', pool_key = '${pool-key}', \
+ SET nasipaddress = '%{NAS-IP-Address}', pool_key = '${pool_key}', \
  callingstationid = '%{Calling-Station-Id}', username = '%{User-Name}', \
- expiry_time = NOW() + INTERVAL ${lease-duration} SECOND \
+ expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
  WHERE framedipaddress = '%I' AND expiry_time IS NULL"
 
 
@@ -66,8 +66,8 @@ allocate_update = "UPDATE ${ippool_table} \
 ## This series of queries frees an IP number when an accounting
 ## START record arrives
 start_update = "UPDATE ${ippool_table} \
- SET expiry_time = NOW() + INTERVAL ${lease-duration} SECOND \
- WHERE nasipaddress = '%{NAS-IP-Address}' AND  pool_key = '${pool-key}' \
+ SET expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
+ WHERE nasipaddress = '%{NAS-IP-Address}' AND  pool_key = '${pool_key}' \
  AND username = '%{User-Name}' \
  AND callingstationid = '%{Calling-Station-Id}' \
  AND framedipaddress = '%{Framed-IP-Address}'"
@@ -77,7 +77,7 @@ start_update = "UPDATE ${ippool_table} \
 stop_clear = "UPDATE ${ippool_table} \
  SET nasipaddress = '', pool_key = 0, callingstationid = '', username = '', \
  expiry_time = NULL \
- WHERE nasipaddress = '%{Nas-IP-Address}' AND pool_key = '${pool-key}' \
+ WHERE nasipaddress = '%{Nas-IP-Address}' AND pool_key = '${pool_key}' \
  AND username = '%{User-Name}' \
  AND callingstationid = '%{Calling-Station-Id}' \
  AND framedipaddress = '%{Framed-IP-Address}'"
@@ -87,8 +87,8 @@ stop_clear = "UPDATE ${ippool_table} \
 ## This series of queries frees an IP number when an accounting
 ## ALIVE record arrives
 alive_update = "UPDATE ${ippool_table} \
- SET expiry_time = NOW() + INTERVAL ${lease-duration} SECOND \
- WHERE nasipaddress = '%{Nas-IP-Address}' AND pool_key = '${pool-key}' \
+ SET expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
+ WHERE nasipaddress = '%{Nas-IP-Address}' AND pool_key = '${pool_key}' \
  AND username = '%{User-Name}' \
  AND callingstationid = '%{Calling-Station-Id}' \
  AND framedipaddress = '%{Framed-IP-Address}'"

--- a/raddb/mods-config/sql/ippool/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool/oracle/queries.conf
@@ -41,34 +41,34 @@ off_begin = "commit"
 
 
  ## This query marks the IP address handed out by "allocate-find" as used
- ## for the period of "lease-duration" after which time it may be reused.
+ ## for the period of "lease_duration" after which time it may be reused.
  allocate_update = "UPDATE ${ippool_table} \
-  SET nasipaddress = '%{NAS-IP-Address}', pool_key = '${pool-key}', \
+  SET nasipaddress = '%{NAS-IP-Address}', pool_key = '${pool_key}', \
   callingstationid = '%{Calling-Station-Id}', username = '%{SQL-User-Name}', \
-  expiry_time = current_timestamp + INTERVAL '${lease-duration}' second(1) \
+  expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
   WHERE framedipaddress = '%I'"
 
 
- ## This query frees the IP address assigned to "pool-key" when a new request
- ## comes in for the same "pool-key". This means that either you are losing
+ ## This query frees the IP address assigned to "pool_key" when a new request
+ ## comes in for the same "pool_key". This means that either you are losing
  ## accounting Stop records or you use Calling-Station-Id instead of NAS-Port
- ## as your "pool-key" and your users are able to reconnect before your NAS
+ ## as your "pool_key" and your users are able to reconnect before your NAS
  ## has timed out their previous session. (Generally on wireless networks)
- ## (Note: If your pool-key is set to Calling-Station-Id and not NAS-Port
+ ## (Note: If your pool_key is set to Calling-Station-Id and not NAS-Port
  ## then you may wish to delete the "AND nasipaddress = '%{Nas-IP-Address}'
  ## from the WHERE clause)
  allocate_clear = "UPDATE ${ippool_table} \
   SET nasipaddress = '', pool_key = 0, callingstationid = '', \
   expiry_time = current_timestamp - INTERVAL '1' second(1) \
-  WHERE pool_key = '${pool-key}'"
+  WHERE pool_key = '${pool_key}'"
 
 
- ## This query extends an IP address lease by "lease-duration" when an accounting
+ ## This query extends an IP address lease by "lease_duration" when an accounting
  ## START record arrives
  start_update = "UPDATE ${ippool_table} \
-  SET expiry_time = current_timestamp + INTERVAL '${lease-duration}' second(1) \
+  SET expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
   WHERE nasipaddress = '%{NAS-IP-Address}' \
-  AND pool_key = '${pool-key}'"
+  AND pool_key = '${pool_key}'"
 
 
  ## This query frees an IP address when an accounting
@@ -77,17 +77,17 @@ off_begin = "commit"
   SET nasipaddress = '', pool_key = 0, callingstationid = '', \
   expiry_time = current_timestamp - INTERVAL '1' second(1) \
   WHERE nasipaddress = '%{Nas-IP-Address}' \
-  AND pool_key = '${pool-key}' \
+  AND pool_key = '${pool_key}' \
   AND username = '%{SQL-User-Name}' \
   AND callingstationid = '%{Calling-Station-Id}'"
 
 
-## This query extends an IP address lease by "lease-duration" when an accounting
+## This query extends an IP address lease by "lease_duration" when an accounting
 ## ALIVE record arrives
 alive_update = "UPDATE ${ippool_table} \
-  SET expiry_time = current_timestamp + INTERVAL '${lease-duration}' second(1) \
+  SET expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
   WHERE nasipaddress = '%{Nas-IP-Address}' \
-  AND pool_key = '${pool-key}' \
+  AND pool_key = '${pool_key}' \
   AND framedipaddress = '%{Framed-IP-Address}' \
   AND username = '%{SQL-User-Name}' \
   AND callingstationid = '%{Calling-Station-Id}'"

--- a/raddb/mods-config/sql/ippool/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool/postgresql/queries.conf
@@ -31,35 +31,35 @@
 
 
  ## This query marks the IP address handed out by "allocate-find" as used
- ## for the period of "lease-duration" after which time it may be reused.
+ ## for the period of "lease_duration" after which time it may be reused.
  allocate_update = "UPDATE ${ippool_table} \
-  SET nasipaddress = '%{NAS-IP-Address}', pool_key = '${pool-key}', \
+  SET nasipaddress = '%{NAS-IP-Address}', pool_key = '${pool_key}', \
   callingstationid = '%{Calling-Station-Id}', username = '%{SQL-User-Name}', \
-  expiry_time = 'now'::timestamp(0) + '${lease-duration} second'::interval \
+  expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval \
   WHERE framedipaddress = '%I'"
 
 
- ## This query frees the IP address assigned to "pool-key" when a new request
- ## comes in for the same "pool-key". This means that either you are losing
+ ## This query frees the IP address assigned to "pool_key" when a new request
+ ## comes in for the same "pool_key". This means that either you are losing
  ## accounting Stop records or you use Calling-Station-Id instead of NAS-Port
- ## as your "pool-key" and your users are able to reconnect before your NAS
+ ## as your "pool_key" and your users are able to reconnect before your NAS
  ## has timed out their previous session. (Generally on wireless networks)
- ## (Note: If your pool-key is set to Calling-Station-Id and not NAS-Port
+ ## (Note: If your pool_key is set to Calling-Station-Id and not NAS-Port
  ## then you may wish to delete the "AND nasipaddress = '%{Nas-IP-Address}'
  ## from the WHERE clause)
  allocate_clear = "UPDATE ${ippool_table} \
   SET nasipaddress = '', pool_key = 0, callingstationid = '', \
   expiry_time = 'now'::timestamp(0) - '1 second'::interval \
   WHERE nasipaddress = '%{NAS-IP-Address}' \
-  AND pool_key = '${pool-key}'"
+  AND pool_key = '${pool_key}'"
 
 
- ## This query extends an IP address lease by "lease-duration" when an accounting
+ ## This query extends an IP address lease by "lease_duration" when an accounting
  ## START record arrives
  start_update = "UPDATE ${ippool_table} \
-  SET expiry_time = 'now'::timestamp(0) + '${lease-duration} second'::interval \
+  SET expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval \
   WHERE nasipaddress = '%{NAS-IP-Address}' \
-  AND pool_key = '${pool-key}'"
+  AND pool_key = '${pool_key}'"
 
 
  ## This query frees an IP address when an accounting
@@ -68,18 +68,18 @@
   SET nasipaddress = '', pool_key = 0, callingstationid = '', \
   expiry_time = 'now'::timestamp(0) - '1 second'::interval \
   WHERE nasipaddress = '%{Nas-IP-Address}' \
-  AND pool_key = '${pool-key}' \
+  AND pool_key = '${pool_key}' \
   AND username = '%{SQL-User-Name}' \
   AND callingstationid = '%{Calling-Station-Id}' \
   AND framedipaddress = '%{Framed-IP-Address}'"
 
 
- ## This query extends an IP address lease by "lease-duration" when an accounting
+ ## This query extends an IP address lease by "lease_duration" when an accounting
  ## ALIVE record arrives
  alive_update = "UPDATE ${ippool_table} \
-  SET expiry_time = 'now'::timestamp(0) + '${lease-duration} seconds'::interval \
+  SET expiry_time = 'now'::timestamp(0) + '${lease_duration} seconds'::interval \
   WHERE nasipaddress = '%{Nas-IP-Address}' \
-  AND pool_key = '${pool-key}' \
+  AND pool_key = '${pool_key}' \
   AND framedipaddress = '%{Framed-IP-Address}' \
   AND username = '%{SQL-User-Name}' \
   AND callingstationid = '%{Calling-Station-Id}'"

--- a/raddb/mods-config/sql/ippool/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool/sqlite/queries.conf
@@ -9,10 +9,10 @@
 #  SET nasipaddress = '', pool_key = 0, \
 #  callingstationid = '', username = '', \
 #  expiry_time = NULL \
-#  WHERE pool_key = '${pool-key}'"
+#  WHERE pool_key = '${pool_key}'"
 
 ## This series of queries allocates an IP address
-## (Note: If your pool-key is set to Calling-Station-Id and not NAS-Port
+## (Note: If your pool_key is set to Calling-Station-Id and not NAS-Port
 ## then you may wish to delete the "AND nasipaddress = '%{Nas-IP-Address}'
 ## from the WHERE clause)
 
@@ -56,9 +56,9 @@ pool_check = "SELECT id FROM ${ippool_table} \
 
 ## This is the final IP Allocation query, which saves the allocated ip details
 allocate_update = "UPDATE ${ippool_table} \
- SET nasipaddress = '%{NAS-IP-Address}', pool_key = '${pool-key}', \
+ SET nasipaddress = '%{NAS-IP-Address}', pool_key = '${pool_key}', \
  callingstationid = '%{Calling-Station-Id}', username = '%{User-Name}', \
- expiry_time = NOW() + INTERVAL ${lease-duration} SECOND \
+ expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
  WHERE framedipaddress = '%I' AND expiry_time IS NULL"
 
 
@@ -66,8 +66,8 @@ allocate_update = "UPDATE ${ippool_table} \
 ## This series of queries frees an IP number when an accounting
 ## START record arrives
 start_update = "UPDATE ${ippool_table} \
- SET expiry_time = NOW() + INTERVAL ${lease-duration} SECOND \
- WHERE nasipaddress = '%{NAS-IP-Address}' AND  pool_key = '${pool-key}' \
+ SET expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
+ WHERE nasipaddress = '%{NAS-IP-Address}' AND  pool_key = '${pool_key}' \
  AND username = '%{User-Name}' \
  AND callingstationid = '%{Calling-Station-Id}' \
  AND framedipaddress = '%{Framed-IP-Address}'"
@@ -77,7 +77,7 @@ start_update = "UPDATE ${ippool_table} \
 stop_clear = "UPDATE ${ippool_table} \
  SET nasipaddress = '', pool_key = 0, callingstationid = '', username = '', \
  expiry_time = NULL \
- WHERE nasipaddress = '%{Nas-IP-Address}' AND pool_key = '${pool-key}' \
+ WHERE nasipaddress = '%{Nas-IP-Address}' AND pool_key = '${pool_key}' \
  AND username = '%{User-Name}' \
  AND callingstationid = '%{Calling-Station-Id}' \
  AND framedipaddress = '%{Framed-IP-Address}'"
@@ -87,8 +87,8 @@ stop_clear = "UPDATE ${ippool_table} \
 ## This series of queries frees an IP number when an accounting
 ## ALIVE record arrives
 alive_update = "UPDATE ${ippool_table} \
- SET expiry_time = NOW() + INTERVAL ${lease-duration} SECOND \
- WHERE nasipaddress = '%{Nas-IP-Address}' AND pool_key = '${pool-key}' \
+ SET expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
+ WHERE nasipaddress = '%{Nas-IP-Address}' AND pool_key = '${pool_key}' \
  AND username = '%{User-Name}' \
  AND callingstationid = '%{Calling-Station-Id}' \
  AND framedipaddress = '%{Framed-IP-Address}'"


### PR DESCRIPTION
rename so that default queries match module config changes
