### PR TITLE
Make radeapclient build/work in 3.0.x branch

### DIFF
--- a/src/modules/rlm_eap/radeapclient.mk
+++ b/src/modules/rlm_eap/radeapclient.mk
@@ -1,11 +1,16 @@
-TARGET   :=
+TARGET   := radeapclient
 SOURCES := radeapclient.c
 
 ifneq ($(OPENSSL_LIBS),)
 SOURCES += ${top_srcdir}/src/main/cb.c ${top_srcdir}/src/main/tls.c
 endif
 
-TGT_PREREQS := libfreeradius-radius.a libfreeradius-eap.a
+SOURCES += ${top_srcdir}/src/main/files.c \
+${top_srcdir}/src/main/threads.c \
+${top_srcdir}/src/main/version.c
+
+TGT_PREREQS := libfreeradius-radius.a libfreeradius-eap.a libfreeradius-server.a
 TGT_LDLIBS  := $(LIBS)
+TGT_LDLIBS	+= -lssl
 
 SRC_INCDIRS  := libeap


### PR DESCRIPTION
My goal was to have a working version of radeapclient in 3.0.x, _not_ to
improve it in any way (for now).
Here is what I did:
1. make the build work.
   This includes the following changes:
- undefined references: SSL_*
  -> added to .mk: -lssl
- undefined references: radlog_request, radlog_request_error,
  rad_assert_fail, radius_exec_program, cf_data_find, cf_section_parse,
  cf_data_add, cf_pair_find, cf_pair_value, cf_item_parent,
  cf_section_sub_find, cf_sectiontoitem, cf_section_sub_find_name2
  -> added to .mk: libfreeradius-server.a
- more undefined references:
  pairlist_read, pairlist_free -> main/files.c
  rad_fork, rad_waitpid -> main/threads.c
- undefined reference: mainconfig
  -> added to radeapclient.c:
  struct main_config_t mainconfig;
- problem with "const" qualifiers in FreeRADIUS structures.
  Using non "const" pointers to make it build/work.
1. fix the segmentation fault issues.
   This includes the following changes:
2. after each "paircreate" for an octets or string attribute, allocate a
   buffer for vp_strvalue (or vp_octets) through talloc_zero_array (or
   talloc_memdup).
3. use a talloc'ed eap_packet_t (instead of a static variable) in
   functions map_eap_methods and map_eapsim_types (because it is used as a
   talloc context by called functions).
4. fix the free -> talloc_free issue in eapsimlib.c
5. removed a check that made no sense in sendrecv_eap.
6. tested for EAP/SIM.
   NOT tested for EAP/MD5, although I corrected the missing allocation in
   the related code.
