### PR TITLE
multiple fixes and minor additions

### DIFF
--- a/src/modules/rlm_couchbase/configure
+++ b/src/modules/rlm_couchbase/configure
@@ -2891,24 +2891,26 @@ fi
 
 
 	have_json="yes"
-	smart_try_dir="$jsonc_include_dir"
+	smart_try_dir="$jsonc_include_dir \
+	/usr/include/json-c /usr/local/include/json-c /opt/include/json-c \
+	/usr/include/json /usr/local/include/json /opt/include/json"
 
 
 
-ac_safe=`echo "json/json.h" | sed 'y%./+-%__pm%'`
+ac_safe=`echo "json.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
 smart_include_dir=
 
 if test "x$smart_try_dir" != "x"; then
   for try in $smart_try_dir; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for json/json.h in $try" >&5
-$as_echo_n "checking for json/json.h in $try... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for json.h in $try" >&5
+$as_echo_n "checking for json.h in $try... " >&6; }
     CPPFLAGS="-isystem $try $old_CPPFLAGS"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-		    #include <json/json.h>
+		    #include <json.h>
 int
 main ()
 {
@@ -2937,12 +2939,12 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for json/json.h" >&5
-$as_echo_n "checking for json/json.h... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for json.h" >&5
+$as_echo_n "checking for json.h... " >&6; }
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-		  #include <json/json.h>
+		  #include <json.h>
 int
 main ()
 {
@@ -2973,7 +2975,7 @@ if test "x$smart_include" = "x"; then
 
 if test "x$LOCATE" != "x"; then
 	DIRS=
-  file=json/json.h
+  file=json.h
 
   for x in `${LOCATE} $file 2>/dev/null`; do
 					base=`echo $x | sed "s%/${file}%%"`
@@ -2997,13 +2999,13 @@ fi
 eval "smart_include_dir=\"\$smart_include_dir $DIRS\""
 
   for try in $smart_include_dir /usr/local/include /opt/include; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for json/json.h in $try" >&5
-$as_echo_n "checking for json/json.h in $try... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for json.h in $try" >&5
+$as_echo_n "checking for json.h in $try... " >&6; }
     CPPFLAGS="-isystem $try $old_CPPFLAGS"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-		    #include <json/json.h>
+		    #include <json.h>
 int
 main ()
 {
@@ -3037,7 +3039,7 @@ if test "x$smart_include" != "x"; then
   SMART_CPPFLAGS="$smart_include $SMART_CPPFLAGS"
 fi
 
-	if test "x$ac_cv_header_json_json_h" != "xyes"; then
+	if test "x$ac_cv_header_json_h" != "xyes"; then
 		have_json="no"
 		{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: json-c headers not found. Use --with-jsonc-include-dir=<path>." >&5
 $as_echo "$as_me: WARNING: json-c headers not found. Use --with-jsonc-include-dir=<path>." >&2;}
@@ -3219,8 +3221,7 @@ if test "x$smart_lib" != "x"; then
   SMART_LIBS="$smart_ldflags $smart_lib $SMART_LIBS"
 fi
 
-	if test "x$ac_cv_lib_json_c_json_c_version" != "xyes"
-	then
+	if test "x$ac_cv_lib_json_c_json_c_version" != "xyes"; then
 
 
 sm_lib_safe=`echo "json" | sed 'y%./+-%__p_%'`
@@ -3395,8 +3396,7 @@ if test "x$smart_lib" != "x"; then
   SMART_LIBS="$smart_ldflags $smart_lib $SMART_LIBS"
 fi
 
-		if test "x$ac_cv_lib_json_json_tokener_new" != "xyes"
-		then
+		if test "x$ac_cv_lib_json_json_tokener_new" != "xyes"; then
 			have_json="no"
 		fi
 	fi
@@ -3809,8 +3809,7 @@ if test "x$smart_lib" != "x"; then
   SMART_LIBS="$smart_ldflags $smart_lib $SMART_LIBS"
 fi
 
-	if test "x$ac_cv_lib_couchbase_lcb_get_version" != "xyes"
-	then
+	if test "x$ac_cv_lib_couchbase_lcb_get_version" != "xyes"; then
 		have_couchbase="no"
 		{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: libcouchbase libraries not found. Use --with-libcouchbase-lib-dir=<path>." >&5
 $as_echo "$as_me: WARNING: libcouchbase libraries not found. Use --with-libcouchbase-lib-dir=<path>." >&2;}
@@ -3844,7 +3843,7 @@ $as_echo "$as_me: WARNING: FAILURE: rlm_couchbase requires: $fail." >&2;};
 fi
 
 mod_ldflags="${SMART_LIBS}"
-mod_cflags="${SMART_CFLAGS}"
+mod_cflags="${SMART_CPPFLAGS}"
 
 
 

--- a/src/modules/rlm_couchbase/configure.ac
+++ b/src/modules/rlm_couchbase/configure.ac
@@ -70,9 +70,11 @@ if test x$with_[]modname != xno; then
 	dnl ############################################################
 
 	have_json="yes"
-	smart_try_dir="$jsonc_include_dir"
-	FR_SMART_CHECK_INCLUDE([json/json.h])
-	if test "x$ac_cv_header_json_json_h" != "xyes"; then
+	smart_try_dir="$jsonc_include_dir \
+	/usr/include/json-c /usr/local/include/json-c /opt/include/json-c \
+	/usr/include/json /usr/local/include/json /opt/include/json"
+	FR_SMART_CHECK_INCLUDE([json.h])
+	if test "x$ac_cv_header_json_h" != "xyes"; then
 		have_json="no"
 		AC_MSG_WARN([json-c headers not found. Use --with-jsonc-include-dir=<path>.])
 	fi
@@ -85,13 +87,11 @@ if test x$with_[]modname != xno; then
 	dnl # Use a json-c specific function which is only
 	dnl # available in newer versions.
 	FR_SMART_CHECK_LIB([json-c], [json_c_version])
-	if test "x$ac_cv_lib_json_c_json_c_version" != "xyes"
-	then
+	if test "x$ac_cv_lib_json_c_json_c_version" != "xyes"; then
 		dnl # Use a function which is included in legacy versions
 		dnl # but which may be available in other json libraries
 		FR_SMART_CHECK_LIB([json], [json_tokener_new])
-		if test "x$ac_cv_lib_json_json_tokener_new" != "xyes"
-		then
+		if test "x$ac_cv_lib_json_json_tokener_new" != "xyes"; then
 			have_json="no"
 		fi
 	fi
@@ -184,8 +184,7 @@ if test x$with_[]modname != xno; then
 
 	smart_try_dir="$libcouchbase_lib_dir"
 	FR_SMART_CHECK_LIB([couchbase], [lcb_get_version])
-	if test "x$ac_cv_lib_couchbase_lcb_get_version" != "xyes"
-	then
+	if test "x$ac_cv_lib_couchbase_lcb_get_version" != "xyes"; then
 		have_couchbase="no"
 		AC_MSG_WARN([libcouchbase libraries not found. Use --with-libcouchbase-lib-dir=<path>.])
 	fi
@@ -220,7 +219,7 @@ if test x"$fail" != x""; then
 fi
 
 mod_ldflags="${SMART_LIBS}"
-mod_cflags="${SMART_CFLAGS}"
+mod_cflags="${SMART_CPPFLAGS}"
 
 AC_SUBST(mod_cflags)
 AC_SUBST(mod_ldflags)

--- a/src/modules/rlm_couchbase/couchbase.c
+++ b/src/modules/rlm_couchbase/couchbase.c
@@ -28,7 +28,7 @@ RCSID("$Id$");
 #include <freeradius-devel/radiusd.h>
 
 #include <libcouchbase/couchbase.h>
-#include <json/json.h>
+#include <json.h>
 
 #include "couchbase.h"
 #include "jsonc_missing.h"

--- a/src/modules/rlm_couchbase/couchbase.h
+++ b/src/modules/rlm_couchbase/couchbase.h
@@ -29,7 +29,7 @@
 RCSIDH(couchbase_h, "$Id$");
 
 #include <libcouchbase/couchbase.h>
-#include <json/json.h>
+#include <json.h>
 
 /* struct to hold cookie data for couchbase callbacks */
 typedef struct cookie_t {

--- a/src/modules/rlm_couchbase/jsonc_missing.c
+++ b/src/modules/rlm_couchbase/jsonc_missing.c
@@ -29,6 +29,12 @@ RCSID("$Id$");
 
 #include "jsonc_missing.h"
 
+#ifndef HAVE_JSON_C_VERSION
+	const char *json_c_version(void) {
+		return "Unknown (less than 0.10) - Please upgrade";
+	}
+#endif
+
 #ifndef HAVE_JSON_OBJECT_GET_STRING_LEN
 int json_object_get_string_len(json_object *obj) {
 	if (json_object_get_type(obj) != json_type_string)

--- a/src/modules/rlm_couchbase/jsonc_missing.h
+++ b/src/modules/rlm_couchbase/jsonc_missing.h
@@ -28,9 +28,13 @@
 
 RCSIDH(jsonc_missing_h, "$Id$");
 
-#include <json/json.h>
+#include <json.h>
 
 #include "config.h"
+
+#ifndef HAVE_JSON_C_VERSION
+	const char *json_c_version(void);
+#endif
 
 #ifndef HAVE_JSON_OBJECT_OBJECT_GET_EX
 	#include <json/json_object_private.h>

--- a/src/modules/rlm_couchbase/mod.c
+++ b/src/modules/rlm_couchbase/mod.c
@@ -28,7 +28,7 @@ RCSID("$Id$");
 #include <freeradius-devel/radiusd.h>
 
 #include <libcouchbase/couchbase.h>
-#include <json/json.h>
+#include <json.h>
 
 #include "mod.h"
 #include "couchbase.h"

--- a/src/modules/rlm_couchbase/mod.h
+++ b/src/modules/rlm_couchbase/mod.h
@@ -28,8 +28,10 @@
 
 RCSIDH(mod_h, "$Id$");
 
+#include <freeradius-devel/radiusd.h>
+
 #include <libcouchbase/couchbase.h>
-#include <json/json.h>
+#include <json.h>
 
 #include "jsonc_missing.h"
 

--- a/src/modules/rlm_couchbase/rlm_couchbase.c
+++ b/src/modules/rlm_couchbase/rlm_couchbase.c
@@ -31,7 +31,7 @@ RCSID("$Id$");
 #include <freeradius-devel/rad_assert.h>
 
 #include <libcouchbase/couchbase.h>
-#include <json/json.h>
+#include <json.h>
 
 #include "mod.h"
 #include "couchbase.h"
@@ -43,7 +43,7 @@ RCSID("$Id$");
 static const CONF_PARSER module_config[] = {
 	{ "acct_key", FR_CONF_OFFSET(PW_TYPE_STRING, rlm_couchbase_t, acct_key), "radacct_%{%{Acct-Unique-Session-Id}:-%{Acct-Session-Id}}" },
 	{ "doctype", FR_CONF_OFFSET(PW_TYPE_STRING, rlm_couchbase_t, doctype), "radacct" },
-	{ "server", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_REQUIRED, rlm_couchbase_t, server), NULL },
+	{ "server", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_REQUIRED, rlm_couchbase_t, server_raw), NULL },
 	{ "bucket", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_REQUIRED, rlm_couchbase_t, bucket), NULL },
 	{ "password", FR_CONF_OFFSET(PW_TYPE_STRING, rlm_couchbase_t, password), NULL },
 	{ "expire", FR_CONF_OFFSET(PW_TYPE_INTEGER, rlm_couchbase_t, expire), 0 },
@@ -59,7 +59,8 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance) {
 
 	if (!version_done) {
 		version_done = true;
-		INFO("rlm_couchbase: liblcouchbase version: %s", lcb_get_version(NULL));
+		INFO("rlm_couchbase: json-c version: %s", json_c_version());
+		INFO("rlm_couchbase: libcouchbase version: %s", lcb_get_version(NULL));
 	}
 
 	{


### PR DESCRIPTION
- fixed json.j includes for new location in recent library versions
- fixed server string building
- added json-c library to version checking

This changes for the json-c include paths will need to be done other places json-c is used as well.  The symlink from include/json-c to include/json is no longer made by the installer as of the most recent release.  I'll try and put another pull request in for rlm_rest later today.
