### PR TITLE
Set CURLOPT_NOSIGNAL in rest module

### DIFF
--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -346,6 +346,7 @@ void *mod_conn_create(TALLOC_CTX *ctx, void *instance)
 		SET_OPTION(CURLOPT_SSL_VERIFYHOST, 0);
 		SET_OPTION(CURLOPT_CONNECT_ONLY, 1);
 		SET_OPTION(CURLOPT_URL, inst->connect_uri);
+		SET_OPTION(CURLOPT_NOSIGNAL, 1);
 
 		DEBUG("rlm_rest (%s): Connecting to \"%s\"", inst->xlat_name, inst->connect_uri);
 
@@ -1929,6 +1930,7 @@ int rest_request_config(rlm_rest_t *instance, rlm_rest_section_t *section,
 	 *	Setup any header options and generic headers.
 	 */
 	SET_OPTION(CURLOPT_URL, uri);
+	SET_OPTION(CURLOPT_NOSIGNAL, 1);
 	SET_OPTION(CURLOPT_USERAGENT, "FreeRADIUS " RADIUSD_VERSION_STRING);
 
 	content_type = fr_int2str(http_content_type_table, type, section->body_str);


### PR DESCRIPTION
This is required for multithreaded applications (see http://curl.haxx.se/libcurl/c/libcurl-tutorial.html#Multi-threading). Once in a while, this would result in a longjump error:

```
*** longjmp causes uninitialized stack frame ***: freeradius terminated
======= Backtrace: =========
/lib/i386-linux-gnu/i686/cmov/libc.so.6(__fortify_fail+0x50)[0xf73b16a0]
/lib/i386-linux-gnu/i686/cmov/libc.so.6(+0xeb60a)[0xf73b160a]
/usr/lib/i386-linux-gnu/libcurl-gnutls.so.4(+0x8085)[0xf71bf085]
```

(file and memory locations may vary among platforms).

The crash occured about once or twice per hour while under continuous load, there is no definite way to reproduce it. I haven't seen it anymore with these changes after several hours of testing.
