### PR TITLE
Clarify conditions of limit hit SNMP notifications

### DIFF
--- a/mibs/FREERADIUS-NOTIFICATION-MIB.txt
+++ b/mibs/FREERADIUS-NOTIFICATION-MIB.txt
@@ -43,7 +43,7 @@ serverStop NOTIFICATION-TYPE
 serverMaxRequests NOTIFICATION-TYPE
        OBJECTS { identity }
        STATUS current
-       DESCRIPTION "Notification that the server has reached the max_requests limit"
+       DESCRIPTION "Notification that the server has hit the max_requests limit"
        ::= { serverGlobal 3 }
 
 serverSignal  OBJECT IDENTIFIER ::= { serverGlobal 4 }
@@ -83,7 +83,7 @@ threadUnresponsive NOTIFICATION-TYPE
 threadMaxThreads NOTIFICATION-TYPE
        OBJECTS { identity }
        STATUS current
-       DESCRIPTION "Notification that the max_threads limit has been reached"
+       DESCRIPTION "Notification that the max_threads limit has been hit"
        ::= { serverThread 4 }
 
 serverModules  OBJECT IDENTIFIER ::= { freeRadiusNotificationMib 2 }


### PR DESCRIPTION
Use "hit" instead of "reach" in the descriptions of serverMaxRequest and
serverMaxThreads SNMP notifications to make it clearer that they trigger
upon attempt to exceed the limit, not upon reaching the maximum allowed
value.
