### PR TITLE
Fixed compile warnings with clang

### DIFF
--- a/src/main/radsniff.c
+++ b/src/main/radsniff.c
@@ -890,7 +890,7 @@ static void rs_packet_process(uint64_t count, rs_event_t *event, struct pcap_pkt
 	 *	End of variable length bits, do basic check now to see if packet looks long enough
 	 */
 	len = (p - data) + sizeof(struct udp_header) + (sizeof(radius_packet_t) - 1);	/* length value */
-	if (len > header->caplen) {
+	if (len > (ssize_t)header->caplen) {
 		REDEBUG("Packet too small, we require at least %zu bytes, captured %i bytes",
 			(size_t) len, header->caplen);
 		return;

--- a/src/modules/rlm_counter/rlm_counter.c
+++ b/src/modules/rlm_counter/rlm_counter.c
@@ -578,7 +578,7 @@ static rlm_rcode_t mod_accounting(void *instance, REQUEST *request)
 	 */
 	key_vp = pairfind(request->packet->vps, PW_ACCT_DELAY_TIME, 0, TAG_ANY);
 	if (key_vp != NULL) {
-		if (key_vp->vp_integer != 0 && (request->timestamp - key_vp->vp_integer) < inst->last_reset) {
+		if (key_vp->vp_integer != 0 && (request->timestamp - key_vp->vp_integer) < (unsigned long)inst->last_reset) {
 			DEBUG("rlm_counter: This packet is too old. Returning NOOP");
 			return RLM_MODULE_NOOP;
 		}
@@ -647,7 +647,7 @@ static rlm_rcode_t mod_accounting(void *instance, REQUEST *request)
 		 *	day). That is the right thing
 		 */
 		diff = request->timestamp - inst->last_reset;
-		counter.user_counter += (count_vp->vp_integer < diff) ? count_vp->vp_integer : diff;
+		counter.user_counter += (count_vp->vp_integer < (unsigned long)diff) ? count_vp->vp_integer : diff;
 
 	} else if (count_vp->da->type == PW_TYPE_INTEGER) {
 		/*
@@ -790,7 +790,7 @@ static rlm_rcode_t mod_authorize(UNUSED void *instance, UNUSED REQUEST *request)
 			*	Before that set the return value to the time
 			*	remaining to next reset
 		 	*/
-			if (inst->reset_time && (res >= (inst->reset_time - request->timestamp))) {
+			if (inst->reset_time && ((time_t)res >= (inst->reset_time - request->timestamp))) {
 				res = inst->reset_time - request->timestamp;
 				res += check_vp->vp_integer;
 			}

--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -445,7 +445,7 @@ static size_t rest_encode_post(void *ptr, size_t size, size_t nmemb,
 	ssize_t s = (size * nmemb) - 1;
 
 	/* Allow manual chunking */
-	if ((ctx->chunk) && (ctx->chunk <= s)) {
+	if ((ctx->chunk) && ((ssize_t)ctx->chunk <= s)) {
 		s = (ctx->chunk - 1);
 	}
 
@@ -611,7 +611,7 @@ static size_t rest_encode_json(void *ptr, size_t size, size_t nmemb,
 	assert(s > 0);
 
 	/* Allow manual chunking */
-	if ((ctx->chunk) && (ctx->chunk <= s)) {
+	if ((ctx->chunk) && ((ssize_t)ctx->chunk <= s)) {
 		s = (ctx->chunk - 1);
 	}
 


### PR DESCRIPTION
First of all, I'm not suggesting this change should be merged. Quite the opposite actually, but this is probably the easiest way to annotate some code.

I tried compiling the source with llvm-clang. This C-compiler generates a lot more warnings that GCC with the default settings (although gcc-4.8 appears to be catching up). This generated a number of warnings about not fully compatible types in assignments and compares, this patch was the simplest way to silence them.

Most times these warnings reveal that an incorrect data type has been used, which may lead to weird bugs, especially when mixing signed and unsigned data types. The best fix is probably to change the data types of some variables. I don't think I know enough of the freeradius code to do those things.
