### PR TITLE
dhcpclient: Load dictionary.dhcp from DICTDIR.

### DIFF
--- a/src/modules/proto_dhcp/dhcpclient.c
+++ b/src/modules/proto_dhcp/dhcpclient.c
@@ -264,6 +264,7 @@ int main(int argc, char **argv)
 	char *p;
 	int c;
 	char const *radius_dir = RADDBDIR;
+	char const *dict_dir = DICTDIR;
 	char const *filename = NULL;
 	DICT_ATTR const *da;
 
@@ -315,7 +316,7 @@ int main(int argc, char **argv)
 	 */
 	da = dict_attrbyname("DHCP-Message-Type");
 	if (!da) {
-		if (dict_read(radius_dir, "dictionary.dhcp") < 0) {
+		if (dict_read(dict_dir, "dictionary.dhcp") < 0) {
 			fprintf(stderr, "Failed reading dictionary.dhcp: %s",
 				fr_strerror());
 			return -1;


### PR DESCRIPTION
Load dictionary.dhcp from DICTDIR instead of RADDBDIR in dhcpclient.c,
as it is found only in the former.

This fixes the following error printed when invoking dhcpclient:

```
Failed reading dictionary.dhcp: dict_init: Couldn't open dictionary
"/etc/raddb/dictionary.dhcp": No such file or directory
```
