### PR TITLE
perl: Don't call detach after failed perl_parse

### DIFF
--- a/src/modules/rlm_perl/rlm_perl.c
+++ b/src/modules/rlm_perl/rlm_perl.c
@@ -73,6 +73,7 @@ typedef struct rlm_perl_t {
 	char const	*xlat_name;
 	char const	*perl_flags;
 	PerlInterpreter	*perl;
+	bool             perl_parsed;
 	pthread_key_t	*thread_key;
 
 #ifdef USE_ITHREADS
@@ -538,6 +539,7 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 	PL_endav = (AV *)NULL;
 
 	if(!exitstatus) {
+		inst->perl_parsed = true;
 		perl_run(inst->perl);
 	} else {
 		ERROR("rlm_perl: perl_parse failed: %s not found or has syntax errors. \n", inst->module);
@@ -1012,7 +1014,7 @@ static int mod_detach(void *instance)
 	}
 #endif
 
-	if (inst->func_detach) {
+	if (inst->perl_parsed && inst->func_detach) {
 		dTHXa(inst->perl);
 		PERL_SET_CONTEXT(inst->perl);
 		{


### PR DESCRIPTION
Don't call "detach" callback in rlm_perl, if perl_parse of the Perl
module failed.

This fixes segfault when the module file cannot be read:

```
Can't open perl script "/etc/raddb/mods-config/perl/example.pl": Permission denied
rlm_perl: perl_parse failed: /etc/raddb/mods-config/perl/example.pl not found or has syntax errors.
/etc/raddb/mods-enabled/perl[7]: Instantiation failed for module "perl"
Segmentation fault
```
