### PR TITLE
Fix error in attribute copying to rlm_perl

### DIFF
--- a/src/modules/rlm_perl/rlm_perl.c
+++ b/src/modules/rlm_perl/rlm_perl.c
@@ -779,10 +779,9 @@ static int do_perl(void *instance, REQUEST *request, char const *function_name)
 		rad_config_hv = get_hv("RAD_CONFIG", 1);
 		rad_request_hv = get_hv("RAD_REQUEST", 1);
 
-		perl_store_vps(request->reply, request, request->reply->vps, rad_reply_hv, "RAD_REPLY", "reply");
-		perl_store_vps(request, request, request->config_items, rad_check_hv, "RAD_CHECK", "control");
 		perl_store_vps(request->packet, request, request->packet->vps, rad_request_hv, "RAD_REQUEST", "request");
 		perl_store_vps(request->reply, request, request->reply->vps, rad_reply_hv, "RAD_REPLY", "reply");
+		perl_store_vps(request, request, request->config_items, rad_check_hv, "RAD_CHECK", "control");
 		perl_store_vps(request, request, request->config_items, rad_config_hv, "RAD_CONFIG", "control");
 
 #ifdef WITH_PROXY


### PR DESCRIPTION
Introduced in commit c225c615760d4c907640ebd249f860d5ab3258dd. It copied the RAD_REPLY hash twice, which had the side effects that some keys dropped out.

The master branch doesn't have this problem, this is just a 3.0.x issue. The shuffle in the ordering is to keep it more in sync with master, so future merges from master are less likely to generate conflicts.
