### PR TITLE
V3.0.x redhat 20140523

### DIFF
--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -397,6 +397,7 @@ rm -rf $RPM_BUILD_ROOT/%{_includedir}
 
 # remove unsupported config files
 rm -f $RPM_BUILD_ROOT/%{_sysconfdir}/raddb/experimental.conf
+rm -rf $RPM_BUILD_ROOT/%{_sysconfdir}/raddb/mods-config/unbound
 
 # install doc files omitted by standard install
 for f in COPYRIGHT CREDITS INSTALL.rst README.rst; do
@@ -595,6 +596,7 @@ fi
 %{_libdir}/freeradius/rlm_sql_sqlite.so
 %{_libdir}/freeradius/rlm_sqlcounter.so
 %{_libdir}/freeradius/rlm_sqlippool.so
+%{_libdir}/freeradius/rlm_unpack.so
 %{_libdir}/freeradius/rlm_unix.so
 %{_libdir}/freeradius/rlm_utf8.so
 %{_libdir}/freeradius/rlm_wimax.so


### PR DESCRIPTION
Build fix for redhat.

Without this, the build fails with

[  178s] error: Installed (but unpackaged) file(s) found:
[  178s]    /etc/raddb/mods-config/unbound/default.conf
[  178s]    /usr/lib64/freeradius/rlm_unpack.so

I'm not sure whether rlm_unpack should even be built, but since rlm_sqlite (which is not stable) is also built and included in the RPM, I added rlm_unpack.so to %files as well.

rlm_unbound was not built, so remove it's orphan config.
