### PR TITLE
Update redhat spec file

### DIFF
--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -246,8 +246,8 @@ This plugin provides Redis support for the FreeRADIUS server project.
 Summary: REST support for FreeRADIUS
 Group: System Environment/Daemons
 Requires: %{name} = %{version}-%{release}
-Requires: json-c >= 0.11
-BuildRequires: json-c-devel >= 0.11
+Requires: json-c >= 0.10
+BuildRequires: json-c-devel >= 0.10
 
 %description rest
 This plugin provides REST support for the FreeRADIUS server project.


### PR DESCRIPTION
Update redhat spec file to account for recent changes.
Updated dependency on json-c to version 0.10 (for rlm_rest)
Version 0.11 is not available for redhat & centos, we currently can't build packages.
rlm_rest builds ok with version 0.10
