### PR TITLE
Slight cleanup and extension of H3C dictionary

### DIFF
--- a/share/dictionary.h3c
+++ b/share/dictionary.h3c
@@ -14,7 +14,22 @@ VENDOR		H3C				25506
 
 BEGIN-VENDOR	H3C
 
+ATTRIBUTE	H3C-Input-Peak-Rate			1	integer
+ATTRIBUTE	H3C-Input-Average-Rate			2	integer
+ATTRIBUTE	H3C-Input-Basic-Rate			3	integer
+ATTRIBUTE	H3C-Remanent-Volume			15	integer
+ATTRIBUTE	H3C-Command				20	integer
+
+VALUE	H3C-Command		Trigger-Request		1
+VALUE	H3C-Command		Terminate-Request	2
+VALUE	H3C-Command		SetPolicy		3
+VALUE	H3C-Command		Result			4
+VALUE	H3C-Command		PortalClear		5
+
+ATTRIBUTE	H3C-Control-Identifier			24	integer
+ATTRIBUTE	H3C-Result-Code				25	integer
 ATTRIBUTE	H3C-Connect_Id				26	integer
+ATTRIBUTE	H3C-Ftp-Directory			28	string
 ATTRIBUTE	H3C-Exec-Privilege			29	integer
 
 VALUE	H3C-Exec-Privilege		Visit			0
@@ -24,6 +39,17 @@ VALUE	H3C-Exec-Privilege		Manage			3
 
 ATTRIBUTE	H3C-NAS-Startup-Timestamp		59	integer
 ATTRIBUTE	H3C-Ip-Host-Addr			60	string
+ATTRIBUTE	H3C-User-Notify				61	string
+ATTRIBUTE	H3C-User-HeartBeat			62	string
+ATTRIBUTE	H3C-User-Group				140	string
+ATTRIBUTE	H3C-Security-Level			141	integer
+ATTRIBUTE	H3C-Input-Interval-Octets		201	integer
+ATTRIBUTE	H3C-Output-Interval-Octets		202	integer
+ATTRIBUTE	H3C-Input-Interval-Packets		203	integer
+ATTRIBUTE	H3C-Output-Interval-Packets		204	integer
+ATTRIBUTE	H3C-Input-Interval-Gigawords		205	integer
+ATTRIBUTE	H3C-Output-Interval-Gigawords		206	integer
+ATTRIBUTE	H3C-Backup-NAS-IP			207 	ipaddr
 ATTRIBUTE	H3C-Product-ID				255	string
 
 END-VENDOR	H3C


### PR DESCRIPTION
Based on previous review from Allan feedback, I hope fixes all nits found:

Rename the recently added H3C-HW-Exec-Privilege to H3C-Exec-Privilege
as well as its value names to match with (now-found) effective H3C documentation.

Extend the H3C dictionary but stick with hyphens instead of H3C documentation 
which uses underlines. Does not modify previous use of underline as current
setups might rely on and such a change would cause breakage.
