### PR TITLE
Ignore SIGTERM when firing stop and signal.term

### DIFF
--- a/src/main/process.c
+++ b/src/main/process.c
@@ -4680,7 +4680,6 @@ static void handle_signal_self(int flag)
 			fr_event_loop_exit(el, 1);
 		} else {
 			INFO("Signalled to terminate");
-			exec_trigger(NULL, NULL, "server.signal.term", true);
 			fr_event_loop_exit(el, 2);
 		}
 

--- a/src/main/radiusd.c
+++ b/src/main/radiusd.c
@@ -594,13 +594,19 @@ int main(int argc, char *argv[])
 		INFO("Exiting normally");
 	}
 
-	exec_trigger(NULL, NULL, "server.stop", false);
-
 	/*
 	 *	Ignore the TERM signal: we're
 	 *	about to die.
 	 */
 	signal(SIGTERM, SIG_IGN);
+
+	/*
+	 * Fire signal and stop triggers after ignoring SIGTERM, so handlers are
+	 * not killed with the rest of the process group, below.
+	 */
+	if (status == 2)
+		exec_trigger(NULL, NULL, "server.signal.term", true);
+	exec_trigger(NULL, NULL, "server.stop", false);
 
 	/*
 	 *	Send a TERM signal to all


### PR DESCRIPTION
Move firing "server.stop" and "server.signal.term" triggers beyond
setting SIGTERM action to SIG_IGN in main().

This way handler commands for these triggers don't receive SIGTERM with
the rest of the process group and don't possibly terminate before doing
their work. E.g. snmptrap manages to send the notifications.

This fixes serverStop and signalTerm SNMP notifications not being sent.

This is a somewhat crude fix, as we cannot be sure that the handler programs
don't enable SIGTERM and so could still be killed. A proper fix could be
perhaps to wait until handlers have completed and then send SIGTERM, or to
re-enable SIGTERM after sending it to the process group and then fire the
triggers.

However, the former could potentially delay termination and for the latter
we'll have to somehow know our own SIGTERM was delivered to our process,
before re-enabling it, which I haven't found how to do.
