### PR TITLE
Perl array fixes

### DIFF
--- a/src/modules/rlm_perl/rlm_perl.c
+++ b/src/modules/rlm_perl/rlm_perl.c
@@ -598,8 +598,10 @@ static void perl_store_vps(UNUSED TALLOC_CTX *ctx, REQUEST *request, VALUE_PAIR 
 		if ((next = fr_cursor_next_peek(&cursor)) && ATTRIBUTE_EQ(vp, next)) {
 			int i;
 			AV *av;
+			vp_cursor_t cursor2;
 
 			av = newAV();
+			cursor2 = cursor;
 			for (i = 0;
 			     (next = fr_cursor_next_by_da(&cursor, vp->da, vp->tag));
 			     i++) {
@@ -631,6 +633,8 @@ static void perl_store_vps(UNUSED TALLOC_CTX *ctx, REQUEST *request, VALUE_PAIR 
 				}
 			}
 			(void)hv_store(rad_hv, name, strlen(name), newRV_noinc((SV *)av), 0);
+			cursor = cursor2;
+			fr_cursor_next(&cursor);
 
 			continue;
 		}


### PR DESCRIPTION
A continuation of #720, because things are never perfect.

The first commit is a bit of a code cleanup of #720, I thought it was pretty ugly to have `fr_cursor_next_by_da(&cursor, vp->da, vp->tag)` twice in a single for-statement.

The second commit actually fixes a bug when copying multi-valued attributes to perl, it stopped where it should continue with the next attribute. The code isn't exactly the best I've ever written, but at least it works.
