### PR TITLE
Use threadsafe wrapper for getpwnam/getgrnam

### DIFF
--- a/src/include/radiusd.h
+++ b/src/include/radiusd.h
@@ -42,6 +42,9 @@ typedef struct rad_request REQUEST;
 #  include <sys/wait.h>
 #endif
 
+#include <pwd.h>
+#include <grp.h>
+
 #ifndef NDEBUG
 #  define REQUEST_MAGIC (0xdeadbeef)
 #endif
@@ -543,6 +546,8 @@ char const	*rad_default_raddb_dir(void);
 char const	*rad_default_run_dir(void);
 char const	*rad_default_sbin_dir(void);
 char const	*rad_radacct_dir(void);
+struct passwd	*rad_getpwnam(const char *name);
+struct group	*rad_getgrnam(const char *name);
 void		verify_request(char const *file, int line, REQUEST *request);	/* only for special debug builds */
 
 /* client.c */

--- a/src/main/command.c
+++ b/src/main/command.c
@@ -2112,7 +2112,7 @@ static int command_socket_parse_unix(CONF_SECTION *cs, rad_listen_t *this)
 	if (sock->uid_name) {
 		struct passwd *pw;
 
-		pw = getpwnam(sock->uid_name);
+		pw = rad_getpwnam(sock->uid_name);
 		if (!pw) {
 			ERROR("Failed getting uid for %s: %s", sock->uid_name, fr_syserror(errno));
 			return -1;
@@ -2126,7 +2126,7 @@ static int command_socket_parse_unix(CONF_SECTION *cs, rad_listen_t *this)
 	if (sock->gid_name) {
 		struct group *gr;
 
-		gr = getgrnam(sock->gid_name);
+		gr = rad_getgrnam(sock->gid_name);
 		if (!gr) {
 			ERROR("Failed getting gid for %s: %s", sock->gid_name, fr_syserror(errno));
 			return -1;

--- a/src/modules/rlm_detail/rlm_detail.c
+++ b/src/modules/rlm_detail/rlm_detail.c
@@ -379,7 +379,7 @@ static rlm_rcode_t CC_HINT(nonnull) detail_do(void *instance, REQUEST *request, 
 	if (inst->group != NULL) {
 		gid = strtol(inst->group, &endptr, 10);
 		if (*endptr != '\0') {
-			grp = getgrnam(inst->group);
+			grp = rad_getgrnam(inst->group);
 			if (!grp) {
 				RDEBUG2("Unable to find system group '%s'", inst->group);
 				goto skip_group;

--- a/src/modules/rlm_opendirectory/rlm_opendirectory.c
+++ b/src/modules/rlm_opendirectory/rlm_opendirectory.c
@@ -359,7 +359,7 @@ static rlm_rcode_t CC_HINT(nonnull) mod_authorize(UNUSED void *instance, REQUEST
 
 	/* resolve SACL */
 	uuid_clear(guid_sacl);
-	groupdata = getgrnam(kRadiusSACLName);
+	groupdata = rad_getgrnam(kRadiusSACLName);
 	if (groupdata != NULL) {
 		err = mbr_gid_to_uuid(groupdata->gr_gid, guid_sacl);
 		if (err != 0) {
@@ -384,7 +384,7 @@ static rlm_rcode_t CC_HINT(nonnull) mod_authorize(UNUSED void *instance, REQUEST
 		 */
 		if (uuid_parse(rad_client->community, guid_nasgroup) != 0) {
 			/* attempt to resolve the name */
-			groupdata = getgrnam(rad_client->community);
+			groupdata = rad_getgrnam(rad_client->community);
 			if (!groupdata) {
 				AUTH("rlm_opendirectory: The group \"%s\" does not exist on this system.", rad_client->community);
 				return RLM_MODULE_FAIL;
@@ -423,7 +423,7 @@ static rlm_rcode_t CC_HINT(nonnull) mod_authorize(UNUSED void *instance, REQUEST
 	/* resolve user */
 	uuid_clear(uuid);
 
-	userdata = getpwnam(request->username->vp_strvalue);
+	userdata = rad_getpwnam(request->username->vp_strvalue);
 	if (userdata != NULL) {
 		err = mbr_uid_to_uuid(userdata->pw_uid, uuid);
 		if (err != 0)

--- a/src/modules/rlm_unix/rlm_unix.c
+++ b/src/modules/rlm_unix/rlm_unix.c
@@ -89,11 +89,11 @@ static int groupcmp(UNUSED void *instance, REQUEST *req, UNUSED VALUE_PAIR *requ
 		return -1;
 	}
 
-	pwd = getpwnam(req->username->vp_strvalue);
+	pwd = rad_getpwnam(req->username->vp_strvalue);
 	if (!pwd)
 		return -1;
 
-	grp = getgrnam(check->vp_strvalue);
+	grp = rad_getgrnam(check->vp_strvalue);
 	if (!grp)
 		return -1;
 
@@ -198,7 +198,7 @@ static rlm_rcode_t CC_HINT(nonnull) mod_authorize(UNUSED void *instance, REQUEST
 		return RLM_MODULE_USERLOCK;
 	}
 #else /* OSFC2 */
-	if ((pwd = getpwnam(name)) == NULL) {
+	if ((pwd = rad_getpwnam(name)) == NULL) {
 		return RLM_MODULE_NOTFOUND;
 	}
 	encrypted_pass = pwd->pw_passwd;


### PR DESCRIPTION
Even if rlm_unix is marked as RLM_TYPE_THREAD_UNSAFE, it runs in a
separate thread than the main thread. Both main thread and rlm_unix
uses thread unsafe getpwnam/getgrnam which causes segfault when under
stress.

We create a thread safe wrapper for those that uses TLS.

This fixes #767
