### PR TITLE
add missing 'acct' option to struct

### DIFF
--- a/src/main/radclient.c
+++ b/src/main/radclient.c
@@ -114,6 +114,7 @@ static void NEVER_RETURNS usage(void)
 static const FR_NAME_NUMBER request_types[] = {
 	{ "auth",	PW_CODE_AUTHENTICATION_REQUEST },
 	{ "challenge",	PW_CODE_ACCESS_CHALLENGE },
+	{ "acct",	PW_CODE_ACCOUNTING_REQUEST },
 	{ "status",	PW_CODE_STATUS_SERVER },
 	{ "disconnect",	PW_CODE_DISCONNECT_REQUEST },
 	{ "coa",	PW_CODE_COA_REQUEST },


### PR DESCRIPTION
It appears 'acct' got left out of the new `request_types` struct with 77accf3565c92035275a2d205948b3a6468e4705 ... this seems to fix the issue.
