### PR TITLE
Fixed quoting for mac-addr-regexp

### DIFF
--- a/raddb/policy.d/canonicalization
+++ b/raddb/policy.d/canonicalization
@@ -48,7 +48,7 @@ split_username_nai.post-proxy {
 #
 #  Normalize the MAC Addresses in the Calling/Called-Station-Id
 #
-mac-addr-regexp = '([0-9a-f]{2})[^0-9a-f]?([0-9a-f]{2})[^0-9a-f]?([0-9a-f]{2})[^0-9a-f]?([0-9a-f]{2})[^0-9a-f]?([0-9a-f]{2})[^0-9a-f]?([0-9a-f]{2})"
+mac-addr-regexp = '([0-9a-f]{2})[^0-9a-f]?([0-9a-f]{2})[^0-9a-f]?([0-9a-f]{2})[^0-9a-f]?([0-9a-f]{2})[^0-9a-f]?([0-9a-f]{2})[^0-9a-f]?([0-9a-f]{2})'
 
 #
 #  Add "rewrite_called_station_id" in the "authorize" and


### PR DESCRIPTION
Otherwise, a "Parse error: Unterminated string" is thrown
