### PR TITLE
Added debian/freeradius-rest to gitignore

### DIFF
--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -6,6 +6,7 @@ freeradius-krb5
 freeradius-ldap
 freeradius-mysql
 freeradius-postgresql
+freeradius-rest
 freeradius-utils
 freeradius
 libfreeradius-dev


### PR DESCRIPTION
Otherwise, building a Debian package leaves a change in the repository.
Tested with Debian Wheezy 32bit on tag release_3_0_4_rc0 and current
master (commit 73c90fc26a6a56becdf9153abce8d05175fdb06a).
