### PR TITLE
Fixed adding attributes with multiple values to rlm_perl

### DIFF
--- a/src/modules/rlm_perl/rlm_perl.c
+++ b/src/modules/rlm_perl/rlm_perl.c
@@ -600,7 +600,7 @@ static void perl_store_vps(UNUSED TALLOC_CTX *ctx, REQUEST *request, VALUE_PAIR 
 			AV *av;
 
 			av = newAV();
-			for (next = fr_cursor_first(&cursor), i = 0;
+			for (next = fr_cursor_next_by_da(&cursor, vp->da, vp->tag), i = 0;
 			     next;
 			     next = fr_cursor_next_by_da(&cursor, vp->da, vp->tag), i++) {
 				switch (vp->da->type) {


### PR DESCRIPTION
Without this fix, the array in Perl would start with the value of the
first attribute in the packet, combined with the actual values of the
attribute.

The debug log would look like this:

$RAD_REPLY{'User-Name'}[0] = &reply:User-Name -> 'anonymous'
$RAD_REPLY{'h323-credit-amount'}[1] = &reply:h323-credit-amount -> '100'
$RAD_REPLY{'h323-credit-amount'}[2] = &reply:h323-credit-amount -> '101'

The actual value of $RAD_REPLY{'h323-credit-amount'} is
['anonymous','100','101']
