### PR TITLE
- Fix build when linking against OpenSSL

### DIFF
--- a/src/main/radattr.mk
+++ b/src/main/radattr.mk
@@ -2,4 +2,4 @@ TARGET		:= radattr
 SOURCES		:= radattr.c
 
 TGT_PREREQS	:= libfreeradius-server.a libfreeradius-radius.a
-TGT_LDLIBS	:= $(LIBS)
+TGT_LDLIBS	:= $(LIBS) $(OPENSSL_LIBS)

--- a/src/main/radclient.mk
+++ b/src/main/radclient.mk
@@ -5,4 +5,4 @@ SOURCES		:= radclient.c ${top_srcdir}/src/modules/rlm_mschap/smbdes.c \
 TGT_PREREQS	:= libfreeradius-radius.a
 
 SRC_CFLAGS	:= -I${top_srcdir}/src/modules/rlm_mschap
-TGT_LDLIBS	:= $(LIBS)
+TGT_LDLIBS	:= $(LIBS) $(OPENSSL_LIBS)

--- a/src/main/radconf2xml.mk
+++ b/src/main/radconf2xml.mk
@@ -2,4 +2,4 @@ TARGET		:= radconf2xml
 SOURCES		:= radconf2xml.c
 
 TGT_PREREQS	:= libfreeradius-server.a libfreeradius-radius.a
-TGT_LDLIBS	:= $(LIBS)
+TGT_LDLIBS	:= $(LIBS) $(OPENSSL_LIBS)

--- a/src/main/radmin.mk
+++ b/src/main/radmin.mk
@@ -4,4 +4,4 @@ SOURCES		:= radmin.c
 
 TGT_INSTALLDIR  := ${sbindir}
 TGT_PREREQS	:= libfreeradius-server.a libfreeradius-radius.a
-TGT_LDLIBS	:= $(LIBS) $(LIBREADLINE)
+TGT_LDLIBS	:= $(LIBS) $(OPENSSL_LIBS) $(LIBREADLINE)

--- a/src/main/radsniff.mk.in
+++ b/src/main/radsniff.mk.in
@@ -9,4 +9,4 @@ endif
 SOURCES		:= radsniff.c collectd.c
 
 TGT_PREREQS	:= libfreeradius-radius.a
-TGT_LDLIBS	:= $(LIBS) $(PCAP_LIBS) $(COLLECTDC_LIBS)
+TGT_LDLIBS	:= $(LIBS) $(OPENSSL_LIBS) $(PCAP_LIBS) $(COLLECTDC_LIBS)

--- a/src/main/radwho.mk
+++ b/src/main/radwho.mk
@@ -2,4 +2,4 @@ TARGET		:= radwho
 SOURCES		:= radwho.c
 
 TGT_PREREQS	:= libfreeradius-server.a libfreeradius-radius.a
-TGT_LDLIBS	:= $(LIBS)
+TGT_LDLIBS	:= $(LIBS) $(OPENSSL_LIBS)

--- a/src/modules/proto_dhcp/dhcpclient.mk
+++ b/src/modules/proto_dhcp/dhcpclient.mk
@@ -2,4 +2,4 @@ TARGET		:= dhcpclient
 SOURCES		:= dhcpclient.c dhcp.c
 
 TGT_PREREQS	:= libfreeradius-radius.a
-TGT_LDLIBS	:= $(LIBS)
+TGT_LDLIBS	:= $(LIBS) $(OPENSSL_LIBS)

--- a/src/modules/rlm_ippool/rlm_ippool.mk
+++ b/src/modules/rlm_ippool/rlm_ippool.mk
@@ -6,4 +6,4 @@ SOURCES		:= rlm_ippool.c
 TARGET		:= rlm_ippool.a
 
 SRC_CFLAGS	:= $(rlm_ippool_CFLAGS) 
-TGT_LDLIBS	:= $(rlm_ippool_LDLIBS)
+TGT_LDLIBS	:= $(OPENSSL_LIBS) $(rlm_ippool_LDLIBS)

--- a/src/modules/rlm_ippool/rlm_ippool_tool.mk
+++ b/src/modules/rlm_ippool/rlm_ippool_tool.mk
@@ -7,6 +7,6 @@ TARGET		:= rlm_ippool_tool
 TGT_PREREQS	:= libfreeradius-radius.a
 
 SRC_CFLAGS	:= $(rlm_ippool_CFLAGS)
-TGT_LDLIBS	:= $(LIBS) $(rlm_ippool_LDLIBS)
+TGT_LDLIBS	:= $(LIBS) $(OPENSSL_LIBS) $(rlm_ippool_LDLIBS)
 
 MAN		:= rlm_ippool_tool.8

--- a/src/modules/rlm_mschap/smbencrypt.mk
+++ b/src/modules/rlm_mschap/smbencrypt.mk
@@ -4,6 +4,6 @@ SOURCES		:= smbencrypt.c smbdes.c
 TGT_PREREQS	:= libfreeradius-radius.a
 
 SRC_CFLAGS	:=
-TGT_LDLIBS	:= $(LIBS)
+TGT_LDLIBS	:= $(LIBS) $(OPENSSL_LIBS)
 
 


### PR DESCRIPTION
Build currently fails with undefined references to MD5_Final, MD5_Update, etc.
