### PR TITLE
FR_SMART_CHECK_INCLUDE prefix fixup

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -218,7 +218,7 @@ ac_safe=`echo "$1" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
 dnl #  The default directories we search in (in addition to the compilers search path)
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 dnl #  Our local versions
 _smart_try_dir=
@@ -260,29 +260,7 @@ if test "x$_smart_try_dir" != "x"; then
 fi
 
 dnl #
-dnl #  Try using the default includes (with prefixes).
-dnl #
-if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    AC_MSG_CHECKING([for ${_prefix}/$1])
-
-    AC_TRY_COMPILE([$2
-		    #include <$1>],
-		   [int a = 1;],
-		   [
-		     smart_include="-isystem ${_prefix}/"
-		     AC_MSG_RESULT(yes)
-		     break
-		   ],
-		   [
-		     smart_include=
-		     AC_MSG_RESULT(no)
-		   ])
-  done
-fi
-
-dnl #
-dnl #  Try using the default includes (without prefixes).
+dnl #  Try using the default includes.
 dnl #
 if test "x$smart_include" = "x"; then
     AC_MSG_CHECKING([for $1])
@@ -302,10 +280,9 @@ if test "x$smart_include" = "x"; then
 fi
 
 dnl #
-dnl #  Try to guess possible locations.
+dnl #  Try to guess possible locations (with prefixes).
 dnl #
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
     FR_LOCATE_DIR(_smart_include_dir,"${_prefix}/${1}")
   done

--- a/configure
+++ b/configure
@@ -7004,7 +7004,7 @@ smart_try_dir="$talloc_include_dir"
 ac_safe=`echo "talloc.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -7056,41 +7056,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/talloc.h" >&5
-$as_echo_n "checking for ${_prefix}/talloc.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <talloc.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for talloc.h" >&5
 $as_echo_n "checking for talloc.h... " >&6; }
 
@@ -7124,7 +7089,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 
@@ -8074,7 +8038,7 @@ See \`config.log' for more details" "$LINENO" 5; }
 ac_safe=`echo "openssl/ssl.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -8126,41 +8090,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/openssl/ssl.h" >&5
-$as_echo_n "checking for ${_prefix}/openssl/ssl.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <openssl/ssl.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for openssl/ssl.h" >&5
 $as_echo_n "checking for openssl/ssl.h... " >&6; }
 
@@ -8194,7 +8123,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 
@@ -8433,7 +8361,7 @@ else
 ac_safe=`echo "pcap.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -8485,41 +8413,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/pcap.h" >&5
-$as_echo_n "checking for ${_prefix}/pcap.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <pcap.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pcap.h" >&5
 $as_echo_n "checking for pcap.h... " >&6; }
 
@@ -8553,7 +8446,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 
@@ -8676,7 +8568,7 @@ else
 ac_safe=`echo "collectd/client.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -8728,41 +8620,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/collectd/client.h" >&5
-$as_echo_n "checking for ${_prefix}/collectd/client.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <collectd/client.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for collectd/client.h" >&5
 $as_echo_n "checking for collectd/client.h... " >&6; }
 
@@ -8796,7 +8653,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 
@@ -10198,7 +10054,7 @@ smart_try_dir=$execinfo_include_dir
 ac_safe=`echo "execinfo.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -10250,41 +10106,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/execinfo.h" >&5
-$as_echo_n "checking for ${_prefix}/execinfo.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <execinfo.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for execinfo.h" >&5
 $as_echo_n "checking for execinfo.h... " >&6; }
 
@@ -10318,7 +10139,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 
@@ -10695,7 +10515,7 @@ if test "x$REGEX" = "x"; then
 ac_safe=`echo "pcreposix.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -10747,41 +10567,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/pcreposix.h" >&5
-$as_echo_n "checking for ${_prefix}/pcreposix.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <pcreposix.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pcreposix.h" >&5
 $as_echo_n "checking for pcreposix.h... " >&6; }
 
@@ -10815,7 +10600,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 
@@ -11112,7 +10896,7 @@ if test "x$REGEX" = "x"; then
 ac_safe=`echo "regex.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -11164,41 +10948,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/regex.h" >&5
-$as_echo_n "checking for ${_prefix}/regex.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <regex.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for regex.h" >&5
 $as_echo_n "checking for regex.h... " >&6; }
 
@@ -11232,7 +10981,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_couchbase/configure
+++ b/src/modules/rlm_couchbase/configure
@@ -2900,7 +2900,7 @@ fi
 ac_safe=`echo "json.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2952,41 +2952,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/json.h" >&5
-$as_echo_n "checking for ${_prefix}/json.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <json.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for json.h" >&5
 $as_echo_n "checking for json.h... " >&6; }
 
@@ -3020,7 +2985,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 
@@ -3572,7 +3536,7 @@ fi
 ac_safe=`echo "libcouchbase/couchbase.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -3624,41 +3588,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/libcouchbase/couchbase.h" >&5
-$as_echo_n "checking for ${_prefix}/libcouchbase/couchbase.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <libcouchbase/couchbase.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libcouchbase/couchbase.h" >&5
 $as_echo_n "checking for libcouchbase/couchbase.h... " >&6; }
 
@@ -3692,7 +3621,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_counter/config.h.in
+++ b/src/modules/rlm_counter/config.h.in
@@ -18,5 +18,8 @@
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
 
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION

--- a/src/modules/rlm_counter/configure
+++ b/src/modules/rlm_counter/configure
@@ -2820,7 +2820,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 ac_safe=`echo "gdbm.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2872,41 +2872,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/gdbm.h" >&5
-$as_echo_n "checking for ${_prefix}/gdbm.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <gdbm.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gdbm.h" >&5
 $as_echo_n "checking for gdbm.h... " >&6; }
 
@@ -2940,7 +2905,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_eap/types/rlm_eap_ikev2/configure
+++ b/src/modules/rlm_eap/types/rlm_eap_ikev2/configure
@@ -2648,7 +2648,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 ac_safe=`echo "EAPIKEv2/connector.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2700,41 +2700,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/EAPIKEv2/connector.h" >&5
-$as_echo_n "checking for ${_prefix}/EAPIKEv2/connector.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <EAPIKEv2/connector.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EAPIKEv2/connector.h" >&5
 $as_echo_n "checking for EAPIKEv2/connector.h... " >&6; }
 
@@ -2768,7 +2733,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_eap/types/rlm_eap_pwd/configure
+++ b/src/modules/rlm_eap/types/rlm_eap_pwd/configure
@@ -2688,7 +2688,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 ac_safe=`echo "openssl/ec.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2740,41 +2740,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/openssl/ec.h" >&5
-$as_echo_n "checking for ${_prefix}/openssl/ec.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <openssl/ec.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for openssl/ec.h" >&5
 $as_echo_n "checking for openssl/ec.h... " >&6; }
 
@@ -2808,7 +2773,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_eap/types/rlm_eap_tnc/configure
+++ b/src/modules/rlm_eap/types/rlm_eap_tnc/configure
@@ -2635,7 +2635,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 ac_safe=`echo "naaeap/naaeap.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2687,41 +2687,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/naaeap/naaeap.h" >&5
-$as_echo_n "checking for ${_prefix}/naaeap/naaeap.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <naaeap/naaeap.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for naaeap/naaeap.h" >&5
 $as_echo_n "checking for naaeap/naaeap.h... " >&6; }
 
@@ -2755,7 +2720,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_example/config.h.in
+++ b/src/modules/rlm_example/config.h.in
@@ -1,38 +1,5 @@
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
-/* Define to 1 if you have the <inttypes.h> header file. */
-#undef HAVE_INTTYPES_H
-
-/* Define to 1 if you have the <memory.h> header file. */
-#undef HAVE_MEMORY_H
-
-/* Define to 1 if you have the `printf' function. */
-#undef HAVE_PRINTF
-
-/* Define to 1 if you have the <stdint.h> header file. */
-#undef HAVE_STDINT_H
-
-/* Define to 1 if you have the <stdio.h> header file. */
-#undef HAVE_STDIO_H
-
-/* Define to 1 if you have the <stdlib.h> header file. */
-#undef HAVE_STDLIB_H
-
-/* Define to 1 if you have the <strings.h> header file. */
-#undef HAVE_STRINGS_H
-
-/* Define to 1 if you have the <string.h> header file. */
-#undef HAVE_STRING_H
-
-/* Define to 1 if you have the <sys/stat.h> header file. */
-#undef HAVE_SYS_STAT_H
-
-/* Define to 1 if you have the <sys/types.h> header file. */
-#undef HAVE_SYS_TYPES_H
-
-/* Define to 1 if you have the <unistd.h> header file. */
-#undef HAVE_UNISTD_H
-
 /* Define to the address where bug reports for this package should be sent. */
 #undef PACKAGE_BUGREPORT
 
@@ -45,8 +12,8 @@
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
 
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
-
-/* Define to 1 if you have the ANSI C header files. */
-#undef STDC_HEADERS

--- a/src/modules/rlm_example/configure
+++ b/src/modules/rlm_example/configure
@@ -2927,7 +2927,7 @@ fi
 ac_safe=`echo "stdio.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2979,41 +2979,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/stdio.h" >&5
-$as_echo_n "checking for ${_prefix}/stdio.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <stdio.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for stdio.h" >&5
 $as_echo_n "checking for stdio.h... " >&6; }
 
@@ -3047,7 +3012,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_idn/configure
+++ b/src/modules/rlm_idn/configure
@@ -2928,7 +2928,7 @@ fi
 ac_safe=`echo "idna.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2980,41 +2980,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/idna.h" >&5
-$as_echo_n "checking for ${_prefix}/idna.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <idna.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for idna.h" >&5
 $as_echo_n "checking for idna.h... " >&6; }
 
@@ -3048,7 +3013,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_ippool/config.h.in
+++ b/src/modules/rlm_ippool/config.h.in
@@ -18,5 +18,8 @@
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
 
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION

--- a/src/modules/rlm_ippool/configure
+++ b/src/modules/rlm_ippool/configure
@@ -2822,7 +2822,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 ac_safe=`echo "gdbm.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2874,41 +2874,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/gdbm.h" >&5
-$as_echo_n "checking for ${_prefix}/gdbm.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <gdbm.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gdbm.h" >&5
 $as_echo_n "checking for gdbm.h... " >&6; }
 
@@ -2942,7 +2907,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_krb5/configure
+++ b/src/modules/rlm_krb5/configure
@@ -2970,7 +2970,7 @@ $as_echo "HEIMDAL" >&6; }
 ac_safe=`echo "krb5.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -3022,41 +3022,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/krb5.h" >&5
-$as_echo_n "checking for ${_prefix}/krb5.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <krb5.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for krb5.h" >&5
 $as_echo_n "checking for krb5.h... " >&6; }
 
@@ -3090,7 +3055,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 
@@ -4340,7 +4304,7 @@ fi
 ac_safe=`echo "com_err.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -4392,41 +4356,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/com_err.h" >&5
-$as_echo_n "checking for ${_prefix}/com_err.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <com_err.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for com_err.h" >&5
 $as_echo_n "checking for com_err.h... " >&6; }
 
@@ -4460,7 +4389,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 
@@ -4567,7 +4495,7 @@ smart_prefix=
 ac_safe=`echo "et/com_err.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -4619,41 +4547,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/et/com_err.h" >&5
-$as_echo_n "checking for ${_prefix}/et/com_err.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <et/com_err.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for et/com_err.h" >&5
 $as_echo_n "checking for et/com_err.h... " >&6; }
 
@@ -4687,7 +4580,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_ldap/configure
+++ b/src/modules/rlm_ldap/configure
@@ -3198,7 +3198,7 @@ fi
 ac_safe=`echo "ldap.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -3250,41 +3250,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/ldap.h" >&5
-$as_echo_n "checking for ${_prefix}/ldap.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <ldap.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ldap.h" >&5
 $as_echo_n "checking for ldap.h... " >&6; }
 
@@ -3318,7 +3283,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_mschap/config.h.in
+++ b/src/modules/rlm_mschap/config.h.in
@@ -1,7 +1,7 @@
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
 /* Build with Apple Open Directory support */
-#undef HAVE_OPEN_DIRECTORY
+#undef HAVE_MEMBERSHIP_H
 
 /* Define to the address where bug reports for this package should be sent. */
 #undef PACKAGE_BUGREPORT

--- a/src/modules/rlm_mschap/configure
+++ b/src/modules/rlm_mschap/configure
@@ -2705,7 +2705,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 ac_safe=`echo "membership.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2757,41 +2757,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/membership.h" >&5
-$as_echo_n "checking for ${_prefix}/membership.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <membership.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for membership.h" >&5
 $as_echo_n "checking for membership.h... " >&6; }
 
@@ -2825,7 +2790,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_opendirectory/configure
+++ b/src/modules/rlm_opendirectory/configure
@@ -2752,7 +2752,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 ac_safe=`echo "membership.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2804,41 +2804,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/membership.h" >&5
-$as_echo_n "checking for ${_prefix}/membership.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <membership.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for membership.h" >&5
 $as_echo_n "checking for membership.h... " >&6; }
 
@@ -2872,7 +2837,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_pam/config.h.in
+++ b/src/modules/rlm_pam/config.h.in
@@ -45,6 +45,9 @@
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
 
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 

--- a/src/modules/rlm_python/configure
+++ b/src/modules/rlm_python/configure
@@ -2864,7 +2864,7 @@ fi
 ac_safe=`echo "Python.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2916,41 +2916,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/Python.h" >&5
-$as_echo_n "checking for ${_prefix}/Python.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <Python.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Python.h" >&5
 $as_echo_n "checking for Python.h... " >&6; }
 
@@ -2984,7 +2949,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_radutmp/config.h.in
+++ b/src/modules/rlm_radutmp/config.h.in
@@ -42,6 +42,9 @@
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
 
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 

--- a/src/modules/rlm_realm/configure
+++ b/src/modules/rlm_realm/configure
@@ -2924,7 +2924,7 @@ fi
 ac_safe=`echo "trust_router/tr_dh.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2976,41 +2976,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/trust_router/tr_dh.h" >&5
-$as_echo_n "checking for ${_prefix}/trust_router/tr_dh.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <trust_router/tr_dh.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for trust_router/tr_dh.h" >&5
 $as_echo_n "checking for trust_router/tr_dh.h... " >&6; }
 
@@ -3044,7 +3009,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_redis/configure
+++ b/src/modules/rlm_redis/configure
@@ -2643,7 +2643,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 ac_safe=`echo "hiredis/hiredis.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2695,41 +2695,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/hiredis/hiredis.h" >&5
-$as_echo_n "checking for ${_prefix}/hiredis/hiredis.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <hiredis/hiredis.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for hiredis/hiredis.h" >&5
 $as_echo_n "checking for hiredis/hiredis.h... " >&6; }
 
@@ -2763,7 +2728,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_rediswho/configure
+++ b/src/modules/rlm_rediswho/configure
@@ -2643,7 +2643,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 ac_safe=`echo "hiredis/hiredis.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2695,41 +2695,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/hiredis/hiredis.h" >&5
-$as_echo_n "checking for ${_prefix}/hiredis/hiredis.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <hiredis/hiredis.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for hiredis/hiredis.h" >&5
 $as_echo_n "checking for hiredis/hiredis.h... " >&6; }
 
@@ -2763,7 +2728,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_rest/configure
+++ b/src/modules/rlm_rest/configure
@@ -3334,7 +3334,7 @@ fi
 ac_safe=`echo "json/json.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -3386,41 +3386,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/json/json.h" >&5
-$as_echo_n "checking for ${_prefix}/json/json.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <json/json.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for json/json.h" >&5
 $as_echo_n "checking for json/json.h... " >&6; }
 
@@ -3454,7 +3419,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_securid/configure
+++ b/src/modules/rlm_securid/configure
@@ -2640,7 +2640,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 ac_safe=`echo "acexport.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2692,41 +2692,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/acexport.h" >&5
-$as_echo_n "checking for ${_prefix}/acexport.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <acexport.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for acexport.h" >&5
 $as_echo_n "checking for acexport.h... " >&6; }
 
@@ -2760,7 +2725,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_smsotp/config.h.in
+++ b/src/modules/rlm_smsotp/config.h.in
@@ -42,6 +42,9 @@
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
 
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 

--- a/src/modules/rlm_sql/drivers/rlm_sql_db2/configure
+++ b/src/modules/rlm_sql/drivers/rlm_sql_db2/configure
@@ -2818,7 +2818,7 @@ fi
 ac_safe=`echo "sqlcli.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2870,41 +2870,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/sqlcli.h" >&5
-$as_echo_n "checking for ${_prefix}/sqlcli.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <sqlcli.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for sqlcli.h" >&5
 $as_echo_n "checking for sqlcli.h... " >&6; }
 
@@ -2938,7 +2903,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_sql/drivers/rlm_sql_firebird/configure
+++ b/src/modules/rlm_sql/drivers/rlm_sql_firebird/configure
@@ -2817,7 +2817,7 @@ fi
 ac_safe=`echo "ibase.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2869,41 +2869,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/ibase.h" >&5
-$as_echo_n "checking for ${_prefix}/ibase.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <ibase.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ibase.h" >&5
 $as_echo_n "checking for ibase.h... " >&6; }
 
@@ -2937,7 +2902,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_sql/drivers/rlm_sql_freetds/configure
+++ b/src/modules/rlm_sql/drivers/rlm_sql_freetds/configure
@@ -2641,7 +2641,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 ac_safe=`echo "ctpublic.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2693,41 +2693,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/ctpublic.h" >&5
-$as_echo_n "checking for ${_prefix}/ctpublic.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <ctpublic.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ctpublic.h" >&5
 $as_echo_n "checking for ctpublic.h... " >&6; }
 
@@ -2761,7 +2726,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_sql/drivers/rlm_sql_iodbc/configure
+++ b/src/modules/rlm_sql/drivers/rlm_sql_iodbc/configure
@@ -2818,7 +2818,7 @@ fi
 ac_safe=`echo "isql.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2870,41 +2870,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/isql.h" >&5
-$as_echo_n "checking for ${_prefix}/isql.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <isql.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for isql.h" >&5
 $as_echo_n "checking for isql.h... " >&6; }
 
@@ -2938,7 +2903,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_sql/drivers/rlm_sql_mysql/config.h.in
+++ b/src/modules/rlm_sql/drivers/rlm_sql_mysql/config.h.in
@@ -18,5 +18,8 @@
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
 
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION

--- a/src/modules/rlm_sql/drivers/rlm_sql_mysql/configure
+++ b/src/modules/rlm_sql/drivers/rlm_sql_mysql/configure
@@ -3311,7 +3311,7 @@ $as_echo "no" >&6; }
 ac_safe=`echo "mysql/mysql.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -3363,41 +3363,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/mysql/mysql.h" >&5
-$as_echo_n "checking for ${_prefix}/mysql/mysql.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <mysql/mysql.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for mysql/mysql.h" >&5
 $as_echo_n "checking for mysql/mysql.h... " >&6; }
 
@@ -3431,7 +3396,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_sql/drivers/rlm_sql_oracle/configure
+++ b/src/modules/rlm_sql/drivers/rlm_sql_oracle/configure
@@ -2646,7 +2646,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 ac_safe=`echo "oci.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2698,41 +2698,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/oci.h" >&5
-$as_echo_n "checking for ${_prefix}/oci.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <oci.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for oci.h" >&5
 $as_echo_n "checking for oci.h... " >&6; }
 
@@ -2766,7 +2731,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_sql/drivers/rlm_sql_postgresql/configure
+++ b/src/modules/rlm_sql/drivers/rlm_sql_postgresql/configure
@@ -2688,7 +2688,7 @@ fi
 ac_safe=`echo "libpq-fe.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2740,41 +2740,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/libpq-fe.h" >&5
-$as_echo_n "checking for ${_prefix}/libpq-fe.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <libpq-fe.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libpq-fe.h" >&5
 $as_echo_n "checking for libpq-fe.h... " >&6; }
 
@@ -2808,7 +2773,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_sql/drivers/rlm_sql_sqlite/configure
+++ b/src/modules/rlm_sql/drivers/rlm_sql_sqlite/configure
@@ -2967,7 +2967,7 @@ done
 ac_safe=`echo "sqlite3.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -3019,41 +3019,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/sqlite3.h" >&5
-$as_echo_n "checking for ${_prefix}/sqlite3.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <sqlite3.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for sqlite3.h" >&5
 $as_echo_n "checking for sqlite3.h... " >&6; }
 
@@ -3087,7 +3052,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_sql/drivers/rlm_sql_unixodbc/configure
+++ b/src/modules/rlm_sql/drivers/rlm_sql_unixodbc/configure
@@ -2818,7 +2818,7 @@ fi
 ac_safe=`echo "sql.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2870,41 +2870,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/sql.h" >&5
-$as_echo_n "checking for ${_prefix}/sql.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <sql.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for sql.h" >&5
 $as_echo_n "checking for sql.h... " >&6; }
 
@@ -2938,7 +2903,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_sqlhpwippool/config.h.in
+++ b/src/modules/rlm_sqlhpwippool/config.h.in
@@ -12,5 +12,8 @@
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
 
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION

--- a/src/modules/rlm_unbound/configure
+++ b/src/modules/rlm_unbound/configure
@@ -2795,7 +2795,7 @@ fi
 ac_safe=`echo "unbound.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2847,41 +2847,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/unbound.h" >&5
-$as_echo_n "checking for ${_prefix}/unbound.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <unbound.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for unbound.h" >&5
 $as_echo_n "checking for unbound.h... " >&6; }
 
@@ -2915,7 +2880,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 

--- a/src/modules/rlm_unix/config.h.in
+++ b/src/modules/rlm_unix/config.h.in
@@ -1,5 +1,8 @@
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
+/* Define to 1 if you have the `getpwnam' function. */
+#undef HAVE_GETPWNAM
+
 /* Define to 1 if you have the `getspnam' function. */
 #undef HAVE_GETSPNAM
 
@@ -53,6 +56,9 @@
 
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
+
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
 
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION

--- a/src/modules/rlm_yubikey/configure
+++ b/src/modules/rlm_yubikey/configure
@@ -2699,7 +2699,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 ac_safe=`echo "yubikey.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -2751,41 +2751,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/yubikey.h" >&5
-$as_echo_n "checking for ${_prefix}/yubikey.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <yubikey.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for yubikey.h" >&5
 $as_echo_n "checking for yubikey.h... " >&6; }
 
@@ -2819,7 +2784,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 
@@ -3125,7 +3089,7 @@ $as_echo "$as_me: WARNING: silently building without yubikey token decryption su
 ac_safe=`echo "ykclient.h" | sed 'y%./+-%__pm%'`
 old_CPPFLAGS="$CPPFLAGS"
 smart_include=
-smart_include_dir="/usr/local/include /opt/include"
+smart_include_dir="/usr/local/include /opt/include /usr/include"
 
 _smart_try_dir=
 _smart_include_dir=
@@ -3177,41 +3141,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-  for _prefix in $smart_prefix; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/ykclient.h" >&5
-$as_echo_n "checking for ${_prefix}/ykclient.h... " >&6; }
-
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-		    #include <ykclient.h>
-int
-main ()
-{
-int a = 1;
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-		     smart_include="-isystem ${_prefix}/"
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-		     break
-
-else
-
-		     smart_include=
-		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-  done
-fi
-
-if test "x$smart_include" = "x"; then
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ykclient.h" >&5
 $as_echo_n "checking for ykclient.h... " >&6; }
 
@@ -3245,7 +3174,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
   for prefix in $smart_prefix; do
 
 


### PR DESCRIPTION
The smart_prefix parts in FR_SMART_CHECK_INCLUDE do not seem to be working as intended in testing on my OSX and Linux systems.

Example: $smart_prefix = "json json-c”

The code checks with: "-isystem json/" and "-isystem json-c/“ but does not succeed when json.h is located under /usr/include/json-c/json.h (which is a standard path).

The intent appears to be that the compiler (clang / gcc) will prepend the system default search paths but this doesn’t seem to be the case.

Under OSX the overall function works when it falls through to the ‘guessing’ section when the file is present under /usr/local/include/json-c/json.h installed by homebrew.

This can be fixed by simply adding "/usr/include" to the end of _smart_include_dir and doing away with the previous check that was attempting to use the default search paths with prefixes.

Anyone have any other thoughts?
