### PR TITLE
Added a NULL check to rlm_perl

### DIFF
--- a/src/modules/rlm_perl/rlm_perl.c
+++ b/src/modules/rlm_perl/rlm_perl.c
@@ -977,7 +977,9 @@ static int mod_detach(void *instance)
 	rlm_perl_t	*inst = (rlm_perl_t *) instance;
 	int 		exitstatus = 0, count = 0;
 
-	hv_undef(inst->rad_perlconf_hv);
+	if (inst->rad_perlconf_hv != NULL) {
+		hv_undef(inst->rad_perlconf_hv);
+	}
 
 #if 0
 	/*


### PR DESCRIPTION
Otherwise, trying to start rlm_perl with an invalid file parameter would cause a segfault.
