### PR TITLE
fix NAS-Port-Id sql error

### DIFF
--- a/raddb/mods-config/sql/main/mysql/queries.conf
+++ b/raddb/mods-config/sql/main/mysql/queries.conf
@@ -193,13 +193,13 @@
 
 		column_list = "\
 			acctsessionid,		acctuniqueid,		username, \
-			realm,			nasipaddress,		nasportid, \
-			nasporttype,		acctstarttime,		acctupdatetime, \
-			acctstoptime,		acctsessiontime, 	acctauthentic, \
-			connectinfo_start,	connectinfo_stop, 	acctinputoctets, \
-			acctoutputoctets,	calledstationid, 	callingstationid, \
-			acctterminatecause,	servicetype,		framedprotocol, \
-			framedipaddress"
+			realm,				nasipaddress,		nasport,\
+			nasportid, 			nasporttype,		acctstarttime, \
+			acctupdatetime, 	acctstoptime,		acctsessiontime, \
+			acctauthentic, 		connectinfo_start,	connectinfo_stop, \
+			acctinputoctets, 	acctoutputoctets,	calledstationid, \
+			callingstationid, 	acctterminatecause,	servicetype, \
+			framedprotocol, 	framedipaddress"
 
 		type {
 			accounting-on {
@@ -237,6 +237,7 @@
 						'%{SQL-User-Name}', \
 						'%{Realm}', \
 						'%{NAS-IP-Address}', \
+						'%{NAS-Port}', \
 						'%{NAS-Port-Id}', \
 						'%{NAS-Port-Type}', \
 						FROM_UNIXTIME(%{integer:Event-Timestamp}), \
@@ -309,6 +310,7 @@
 						'%{SQL-User-Name}', \
 						'%{Realm}', \
 						'%{NAS-IP-Address}', \
+						'%{NAS-Port}', \						
 						'%{NAS-Port-Id}', \
 						'%{NAS-Port-Type}', \
 						FROM_UNIXTIME(%{integer:Event-Timestamp} - \
@@ -360,6 +362,7 @@
 						'%{SQL-User-Name}', \
 						'%{Realm}', \
 						'%{NAS-IP-Address}', \
+						'%{NAS-Port}', \						
 						'%{NAS-Port-Id}', \
 						'%{NAS-Port-Type}', \
 						FROM_UNIXTIME(%{integer:Event-Timestamp} - \

--- a/raddb/mods-config/sql/main/mysql/schema.sql
+++ b/raddb/mods-config/sql/main/mysql/schema.sql
@@ -22,6 +22,7 @@ CREATE TABLE radacct (
   groupname varchar(64) NOT NULL default '',
   realm varchar(64) default '',
   nasipaddress varchar(15) NOT NULL default '',
+  nasport int(6) default NULL,
   nasportid varchar(50) default NULL,
   nasporttype varchar(32) default NULL,
   acctstarttime datetime NULL default NULL,


### PR DESCRIPTION
queries.conf :
NAS-Port-Id not updated correctly in mysql because the value inserted
was %{NAS-Port} instead of %{NAS-Port-Id}
schema.sql :
altered column nasportid from varchar(15) to varchar(50) to allow bigger
NAS-Port-ID information (maximum from RFC 2869 is 253 octets, but 50
should be enough)
