### PR TITLE
Update freeradius.spec

### DIFF
--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -63,6 +63,7 @@ BuildRequires: net-snmp-utils
 BuildRequires: readline-devel
 BuildRequires: libpcap-devel
 BuildRequires: libtalloc-devel
+BuildRequires: libcurl-devel
 
 Requires(pre): shadow-utils glibc-common
 Requires(post): /sbin/chkconfig


### PR DESCRIPTION
rlm_rest module needs libcurl-devel package.
