### PR TITLE
Remove support for max_threads event

### DIFF
--- a/mibs/FREERADIUS-NOTIFICATION-MIB.txt
+++ b/mibs/FREERADIUS-NOTIFICATION-MIB.txt
@@ -80,12 +80,6 @@ threadUnresponsive NOTIFICATION-TYPE
        DESCRIPTION "Notification that a child thread is unresponsive"
        ::= { serverThread 3 }
 
-threadMaxThreads NOTIFICATION-TYPE
-       OBJECTS { identity }
-       STATUS current
-       DESCRIPTION "Notification that the max_threads limit has been hit"
-       ::= { serverThread 4 }
-
 serverModules  OBJECT IDENTIFIER ::= { freeRadiusNotificationMib 2 }
 
 serverModuleGeneric  OBJECT IDENTIFIER ::= { serverModules 1 }

--- a/raddb/trigger.conf
+++ b/raddb/trigger.conf
@@ -153,9 +153,6 @@ trigger {
 
 		       # an existing thread is unresponsive
 		       unresponsive = "${snmptrap}::threadUnresponsive"
-
-		       # the "max_threads" limit has been reached
-		       max_threads = "${snmptrap}::threadMaxThreads"
 		}
 	}
 

--- a/src/main/threads.c
+++ b/src/main/threads.c
@@ -791,7 +791,6 @@ static THREAD_HANDLE *spawn_thread(time_t now, int do_trigger)
 	 */
 	if (thread_pool.total_threads >= thread_pool.max_threads) {
 		DEBUG2("Thread spawn failed.  Maximum number of threads (%d) already running.", thread_pool.max_threads);
-		exec_trigger(NULL, NULL, "server.thread.max_threads", true);
 		return NULL;
 	}
 


### PR DESCRIPTION
After testing and reading the code it seems that max_threads trigger cannot be
possibly activated with the current design (i.e. spawn_thread is never called
to exceed max_threads).

It seems it cannot be triggered with any kind of load, and if it were
possible to trigger by invalid configuration (which was the case before the
check for start_threads <= max_threads was added), it wouldn't warrant a
trigger.

Still, I might be wrong, or there might be a plan to make it useful. In that
case, please feel free to reject the change. Thank you.
