### PR TITLE
Prevent assert(0) in rlm_rest

### DIFF
--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -2296,6 +2296,10 @@ int rest_response_decode(rlm_rest_t *instance, UNUSED rlm_rest_section_t *sectio
 	case HTTP_BODY_UNSUPPORTED:
 	case HTTP_BODY_UNAVAILABLE:
 	case HTTP_BODY_INVALID:
+#ifndef HAVE_JSON
+	case HTTP_BODY_JSON:
+		RERROR("Received JSON data, JSON is not available in this build");
+#endif
 		return -1;
 
 	default:


### PR DESCRIPTION
If the RADIUS server is compiled without JSON support, it is still possible that the other end of the rlm_rest module returns JSON. This triggered an "assert(0)" and crashed the server. This fixes this by printing an error message to indicate that the reply of the REST server couldn't be parsed, and failing the module gracefully.
