### PR TITLE
Small fast followers to 'checksimul' feature

### DIFF
--- a/raddb/mods-available/couchbase
+++ b/raddb/mods-available/couchbase
@@ -112,6 +112,10 @@ couchbase {
 	# Couchbase view that should return all account documents keyed by username.
 	#simul_view = "_design/acct/_view/by_user"
 
+	# The key to the above view.
+	# NOTE: This will need to match EXACTLY what you emit from your view.
+	#simul_vkey = "%{tolower:%{%{Stripped-User-Name}:-%{User-Name}}}"
+
 	# Set to 'yes' to enable verification of the results returned from the above view.
 	# NOTE: This may be an additional performance penalty to the actual check and
 	# should be avoided unless absolutely neccessary.

--- a/src/modules/rlm_couchbase/mod.c
+++ b/src/modules/rlm_couchbase/mod.c
@@ -461,16 +461,14 @@ int mod_ensure_start_timestamp(json_object *json, VALUE_PAIR *vps)
 	/* get our current start timestamp from our json body */
 	if (json_object_object_get_ex(json, "startTimestamp", &jval) == 0) {
 		/* debugging ... this shouldn't ever happen */
-		DEBUG("rlm_couchbase: failed to find start timestamp in current json body");
+		DEBUG("rlm_couchbase: failed to find 'startTimestamp' in current json body");
 		/* return */
 		return -1;
 	}
 
-	/* check the value */
-	if (strcmp(json_object_get_string(jval), "") != 0) {
-		/* debugging */
-		DEBUG("rlm_couchbase: start timestamp looks good - nothing to do");
-		/* already set - nothing else to do */
+	/* check for null value */
+	if (json_object_get_string(jval) != NULL) {
+		/* already set - nothing left to do */
 		return 0;
 	}
 

--- a/src/modules/rlm_couchbase/mod.h
+++ b/src/modules/rlm_couchbase/mod.h
@@ -60,6 +60,7 @@ typedef struct rlm_couchbase_t {
 	bool check_simul;           //!< Toggle to enable simultaneous use checking.
 	const char *simul_view;     //!< Couchbase view that returns accounting documents.
 	bool verify_simul;          //!< Toggle to enable user login state verification.
+	const char *simul_vkey;     //!< The query key to be used with simul_view.
 	bool delete_stale_sessions; //!< Toggle to trigger zapping of stale sessions.
 	json_object *map;           //!< Json object to hold user defined attribute map.
 	fr_connection_pool_t *pool; //!< Connection pool.


### PR DESCRIPTION
- remove redundant free
- use actual null values instead of empty strings for start/stop timestamp
- allow user specification of the view query key with xlat
- add pre and post verification session count debugging
- update example strip policy to new reference style
- adjust documentation as needed
