### PR TITLE
V2.x.x redhat 20140523

### DIFF
--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -308,6 +308,7 @@ exit 0
 %config(noreplace) /etc/raddb/ldap.attrmap
 %dir %attr(750,root,radiusd) /etc/raddb/modules
 %attr(640,root,radiusd) %config(noreplace) /etc/raddb/modules/*
+%attr(640,root,radiusd) %config(noreplace) /etc/raddb/panic.gdb
 %attr(640,root,radiusd) %config(noreplace) /etc/raddb/policy.conf
 %config(noreplace) /etc/raddb/policy.txt
 %attr(640,root,radiusd) %config(noreplace) /etc/raddb/preproxy_users


### PR DESCRIPTION
redhat build fix: add new config file (panic.gdb) to %files.

Tested to succesfully create fr-2.2.5 packages for centos 5 & 6 on
http://software.opensuse.org/download.html?project=home%3Afreeradius%3A2.x.x%3Acentos&package=freeradius
