### PR TITLE
rlm_rest bugfix

### DIFF
--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -893,10 +893,10 @@ static int rest_decode_post(UNUSED rlm_rest_t *instance,
 
 	while (((q = strchr(p, '=')) != NULL) &&
 	       (count < REST_BODY_MAX_ATTRS)) {
-		attribute = name;
 		reference = request;
 
 		name = curl_easy_unescape(candle, p, (q - p), &curl_len);
+		attribute = name;
 		p = (q + 1);
 
 		RDEBUG("Decoding attribute \"%s\"", name);
@@ -910,7 +910,7 @@ static int rest_decode_post(UNUSED rlm_rest_t *instance,
 			continue;
 		}
 
-		if (!radius_request(&reference, request_name)) {
+		if (radius_request(&reference, request_name)) {
 			RWDEBUG("Attribute name refers to outer request"
 		       	       " but not in a tunnel, skipping");
 
@@ -1000,6 +1000,8 @@ static int rest_decode_post(UNUSED rlm_rest_t *instance,
 			talloc_free(vp);
 			goto skip;
 		}
+
+		if (vps) pairadd(vps, vp);
 
 		if (++count == REST_BODY_MAX_ATTRS) {
 			REDEBUG("At maximum attribute limit");


### PR DESCRIPTION
I've made some changes to rlm_rest when used with x-www-form-urlencoded POST data; I couldn't make current source work without these changes; it could be my fault, but with these changes it works as expected, at least for me. Since rlm_rest isn't compiled by default I deduced that some bugs could be present. Please, let me know if this patch can be merged in the master repository in order to be included in the next freeradius release.
