### PR TITLE
comment out of the mixed-case check

### DIFF
--- a/raddb/policy.d/filter
+++ b/raddb/policy.d/filter
@@ -16,18 +16,19 @@ deny_realms {
 #  what constitutes a user name.
 #
 filter_username {
-	#
-	#  reject mixed case
-	#  e.g. "UseRNaMe"
-	#
+	
 
 	if (!User-Name) {
 		noop
 	}
 
-	if (User-Name != "%{tolower:%{User-Name}}") {
-		reject
-	}
+	#
+	#  reject mixed case e.g. "UseRNaMe"
+	#
+	
+	#if (User-Name != "%{tolower:%{User-Name}}") {
+	#	reject
+	#}
 
 	#
 	#  reject all whitespace


### PR DESCRIPTION
its annoying to have this check on by default. its not used by many places and when they do try to implement pseudo NAI filtering for best practice it breaks their auths.
