### PR TITLE
man: Mention eap-md5 in radtest synopsis

### DIFF
--- a/man/man1/radtest.1
+++ b/man/man1/radtest.1
@@ -6,7 +6,7 @@ radtest - send packets to a RADIUS server, show reply
 .RB [ \-d
 .IR raddb_directory ]
 .RB [ \-t
-.IR pap/chap/mschap ]
+.IR pap/chap/mschap/eap-md5 ]
 .RB [ \-x
 .IR ]
 .RB [ \-4


### PR DESCRIPTION
Add "eap-md5" to the possible values of -t option in radtest's manpage
SYNOPSIS to match the detailed description in the OPTIONS.
