### PR TITLE
Fix DAS response Message-Authenticator calculation

### DIFF
--- a/src/lib/radius.c
+++ b/src/lib/radius.c
@@ -1925,10 +1925,7 @@ int rad_sign(RADIUS_PACKET *packet, RADIUS_PACKET const *original,
 
 		case PW_CODE_ACCOUNTING_REQUEST:
 		case PW_CODE_DISCONNECT_REQUEST:
-		case PW_CODE_DISCONNECT_ACK:
-		case PW_CODE_DISCONNECT_NAK:
 		case PW_CODE_COA_REQUEST:
-		case PW_CODE_COA_ACK:
 			memset(hdr->vector, 0, AUTH_VECTOR_LEN);
 			break;
 
@@ -1936,6 +1933,10 @@ int rad_sign(RADIUS_PACKET *packet, RADIUS_PACKET const *original,
 		case PW_CODE_AUTHENTICATION_ACK:
 		case PW_CODE_AUTHENTICATION_REJECT:
 		case PW_CODE_ACCESS_CHALLENGE:
+		case PW_CODE_DISCONNECT_ACK:
+		case PW_CODE_DISCONNECT_NAK:
+		case PW_CODE_COA_ACK:
+		case PW_CODE_COA_NAK:
 			if (!original) {
 				fr_strerror_printf("ERROR: Cannot sign response packet without a request packet");
 				return -1;
@@ -2754,11 +2755,7 @@ int rad_verify(RADIUS_PACKET *packet, RADIUS_PACKET *original,
 
 			case PW_CODE_ACCOUNTING_REQUEST:
 			case PW_CODE_DISCONNECT_REQUEST:
-			case PW_CODE_DISCONNECT_ACK:
-			case PW_CODE_DISCONNECT_NAK:
 			case PW_CODE_COA_REQUEST:
-			case PW_CODE_COA_ACK:
-			case PW_CODE_COA_NAK:
 			  	memset(packet->data + 4, 0, AUTH_VECTOR_LEN);
 				break;
 
@@ -2766,6 +2763,10 @@ int rad_verify(RADIUS_PACKET *packet, RADIUS_PACKET *original,
 			case PW_CODE_AUTHENTICATION_ACK:
 			case PW_CODE_AUTHENTICATION_REJECT:
 			case PW_CODE_ACCESS_CHALLENGE:
+			case PW_CODE_DISCONNECT_ACK:
+			case PW_CODE_DISCONNECT_NAK:
+			case PW_CODE_COA_ACK:
+			case PW_CODE_COA_NAK:
 				if (!original) {
 					fr_strerror_printf("ERROR: Cannot validate Message-Authenticator in response packet without a request packet");
 					return -1;


### PR DESCRIPTION
Message-Authenticator attribute in CoA-ACK, CoA-NAK,
Disconnect-ACK or Disconnect-NAK is calculated with
Request Authenticator taken from request by rfc5176.
