### PR TITLE
dhcpclient - allow to specify interface and send/recv at raw packet level

### DIFF
--- a/src/include/dhcp.h
+++ b/src/include/dhcp.h
@@ -45,6 +45,13 @@ int fr_dhcp_encode(RADIUS_PACKET *packet);
 ssize_t fr_dhcp_decode_options(VALUE_PAIR **out, TALLOC_CTX *ctx, uint8_t const *data, size_t len);
 int fr_dhcp_decode(RADIUS_PACKET *packet);
 
+#ifdef HAVE_LINUX_IF_PACKET_H
+#include <linux/if_packet.h>
+int fr_socket_packet(int iface_index, struct sockaddr_ll *p_ll);
+int fr_dhcp_send_raw_packet(int sockfd, struct sockaddr_ll *p_ll, RADIUS_PACKET *packet);
+RADIUS_PACKET *fr_dhcp_recv_raw_packet(int sockfd, struct sockaddr_ll *p_ll, RADIUS_PACKET *request);
+#endif
+
 /*
  *	This is a horrible hack.
  */

--- a/src/include/net.h
+++ b/src/include/net.h
@@ -73,6 +73,8 @@ typedef enum {
 #define IP_V(ip)	(((ip)->ip_vhl & 0xf0) >> 4)
 #define IP_HL(ip)       ((ip)->ip_vhl & 0x0f)
 
+#define IP_VHL(v, hl) ((v & 0x0f) << 4) | (hl & 0x0f)
+
 #define	I_DF		0x4000		//!< Dont fragment flag.
 #define IP_MF		0x2000		//!< More fragments flag.
 #define IP_OFFMASK	0x1fff		//!< Mask for fragmenting bits.
@@ -80,11 +82,11 @@ typedef enum {
 /*
  *	Structure of a DEC/Intel/Xerox or 802.3 Ethernet header.
  */
-struct ethernet_header {
+typedef struct ethernet_header {
 	uint8_t		ether_dst[ETHER_ADDR_LEN];
 	uint8_t		ether_src[ETHER_ADDR_LEN];
 	uint16_t	ether_type;
-};
+} ethernet_header_t;
 
 /*
  *	Structure of an internet header, naked of options.
@@ -135,4 +137,5 @@ typedef struct radius_packet_t {
 ssize_t fr_link_layer_offset(uint8_t const *data, size_t len, int link_type);
 uint16_t fr_udp_checksum(uint8_t const *data, uint16_t len, uint16_t checksum,
 			 struct in_addr const src_addr, struct in_addr const dst_addr);
+uint16_t fr_iph_checksum(uint8_t const *data, uint8_t ihl);
 #endif /* FR_NET_H */

--- a/src/lib/net.c
+++ b/src/lib/net.c
@@ -168,3 +168,25 @@ uint16_t fr_udp_checksum(uint8_t const *data, uint16_t len, uint16_t checksum,
 
 	return ((uint16_t) ~sum);
 }
+
+/** Calculate IP header checksum.
+ *
+ * Zero out IP header checksum in IP header before calling fr_iph_checksum to get 'expected' checksum.
+ *
+ * @param data Pointer to the start of the IP header
+ * @param ihl value of ip header length field (number of 32 bit words)
+ */
+uint16_t fr_iph_checksum(uint8_t const *data, uint8_t ihl)
+{
+	uint64_t sum = 0;
+	uint16_t const *p = (uint16_t const *)data;
+	
+	uint8_t nwords = (ihl << 1); /* number of 16-bit words */
+	
+	for (sum = 0; nwords > 0; nwords--) {
+		sum += *p++;
+	}
+	sum = (sum >> 16) + (sum & 0xffff);
+	sum += (sum >> 16);
+	return ((uint16_t) ~sum);
+}

--- a/src/modules/proto_dhcp/dhcp.c
+++ b/src/modules/proto_dhcp/dhcp.c
@@ -26,6 +26,7 @@ RCSID("$Id$")
 #include <freeradius-devel/libradius.h>
 #include <freeradius-devel/udpfromto.h>
 #include <freeradius-devel/dhcp.h>
+#include <freeradius-devel/net.h>
 
 #ifndef __MINGW32__
 #include <sys/ioctl.h>
@@ -52,12 +53,34 @@ RCSID("$Id$")
 #define INADDR_BROADCAST INADDR_NONE
 #endif
 
+#define ETH_HDR_SIZE   14
+#define IP_HDR_SIZE    20
+#define UDP_HDR_SIZE   8
+#define ETH_ADDR_LEN   6
+#define ETH_TYPE_IP    0x0800
+#define ETH_P_ALL      0x0003
+
 /* @todo: this is a hack */
 #  define DEBUG			if (fr_debug_flag && fr_log_fp) fr_printf_log
 #  define debug_pair(vp)	do { if (fr_debug_flag && fr_log_fp) { \
 					vp_print(fr_log_fp, vp); \
 				     } \
 				} while(0)
+
+#ifdef HAVE_LINUX_IF_PACKET_H
+static uint8_t eth_bcast[ETH_ADDR_LEN] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff };
+#endif
+
+/* Discard raw packets which we are not interested in. Allow to trace why we discard. */
+#define DISCARD_RP(...) { \
+	if (fr_debug_flag > 2) { \
+		fprintf(stdout, "dhcpclient: discarding received packet: "); \
+		fprintf(stdout, ## __VA_ARGS__); \
+		fprintf(stdout, "\n"); \
+	} \
+	rad_free(&packet); \
+	return NULL; \
+}
 
 typedef struct dhcp_packet_t {
 	uint8_t		opcode;
@@ -1847,5 +1870,322 @@ int fr_dhcp_add_arp_entry(UNUSED int fd, UNUSED char const *interface,
 {
 	fr_strerror_printf("Adding ARP entry is unsupported on this system");
 	return -1;
+}
+#endif
+
+
+#ifdef HAVE_LINUX_IF_PACKET_H
+/*
+ *	Open a packet interface raw socket.
+ *	Bind it to the specified interface using a device independent physical layer address.
+ */
+int fr_socket_packet(int iface_index, struct sockaddr_ll *p_ll)
+{
+	int lsockfd;
+
+	/* PF_PACKET - packet interface on device level.
+	   using a raw socket allows packet data to be unchanged by the device driver.
+	 */
+	lsockfd = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+	if (lsockfd < 0) {
+		fr_strerror_printf("cannot open socket: %s", fr_syserror(errno));
+		return lsockfd;
+	} 
+
+	/* Set link layer parameters */
+	memset(p_ll, 0, sizeof(struct sockaddr_ll));
+
+	p_ll->sll_family = AF_PACKET;
+	p_ll->sll_protocol = htons(ETH_P_ALL);
+	p_ll->sll_ifindex = iface_index;
+	p_ll->sll_hatype = ARPHRD_ETHER;
+	p_ll->sll_pkttype = PACKET_OTHERHOST;
+	p_ll->sll_halen = 6;
+    
+	if (bind(lsockfd, (struct sockaddr *)p_ll, sizeof(struct sockaddr_ll)) < 0) {
+		close(lsockfd);
+		fr_strerror_printf("cannot bind raw socket: %s", fr_syserror(errno));
+		return -1;
+	}
+
+	return lsockfd;
+}
+
+/*
+ *	Encode and send a DHCP packet on a raw packet socket.
+ */
+int fr_dhcp_send_raw_packet(int sockfd, struct sockaddr_ll *p_ll, RADIUS_PACKET *packet)
+{
+	VALUE_PAIR *vp;
+	u_char dhcp_packet[1518] = { 0 };
+
+	/* set ethernet source address to our MAC address (DHCP-Client-Hardware-Address). */
+	u_char dhmac[ETH_ADDR_LEN] = { 0 };
+	if ((vp = pairfind(packet->vps, 267, DHCP_MAGIC_VENDOR, TAG_ANY))) {
+		if (vp->length == sizeof(vp->vp_ether)) {
+			memcpy(dhmac, vp->vp_ether, vp->length);
+		}
+	}
+
+	/* fill in Ethernet layer (L2) */
+	struct ethernet_header *ethhdr = (struct ethernet_header *)dhcp_packet;
+	memcpy(ethhdr->ether_dst, eth_bcast, ETH_ADDR_LEN);
+	memcpy(ethhdr->ether_src, dhmac, ETH_ADDR_LEN);
+	ethhdr->ether_type = htons(ETH_TYPE_IP);
+
+	/* fill in IP layer (L3) */
+	struct ip_header *iph = (struct ip_header *)(dhcp_packet + ETH_HDR_SIZE);
+	iph->ip_vhl = IP_VHL(4, 5);
+	iph->ip_tos = 0;
+	iph->ip_len = htons(IP_HDR_SIZE +  UDP_HDR_SIZE + packet->data_len);  
+	iph->ip_id = 0;
+	iph->ip_off = 0;
+	iph->ip_ttl = 64;
+	iph->ip_p = 17;
+	iph->ip_sum = 0; /* Filled later */
+
+	/* saddr: Packet-Src-IP-Address (default: 0.0.0.0). */
+	iph->ip_src.s_addr = packet->src_ipaddr.ipaddr.ip4addr.s_addr;
+
+	/* daddr: packet destination IP addr (should be 255.255.255.255 for broadcast). */
+	iph->ip_dst.s_addr = packet->dst_ipaddr.ipaddr.ip4addr.s_addr;
+
+	/* IP header checksum */
+	iph->ip_sum = fr_iph_checksum((uint8_t const *)iph, 5);
+
+	/* fill in UDP layer (L4) */
+	udp_header_t *uh = (udp_header_t *) (dhcp_packet + ETH_HDR_SIZE + IP_HDR_SIZE);
+
+	uh->src = htons(68);
+	uh->dst = htons(67);
+	u_int16_t l4_len = (UDP_HDR_SIZE + packet->data_len);
+	uh->len = htons(l4_len);
+	uh->checksum = 0; /* UDP checksum will be done after dhcp header */
+
+	/* DHCP layer (L7) */
+	dhcp_packet_t *dhpointer = (dhcp_packet_t *)(dhcp_packet + ETH_HDR_SIZE + IP_HDR_SIZE + UDP_HDR_SIZE);
+	/* just copy what FreeRADIUS has encoded for us. */
+	memcpy(dhpointer, packet->data, packet->data_len);
+
+	/* UDP checksum is done here */
+	uh->checksum = fr_udp_checksum((uint8_t const *)(dhcp_packet + ETH_HDR_SIZE + IP_HDR_SIZE), ntohs(uh->len), uh->checksum,
+					packet->src_ipaddr.ipaddr.ip4addr, packet->dst_ipaddr.ipaddr.ip4addr);
+
+	if (fr_debug_flag > 1) {
+		char type_buf[64];
+		char const *name = type_buf;
+		char src_ip_buf[INET6_ADDRSTRLEN];
+		char dst_ip_buf[INET6_ADDRSTRLEN];
+
+		if ((packet->code >= PW_DHCP_DISCOVER) &&
+		    (packet->code <= PW_DHCP_INFORM)) {
+			name = dhcp_message_types[packet->code - PW_DHCP_OFFSET];
+		} else {
+			snprintf(type_buf, sizeof(type_buf), "%d",
+			    packet->code - PW_DHCP_OFFSET);
+		}
+
+		DEBUG(
+		"Sending %s Id %08x from %s:%d to %s:%d\n",
+		   name, (unsigned int) packet->id,
+		   inet_ntop(packet->src_ipaddr.af, &packet->src_ipaddr.ipaddr, src_ip_buf, sizeof(src_ip_buf)), packet->src_port,
+		   inet_ntop(packet->dst_ipaddr.af, &packet->dst_ipaddr.ipaddr, dst_ip_buf, sizeof(dst_ip_buf)), packet->dst_port);
+	}
+
+	return sendto(sockfd, dhcp_packet, 
+		(ETH_HDR_SIZE + IP_HDR_SIZE + UDP_HDR_SIZE + packet->data_len),
+		0, (struct sockaddr *) p_ll, sizeof(struct sockaddr_ll));
+}
+
+/*
+ *	print an ethernet address in a buffer
+ */
+char * ether_addr_print(const uint8_t *addr, char *buf)
+{
+	sprintf (buf, "%02x:%02x:%02x:%02x:%02x:%02x",
+		addr[0], addr[1], addr[2], addr[3], addr[4], addr[5]);
+	return buf;
+}
+
+/*
+ *	Receive a DHCP packet from a raw packet socket. Make sure it matches the ongoing request.
+ */
+RADIUS_PACKET *fr_dhcp_recv_raw_packet(int sockfd, struct sockaddr_ll *p_ll, RADIUS_PACKET *request)
+{
+	VALUE_PAIR		*vp;
+	RADIUS_PACKET	*packet;
+	uint8_t			*code;
+	uint32_t		magic, xid;
+	ssize_t			data_len;
+
+	uint8_t *raw_packet;
+	ethernet_header_t *ph_eth;
+	struct ip_header *ph_ip;
+	udp_header_t *ph_udp;
+	dhcp_packet_t *ph_dhcp;
+	uint16_t udp_src_port;
+	uint16_t udp_dst_port;
+	unsigned int dhcp_data_len;
+	int retval;
+	socklen_t sock_len;
+	fd_set read_fd;
+
+	packet = rad_alloc(NULL, false);
+	if (!packet) {
+		fr_strerror_printf("Failed allocating packet");
+		return NULL;
+	}
+
+	packet->data = talloc_zero_array(packet, uint8_t, MAX_PACKET_SIZE);
+	if (!packet->data) {
+		fr_strerror_printf("Out of memory");
+		rad_free(&packet);
+		return NULL;
+	}
+
+	raw_packet = talloc_zero_array(packet, uint8_t, MAX_PACKET_SIZE);
+	if (!raw_packet) {
+		fr_strerror_printf("Out of memory");
+		rad_free(&packet);
+		return NULL;
+	}
+
+	packet->sockfd = sockfd;
+
+	/* a packet was received (but maybe it is not for us) */
+
+	memset(raw_packet, 0, MAX_PACKET_SIZE);
+
+	sock_len = sizeof(struct sockaddr_ll);
+	data_len = recvfrom(sockfd, raw_packet, MAX_PACKET_SIZE, 0,
+		(struct sockaddr *)p_ll, &sock_len);
+
+	uint8_t data_offset = ETH_HDR_SIZE + IP_HDR_SIZE + UDP_HDR_SIZE; // DHCP data starts after Ethernet, IP, UDP.
+
+	if (data_len <= data_offset) DISCARD_RP("Payload (%d) smaller than required for layers 2+3+4", (int)data_len);
+
+	/* map raw packet to packet header of the different layers (Ethernet, IP, UDP) */
+	ph_eth = (ethernet_header_t *)raw_packet;
+	ph_ip = (struct ip_header *)(raw_packet + ETH_HDR_SIZE);
+	ph_udp = (udp_header_t *)(raw_packet + ETH_HDR_SIZE + IP_HDR_SIZE);
+	ph_dhcp = (dhcp_packet_t *)(raw_packet + ETH_HDR_SIZE + IP_HDR_SIZE + UDP_HDR_SIZE);
+
+	/* a. Check Ethernet layer data (L2) */
+	if (ntohs(ph_eth->ether_type) != ETH_TYPE_IP) DISCARD_RP("Ethernet type (%d) != IP", ntohs(ph_eth->ether_type));
+
+	/* If Ethernet destination is not broadcast (ff:ff:ff:ff:ff:ff)
+	 * Check if it matches the source HW address used (DHCP-Client-Hardware-Address = 267)
+	 */
+	if ( (memcmp(&eth_bcast, &ph_eth->ether_dst, ETH_ADDR_LEN) != 0) &&
+			(vp = pairfind(request->vps, 267, DHCP_MAGIC_VENDOR, TAG_ANY)) &&
+			(vp->length == sizeof(vp->vp_ether)) &&
+			(memcmp(vp->vp_ether, &ph_eth->ether_dst, ETH_ADDR_LEN) != 0) ) {
+		/* No match. */
+		char eth_dest[17+1];
+		char eth_req_src[17+1];
+		DISCARD_RP("Ethernet destination (%s) is not broadcast and doesn't match request source (%s)", 
+			ether_addr_print(ph_eth->ether_dst, eth_dest),
+			ether_addr_print(vp->vp_ether, eth_req_src));
+	}
+
+	/* b. Check IPv4 layer data (L3) */
+	if (ph_ip->ip_p != 17) DISCARD_RP("IP protocol (%d) != UDP", ph_ip->ip_p);
+	/* note: checking the destination IP address is not useful (it would be the offered IP address
+	 * - which we don't know beforehand, or the broadcast address).
+	 */
+
+	/* c. Check UDP layer data (L4) */
+	udp_src_port = ntohs(ph_udp->src);
+	udp_dst_port = ntohs(ph_udp->dst);
+	/* A DHCP server will always respond to port 68 (to a client) or 67 (to a relay).
+	 * Just check that both ports are 67 or 68.
+	 */
+	if (udp_src_port != 67 && udp_src_port != 68) DISCARD_RP("UDP src port (%d) != DHCP (67 or 68)", udp_src_port);
+	if (udp_dst_port != 67 && udp_dst_port != 68) DISCARD_RP("UDP dst port (%d) != DHCP (67 or 68)", udp_dst_port);
+
+	/* d. Check DHCP layer data */
+	dhcp_data_len = data_len - data_offset;
+
+	if (dhcp_data_len < MIN_PACKET_SIZE) DISCARD_RP("DHCP packet is too small (%d < %d)", dhcp_data_len, MIN_PACKET_SIZE);
+	if (dhcp_data_len > MAX_PACKET_SIZE) DISCARD_RP("DHCP packet is too large (%d > %d)", dhcp_data_len, MAX_PACKET_SIZE);
+	
+	if (ph_dhcp->htype != 1) DISCARD_RP("DHCP hardware type (%d) != Ethernet (1)", ph_dhcp->htype);
+	if (ph_dhcp->hlen != 6) DISCARD_RP("DHCP hardware address length (%d) != 6", ph_dhcp->hlen);
+
+	magic = ntohl(ph_dhcp->option_format);
+	if (magic != DHCP_OPTION_MAGIC_NUMBER) DISCARD_RP("DHCP magic cookie (0x%04x) != DHCP (0x%04x)", magic, DHCP_OPTION_MAGIC_NUMBER);
+
+	/*
+	 *	Reply transaction id must match value from request.
+	 */
+	xid = ntohl(ph_dhcp->xid);
+	if (xid != (uint32_t)request->id) DISCARD_RP("DHCP transaction ID (0x%04x) != xid from request (0x%04x)", xid, request->id)
+
+	/* all checks ok! this is a DHCP reply we're interested in. */
+	packet->data_len = dhcp_data_len;
+	memset(packet->data, 0, MAX_PACKET_SIZE);
+	memcpy(packet->data, raw_packet+data_offset, dhcp_data_len);
+	packet->id = xid;
+
+	code = dhcp_get_option((dhcp_packet_t *) packet->data,
+				   packet->data_len, 53);
+	if (!code) {
+		fr_strerror_printf("No message-type option was found in the packet");
+		rad_free(&packet);
+		return NULL;
+	}
+
+	if ((code[1] < 1) || (code[2] == 0) || (code[2] > 8)) {
+		fr_strerror_printf("Unknown value for message-type option");
+		rad_free(&packet);
+		return NULL;
+	}
+
+	packet->code = code[2] | PW_DHCP_OFFSET;
+
+	/*
+	 *	Create a unique vector from the MAC address and the
+	 *	DHCP opcode.  This is a hack for the RADIUS
+	 *	infrastructure in the rest of the server.
+	 *
+	 *	Note: packet->data[2] == 6, which is smaller than
+	 *	sizeof(packet->vector)
+	 *
+	 *	FIXME:  Look for client-identifier in packet,
+	 *      and use that, too?
+	 */
+	memset(packet->vector, 0, sizeof(packet->vector));
+	memcpy(packet->vector, packet->data + 28, packet->data[2]);
+	packet->vector[packet->data[2]] = packet->code & 0xff;
+
+	packet->src_port = udp_src_port;
+	packet->dst_port = udp_dst_port;
+
+	packet->src_ipaddr.af = AF_INET;
+	packet->src_ipaddr.ipaddr.ip4addr.s_addr = ph_ip->ip_src.s_addr;
+	packet->dst_ipaddr.af = AF_INET;
+	packet->dst_ipaddr.ipaddr.ip4addr.s_addr = ph_ip->ip_dst.s_addr;
+
+	if (fr_debug_flag > 1) {
+		char type_buf[64];
+		char const *name = type_buf;
+		char src_ip_buf[256], dst_ip_buf[256];
+
+		if ((packet->code >= PW_DHCP_DISCOVER) &&
+		    (packet->code <= PW_DHCP_INFORM)) {
+			name = dhcp_message_types[packet->code - PW_DHCP_OFFSET];
+		} else {
+			snprintf(type_buf, sizeof(type_buf), "%d", packet->code - PW_DHCP_OFFSET);
+		}
+
+		DEBUG("Received %s of Id %08x from %s:%d to %s:%d\n",
+		       name, (unsigned int) packet->id,
+		       inet_ntop(packet->src_ipaddr.af, &packet->src_ipaddr.ipaddr, src_ip_buf, sizeof(src_ip_buf)),
+		       packet->src_port,
+		       inet_ntop(packet->dst_ipaddr.af, &packet->dst_ipaddr.ipaddr, dst_ip_buf, sizeof(dst_ip_buf)),
+		       packet->dst_port);
+	}
+
+	return packet;
 }
 #endif

--- a/src/modules/proto_dhcp/dhcpclient.c
+++ b/src/modules/proto_dhcp/dhcpclient.c
@@ -39,9 +39,15 @@ RCSID("$Id$")
 
 #include <assert.h>
 
+#include <net/if.h>
+
+/* @todo: this is a hack */
+#  define DEBUG			if (fr_debug_flag && fr_log_fp) fr_printf_log
+
 static int success = 0;
 static int retries = 3;
 static float timeout = 5;
+static struct timeval tv_timeout;
 
 static uint16_t server_port = 0;
 static int packet_code = 0;
@@ -52,6 +58,12 @@ static uint16_t client_port = 0;
 
 static int sockfd;
 
+#ifdef HAVE_LINUX_IF_PACKET_H
+struct sockaddr_ll ll;	/* Socket address structure */
+static char *iface = NULL;
+static int iface_ind = -1;
+#endif
+
 static RADIUS_PACKET *request = NULL;
 static RADIUS_PACKET *reply = NULL;
 
@@ -60,6 +72,12 @@ static RADIUS_PACKET *reply = NULL;
 #define DHCP_FILE_LEN	(128)
 #define DHCP_VEND_LEN	(308)
 #define DHCP_OPTION_MAGIC_NUMBER (0x63825363)
+
+/* structure to keep track of offered IP addresses */
+typedef struct dc_offer {
+	uint32_t server_addr;
+	uint32_t offered_addr;
+} dc_offer_t;
 
 char const *dhcpclient_version = "dhcpclient version " RADIUSD_VERSION_STRING
 #ifdef RADIUSD_VERSION_COMMIT
@@ -74,6 +92,9 @@ static void NEVER_RETURNS usage(void)
 	fprintf(stderr, "  <command>              One of discover, request, offer, decline, release, inform.\n");
 	fprintf(stderr, "  -d <raddb>             Set user dictionary directory (defaults to " RADDBDIR ").\n");
 	fprintf(stderr, "  -f <file>              Read packets from file, not stdin.\n");
+#ifdef HAVE_LINUX_IF_PACKET_H
+	fprintf(stderr, "  -i <interface>         Use this interface to send/receive at packet level on a raw socket.\n");
+#endif
 	fprintf(stderr, "  -t <timeout>           Wait 'timeout' seconds for a reply (may be a floating point number).\n");
 	fprintf(stderr, "  -v                     Show program version information.\n");
 	fprintf(stderr, "  -x                     Debugging mode.\n");
@@ -259,6 +280,98 @@ static void print_hex(RADIUS_PACKET *packet)
 	fflush(stdout);
 }
 
+#ifdef HAVE_LINUX_IF_PACKET_H
+/*
+ *	Loop waiting for DHCP replies until timer expires.
+ *	Note that there may be more than one reply: multiple DHCP servers can respond to a broadcast discover.
+ *	A real client would pick one of the proposed replies.
+ *	We'll just return the first eligible reply, and display the others.
+ */
+static RADIUS_PACKET *fr_dhcp_recv_raw_loop(int lsockfd, struct sockaddr_ll *p_ll, RADIUS_PACKET *request_p)
+{
+	struct timeval tval;
+	RADIUS_PACKET *reply_p = NULL;
+	RADIUS_PACKET *cur_reply_p = NULL;
+	int nb_reply = 0;
+	int nb_offer = 0;
+	dc_offer_t *offer_list = NULL;
+	fd_set read_fd;
+	int retval;
+
+	memcpy(&tval, &tv_timeout, sizeof(struct timeval));
+
+	/* Loop waiting for DHCP replies until timer expires */
+	while (timerisset(&tval)) {
+		if ((!reply_p) || (cur_reply_p)) { // only debug at start and each time we get a valid DHCP reply on raw socket
+			DEBUG("Waiting for%sDHCP replies for: %d.%06d\n", 
+				(nb_reply>0)?" additional ":" ", (int)tval.tv_sec, (int)tval.tv_usec);
+		}
+
+		cur_reply_p = NULL;
+		FD_ZERO(&read_fd);
+		FD_SET(lsockfd, &read_fd);
+		retval = select(lsockfd + 1, &read_fd, NULL, NULL, &tval);
+
+		if (retval < 0) {
+			fr_strerror_printf("Select on DHCP socket failed: %s", fr_syserror(errno));
+			return NULL;
+		}
+
+		if ( retval > 0 && FD_ISSET(lsockfd, &read_fd)) {
+			/* There is something to read on our socket */
+			cur_reply_p = fr_dhcp_recv_raw_packet(lsockfd, p_ll, request_p);
+		}
+		
+		if (cur_reply_p) {
+			nb_reply ++;
+			
+			if (fr_debug_flag) print_hex(cur_reply_p);
+
+			if (fr_dhcp_decode(cur_reply_p) < 0) {
+				fprintf(stderr, "dhcpclient: failed decoding reply\n");
+				return NULL;
+			}
+			
+			if (!reply_p) reply_p = cur_reply_p;
+			
+			if (cur_reply_p->code == PW_DHCP_OFFER) {
+				VALUE_PAIR *vp1 = pairfind(cur_reply_p->vps, 54,  DHCP_MAGIC_VENDOR, TAG_ANY); /* DHCP-DHCP-Server-Identifier */
+				VALUE_PAIR *vp2 = pairfind(cur_reply_p->vps, 264, DHCP_MAGIC_VENDOR, TAG_ANY); /* DHCP-Your-IP-address */
+				
+				if (vp1 && vp2) {
+					nb_offer ++;
+					offer_list = talloc_realloc(request_p, offer_list, dc_offer_t, nb_offer);
+					offer_list[nb_offer-1].server_addr = vp1->vp_ipaddr;
+					offer_list[nb_offer-1].offered_addr = vp2->vp_ipaddr;
+				}
+			}
+		}
+	}
+	
+	if (0 == nb_reply) {
+		fr_strerror_printf("No valid DHCP reply received");
+		return NULL;
+	}
+	
+	/* display offer(s) received */
+	if (nb_offer > 0 ) {
+		DEBUG("Received %d DHCP Offer(s):\n", nb_offer);
+		int i;
+		for (i=0; i<nb_reply; i++) {
+			char server_addr_buf[INET6_ADDRSTRLEN];
+			char offered_addr_buf[INET6_ADDRSTRLEN];
+			
+			DEBUG("IP address: %s offered by DHCP server: %s\n",
+				inet_ntop(AF_INET, &offer_list[i].offered_addr, offered_addr_buf, sizeof(offered_addr_buf)),
+				inet_ntop(AF_INET, &offer_list[i].server_addr, server_addr_buf, sizeof(server_addr_buf))
+			);
+		}
+	}
+	
+	return reply_p;
+}
+#endif
+
 int main(int argc, char **argv)
 {
 	char *p;
@@ -268,13 +381,22 @@ int main(int argc, char **argv)
 
 	fr_debug_flag = 0;
 
-	while ((c = getopt(argc, argv, "d:f:hr:t:vx")) != EOF) switch(c) {
+	while ((c = getopt(argc, argv, "d:f:hr:t:vx"
+#ifdef HAVE_LINUX_IF_PACKET_H
+		"i:"
+#endif
+	)) != EOF) switch(c) {
 		case 'd':
 			radius_dir = optarg;
 			break;
 		case 'f':
 			filename = optarg;
 			break;
+#ifdef HAVE_LINUX_IF_PACKET_H
+		case 'i':
+			iface = optarg;
+			break;
+#endif
 		case 'r':
 			if (!isdigit((int) *optarg))
 				usage();
@@ -303,6 +425,10 @@ int main(int argc, char **argv)
 	argv += (optind - 1);
 
 	if (argc < 2) usage();
+
+	/*	convert timeout to a struct timeval */
+	tv_timeout.tv_sec = (time_t)timeout;
+	tv_timeout.tv_usec = (uint64_t)(timeout * 1000000) - (tv_timeout.tv_sec * 1000000);
 
 	if (dict_init(radius_dir, RADIUS_DICTIONARY) < 0) {
 		fr_perror("dhcpclient");
@@ -408,21 +534,43 @@ int main(int argc, char **argv)
 		client_ipaddr = request->src_ipaddr;
 		client_port = request->src_port;
 	}
-	sockfd = fr_socket(&client_ipaddr, client_port);
+	
+	/* set "raw mode" if an interface is specified and if destination IP address is the broadcast address. */
+	bool dc_raw_mode = false;
+#ifdef HAVE_LINUX_IF_PACKET_H
+	if (iface) {
+		iface_ind = if_nametoindex(iface);
+		if (iface_ind <= 0) {
+			fprintf(stderr, "dhcpclient: unknown interface: %s\n", iface);
+			exit(1);
+		}
+		if (server_ipaddr.ipaddr.ip4addr.s_addr == 0xFFFFFFFF) {
+			DEBUG("dhcpclient: Using interface: %s (index: %d) in raw packet mode\n", iface, iface_ind);
+			dc_raw_mode = true;
+		}
+	}
+#endif
+
+	if (!dc_raw_mode) {
+		sockfd = fr_socket(&client_ipaddr, client_port);
+		
+		/*
+		 *	Set option 'receive timeout' on socket.
+		 *	Note: in case of a timeout, the error will be "Resource temporarily unavailable".
+		 */
+		setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv_timeout, sizeof(struct timeval));
+
+	} else {
+#ifdef HAVE_LINUX_IF_PACKET_H
+		sockfd = fr_socket_packet(iface_ind, &ll);
+#endif
+	}
+
 	if (sockfd < 0) {
 		fprintf(stderr, "dhcpclient: socket: %s\n", fr_strerror());
 		exit(1);
 	}
 
-	/*
-	 *	Set option 'receive timeout' on socket.
-	 *	Note: in case of a timeout, the error will be "Resource temporarily unavailable".
-	 */
-	struct timeval tv;
-	tv.tv_sec = (time_t)timeout;
-	tv.tv_usec = (uint64_t)(timeout * 1000000) - (tv.tv_sec * 1000000);
-	setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, (char *)&tv,sizeof(struct timeval));
-	
 	request->sockfd = sockfd;
 	if (request->src_ipaddr.af == AF_UNSPEC) {
 		request->src_ipaddr = client_ipaddr;
@@ -443,22 +591,39 @@ int main(int argc, char **argv)
 	}
 	if (fr_debug_flag) print_hex(request);
 
-	if (fr_dhcp_send(request) < 0) {
-		fprintf(stderr, "dhcpclient: failed sending: %s\n",
-			fr_syserror(errno));
-		exit(1);
-	}
+	if (!dc_raw_mode) {
+		if (fr_dhcp_send(request) < 0) {
+			fprintf(stderr, "dhcpclient: failed sending: %s\n",
+				fr_syserror(errno));
+			exit(1);
+		}
 
-	reply = fr_dhcp_recv(sockfd);
-	if (!reply) {
-		fprintf(stderr, "dhcpclient: Error receiving reply %s\n", fr_strerror());
-		exit(1);
-	}
-	if (fr_debug_flag) print_hex(reply);
+		reply = fr_dhcp_recv(sockfd);
+		if (!reply) {
+			fprintf(stderr, "dhcpclient: Error receiving reply %s\n", fr_strerror());
+			exit(1);
+		}
+		if (fr_debug_flag) print_hex(reply);
 
-	if (fr_dhcp_decode(reply) < 0) {
-		fprintf(stderr, "dhcpclient: failed decoding\n");
-		return 1;
+		if (fr_dhcp_decode(reply) < 0) {
+			fprintf(stderr, "dhcpclient: failed decoding\n");
+			return 1;
+		}
+
+	} else {
+#ifdef HAVE_LINUX_IF_PACKET_H
+		if (fr_dhcp_send_raw_packet(sockfd, &ll, request) < 0) {
+			fprintf(stderr, "dhcpclient: failed sending (fr_dhcp_send_raw_packet): %s\n",
+				fr_syserror(errno));
+			exit(1);
+		}
+		
+		reply = fr_dhcp_recv_raw_loop(sockfd, &ll, request);
+		if (!reply) {
+			fprintf(stderr, "dhcpclient: Error receiving reply (fr_dhcp_recv_raw_loop)\n");
+			exit(1);
+		}
+#endif
 	}
 
 	dict_free();


### PR DESCRIPTION
This replace the following pull request (which can be closed):
https://github.com/FreeRADIUS/freeradius-server/pull/741



As discussed earlier on the list:
- if the client host has multiple interfaces,
- and at least one of them already has an IP address, Then the source IP
address cannot be 0.0.0.0 (even with "Packet-Src-IP-Address=0.0.0.0").
An actual IP address is automatically used as source.
This is modified by the device driver.

This patch does the following:
- Add an option to dhcpclient allowing to specify which network
interface to use.
- Open a raw socket on the low level packet interface. This allows
packet data to be left unchanged by the device driver.
- Encode Ethernet (send to ff:ff:ff:ff:ff:ff), IP and UDP layers
manually. And let FreeRADIUS do the DHCP stuff, as before.

(This required new specific socket / send / recv functions.)

The existing behaviour of dhcpclient is unchanged, it is used if the new
option -i is not set (or if destination is not broadcast).