### PR TITLE
disable softfail by default (in line with documentation)

### DIFF
--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -917,7 +917,7 @@ static CONF_PARSER ocsp_config[] = {
 	{ "url", FR_CONF_OFFSET(PW_TYPE_STRING, fr_tls_server_conf_t, ocsp_url), NULL },
 	{ "use_nonce", FR_CONF_OFFSET(PW_TYPE_BOOLEAN, fr_tls_server_conf_t, ocsp_use_nonce), "yes" },
 	{ "timeout", FR_CONF_OFFSET(PW_TYPE_INTEGER, fr_tls_server_conf_t, ocsp_timeout), "yes" },
-	{ "softfail", FR_CONF_OFFSET(PW_TYPE_BOOLEAN, fr_tls_server_conf_t, ocsp_softfail), "yes" },
+	{ "softfail", FR_CONF_OFFSET(PW_TYPE_BOOLEAN, fr_tls_server_conf_t, ocsp_softfail), "no" },
 	{ NULL, -1, 0, NULL, NULL }	   /* end the list */
 };
 #endif


### PR DESCRIPTION
The documentation in mods-available/eap says that OCSP softfail is disabled by default, which is the more secure option (inability to contact the OCSP server results in auth failure).

However, the code enables it by default, which could easily be insecure if misunderstood. This patch reverses that.
