### PR TITLE
Update to rlm_perl to also handle sub-sections in "config" section

### DIFF
--- a/raddb/mods-available/perl
+++ b/raddb/mods-available/perl
@@ -29,11 +29,15 @@ perl {
 	#  which is included.
 	#
 
-	# You can define configuration items in perl "config" sub-section.
+	# You can define configuration items (and nested sub-sections) in perl "config" section.
 	# These items will be accessible in the perl script through %RAD_PERLCONF hash.
-	# For instance: $RAD_PERLCONF{'name'}
+	# For instance: $RAD_PERLCONF{'name'} $RAD_PERLCONF{'sub-config'}->{'name'}
+	#
 	#config {
-	#	name = value
+	#	name = "value"
+	#	sub-config {
+	#		name = "value of name from config.sub-config"
+	#	}
 	#}
 	
 	#


### PR DESCRIPTION
Also, the code is more efficient now: the HV only needs to be built
once, at instantiate (because its content cannot change).
