### PR TITLE
V3.0.x suse specfile build fix

### DIFF
--- a/suse/freeradius.spec
+++ b/suse/freeradius.spec
@@ -26,6 +26,7 @@ BuildRequires: gdbm-devel
 BuildRequires: glibc-devel
 BuildRequires: libtalloc-devel
 BuildRequires: openldap2-devel
+BuildRequires: openssl
 BuildRequires: openssl-devel
 BuildRequires: pam-devel
 BuildRequires: perl
@@ -216,6 +217,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_sysconfdir}/init.d/freeradius
 %config %{_sysconfdir}/pam.d/radiusd
 %config %{_sysconfdir}/logrotate.d/freeradius-server
+%dir %{_sysconfdir}/tmpfiles.d
 %config %{_sysconfdir}/tmpfiles.d/radiusd.conf
 %dir %attr(755,radiusd,radiusd) %{_localstatedir}/lib/radiusd
 # configs
@@ -243,13 +245,16 @@ rm -rf $RPM_BUILD_ROOT
 %attr(755,root,root) %{_libdir}/freeradius/rlm_*.so*
 
 %files utils
+%defattr(-,root,root)
 /usr/bin/*
 
 %files libs
 # RADIUS shared libs
 %attr(755,root,root) %dir %{_libdir}/freeradius
-%attr(755,root,root) %{_libdir}/freeradius/*.so*
+%attr(755,root,root) %{_libdir}/freeradius/lib*.so*
+%attr(755,root,root) %{_libdir}/freeradius/proto*.so*
 
 %files devel
 %defattr(-,root,root)
+%dir /usr/include/freeradius
 %attr(644,root,root) /usr/include/freeradius/*.h


### PR DESCRIPTION
Fixes the following build errors:

sle11sp2:
[  201s] ... checking for files with abuild user/group
[  201s]   abuild abuild /usr/bin/dhcpclient
[  201s]   abuild abuild /usr/bin/rad_counter
[  201s]   abuild abuild /usr/bin/radattr
...
=> +%defattr(-,root,root)

sle 11sp3:
[  342s] openssl dhparam -out dh 1024
[  342s] gmake[1]: openssl: Command not found
[  342s] gmake[1]: **\* [dh] Error 127
[  342s] gmake[1]: Leaving directory `/var/tmp/freeradius-server-3.0.3-build/etc/raddb/certs'
[  342s] make: **\* [/var/tmp/freeradius-server-3.0.3-build/etc/raddb/certs/ca.key] Error 2
[  342s] error: Bad exit status from /var/tmp/rpm-tmp.15861 (%install)
=> +BuildRequires: openssl

opensuse 13.1:
[  489s] freeradius-server-devel-3.0.3-8.1.x86_64.rpm: directories not owned by a package:
[  489s]  - /usr/include/freeradius
=> +%dir /usr/include/freeradius

opensuse factory:
[  614s] found conflict of freeradius-server-3.0.3-9.1.x86_64 with freeradius-server-libs-3.0.3-9.1.x86_64:
[  614s]   - /usr/lib64/freeradius/rlm_always.so
[  614s]   - /usr/lib64/freeradius/rlm_attr_filter.so
...
=>
 -%attr(755,root,root) %{_libdir}/freeradius/_.so_
 +%attr(755,root,root) %{_libdir}/freeradius/lib_.so_
 +%attr(755,root,root) %{_libdir}/freeradius/proto_.so_

Build status: https://build.opensuse.org/package/show/home:freeradius:3.0.x:suse/freeradius-server
Packages: http://software.opensuse.org/download.html?project=home%3Afreeradius%3A3.0.x%3Asuse&package=freeradius-server
