### PR TITLE
Validate availability of json on startup in rlm_rest

### DIFF
--- a/src/modules/rlm_rest/rlm_rest.c
+++ b/src/modules/rlm_rest/rlm_rest.c
@@ -650,6 +650,13 @@ static int parse_sub_section(CONF_SECTION *parent, rlm_rest_section_t *config, r
 				      "markup format", config->body_str);
 			return -1;
 
+#ifndef HAVE_JSON
+		case HTTP_BODY_UNAVAILABLE:
+			cf_log_err_cs(cs, "Unavailable HTTP body type.  \"%s\" is not available in this "
+				      "build", config->body_str);
+			return -1;
+#endif
+
 		default:
 			break;
 		}


### PR DESCRIPTION
If the server was compiled without json support and json was requested in rlm_rest, the server would startup without any problem. However, on the first use of the module, an "assert(false)" was triggered.

This patch validates the bevahiour during the startup phase.
