### PR TITLE
Fix compilation of rlm_eap

### DIFF
--- a/src/modules/rlm_eap/types/rlm_eap_tnc/rlm_eap_tnc.c
+++ b/src/modules/rlm_eap/types/rlm_eap_tnc/rlm_eap_tnc.c
@@ -60,7 +60,7 @@
 #define SET_START(x) 		((x) | (0x20))
 
 typedef struct rlm_eap_tnc {
-	char	*connection_string;
+	char const	*connection_string;
 } rlm_eap_tnc_t;
 
 static CONF_PARSER module_config[] = {


### PR DESCRIPTION
Mark rlm_eap_tnc connection_string const to cater to FR_CONF_OFFSET
invocation. This fixes the build of rlm_eap module.

The reported error was this:
src/modules/rlm_eap/types/rlm_eap_tnc/rlm_eap_tnc.c:67:2: error: initializer element is not constant
  { "connection_string", FR_CONF_OFFSET(PW_TYPE_STRING, rlm_eap_tnc_t, connection_string), "NAS Port: %{NAS-Port} NAS IP: %{NAS-IP-Address} NAS_PORT_TYPE: %{NAS-Port-Type}" },
  ^
src/modules/rlm_eap/types/rlm_eap_tnc/rlm_eap_tnc.c:67:2: error: (near initialization for ‘module_config[0].offset’)
