### PR TITLE
Fix crash in krb5 when acquiring the TGT fails

### DIFF
--- a/src/modules/rlm_krb5/rlm_krb5.c
+++ b/src/modules/rlm_krb5/rlm_krb5.c
@@ -458,6 +458,7 @@ static rlm_rcode_t mod_authenticate(void *instance, REQUEST *request)
 					   NULL, NULL, 0, NULL, inst->gic_options);
 	if (ret) {
 		rcode = krb5_process_error(request, conn, ret);
+		goto cleanup;
 	}
 
 	RDEBUG("Attempting to authenticate against service principal");


### PR DESCRIPTION
rlm_krb5 will log the error code but continue anyway, so any kind of failed Kerberos authentication (unknown user, wrong password, etc.) would instantly crash radiusd.
