### PR TITLE
3.0.x - Make EAP-SIM work again - proper encoding of EAP-SIM attributes ...

### DIFF
--- a/src/modules/rlm_eap/libeap/eapsimlib.c
+++ b/src/modules/rlm_eap/libeap/eapsimlib.c
@@ -114,7 +114,7 @@ int map_eapsim_basictypes(RADIUS_PACKET *r, eap_packet_t *ep)
 		 *
 		 * At this point, we only care about the size.
 		 */
-		if(vp->da->attr == PW_EAP_SIM_BASE + PW_EAP_SIM_MAC) {
+		if(vp->da->attr == PW_EAP_SIM_MAC) {
 			vplen = 18;
 		}
 
@@ -195,7 +195,7 @@ int map_eapsim_basictypes(RADIUS_PACKET *r, eap_packet_t *ep)
 		 * At this point, we put in zeros, and remember where the
 		 * sixteen bytes go.
 		 */
-		if(vp->da->attr == PW_EAP_SIM_BASE+PW_EAP_SIM_MAC) {
+		if(vp->da->attr == PW_EAP_SIM_MAC) {
 			roundedlen = 20;
 			memset(&attr[2], 0, 18);
 			macspace = &attr[4];
@@ -367,7 +367,7 @@ int eapsim_checkmac(TALLOC_CTX *ctx, VALUE_PAIR *rvps, uint8_t key[EAPSIM_AUTH_S
 	int elen,len;
 	VALUE_PAIR *mac;
 
-	mac = pairfind(rvps, PW_EAP_SIM_BASE+PW_EAP_SIM_MAC, 0, TAG_ANY);
+	mac = pairfind(rvps, PW_EAP_SIM_MAC, 0, TAG_ANY);
 
 	if(!mac || mac->length != 18) {
 		/* can't check a packet with no AT_MAC attribute */

--- a/src/modules/rlm_eap/radeapclient.c
+++ b/src/modules/rlm_eap/radeapclient.c
@@ -304,7 +304,7 @@ static int process_eap_start(RADIUS_PACKET *req,
 	/* form new response clear of any EAP stuff */
 	cleanresp(rep);
 
-	if((vp = pairfind(req->vps, PW_EAP_SIM_BASE+PW_EAP_SIM_VERSION_LIST, 0, TAG_ANY)) == NULL) {
+	if((vp = pairfind(req->vps, PW_EAP_SIM_VERSION_LIST, 0, TAG_ANY)) == NULL) {
 		ERROR("illegal start message has no VERSION_LIST");
 		return 0;
 	}
@@ -363,9 +363,9 @@ static int process_eap_start(RADIUS_PACKET *req,
 	 * anyway we like, but it is illegal to have more than one
 	 * present.
 	 */
-	anyidreq_vp = pairfind(req->vps, PW_EAP_SIM_BASE+PW_EAP_SIM_ANY_ID_REQ, 0, TAG_ANY);
-	fullauthidreq_vp = pairfind(req->vps, PW_EAP_SIM_BASE+PW_EAP_SIM_FULLAUTH_ID_REQ, 0, TAG_ANY);
-	permanentidreq_vp = pairfind(req->vps, PW_EAP_SIM_BASE+PW_EAP_SIM_PERMANENT_ID_REQ, 0, TAG_ANY);
+	anyidreq_vp = pairfind(req->vps, PW_EAP_SIM_ANY_ID_REQ, 0, TAG_ANY);
+	fullauthidreq_vp = pairfind(req->vps, PW_EAP_SIM_FULLAUTH_ID_REQ, 0, TAG_ANY);
+	permanentidreq_vp = pairfind(req->vps, PW_EAP_SIM_PERMANENT_ID_REQ, 0, TAG_ANY);
 
 	if(!fullauthidreq_vp ||
 	   anyidreq_vp != NULL ||
@@ -390,7 +390,7 @@ static int process_eap_start(RADIUS_PACKET *req,
 
 		no_versions = htons(selectedversion);
 
-		newvp = paircreate(rep, PW_EAP_SIM_BASE + PW_EAP_SIM_SELECTED_VERSION, 0);
+		newvp = paircreate(rep, PW_EAP_SIM_SELECTED_VERSION, 0);
 		pairmemcpy(newvp, (uint8_t *) &no_versions, 2);
 		pairreplace(&(rep->vps), newvp);
 
@@ -411,7 +411,7 @@ static int process_eap_start(RADIUS_PACKET *req,
 		nonce[2]=fr_rand();
 		nonce[3]=fr_rand();
 
-		newvp = paircreate(rep, PW_EAP_SIM_BASE+PW_EAP_SIM_NONCE_MT, 0);
+		newvp = paircreate(rep, PW_EAP_SIM_NONCE_MT, 0);
 
 		p = talloc_zero_array(newvp, uint8_t, 18); /* 18 = 16 bytes of nonce + padding */
 		memcpy(&p[2], nonce, 16);
@@ -437,7 +437,7 @@ static int process_eap_start(RADIUS_PACKET *req,
 			ERROR("eap-sim: We need to have a User-Name attribute!");
 			return 0;
 		}
-		newvp = paircreate(rep, PW_EAP_SIM_BASE+PW_EAP_SIM_IDENTITY, 0);
+		newvp = paircreate(rep, PW_EAP_SIM_IDENTITY, 0);
 
 		idlen = strlen(vp->vp_strvalue);
 		p = talloc_zero_array(newvp, uint8_t, idlen + 2);
@@ -475,8 +475,8 @@ static int process_eap_challenge(RADIUS_PACKET *req, RADIUS_PACKET *rep)
 	uint8_t calcmac[20];
 
 	/* look for the AT_MAC and the challenge data */
-	mac   = pairfind(req->vps, PW_EAP_SIM_BASE+PW_EAP_SIM_MAC, 0, TAG_ANY);
-	randvp= pairfind(req->vps, PW_EAP_SIM_BASE+PW_EAP_SIM_RAND, 0, TAG_ANY);
+	mac   = pairfind(req->vps, PW_EAP_SIM_MAC, 0, TAG_ANY);
+	randvp= pairfind(req->vps, PW_EAP_SIM_RAND, 0, TAG_ANY);
 	if(!mac || !randvp) {
 		ERROR("challenge message needs to contain RAND and MAC");
 		return 0;
@@ -617,7 +617,7 @@ static int process_eap_challenge(RADIUS_PACKET *req, RADIUS_PACKET *rep)
 		 * fill the SIM_MAC with a field that will in fact get appended
 		 * to the packet before the MAC is calculated
 		 */
-		newvp = paircreate(rep, PW_EAP_SIM_BASE+PW_EAP_SIM_MAC, 0);
+		newvp = paircreate(rep, PW_EAP_SIM_MAC, 0);
 
 		p = talloc_zero_array(newvp, uint8_t, EAPSIM_SRES_SIZE*3);
 		memcpy(p+EAPSIM_SRES_SIZE * 0, sres1->vp_strvalue, EAPSIM_SRES_SIZE);
@@ -1557,7 +1557,7 @@ main(int argc, char *argv[])
 			vp_printlist(stdout, req2->vps);
 		}
 
-		vp = pairfind(req2->vps, PW_EAP_SIM_BASE+PW_EAP_SIM_MAC, 0, TAG_ANY);
+		vp = pairfind(req2->vps, PW_EAP_SIM_MAC, 0, TAG_ANY);
 		vpkey   = pairfind(req->vps, PW_EAP_SIM_KEY, 0, TAG_ANY);
 		vpextra = pairfind(req->vps, PW_EAP_SIM_EXTRA, 0, TAG_ANY);
 

--- a/src/modules/rlm_eap/types/rlm_eap_sim/rlm_eap_sim.c
+++ b/src/modules/rlm_eap/types/rlm_eap_sim/rlm_eap_sim.c
@@ -83,7 +83,7 @@ static int eap_sim_sendstart(eap_handler_t *handler)
 	words[1] = htons(EAP_SIM_VERSION);
 	words[2] = 0;
 
-	newvp = paircreate(packet, PW_EAP_SIM_BASE + PW_EAP_SIM_VERSION_LIST, 0);
+	newvp = paircreate(packet, PW_EAP_SIM_VERSION_LIST, 0);
 	pairmemcpy(newvp, (uint8_t const *) words, sizeof(words));
 
 	pairadd(vps, newvp);
@@ -98,7 +98,7 @@ static int eap_sim_sendstart(eap_handler_t *handler)
 	memcpy(ess->keys.versionlist, words + 1, ess->keys.versionlistlen);
 
 	/* the ANY_ID attribute. We do not support re-auth or pseudonym */
-	newvp = paircreate(packet, PW_EAP_SIM_BASE + PW_EAP_SIM_FULLAUTH_ID_REQ, 0);
+	newvp = paircreate(packet, PW_EAP_SIM_FULLAUTH_ID_REQ, 0);
 	newvp->length = 2;
 	newvp->vp_octets = p = talloc_array(newvp, uint8_t, 2);
 
@@ -301,7 +301,7 @@ static int eap_sim_sendchallenge(eap_handler_t *handler)
 	/*
 	 *	Okay, we got the challenges! Put them into an attribute.
 	 */
-	newvp = paircreate(packet, PW_EAP_SIM_BASE + PW_EAP_SIM_RAND, 0);
+	newvp = paircreate(packet, PW_EAP_SIM_RAND, 0);
 	newvp->length = 2 + (EAPSIM_RAND_SIZE * 3);
 	newvp->vp_octets = p = talloc_array(newvp, uint8_t, newvp->length);
 
@@ -330,7 +330,7 @@ static int eap_sim_sendchallenge(eap_handler_t *handler)
 	/*
 	 *	Use the SIM identity, if available
 	 */
-	newvp = pairfind(*invps, PW_EAP_SIM_BASE + PW_EAP_SIM_IDENTITY, 0, TAG_ANY);
+	newvp = pairfind(*invps, PW_EAP_SIM_IDENTITY, 0, TAG_ANY);
 	if (newvp && newvp->length > 2) {
 		uint16_t len;
 
@@ -357,7 +357,7 @@ static int eap_sim_sendchallenge(eap_handler_t *handler)
 	 *	We store the NONCE_MT in the MAC for the encoder, which
 	 *	will pull it out before it does the operation.
 	 */
-	newvp = paircreate(packet, PW_EAP_SIM_BASE + PW_EAP_SIM_MAC, 0);
+	newvp = paircreate(packet, PW_EAP_SIM_MAC, 0);
 	pairmemcpy(newvp, ess->keys.nonce_mt, 16);
 	pairreplace(outvps, newvp);
 
@@ -505,8 +505,8 @@ static int process_eap_sim_start(eap_handler_t *handler, VALUE_PAIR *vps)
 	uint16_t simversion;
 	ess = (eap_sim_state_t *)handler->opaque;
 
-	nonce_vp = pairfind(vps, PW_EAP_SIM_BASE + PW_EAP_SIM_NONCE_MT, 0, TAG_ANY);
-	selectedversion_vp = pairfind(vps, PW_EAP_SIM_BASE + PW_EAP_SIM_SELECTED_VERSION, 0, TAG_ANY);
+	nonce_vp = pairfind(vps, PW_EAP_SIM_NONCE_MT, 0, TAG_ANY);
+	selectedversion_vp = pairfind(vps, PW_EAP_SIM_SELECTED_VERSION, 0, TAG_ANY);
 	if (!nonce_vp || !selectedversion_vp) {
 		RDEBUG2("Client did not select a version and send a NONCE");
 		eap_sim_stateenter(handler, ess, eapsim_server_start);


### PR DESCRIPTION
...within EAP-Message

This fix follows the issue I logged (on the mailing list, not on GitHub)
on June 11th.

As a reminder, the problem happened after a commit which (among other
things) modified the EAP-SIM attributes.
Since this commit, EAP-SIM authentication do not work because
EAP-Message is not properly encoded anymore by FreeRADIUS.

I believe the commit is the following:

https://github.com/FreeRADIUS/freeradius-server/commit/39df09e42d80a96363be0bddee2ff0ba97fdb035

So, here is a fix.

I also fixed the attributes issue in radeapclient, but at the moment the
binary is unusable: it crashes, and I don't have time to look into this.
(I tested the fix with another EAP client)
