### PR TITLE
Add FR_TIMEVAL_BOUND_CHECK

### DIFF
--- a/src/include/conffile.h
+++ b/src/include/conffile.h
@@ -126,6 +126,17 @@ do {\
 
 #define FR_INTEGER_BOUND_CHECK(_name, _var, _op, _bound) FR_INTEGER_COND_CHECK(_name, _var, (_var _op _bound), _bound)
 
+#define FR_TIMEVAL_BOUND_CHECK(_name, _var, _op, _bound_sec, _bound_usec)\
+do {\
+	struct timeval _bound = {_bound_sec, _bound_usec};\
+	if (!timercmp(_var, &_bound, _op)) {\
+		WARN("WARNING: Ignoring \"" _name " = %d.%.06d\", forcing to \"" _name " = %d.%06d\"",\
+			(int)(_var)->tv_sec, (int)(_var)->tv_usec,\
+			(int)_bound.tv_sec, (int)_bound.tv_usec);\
+		*_var = _bound;\
+	}\
+} while (0)
+
 typedef struct CONF_PARSER {
 	char const	*name;
 	int		type;			//!< PW_TYPE_STRING, etc.

--- a/src/main/client.c
+++ b/src/main/client.c
@@ -762,23 +762,10 @@ static RADCLIENT *client_parse(CONF_SECTION *cs, int in_server)
 		break;
 	}
 
-	if (!c->response_window.tv_sec) {
-		uint32_t tmp = c->response_window.tv_usec; /* which isn't an integer */
-
-		FR_INTEGER_BOUND_CHECK("response_window microseconds", tmp, >=, 1000);
-		c->response_window.tv_usec = tmp;
-
-	} else {
-		int tmp = (int)c->response_window.tv_sec; /* which isn't an integer */
-
-		FR_INTEGER_BOUND_CHECK("response_window", tmp, <=, 60);
-		FR_INTEGER_BOUND_CHECK("response_window", tmp, <=, (int)main_config.max_request_time);
-
-		if (c->response_window.tv_sec != tmp) {
-			c->response_window.tv_sec = tmp;
-			c->response_window.tv_usec = 0;
-		}
-	}
+	FR_TIMEVAL_BOUND_CHECK("response_window", &c->response_window, >=, 0, 1000);
+	FR_TIMEVAL_BOUND_CHECK("response_window", &c->response_window, <=, 60, 0);
+	FR_TIMEVAL_BOUND_CHECK("response_window", &c->response_window, <=,
+				main_config.max_request_time, 0);
 
 #ifdef WITH_DYNAMIC_CLIENTS
 	if (c->client_server) {

--- a/src/main/realms.c
+++ b/src/main/realms.c
@@ -671,23 +671,10 @@ static int home_server_add(realm_config_t *rc, CONF_SECTION *cs)
 	FR_INTEGER_BOUND_CHECK("ping_interval", home->ping_interval, >=, 6);
 	FR_INTEGER_BOUND_CHECK("ping_interval", home->ping_interval, <=, 120);
 
-	if (!home->response_window.tv_sec) {
-		uint32_t tmp = home->response_window.tv_usec; /* which isn't an integer */
-
-		FR_INTEGER_BOUND_CHECK("response_window microseconds", tmp, >=, 1000);
-		home->response_window.tv_usec = tmp;
-
-	} else {
-		int tmp = (int)home->response_window.tv_sec; /* which isn't an integer */
-
-		FR_INTEGER_BOUND_CHECK("response_window", tmp, <=, 60);
-		FR_INTEGER_BOUND_CHECK("response_window", tmp, <=, (int)main_config.max_request_time);
-
-		if (home->response_window.tv_sec != tmp) {
-			home->response_window.tv_sec = tmp;
-			home->response_window.tv_usec = 0;
-		}
-	}
+	FR_TIMEVAL_BOUND_CHECK("response_window", &home->response_window, >=, 0, 1000);
+	FR_TIMEVAL_BOUND_CHECK("response_window", &home->response_window, <=, 60, 0);
+	FR_TIMEVAL_BOUND_CHECK("response_window", &home->response_window, <=,
+				main_config.max_request_time, 0);
 
 	/*
 	 *	Track the minimum response window, so that we can


### PR DESCRIPTION
Add FR_TIMEVAL_BOUND_CHECK implementing bounding for struct
timeval values, similarly to FR_INTEGER_BOUND_CHECK. Use it in
home_server_add and client_parse to increase readability.
