### PR TITLE
V2.x.x suse specfile build fix

### DIFF
--- a/suse/freeradius.spec
+++ b/suse/freeradius.spec
@@ -24,12 +24,10 @@ PreReq:       perl
 PreReq:       %insserv_prereq %fillup_prereq
 BuildRoot:    %{_tmppath}/%{name}-%{version}-build
 %define _oracle_support	0
-%define apxs2 apxs2-prefork
-%define apache2_sysconfdir %(%{_sbindir}/%{apxs2} -q SYSCONFDIR)
+%define apache2_sysconfdir /etc/apache2
 Requires:      %{name}-libs = %{version}
 Requires:      python
 Recommends:    logrotate
-BuildRequires: apache2-devel 
 BuildRequires: cyrus-sasl-devel
 BuildRequires: db-devel
 BuildRequires: gcc-c++
@@ -328,6 +326,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_sysconfdir}/init.d/radiusd
 %config %{_sysconfdir}/pam.d/radiusd
 %config %{_sysconfdir}/logrotate.d/freeradius-server
+%dir %{_sysconfdir}/tmpfiles.d
 %config %{_sysconfdir}/tmpfiles.d/radiusd.conf
 %{_sbindir}/rcradiusd
 %dir %attr(755,radiusd,radiusd) %{_localstatedir}/lib/radiusd
@@ -433,6 +432,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/dialup_admin/sql/
 %dir %{_datadir}/dialup_admin/conf/
 %config(noreplace) %{_datadir}/dialup_admin/conf/*
+%dir %{apache2_sysconfdir}
+%dir %{apache2_sysconfdir}/conf.d
 %config(noreplace) %{apache2_sysconfdir}/conf.d/radius.conf
 %{_datadir}/dialup_admin/Changelog
 %{_datadir}/dialup_admin/README


### PR DESCRIPTION
The first commit is similar to the one already commiteed for redhat: add raddb/panic.gdb

The second one is to fix an error that were not catched previously, but manifested itself on opensuse build service, since the build service also installs the build packages as part of its internal test. 

The build service would complain

[   79s] Warning: spec file parser line 280: can't expand %(...)
[   79s] Warning: spec file parser line 281: can't expand %(...)
[   79s] Warning: spec file parser line 436: can't expand %(...)

... when it sees lines like this

install -d -m 755 $RPM_BUILD_ROOT%{apache2_sysconfdir}/conf.d

... because it can't expand this line early in the spec file

%define apache2_sysconfdir %(%{_sbindir}/%{apxs2} -q SYSCONFDIR)

... which it turns leads the conf.d dir to be expanded as /conf.d (which is incorrect).

Changing it to %define apache2_sysconfdir /etc/apache2 fixes part of the issue, but at the end the build service would still error out with lines like these

[  328s] freeradius-server-2.2.5-20.1.x86_64.rpm: directories not owned by a package:
[  328s]  - /etc/tmpfiles.d

[  654s] freeradius-server-dialupadmin-2.2.5-17.1.x86_64.rpm: directories not owned by a package:
[  654s]  - /etc/apache2
[  654s]  - /etc/apache2/conf.d

Since directories can be owned by multiple package, the quick fix was to list them as directories owned by their respective packages. Until someone with better knowledge of *suse steps in, it will have to do.

Build status for all suse versions supported by opensuse build service (all built successfully, except for arm, which at the point of writing is at "scheduled"): https://build.opensuse.org/package/show/home:freeradius:2.x.x:suse/freeradius-server

Binary/repo links for various suse versions:  http://software.opensuse.org/download.html?project=home%3Afreeradius%3A2.x.x%3Asuse&package=freeradius-server
