### PR TITLE
3.0.x - radeapclient - parallel mode (and more stuff)

### DIFF
--- a/src/modules/rlm_perl/rlm_perl.c
+++ b/src/modules/rlm_perl/rlm_perl.c
@@ -662,7 +662,8 @@ static int pairadd_sv(TALLOC_CTX *ctx, REQUEST *request, VALUE_PAIR **vps, char 
 	VALUE_PAIR      *vp;
 
 	if (SvOK(sv)) {
-		val = SvPV_nolen(sv);
+		STRLEN len;
+		val = SvPV(sv, len);
 		vp = pairmake(ctx, vps, key, NULL, op);
 		if (!vp) {
 		fail:
@@ -673,7 +674,7 @@ static int pairadd_sv(TALLOC_CTX *ctx, REQUEST *request, VALUE_PAIR **vps, char 
 		if (vp->da->type != PW_TYPE_STRING) {
 			if (!pairparsevalue(vp, val)) goto fail;
 		} else {
-			pairstrcpy(vp, val);
+			pairstrncpy(vp, val, len);
 		}
 
 		RDEBUG("-->  %s = %s", key, val);


### PR DESCRIPTION
I know, the diff will be useless on so many changes, but it wasn't feasible to do small commits on this one.
Anyhow, it works. Still does all what the old radeapclient was doing before, and much more.
I use it mainly for EAP-SIM, but tested also EAP-MD5 (and non EAP requests).
As always, all comments are welcome :)

- Added a "rce_request_t" structure which allows to store a request
context.
- Load all requests from files (or stdin) in memory in a list of
"rce_request_t".
- Use packet list and socket functions provided by FreeRADIUS library.
- Added support for "parallel" (option -p) and "send rate" (option -n).
- Added a "receive/send" loop, sends requests in parallel mode (similar
to radclient).
- Added statistics (option -s).
- Better handling of output according to debug/quiet (options -x and
-q). No more wilds printf's.
- Bug fix in EAP-SIM client state machine (error case).
- Updated attribute handling as from latest radclient code.