### PR TITLE
Debian: Ensure some directories exist

### DIFF
--- a/debian/freeradius.postinst
+++ b/debian/freeradius.postinst
@@ -13,10 +13,12 @@ case "$1" in
           # Set up initial permissions on all the freeradius directories
 
           if ! dpkg-statoverride --list | grep -q /var/run/freeradius$; then
+            mkdir -p /var/run/freeradius
             dpkg-statoverride --add --update freerad freerad 0755 /var/run/freeradius
           fi
 
           if ! dpkg-statoverride --list | grep -q /var/log/freeradius$; then
+            mkdir -p /var/log/freeradius
             dpkg-statoverride --add --update freerad freerad 0750 /var/log/freeradius
           fi
 


### PR DESCRIPTION
This prevents some warnings when installing the package.

Fun fact: these warnings occur with the official Debian packages too.
