### PR TITLE
radeapclient - fix send_packet

### DIFF
--- a/src/modules/rlm_eap/radeapclient.c
+++ b/src/modules/rlm_eap/radeapclient.c
@@ -168,7 +168,7 @@ static int send_packet(RADIUS_PACKET *req, RADIUS_PACKET **rep)
 	int i;
 	struct timeval	tv;
 
-	if (!req || !rep || !*rep) return -1;
+	if (!req || !rep) return -1;
 
 	for (i = 0; i < retries; i++) {
 		fd_set		rdfdesc;
@@ -941,9 +941,9 @@ static int sendrecv_eap(RADIUS_PACKET *rep)
 	} /* there WAS a password */
 
 	/* send the response, wait for the next request */
-	send_packet(req, &rep);
-	if (!rep) {
-		ERROR("Failed getting response");
+	send_packet(rep, &req);
+	if (!req) {
+		ERROR("Failed getting response (EAP-Request from server)");
 		return -1;
 	}
 


### PR DESCRIPTION
I spotted two errors in radeapclient.c, introduced in the following
previous commits.
With this fix, radeapclient is now useable again.

1)
Commit: c8a062a112f17a5810d311dc0e0acfe963b2d440
(2014/06/13)
## \- send_packet(rep, &req);
- if (!req) return -1;
- send_packet(req, &rep);
- if (!rep) {

Arguments got reversed. Hence segmentation fault later when doing:

for (vp = req->vps; vp != NULL; vp = vpnext) {

Bit of caution on the wording used in radeapclient:
"req" is the request coming FROM the server. (because this is not a
"request" in RADIUS sense, but an EAP-Request within the EAP-SIM
transaction.)
"rep" is the response from the client TO the server (EAP-Response).

2)
Commit: bc3676835c3dcc220ab518d4c3c35962bc0f8be2
(2014/05/02)

In "send_packet":
- if (!req || !rep || !*rep) return -1;

*rep == NULL is the expected behaviour...
