### PR TITLE
rlm_rest bugfix

### DIFF
--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -891,7 +891,6 @@ static int rest_decode_post(UNUSED rlm_rest_t *instance,
 		reference = request;
 
 		name = curl_easy_unescape(candle, p, (q - p), &curl_len);
-		attribute = name;
 		p = (q + 1);
 
 		RDEBUG("Decoding attribute \"%s\"", name);


### PR DESCRIPTION
When web server replies to a REST request with a x-www-form-urlencoded body, if more than one attribute is provided then rlm_rest makes freeradius crash.

The problem appears to be related with the behavior of the "radius_axlat" function. If the pointer to the output buffer provided as parameter isn't NULL, the function uses the current value instead of providing a new buffer; and if the buffer pointed to has already been freed, the process segfaults.
