### PR TITLE
option to add HTTP Host: header in OCSP request

### DIFF
--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -471,16 +471,8 @@ eap {
 			override_cert_url = yes
 
 			#
-			#  If the OCSP Responder address is not
-			#  extracted from the certificate, the
-			#  URL can be defined here.
-
-			#
-			#  Limitation: Currently the HTTP
-			#  Request is not sending the "Host: "
-			#  information to the web-server.  This
-			#  can be a problem if the OCSP
-			#  Responder is running as a vhost.
+			#  If the OCSP Responder address is not extracted from
+			#  the certificate, the URL can be defined here.
 			#
 			url = "http://127.0.0.1/ocsp/"
 

--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -1320,6 +1320,7 @@ static int ocsp_check(X509_STORE *store, X509 *issuer_cert, X509 *client_cert,
 	char *host = NULL;
 	char *port = NULL;
 	char *path = NULL;
+	char hostheader[1024];
 	int use_ssl = -1;
 	long nsec = MAX_VALIDITY_PERIOD, maxage = -1;
 	BIO *cbio, *bio_out;
@@ -1368,6 +1369,13 @@ static int ocsp_check(X509_STORE *store, X509 *issuer_cert, X509 *client_cert,
 
 	DEBUG2("[ocsp] --> Responder URL = http://%s:%s%s", host, port, path);
 
+	/* Check host and port length are sane, then create Host: HTTP header */
+	if ((strlen(host) + strlen(port) + 2) > sizeof(hostheader)) {
+		ERROR("OCSP Host and port too long");
+		goto ocsp_skip;
+	}
+	snprintf(hostheader, sizeof(hostheader), "%s:%s", host, port);
+
 	/* Setup BIO socket to OCSP responder */
 	cbio = BIO_new_connect(host);
 
@@ -1402,9 +1410,21 @@ static int ocsp_check(X509_STORE *store, X509 *issuer_cert, X509 *client_cert,
 		goto ocsp_end;
 	}
 
-	ctx = OCSP_sendreq_new(cbio, path, req, -1);
+	ctx = OCSP_sendreq_new(cbio, path, NULL, -1);
 	if (!ctx) {
-		ERROR("Couldn't send OCSP request");
+		ERROR("Couldn't create OCSP request");
+		ocsp_ok = 2;
+		goto ocsp_end;
+	}
+
+	if (!OCSP_REQ_CTX_add1_header(ctx, "Host", hostheader)) {
+		ERROR("Couldn't set Host header");
+		ocsp_ok = 2;
+		goto ocsp_end;
+	}
+
+	if (!OCSP_REQ_CTX_set1_req(ctx, req)) {
+		ERROR("Couldn't add data to OCSP request");
 		ocsp_ok = 2;
 		goto ocsp_end;
 	}


### PR DESCRIPTION
Adds the option to fix the problem where OCSP requests can fail if the server is running in a vhost due to lack of HTTP Host: header.
