### PR TITLE
Only put the clone_mutex in the rlm_perl struct if using ITHREADS

### DIFF
--- a/src/modules/rlm_perl/rlm_perl.c
+++ b/src/modules/rlm_perl/rlm_perl.c
@@ -75,7 +75,9 @@ typedef struct rlm_perl_t {
 	PerlInterpreter *perl;
 	pthread_key_t	*thread_key;
 
+#ifdef USE_ITHREADS
 	pthread_mutex_t clone_mutex;
+#endif
 } rlm_perl_t;
 /*
  *	A mapping of configuration file names to internal variables.


### PR DESCRIPTION
All the code concerning clone_mutex has been wrapped in ifdef-blocks. This way we don't have lingering variables around.
