### PR TITLE
Various whitespace fixes

### DIFF
--- a/src/modules/rlm_perl/example.pl
+++ b/src/modules/rlm_perl/example.pl
@@ -47,15 +47,15 @@ our (%RAD_REQUEST, %RAD_REPLY, %RAD_CHECK);
 # This the remapping of return values
 #
 use constant {
-	RLM_MODULE_REJECT 	=> 0, # immediately reject the request
-	RLM_MODULE_OK		=> 2, # the module is OK, continue
-	RLM_MODULE_HANDLED	=> 3, # the module handled the request, so stop
-	RLM_MODULE_INVALID	=> 4, # the module considers the request invalid
-	RLM_MODULE_USERLOCK	=> 5, # reject the request (user is locked out)
-	RLM_MODULE_NOTFOUND	=> 6, # user not found
-	RLM_MODULE_NOOP		=> 7, # module succeeded without doing anything
-	RLM_MODULE_UPDATED	=> 8, # OK (pairs modified)
-	RLM_MODULE_NUMCODES	=> 9  # How many return codes there are
+	RLM_MODULE_REJECT   => 0, # immediately reject the request
+	RLM_MODULE_OK       => 2, # the module is OK, continue
+	RLM_MODULE_HANDLED  => 3, # the module handled the request, so stop
+	RLM_MODULE_INVALID  => 4, # the module considers the request invalid
+	RLM_MODULE_USERLOCK => 5, # reject the request (user is locked out)
+	RLM_MODULE_NOTFOUND => 6, # user not found
+	RLM_MODULE_NOOP     => 7, # module succeeded without doing anything
+	RLM_MODULE_UPDATED  => 8, # OK (pairs modified)
+	RLM_MODULE_NUMCODES => 9  # How many return codes there are
 };
 
 # Same as src/include/radiusd.h

--- a/src/modules/rlm_python/prepaid.py
+++ b/src/modules/rlm_python/prepaid.py
@@ -26,9 +26,9 @@ import MySQLdb
 configDb = 'python'                     # Database name
 configHost = 'localhost'                # Database host
 configUser = 'python'                   # Database user and password
-configPasswd = 'python'         
+configPasswd = 'python'
 
-# xxx Database 
+# xxx Database
 
 # Globals
 dbHandle = None
@@ -65,7 +65,7 @@ def authorize(authData):
   # Extract the data we need.
   userName = None
   userPasswd = None
-  
+
   for t in authData:
     if t[0] == 'User-Name':
       userName = t[1]
@@ -76,7 +76,7 @@ def authorize(authData):
   # radiusd puts double quotes (") around the string representation of
   # the RADIUS packet.
   sql = 'select passwd, maxseconds from users where username = ' +  userName
-  
+
   log(radiusd.L_DBG, sql)
 
   # Get a cursor
@@ -94,7 +94,7 @@ def authorize(authData):
     log(radiusd.L_ERR, str(e))
     dbCursor.close()
     return radiusd.RLM_MODULE_FAIL
-  
+
   # Get the result. (passwd, maxseconds)
   result = dbCursor.fetchone()
   if not result:
@@ -104,7 +104,7 @@ def authorize(authData):
     return radiusd.RLM_MODULE_NOTFOUND
 
 
- 
+
   # Compare passwords
   # Ignore the quotes around userPasswd.
   if result[0] != userPasswd[1:-1]:
@@ -114,12 +114,12 @@ def authorize(authData):
   maxSeconds = result[1]
 
   # Compute their session limit
-  
+
   # Build and log the SQL statement
   sql = 'select sum(seconds) from sessions where username = ' + userName
 
   log(radiusd.L_DBG, sql)
-  
+
   # Execute the SQL statement
   try:
     dbCursor.execute(sql)
@@ -127,7 +127,7 @@ def authorize(authData):
     log(radiusd.L_ERR, str(e))
     dbCursor.close()
     return radiusd.RLM_MODULE_FAIL
-  
+
   # Get the result. (sum,)
   result = dbCursor.fetchone()
   if (not result) or (not result[0]):
@@ -141,10 +141,10 @@ def authorize(authData):
 
   # Note that MySQL returns the result of SUM() as a float.
   sessionTimeout = maxSeconds - int(secondsUsed)
-  
+
   if sessionTimeout <= 0:
     # No more time, reject outright
-    log(radiusd.L_INFO, 'user out of time: ' + userName)    
+    log(radiusd.L_INFO, 'user out of time: ' + userName)
     return radiusd.RLM_MODULE_REJECT
 
   # Log the success
@@ -158,7 +158,7 @@ def authorize(authData):
   return (radiusd.RLM_MODULE_UPDATED,
           (('Session-Timeout', str(sessionTimeout)),),
           (('Auth-Type', 'python'),))
-  # If you want to use different operators 
+  # If you want to use different operators
   # you can do
   # return (radiusd.RLM_MODULE_UPDATED,
   #         radiusd.resolve(
@@ -168,7 +168,7 @@ def authorize(authData):
   #         radiusd.resolve(
   #            'Auth-Type := python'
   #         )
-  #        ) 
+  #        )
   # Edit operators you need in OP_TRY in radiusd.py
 
 def authenticate(p):
@@ -203,16 +203,16 @@ def accounting(acctData):
   # We may later, for simultaneous checks and the like.
   if acctStatusType == 'Start':
     return radiusd.RLM_MODULE_OK
-  
+
   # Build and log the SQL statement
   # radiusd puts double quotes (") around the string representation of
   # the RADIUS packet.
   #
   # xxx This is simplistic as it does not record the time, etc.
-  # 
+  #
   sql = 'insert into sessions (username, seconds) values (%s, %d)' % \
         (userName, int(acctSessionTime))
-  
+
   log(radiusd.L_DBG, sql)
 
   # Get a cursor
@@ -231,7 +231,7 @@ def accounting(acctData):
     dbCursor.close()
     return radiusd.RLM_MODULE_FAIL
 
-  
+
   return radiusd.RLM_MODULE_OK
 
 
@@ -246,7 +246,7 @@ def detach():
 
 
 
-# Test the modules 
+# Test the modules
 if __name__ == '__main__':
   instantiate(None)
   print authorize((('User-Name', '"map"'), ('User-Password', '"abc"')))

--- a/src/modules/rlm_python/radiusd.py
+++ b/src/modules/rlm_python/radiusd.py
@@ -19,7 +19,7 @@ RLM_MODULE_HANDLED = 3
 RLM_MODULE_INVALID = 4
 RLM_MODULE_USERLOCK = 5
 RLM_MODULE_NOTFOUND = 6
-RLM_MODULE_NOOP = 7	
+RLM_MODULE_NOOP = 7
 RLM_MODULE_UPDATED = 8
 RLM_MODULE_NUMCODES = 9
 
@@ -29,7 +29,7 @@ L_DBG = 1
 L_AUTH = 2
 L_INFO = 3
 L_ERR = 4
-L_PROXY	= 5
+L_PROXY = 5
 L_CONS = 128
 
 OP={       '{':2,   '}':3,   '(':4,   ')':5,   ',':6,   ';':7,  '+=':8,  '-=':9,  ':=':10,

--- a/src/modules/rlm_rest/demo.pl
+++ b/src/modules/rlm_rest/demo.pl
@@ -14,15 +14,15 @@ while (my $c = $d->accept) {
 		print "Got " . $r->method . " request\n";
 		if ($r->method eq 'POST' and $r->url->path eq "/") {
 			my $resp = HTTP::Response->new( '200', 'OK' );
-	
-			$resp->header("Content-Type" => "application/x-www-form-urlencoded");	
+
+			$resp->header("Content-Type" => "application/x-www-form-urlencoded");
 			$resp->content("control:Cleartext-Password=password&reply:Reply-Message=testing123");
-		
+
 			$c->send_response($resp);
 		} else {
 			$c->send_error(RC_FORBIDDEN)
 		}
- 	}
-      	$c->close;
+	}
+	$c->close;
 	undef($c);
- }
+}

--- a/src/modules/rlm_ruby/example.rb
+++ b/src/modules/rlm_ruby/example.rb
@@ -1,25 +1,25 @@
 #This is example radius.rb script
 module Radiusd
     def Radiusd.instantiate(arg)
-	radlog(L_DBG,"[ruby]Running ruby instantiate")
+        radlog(L_DBG,"[ruby]Running ruby instantiate")
         p arg
-	return Radiusd::RLM_MODULE_OK
+        return Radiusd::RLM_MODULE_OK
     end
     def Radiusd.authenticate(arg)
-    	radlog(L_DBG,"[ruby]Running ruby authenticate")
+        radlog(L_DBG,"[ruby]Running ruby authenticate")
         p arg
-	return Radiusd::RLM_MODULE_NOOP
+        return Radiusd::RLM_MODULE_NOOP
     end
     def Radiusd.authorize(arg)
-    	radlog(L_DBG,"[ruby]Running ruby authorize")
-	p arg
-	#Here we return Cleartext-Password, which could have been retrieved from DB.
-	return [Radiusd::RLM_MODULE_UPDATED, [],[["Cleartext-Password","pass"]]]
+        radlog(L_DBG,"[ruby]Running ruby authorize")
+        p arg
+        #Here we return Cleartext-Password, which could have been retrieved from DB.
+        return [Radiusd::RLM_MODULE_UPDATED, [],[["Cleartext-Password","pass"]]]
     end
     def Radiusd.accounting(arg)
-    	radlog(L_DBG,"[ruby]Running ruby accounting")
-	p arg
-	return Radiusd::RLM_MODULE_NOOP
+        radlog(L_DBG,"[ruby]Running ruby accounting")
+        p arg
+        return Radiusd::RLM_MODULE_NOOP
     end
 
 end


### PR DESCRIPTION
- Don't mix up tabs and spaces, this will lead to unreadable code
- Removed trailing whitespace

No functional changes have been introduced, it's just a little cleaner this way.

I only looked at the perl/python/ruby scripts in the distribution, possibly there are more mixups of tabs and spaces in the code base.
