### PR TITLE
process: Talloc home_trigger dummy request

### DIFF
--- a/src/main/process.c
+++ b/src/main/process.c
@@ -3222,16 +3222,17 @@ static void ping_home_server(void *ctx)
 
 static void home_trigger(home_server_t *home, char const *trigger)
 {
-	REQUEST my_request;
-	RADIUS_PACKET my_packet;
+	REQUEST *my_request;
+	RADIUS_PACKET *my_packet;
 
-	memset(&my_request, 0, sizeof(my_request));
-	memset(&my_packet, 0, sizeof(my_packet));
-	my_request.proxy = &my_packet;
-	my_packet.dst_ipaddr = home->ipaddr;
-	my_packet.src_ipaddr = home->src_ipaddr;
+	my_request = talloc_zero(NULL, REQUEST);
+	my_packet = talloc_zero(my_request, RADIUS_PACKET);
+	my_request->proxy = my_packet;
+	my_packet->dst_ipaddr = home->ipaddr;
+	my_packet->src_ipaddr = home->src_ipaddr;
 
-	exec_trigger(&my_request, home->cs, trigger, false);
+	exec_trigger(my_request, home->cs, trigger, false);
+	talloc_free(my_request);
 }
 
 static void mark_home_server_zombie(home_server_t *home, struct timeval *now, struct timeval *response_window)


### PR DESCRIPTION
Allocate the dummy request in home_trigger with talloc, instead of
allocating it on the stack, as the rest of the code expects it to be a
valid talloc context.

This fixes a talloc_abort resulting from xlat_tokenize_request invoking
talloc_typed_strdup with the dummy request as the talloc context.

NOTE: Besides this one, master seems to have two similar cases in
src/modules/proto_bfd/bfd.c, found with "grep -r --include '_.[hc]'
'^\s_REQUEST\s+[a-zA-Z]' *".
