### PR TITLE
Create eap-inner-outer-reply policy

### DIFF
--- a/raddb/policy.d/eap-inner-outer-reply
+++ b/raddb/policy.d/eap-inner-outer-reply
@@ -1,0 +1,30 @@
+#  This policy checks which reply we need to update
+#
+eap-inner_outer_reply.post-auth {
+	# if EAP-TTLS and using the tunneled reply, set control flag to 0
+	if ( ("%{outer.request:EAP-Type}" == 'TTLS') && ("${modules.eap.ttls.use_tunneled_reply}" == 'yes') ) {
+		update control {
+			Use-Outer-Reply := 0
+		}
+	} 
+	# if EAP-TTLS and NOT using the tunneled reply, set control flag to 1
+	elsif ( ("%{outer.request:EAP-Type}" == 'TTLS') && ("${modules.eap.ttls.use_tunneled_reply}" == 'no') ) {
+		update control {
+			Use-Outer-Reply := 1
+		}
+	}
+	# if PEAP and using the tunneled reply, set control flag to 0
+	elsif ( ("%{outer.request:EAP-Type}" == 'PEAP') && ("${modules.eap.peap.use_tunneled_reply}" == 'yes') ) {
+		update control {
+			Use-Outer-Reply := 0
+		}
+	}
+	# if PEAP and NOT using the tunneled reply, set control flag to 1
+	elsif ( ("%{outer.request:EAP-Type}" == 'PEAP') && ("${modules.eap.peap.use_tunneled_reply}" == 'no') ) {
+		update control {
+			Use-Outer-Reply := 1
+		}
+	}
+}
+
+


### PR DESCRIPTION
Create an easy-to-use policy that allows other policies to figure out whether to use reply or outer.reply in a call.

Use-Outer-Reply is an attribute only used in control, so it should be defined in dictionary.freeradius.internal (but I don't know which attribute number to give it), so I haven't defined one. 

If you can do this as a virtual attribute internally without using this policy, then so much the better, and feel free to reject this pull request.
