### PR TITLE
Make internal references match configuration references and update README

### DIFF
--- a/src/modules/rlm_couchbase/README.md
+++ b/src/modules/rlm_couchbase/README.md
@@ -43,7 +43,7 @@ This exmaple is from an Aerohive wireless access point.
       "strippedUserDomain": "blargs.com"
     }
 
-To generate the 'calledStationSSID' fields you will need to use the ```rewrite_called_station_id``` policy in the ```preacct``` section of your config.  Similarly to get the 'Stripped-User-Name' and 'Stripped-User-Domain' attributes I create a file in ```raddb/policy.d/``` with the following content:
+To generate the 'calledStationSSID' fields you will need to use the ```rewrite_called_station_id``` policy in the ```preacct``` section of your config.  Similarly to get the 'Stripped-User-Name' and 'Stripped-User-Domain' attributes you can create a file in ```raddb/policy.d/``` with the following content:
 
     ## nt domain regex
     simple_nt_regexp = "^([^\\\\\\\\]*)(\\\\\\\\(.*))$"
@@ -70,14 +70,14 @@ To generate the 'calledStationSSID' fields you will need to use the ```rewrite_c
       }
     }
 
-I then reference this policy in both the ```preacct``` and ```authorization``` sections of my configuration before referencing this module.
+You can then reference this policy in both the ```preacct``` and ```authorization``` sections of your configuration before calling this module.
 
 Authorization
 -------------
 
 The authorization funcionality relies on the user documents being stored with deterministic keys based on information available in the authorization request.  The format of those keys may be specified in unlang like the example below:
 
-    userkey = "raduser_%{md5:%{tolower:%{%{Stripped-User-Name}:-%{User-Name}}}}"
+    user_key = "raduser_%{md5:%{tolower:%{%{Stripped-User-Name}:-%{User-Name}}}}"
 
 This will create an md5 hash of the lowercase 'Stripped-User-Name' attribute or the 'User-Name' attribute if 'Stripped-User-Name' doesn't exist.  The module will then attempt to fetch the resulting key from the configured couchbase bucket.
 
@@ -125,11 +125,11 @@ Configuration
         # Couchbase bucket name
         bucket = "radius"
 
-        # Couchbase bucket password
-        #pass = "password"
+        # Couchbase bucket password (optional)
+        #password = "password"
 
         # Couchbase accounting document key (unlang supported)
-        acctkey = "radacct_%{%{Acct-Unique-Session-Id}:-%{Acct-Session-Id}}"
+        acct_key = "radacct_%{%{Acct-Unique-Session-Id}:-%{Acct-Session-Id}}"
 
         # Value for the 'docType' element in the json body for accounting documents
         doctype = "radacct"
@@ -176,7 +176,7 @@ Configuration
         }
 
         # Couchbase document key for user documents (unlang supported)
-        userkey = "raduser_%{md5:%{tolower:%{%{Stripped-User-Name}:-%{User-Name}}}}"
+        user_key = "raduser_%{md5:%{tolower:%{%{Stripped-User-Name}:-%{User-Name}}}}"
 
         #
         #  The connection pool is new for 3.0, and will be used in many
@@ -230,9 +230,3 @@ Configuration
             # or increase lifetime/idle_timeout.
         }
     }
-
-Notes
------
-
-This module was built and tested against the latest [FreeRADIUS v3.0.x branch](https://github.com/FreeRADIUS/freeradius-server/tree/v3.0.x)
-as of the most current commit to this repository.

--- a/src/modules/rlm_couchbase/mod.c
+++ b/src/modules/rlm_couchbase/mod.c
@@ -43,7 +43,7 @@ void *mod_conn_create(void *instance) {
 	lcb_error_t cb_error = LCB_SUCCESS;         /* couchbase error status */
 
 	/* create instance */
-	cb_inst = couchbase_init_connection(inst->server, inst->bucket, inst->pass);
+	cb_inst = couchbase_init_connection(inst->server, inst->bucket, inst->password);
 
 	/* check couchbase instance status */
 	if ((cb_error = lcb_get_last_error(cb_inst)) != LCB_SUCCESS) {

--- a/src/modules/rlm_couchbase/mod.h
+++ b/src/modules/rlm_couchbase/mod.h
@@ -41,13 +41,13 @@ RCSIDH(mod_h, "$Id$");
 
 /* configuration struct */
 typedef struct rlm_couchbase_t {
-	const char *acctkey;            /* accounting document key */
+	const char *acct_key;           /* accounting document key */
 	const char *doctype;            /* value of 'docType' element name */
 	char *server;                   /* couchbase server list */
 	const char *bucket;             /* couchbase bucket */
-	const char *pass;               /* couchbase bucket password */
+	const char *password;           /* couchbase bucket password */
 	unsigned int expire;            /* document expire time in seconds */
-	const char *userkey;            /* user document key */
+	const char *user_key;           /* user document key */
 	json_object *map;               /* json object to hold user defined attribute map */
 	fr_connection_pool_t *pool;     /* connection pool */
 } rlm_couchbase_t;

--- a/src/modules/rlm_couchbase/rlm_couchbase.c
+++ b/src/modules/rlm_couchbase/rlm_couchbase.c
@@ -41,14 +41,14 @@ RCSID("$Id$");
  * Module Configuration
  */
 static const CONF_PARSER module_config[] = {
-	{"acct_key", PW_TYPE_STRING_PTR, offsetof(rlm_couchbase_t, acctkey), NULL,
+	{"acct_key", PW_TYPE_STRING_PTR, offsetof(rlm_couchbase_t, acct_key), NULL,
 		"radacct_%{%{Acct-Unique-Session-Id}:-%{Acct-Session-Id}}"},
 	{"doctype", PW_TYPE_STRING_PTR, offsetof(rlm_couchbase_t, doctype), NULL, "radacct"},
 	{"server", PW_TYPE_STRING_PTR | PW_TYPE_REQUIRED, offsetof(rlm_couchbase_t, server), NULL, NULL},
 	{"bucket", PW_TYPE_STRING_PTR | PW_TYPE_REQUIRED, offsetof(rlm_couchbase_t, bucket), NULL, NULL},
-	{"password", PW_TYPE_STRING_PTR, offsetof(rlm_couchbase_t, pass), NULL, NULL},
+	{"password", PW_TYPE_STRING_PTR, offsetof(rlm_couchbase_t, password), NULL, NULL},
 	{"expire", PW_TYPE_INTEGER, offsetof(rlm_couchbase_t, expire), NULL, 0},
-	{"user_key", PW_TYPE_STRING_PTR | PW_TYPE_REQUIRED, offsetof(rlm_couchbase_t, userkey), NULL,
+	{"user_key", PW_TYPE_STRING_PTR | PW_TYPE_REQUIRED, offsetof(rlm_couchbase_t, user_key), NULL,
 		"raduser_%{md5:%{tolower:%{%{Stripped-User-Name}:-%{User-Name}}}}"},
 	{NULL, -1, 0, NULL, NULL}     /* end the list */
 };
@@ -119,9 +119,9 @@ static rlm_rcode_t CC_HINT(nonnull) mod_authorize(void *instance, REQUEST *reque
 	rad_assert(request->packet != NULL);
 
 	/* attempt to build document key */
-	if (radius_xlat(dockey, sizeof(dockey), request, inst->userkey, NULL, NULL) < 0) {
+	if (radius_xlat(dockey, sizeof(dockey), request, inst->user_key, NULL, NULL) < 0) {
 		/* log error */
-		RERROR("could not find user key attribute (%s) in packet", inst->userkey);
+		RERROR("could not find user key attribute (%s) in packet", inst->user_key);
 		/* return */
 		return RLM_MODULE_FAIL;
 	}
@@ -266,9 +266,9 @@ static rlm_rcode_t CC_HINT(nonnull) mod_accounting(void *instance, REQUEST *requ
 	}
 
 	/* attempt to build document key */
-	if (radius_xlat(dockey, sizeof(dockey), request, inst->acctkey, NULL, NULL) < 0) {
+	if (radius_xlat(dockey, sizeof(dockey), request, inst->acct_key, NULL, NULL) < 0) {
 		/* log error */
-		RERROR("could not find accounting key attribute (%s) in packet", inst->acctkey);
+		RERROR("could not find accounting key attribute (%s) in packet", inst->acct_key);
 		/* release handle */
 		if (handle) {
 			fr_connection_release(inst->pool, handle);


### PR DESCRIPTION
Small tweaks to make internal references match the newly renamed configuration items.  I also changed the README.md file to reflect the new config items.
