### PR TITLE
Fixed off-by-one error when trying to cast attribute to ascend

### DIFF
--- a/src/lib/filters.c
+++ b/src/lib/filters.c
@@ -965,7 +965,7 @@ int ascend_parse_filter(value_data_t *out, char const *value, size_t len)
 	/*
 	 *	Tokenize the input string in the VP.
 	 *
-	 *	Once the filter is *completelty* parsed, then we will
+	 *	Once the filter is *completely* parsed, then we will
 	 *	over-write it with the final binary filter.
 	 */
 	p = talloc_memdup(NULL, value, len+1);


### PR DESCRIPTION
This fixes the bug described in #843
