### PR TITLE
Typo fix in comment in rlm_rest

### DIFF
--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -230,7 +230,7 @@ typedef struct json_flags {
 
 /** Initialises libcurl.
  *
- * Allocates global variables and memory required for libcurl to fundtion.
+ * Allocates global variables and memory required for libcurl to function.
  * MUST only be called once per module instance.
  *
  * rest_cleanup must not be called if rest_init fails.


### PR DESCRIPTION
fundtion => function

(It's the only documentation related fix I had collected in the last months. With 3.0.5 on its way, it might be a nice moment to merge it)
