### PR TITLE
Cast interval values to ints before use, so we don't get sign issues ...

### DIFF
--- a/src/modules/rlm_cache/rlm_cache.c
+++ b/src/modules/rlm_cache/rlm_cache.c
@@ -202,7 +202,7 @@ static rlm_cache_entry_t *cache_find(rlm_cache_t *inst, REQUEST *request,
 	 *	passed.  Delete it, and pretend it doesn't exist.
 	 */
 	if ((c->expires < request->timestamp) ||
-	    (c->created < inst->epoch)) {
+	    (c->created < (int)inst->epoch)) {
 	delete:
 		RDEBUG("Entry has expired, removing");
 


### PR DESCRIPTION
... with time_t.

This one escaped in #659, and I didn't really see a button to reopen a closed issue.
