### PR TITLE
basic config for dhcp IP allocation using sqlite

### DIFF
--- a/raddb/mods-available/dhcp_sqlippool
+++ b/raddb/mods-available/dhcp_sqlippool
@@ -14,8 +14,14 @@ sqlippool dhcp_sqlippool {
 	# Client's MAC address is mapped to Calling-Station-Id in policy.conf
 	pool_key = "%{Calling-Station-Id}"
 
-	# For now, it only works with MySQL.
+	# For now, it works with MySQL.
 	$INCLUDE ${modconfdir}/sql/ippool-dhcp/mysql/queries.conf
+
+	# It may also work with sqlite - this is very experimental.
+	# Comment out the above line and add the following include.
+	# To use sqlite you need to add '%' to safe_characters in
+	# raddb/mods-config/sql/main/sqlite/queries.conf.
+	# $INCLUDE ${modconfdir}/sql/ippool-dhcp/sqlite/queries.conf
 
 	sqlippool_log_exists = "DHCP: Existing IP: %{reply:Framed-IP-Address} (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
 

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -4,6 +4,11 @@
 ##
 ##	$Id$
 
+
+# To use these queries you need to add '%' to safe_characters
+# in raddb/mods-config/sql/main/sqlite/queries.conf
+
+
 # ## This series of queries allocates an IP address
 # allocate_clear = "UPDATE ${ippool_table} \
 #  SET nasipaddress = '', pool_key = 0, \
@@ -20,7 +25,7 @@ allocate_clear = "UPDATE ${ippool_table} \
   SET nasipaddress = '', pool_key = 0, \
   callingstationid = '', username = '', \
   expiry_time = NULL \
-  WHERE expiry_time <= NOW() - INTERVAL 1 SECOND \
+  WHERE expiry_time <= datetime(strftime('%%%%s', 'now') - 1, 'unixepoch') \
   AND nasipaddress = '%{Nas-IP-Address}'"
 
 
@@ -28,12 +33,13 @@ allocate_clear = "UPDATE ${ippool_table} \
 ## The ORDER BY clause of this query tries to allocate the same IP-address
 ## which user had last session...
 allocate_find = "SELECT framedipaddress FROM ${ippool_table} \
- WHERE pool_name = '%{control:Pool-Name}' AND (expiry_time < NOW() OR expiry_time IS NULL) \
- ORDER BY (username <> '%{User-Name}'), \
- (callingstationid <> '%{Calling-Station-Id}'), \
+ WHERE pool_name = '%{control:Pool-Name}' AND \
+   ( (expiry_time < datetime('now') OR expiry_time IS NULL) \
+     OR \
+     (callingstationid = '%{Calling-Station-Id}') AND expiry_time > datetime('now') ) \
+ ORDER BY (callingstationid <> '%{Calling-Station-Id}'), \
  expiry_time \
- LIMIT 1 \
- FOR UPDATE"
+ LIMIT 1"
 
 # ## If you prefer to allocate a random IP address every time, i
 # ## use this query instead
@@ -58,15 +64,19 @@ pool_check = "SELECT id FROM ${ippool_table} \
 allocate_update = "UPDATE ${ippool_table} \
  SET nasipaddress = '%{NAS-IP-Address}', pool_key = '${pool_key}', \
  callingstationid = '%{Calling-Station-Id}', username = '%{User-Name}', \
- expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
+ expiry_time = datetime(strftime('%%%%s', 'now') + ${lease_duration}, 'unixepoch') \
  WHERE framedipaddress = '%I' AND expiry_time IS NULL"
 
+
+
+
+# The following queries are not used for DHCP IP assignment.
 
 
 ## This series of queries frees an IP number when an accounting
 ## START record arrives
 start_update = "UPDATE ${ippool_table} \
- SET expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
+ SET expiry_time = datetime(strftime('%%%%s', 'now') + ${lease_duration}, 'unixepoch') \
  WHERE nasipaddress = '%{NAS-IP-Address}' AND  pool_key = '${pool_key}' \
  AND username = '%{User-Name}' \
  AND callingstationid = '%{Calling-Station-Id}' \
@@ -87,7 +97,7 @@ stop_clear = "UPDATE ${ippool_table} \
 ## This series of queries frees an IP number when an accounting
 ## ALIVE record arrives
 alive_update = "UPDATE ${ippool_table} \
- SET expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
+ SET expiry_time = datetime(strftime('%%%%s', 'now') + ${lease_duration}, 'unixepoch') \
  WHERE nasipaddress = '%{Nas-IP-Address}' AND pool_key = '${pool_key}' \
  AND username = '%{User-Name}' \
  AND callingstationid = '%{Calling-Station-Id}' \

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
@@ -1,0 +1,18 @@
+CREATE TABLE radippool (
+        id                      int PRIMARY KEY,
+        pool_name               varchar(30) NOT NULL,
+        framedipaddress         varchar(30) NOT NULL,
+        nasipaddress            varchar(30) NOT NULL DEFAULT '',
+        pool_key                varchar(64) NOT NULL DEFAULT '',
+        calledstationid         varchar(64),
+        callingstationid        varchar(64) NOT NULL DEFAULT '',
+        expiry_time             timestamp DEFAULT NULL,
+        username                varchar(100)
+);
+ 
+-- Example of how to put IPs in the pool
+-- INSERT INTO radippool (id, pool_name, framedipaddress) VALUES (1, 'local', '192.168.5.10');
+-- INSERT INTO radippool (id, pool_name, framedipaddress) VALUES (2, 'local', '192.168.5.11');
+-- INSERT INTO radippool (id, pool_name, framedipaddress) VALUES (3, 'local', '192.168.5.12');
+-- INSERT INTO radippool (id, pool_name, framedipaddress) VALUES (4, 'local', '192.168.5.13');
+

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -149,7 +149,11 @@ dhcp DHCP-Discover {
 	# ...
 	#}
 
-	#  Or, allocate IPs from the DHCP pool in SQL.
+	#  Or, allocate IPs from the DHCP pool in SQL. You may need to
+	#  set the pool name here if you haven't set it elsewhere.
+#	update control {
+#		Pool-Name := "local"
+#	}
 #	dhcp_sqlippool
 
 	#  If DHCP-Message-Type is not set, returning "ok" or
@@ -191,7 +195,11 @@ dhcp DHCP-Request {
 	# ...
 	#}
 
-	#  Or, allocate IPs from the DHCP pool in SQL.
+	#  Or, allocate IPs from the DHCP pool in SQL. You may need to
+	#  set the pool name here if you haven't set it elsewhere.
+#	update control {
+#		Pool-Name := "local"
+#	}
 #	dhcp_sqlippool
 
 	#  If DHCP-Message-Type is not set, returning "ok" or


### PR DESCRIPTION
This is rather experimental, but does seem to work. I've got 4 addresses in a pool and FR is currently allocating them to two devices, storing in an sqlite database. That's as much as I've tested...
