### PR TITLE
change default EAP type

### DIFF
--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -27,7 +27,7 @@ eap {
 	#  then that EAP type takes precedence over the
 	#  default type configured here.
 	#
-	default_eap_type = md5
+	default_eap_type = ttls
 
 	#  A list is maintained to correlate EAP-Response
 	#  packets with EAP-Request packets.  After a


### PR DESCRIPTION
MD5 should be dead and buried. TTLS is the current favourite (HS 2.0/802.11u) and channel binding etc.
