### PR TITLE
Changed policy.d/cui to also lower-case the Operator-Name in CUI generation

### DIFF
--- a/raddb/policy.d/cui
+++ b/raddb/policy.d/cui
@@ -69,7 +69,7 @@ cui.post-auth {
 	if (!control:Proxy-To-Realm && Chargeable-User-Identity && !reply:Chargeable-User-Identity && \
 	    (Operator-Name || ('${policy.cui_require_operator_name}' != 'yes')) ) {
 		update reply {
-			Chargeable-User-Identity = "%{sha1:${policy.cui_hash_key}%{tolower:%{User-Name}}%{%{Operator-Name}:-}}"
+			Chargeable-User-Identity = "%{sha1:${policy.cui_hash_key}%{tolower:%{User-Name}%{%{Operator-Name}:-}}}"
 		}
 	}
 	update reply {
@@ -91,7 +91,7 @@ cui-inner.post-auth {
 	if (outer.request:Chargeable-User-Identity && \
 	    (outer.request:Operator-Name || ('${policy.cui_require_operator_name}' != 'yes'))) {
 		update reply {
-			Chargeable-User-Identity := "%{sha1:${policy.cui_hash_key}%{tolower:%{User-Name}}%{%{outer.request:Operator-Name}:-}}"
+			Chargeable-User-Identity := "%{sha1:${policy.cui_hash_key}%{tolower:%{User-Name}%{%{outer.request:Operator-Name}:-}}}"
 		}
 	}
 }


### PR DESCRIPTION
If Operator-Name is technically case-insensitive, normalise it before generating a CUI.
