### PR TITLE
Rename min_response_window to init_delay

### DIFF
--- a/src/include/radiusd.h
+++ b/src/include/radiusd.h
@@ -433,7 +433,7 @@ typedef struct main_config_t {
 	bool		memory_report;
 	char const	*panic_action;
 	char const	*denied_msg;
-	struct timeval	min_response_window; /* for home servers */
+	struct timeval	init_delay; /* initial request processing delay */
 } MAIN_CONFIG_T;
 
 #define SECONDS_PER_DAY		86400

--- a/src/main/mainconfig.c
+++ b/src/main/mainconfig.c
@@ -913,8 +913,13 @@ do {\
 	FR_INTEGER_BOUND_CHECK("reject_delay", main_config.reject_delay, <=, 10);
 	FR_INTEGER_BOUND_CHECK("cleanup_delay", main_config.cleanup_delay, <=, 10);
 
-	main_config.min_response_window.tv_sec = 0;
-	main_config.min_response_window.tv_usec = 1000000 / 3;
+	/*
+	 * Set default initial request processing delay to 1/3 of a second.
+	 * Will be updated by the lowest response window across all home servers,
+	 * if it is less than this.
+	 */
+	main_config.init_delay.tv_sec = 0;
+	main_config.init_delay.tv_usec = 1000000 / 3;
 
 	/*
 	 *	Free the old configuration items, and replace them

--- a/src/main/process.c
+++ b/src/main/process.c
@@ -972,7 +972,7 @@ static void request_queue_or_run(UNUSED REQUEST *request,
 		/*
 		 *	(re) set the initial delay.
 		 */
-		request->delay =  (main_config.min_response_window.tv_sec * USEC) + main_config.min_response_window.tv_usec;
+		request->delay =  (main_config.init_delay.tv_sec * USEC) + main_config.init_delay.tv_usec;
 		if (request->delay > USEC) request->delay = USEC;
 		gettimeofday(&when, NULL);
 		tv_add(&when, request->delay);

--- a/src/main/realms.c
+++ b/src/main/realms.c
@@ -693,8 +693,8 @@ static int home_server_add(realm_config_t *rc, CONF_SECTION *cs)
 	 *	Track the minimum response window, so that we can
 	 *	correctly set the timers in process.c
 	 */
-	if (timercmp(&main_config.min_response_window, &home->response_window, >)) {
-		main_config.min_response_window = home->response_window;
+	if (timercmp(&main_config.init_delay, &home->response_window, >)) {
+		main_config.init_delay = home->response_window;
 	}
 
 	FR_INTEGER_BOUND_CHECK("zombie_period", home->zombie_period, >=, 1);


### PR DESCRIPTION
Rename main_config's "min_response_window" field to "init_delay", as it
better reflects the usage and because its value won't be related to any
response window in case they're all higher than 1/3 s, which is true
most of the time.

I've changed my mind back to "init_delay" while working on the changes
you suggested as it seemed to fit better. Applying this wouldn't change
any functionality, but might make code slightly easier to understand later.

Please feel free to reject, if you think otherwise.
