### PR TITLE
fix NAS-Port-Id sql error

### DIFF
--- a/raddb/mods-config/sql/main/mysql/queries.conf
+++ b/raddb/mods-config/sql/main/mysql/queries.conf
@@ -237,7 +237,7 @@
 						'%{SQL-User-Name}', \
 						'%{Realm}', \
 						'%{NAS-IP-Address}', \
-						'%{NAS-Port}', \
+						'%{%{NAS-Port-ID}:-%{NAS-Port}}', \
 						'%{NAS-Port-Type}', \
 						FROM_UNIXTIME(%{integer:Event-Timestamp}), \
 						FROM_UNIXTIME(%{integer:Event-Timestamp}), \
@@ -309,7 +309,7 @@
 						'%{SQL-User-Name}', \
 						'%{Realm}', \
 						'%{NAS-IP-Address}', \
-						'%{NAS-Port}', \
+						'%{%{NAS-Port-ID}:-%{NAS-Port}}', \
 						'%{NAS-Port-Type}', \
 						FROM_UNIXTIME(%{integer:Event-Timestamp} - \
 							%{%{Acct-Session-Time}:-0}), \
@@ -360,7 +360,7 @@
 						'%{SQL-User-Name}', \
 						'%{Realm}', \
 						'%{NAS-IP-Address}', \
-						'%{NAS-Port}', \
+						'%{%{NAS-Port-ID}:-%{NAS-Port}}', \
 						'%{NAS-Port-Type}', \
 						FROM_UNIXTIME(%{integer:Event-Timestamp} - \
 							%{%{Acct-Session-Time}:-0}), \

--- a/raddb/mods-config/sql/main/mysql/schema.sql
+++ b/raddb/mods-config/sql/main/mysql/schema.sql
@@ -22,7 +22,7 @@ CREATE TABLE radacct (
   groupname varchar(64) NOT NULL default '',
   realm varchar(64) default '',
   nasipaddress varchar(15) NOT NULL default '',
-  nasportid varchar(15) default NULL,
+  nasportid varchar(50) default NULL,
   nasporttype varchar(32) default NULL,
   acctstarttime datetime NULL default NULL,
   acctupdatetime datetime NULL default NULL,


### PR DESCRIPTION
queries.conf :
NAS-Port-Id not updated correctly in mysql because the value inserted
was %{NAS-Port} instead of %{NAS-Port-Id} (if sent by NAS) or
%{NAS-Port} (if NAS-Port-Id not sent by NAS)

schema.sql :
altered column nasportid from varchar(15) to varchar(50) to allow bigger
NAS-Port-ID information (maximum from RFC 2869 is 253 octets, but 50
should be enough)

(initial pull request # 468 was modified as discussed)
