### PR TITLE
Add minimal rlm_krb5 documentation file

### DIFF
--- a/doc/modules/rlm_krb5
+++ b/doc/modules/rlm_krb5
@@ -1,0 +1,47 @@
+The `rlm_krb5` FreeRADIUS module enables the use of Kerberos 5 for
+authentication.
+
+Compilation issues
+==================
+
+MIT libraries
+-------------
+
+The `rlm_krb5` module, by default, presumes you have the MIT Kerberos 5
+distribution. Notes from that distribution:
+
+On linux, you may have to change:
+
+    deplibs_test_method="pass_all"
+
+in `../libtool`
+
+Otherwise, it complains if the krb5 libs aren't shared.
+
+Heimdal libraries
+-----------------
+
+If you are using the Heimdal Kerberos 5 distribution, pass an
+`--enable-heimdal-krb5` option to `configure`.
+
+Configuration parameters
+========================
+
+You can configure the module with the following parameters:
+
+    krb5 {
+        # Keytab containing the key used by rlm_krb5
+        keytab = /path/to/keytab
+
+        # Principal that is used by rlm_krb5
+        service_principal = radius/some.host.com
+    }
+
+Make sure the keytab is readable by the user that is used to run `radiusd` and
+that your authorization configuration really uses `rlm_krb5` to do the
+authentication. You will need to add the following to the 'authenticate'
+section of your radiusd.conf file:
+
+    Auth-Type Kerberos {
+        krb5
+    }

--- a/raddb/mods-available/krb5
+++ b/raddb/mods-available/krb5
@@ -3,7 +3,7 @@
 #  $Id$
 
 #
-#  Kerberos.  See doc/rlm_krb5 for minimal docs.
+#  Kerberos.  See doc/modules/rlm_krb5 for minimal docs.
 #
 krb5 {
 	keytab = /path/to/keytab


### PR DESCRIPTION
Add doc/modules/rlm_krb5 - a minimal rlm_krb5 module documentation file,
based on the wiki page. Update raddb/mods-available/krb5 comments to
point to the actual and proper location.
