### PR TITLE
Prevent a segfault when using rlm_rest

### DIFF
--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -1137,7 +1137,9 @@ static VALUE_PAIR *json_pairmake_leaf(UNUSED rlm_rest_t *instance, UNUSED rlm_re
 	value = json_object_get_string(leaf);
 
 	RDEBUG3("\tType   : %s", fr_int2str(dict_attr_types, da->type, "<INVALID>"));
-	RDEBUG3("\tLength : %zu", strlen(value));
+	if (value != NULL) {
+		RDEBUG3("\tLength : %zu", strlen(value));
+	}
 	RDEBUG3("\tValue  : \"%s\"", value);
 
 	if (flags->do_xlat) {


### PR DESCRIPTION
The debug statement tried to calculate the length of a attribute, that could be NULL.

The debug line below it already showed the value was actually NULL, so no need to add another debug line to do that.
