### PR TITLE
Typo fix in man radiusd(8)

### DIFF
--- a/man/man8/radiusd.8
+++ b/man/man8/radiusd.8
@@ -221,7 +221,7 @@ from the hints file. Authentication is then based on the contents of
 the UNIX \fI/etc/passwd\fP file. However it is also possible to define all
 users, and their passwords, in this file.
 .SH SEE ALSO
-rradiusd.conf(5), users(5), huntgroups(5), hints(5),
+radiusd.conf(5), users(5), huntgroups(5), hints(5),
 dictionary(5), raddebug(8)
 .SH AUTHOR
 The FreeRADIUS Server Project (http://www.freeradius.org)


### PR DESCRIPTION
The `see also'' section contained a reference to rradiusd.conf(5), which of
course should be written with a single`r''
