### PR TITLE
Replaced Nullav with (AV*)NULL in rlm_perl

### DIFF
--- a/src/modules/rlm_perl/rlm_perl.c
+++ b/src/modules/rlm_perl/rlm_perl.c
@@ -518,7 +518,7 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 	exitstatus = perl_parse(inst->perl, xs_init, argc, embed, NULL);
 
 	end_AV = PL_endav;
-	PL_endav = Nullav;
+	PL_endav = (AV *)NULL;
 
 	if(!exitstatus) {
 		perl_run(inst->perl);


### PR DESCRIPTION
Nullav is deperacted, see http://perldoc.perl.org/5.12.1/perlapi.html#Handy-Values
