### PR TITLE
pairadd: Don't add a VP if it's already present

### DIFF
--- a/src/lib/valuepair.c
+++ b/src/lib/valuepair.c
@@ -283,8 +283,11 @@ void pairadd(VALUE_PAIR **first, VALUE_PAIR *add)
 		*first = add;
 		return;
 	}
-	for(i = *first; i->next; i = i->next)
+	for(i = *first; i->next; i = i->next) {
 		VERIFY_VP(i);
+		if(i == add)
+			return;
+	}
 	i->next = add;
 }
 


### PR DESCRIPTION
In the 3.0 code base, pairmake() will already do a pairadd()
automatically. If an old code base (e.g. modules originally written for
FreeRADIUS 2.x) uses pairmake() and then pairadd() explicitly, this will
add the VP _twice_, thus creating a cyclic list structure, e.g.:

```
A->next == B;
B->next == B;
B->next == B;
B->next == B;
...
```

This makes any function that walks all value pairs end up eating 100%
CPU.

Since VPs are added at the end of the list, we can simply stop
traversing the list and return silently in case the VP is already
present.
