### PR TITLE
Restore most-recent return code match in if()/elsif()

### DIFF
--- a/src/main/modcall.c
+++ b/src/main/modcall.c
@@ -470,7 +470,7 @@ redo:
 		RDEBUG2("%.*s? %s %s", depth + 1, modcall_spaces,
 			group_name[c->type], c->name);
 
-		condition = radius_evaluate_cond(request, entry->result, 0, g->cond);
+		condition = radius_evaluate_cond(request, result, 0, g->cond);
 		if (condition < 0) {
 			switch (condition) {
 			case -2:


### PR DESCRIPTION
This puts the old behaviour back of matching the most recent
return code, not the highest priority one.

NOTE: assuming this is actually the desired behaviour of course...
