### PR TITLE
Clamp init_delay to half the minimum response window 

### DIFF
--- a/src/main/mainconfig.c
+++ b/src/main/mainconfig.c
@@ -913,7 +913,7 @@ do {\
 
 	/*
 	 * Set default initial request processing delay to 1/3 of a second.
-	 * Will be updated by the lowest response window across all home servers,
+	 * Will be updated by half the lowest response window across all home servers,
 	 * if it is less than this.
 	 */
 	main_config.init_delay.tv_sec = 0;

--- a/src/main/realms.c
+++ b/src/main/realms.c
@@ -351,6 +351,7 @@ static int home_server_add(realm_config_t *rc, CONF_SECTION *cs)
 	bool dual = false;
 	CONF_PAIR *cp;
 	CONF_SECTION *tls;
+	struct timeval half_response_window;
 
 	hs_virtual_server = NULL;
 
@@ -669,8 +670,11 @@ static int home_server_add(realm_config_t *rc, CONF_SECTION *cs)
 	 *	Track the minimum response window, so that we can
 	 *	correctly set the timers in process.c
 	 */
-	if (timercmp(&main_config.init_delay, &home->response_window, >)) {
-		main_config.init_delay = home->response_window;
+	half_response_window.tv_sec = home->response_window.tv_sec / 2;
+	half_response_window.tv_usec = (home->response_window.tv_sec * 500000 +
+					home->response_window.tv_usec / 2) % 1000000;
+	if (timercmp(&main_config.init_delay, &half_response_window, >)) {
+		main_config.init_delay = half_response_window;
 	}
 
 	FR_INTEGER_BOUND_CHECK("zombie_period", home->zombie_period, >=, 1);


### PR DESCRIPTION
Update main_config init_delay with half the minimum response window
across all home servers, if it's less, instead of the whole.

This makes proxy timeouts match the response windows near to and lower
than 1/3 of a second, which fixes issue #673.

We've verified these response windows to work correctly:

1.2
0.8
0.6
0.4
0.2
0.04
0.02
