### PR TITLE
Fix debian package logrotate.

### DIFF
--- a/debian/freeradius.logrotate
+++ b/debian/freeradius.logrotate
@@ -1,6 +1,9 @@
 /var/log/freeradius/*.log {
         weekly
         rotate 52
+        postrotate
+                service freeradius reload > /dev/null
+        endscript
         compress
         notifempty
 }


### PR DESCRIPTION
Logrotate moves the log file from underneath FreeRADIUS, resulting in no further logging.
