### PR TITLE
fixes for json.h detection and deprecated libcouchbase functions

### DIFF
--- a/src/modules/rlm_couchbase/configure
+++ b/src/modules/rlm_couchbase/configure
@@ -2891,9 +2891,7 @@ fi
 
 
 	have_json="yes"
-
-	smart_prefix="json-c json"
-	smart_try_dir="$jsonc_include_dir"
+	smart_try_dir="$jsonc_include_dir /usr/local/include/json-c /usr/local/include/json /usr/include/json-c /usr/include/json"
 
 
 

--- a/src/modules/rlm_couchbase/configure.ac
+++ b/src/modules/rlm_couchbase/configure.ac
@@ -70,9 +70,7 @@ if test x$with_[]modname != xno; then
 	dnl ############################################################
 
 	have_json="yes"
-
-	smart_prefix="json-c json"
-	smart_try_dir="$jsonc_include_dir"
+	smart_try_dir="$jsonc_include_dir /usr/local/include/json-c /usr/local/include/json /usr/include/json-c /usr/include/json"
 	FR_SMART_CHECK_INCLUDE([json.h])
 	if test "x$ac_cv_header_json_h" != "xyes"; then
 		have_json="no"

--- a/src/modules/rlm_couchbase/couchbase.h
+++ b/src/modules/rlm_couchbase/couchbase.h
@@ -44,8 +44,9 @@ typedef union cookie_u {
 	void *data;
 } cookie_u;
 
-/* general error callback */
-void couchbase_error_callback(lcb_t instance, lcb_error_t error, const char *errinfo);
+/* couchbase statistics callback */
+void couchbase_stat_callback(lcb_t instance, const void *cookie, lcb_error_t error,
+	const lcb_server_stat_resp_t *resp);
 
 /* store a key/document in couchbase */
 void couchbase_store_callback(lcb_t instance, const void *cookie, lcb_storage_t operation,
@@ -56,7 +57,10 @@ void couchbase_get_callback(lcb_t instance, const void *cookie, lcb_error_t erro
 	const lcb_get_resp_t *item);
 
 /* create a couchbase instance and connect to the cluster */
-lcb_t couchbase_init_connection(const char *host, const char *bucket, const char *pass);
+lcb_error_t couchbase_init_connection(lcb_t *instance, const char *host, const char *bucket, const char *pass);
+
+/* get server statistics */
+lcb_error_t couchbase_server_stats(lcb_t instance, const void *cookie);
 
 /* store document/key in couchbase */
 lcb_error_t couchbase_set_key(lcb_t instance, const char *key, const char *document, int expire);

--- a/src/modules/rlm_couchbase/mod.c
+++ b/src/modules/rlm_couchbase/mod.c
@@ -56,10 +56,10 @@ void *mod_conn_create(TALLOC_CTX *ctx, void *instance)
 	lcb_error_t cb_error = LCB_SUCCESS;         /* couchbase error status */
 
 	/* create instance */
-	cb_inst = couchbase_init_connection(inst->server, inst->bucket, inst->password);
+	cb_error = couchbase_init_connection(&cb_inst, inst->server, inst->bucket, inst->password);
 
-	/* check couchbase instance status */
-	if ((cb_error = lcb_get_last_error(cb_inst)) != LCB_SUCCESS) {
+	/* check couchbase instance */
+	if (cb_error != LCB_SUCCESS) {
 		ERROR("rlm_couchbase: failed to initiate couchbase connection: %s (0x%x)", lcb_strerror(NULL, cb_error), cb_error);
 		/* destroy/free couchbase instance */
 		lcb_destroy(cb_inst);
@@ -91,13 +91,10 @@ int mod_conn_alive(UNUSED void *instance, void *handle)
 	lcb_t cb_inst = chandle->handle;            /* couchbase instance */
 	lcb_error_t cb_error = LCB_SUCCESS;         /* couchbase error status */
 
-	/* attempt to get server list */
-	const char *const *servers = lcb_get_server_list(cb_inst);
-
-	/* check error state and server list return */
-	if (((cb_error = lcb_get_last_error(cb_inst)) != LCB_SUCCESS) || (servers == NULL)) {
+	/* attempt to get server stats */
+	if ((cb_error = couchbase_server_stats(cb_inst, NULL)) != LCB_SUCCESS) {
 		/* log error */
-		ERROR("rlm_couchbase: failed to get couchbase server topology: %s (0x%x)", lcb_strerror(NULL, cb_error), cb_error);
+		ERROR("rlm_couchbase: failed to get couchbase server stats: %s (0x%x)", lcb_strerror(NULL, cb_error), cb_error);
 		/* return false */
 		return false;
 	}


### PR DESCRIPTION
fixes json-c header detection as discussed in pull #791 by using full paths and reworks small sections of code to eliminate deprecated functions in newer versions of libcouchbase (2.4.0+)
