### PR TITLE
Initialize IPv6 scope in ip_ptonx

### DIFF
--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -537,6 +537,8 @@ int ip_ptonx(char const *src, fr_ipaddr_t *dst)
 	}
 #endif
 
+	dst->scope = 0;
+
 	return 0;
 }
 


### PR DESCRIPTION
Set IPv6 address scope ID (fr_ip_addr_t.scope) to zero in ip_ptonx.

This avoids possible random %{getclient:<ipaddr>.foo} IPv6 client lookup
failures due to the scope ID being uninitialized, but then used in
fr_ipaddr_cmp, invoked by client_find, used in xlat_getclient.

The issue was found during a Coverity scan of 3.0.1 and reported as
follows:

freeradius-server-3.0.1/src/main/mainconfig.c:374: var_decl: Declaring variable "ip" without initializer.
freeradius-server-3.0.1/src/main/mainconfig.c:394: uninit_use_in_call: Using uninitialized value "ip". Field "ip.scope" is uninitialized when calling "client_find(RADCLIENT_LIST const *, fr_ipaddr_t const *, int)".
freeradius-server-3.0.1/src/main/client.c:466:3: read_parm: Reading a parameter value.
