### PR TITLE
Trigger max_threads upon reaching the limit

### DIFF
--- a/mibs/FREERADIUS-NOTIFICATION-MIB.txt
+++ b/mibs/FREERADIUS-NOTIFICATION-MIB.txt
@@ -83,7 +83,7 @@ threadUnresponsive NOTIFICATION-TYPE
 threadMaxThreads NOTIFICATION-TYPE
        OBJECTS { identity }
        STATUS current
-       DESCRIPTION "Notification that the max_threads limit has been hit"
+       DESCRIPTION "Notification that the max_threads limit has been reached"
        ::= { serverThread 4 }
 
 serverModules  OBJECT IDENTIFIER ::= { freeRadiusNotificationMib 2 }

--- a/src/main/threads.c
+++ b/src/main/threads.c
@@ -791,7 +791,6 @@ static THREAD_HANDLE *spawn_thread(time_t now, int do_trigger)
 	 */
 	if (thread_pool.total_threads >= thread_pool.max_threads) {
 		DEBUG2("Thread spawn failed.  Maximum number of threads (%d) already running.", thread_pool.max_threads);
-		exec_trigger(NULL, NULL, "server.thread.max_threads", true);
 		return NULL;
 	}
 
@@ -847,6 +846,12 @@ static THREAD_HANDLE *spawn_thread(time_t now, int do_trigger)
 	 *	Update the time we last spawned a thread.
 	 */
 	thread_pool.time_last_spawned = now;
+
+	/*
+	 * Fire trigger if maximum number of threads reached
+	 */
+	if (thread_pool.total_threads >= thread_pool.max_threads)
+		exec_trigger(NULL, NULL, "server.thread.max_threads", true);
 
 	/*
 	 *	And return the new handle to the caller.


### PR DESCRIPTION
Trigger "max_threads" event (and thus "threadMaxThreads" trap, with
default SNMP configuration) upon reaching "max_servers" thread limit,
instead of on an attempt to exceed it, as the latter never happens.
