### PR TITLE
Talk to ntlm_auth over socket for mschap

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,7 @@ Build-Depends: debhelper (>= 7.4),
  libsqlite3-dev,
  libssl-dev,
  libtalloc-dev,
+ libwbclient-dev,
  libyubikey-dev,
  python-dev
 Section: net

--- a/raddb/mods-available/mschap
+++ b/raddb/mods-available/mschap
@@ -33,10 +33,24 @@ mschap {
 	# directive tells the module which authentication method
 	# to use.
 	#
-	# Valid options are 'internal' or 'ntlm_auth'.
+	# Valid options are:
+	#   'internal' do internal authentication within the
+	#              mschap module
+	#   'ntlm_auth' exec ntlm_auth to perform each
+	#               authentication
+	#   'ntlm_auth_helper' start a pool of ntlm_auth
+	#                      processes and pass authentication
+	#                      data to them
+	#
+	# The default method is "internal", unless the ntlm_auth
+	# option below is uncommented, in which case "ntlm_auth"
+	# is used instead.
 	#
 #	auth_method = internal
 
+
+	# Options for auth method 'ntlm_auth':
+	#
 	# This configuration directive gives the ntlm_auth command
 	# to use when the auth method is 'ntlm_auth'. This will do
 	# the authentication against a Windows Domain Controller
@@ -72,6 +86,90 @@ mschap {
 	# usually finishes quicker. Range 1 to 10 seconds.
 	#
 #	ntlm_auth_timeout = 10
+
+
+	# Username and domain to pass for authentication when using
+	# the ntlm_auth_helper auth method.
+	#
+	ntlm_username = "%{mschap:User-Name}"
+	#
+	# If this string expands to nothing, no domain is
+	# sent. If the domain is wrong, authentication
+	# will fail.
+	#
+	ntlm_domain = "%{mschap:NT-Domain}"
+
+
+	# Options for auth method 'ntlm_auth_helper':
+	#
+	# This method will start ntlm_auth processes running
+	# and pass authentication data to them. It should be
+	# faster than the traditional ntlm_auth method above as it
+	# saves the process start-up time. However, it is less
+	# well tested.
+	#
+	ntlm_auth_helper {
+		# Command to run. See ntlm_auth man page for
+		# details. The only thing that should need
+		# changing here is the path to the binary.
+		#
+		ntlm_auth = "/usr/bin/ntlm_auth --helper-protocol=ntlm-server-1"
+
+		# Standard connection pool settings. The pool is
+		# used to start up a number of child ntlm_auth
+		# processes to which authentication data is
+		# passed.
+		#
+		pool {
+			# Number of connections to start
+			start = 5
+
+			# Minimum number of connections to keep open
+			min = 3
+
+			# Maximum number of connections
+			#
+			# If these connections are all in use and a new one
+			# is requested, the request will NOT get a connection.
+			max = 10
+
+			# Spare connections to be left idle
+			#
+			# NOTE: Idle connections WILL be closed if
+			# "idle_timeout" is set.
+			spare = 3
+
+			# Number of uses before the connection is closed
+			#
+			# 0 means "infinite"
+			uses = 0
+
+			# The lifetime (in seconds) of the connection
+			lifetime = 0
+
+			# idle timeout (in seconds).  A connection which is
+			# unused for this length of time will be closed.
+			idle_timeout = 60
+
+			# The number of seconds to wait after the server tries
+			# to open a connection, and fails.  During this time,
+			# no new connections will be opened.
+			#
+			retry_delay = 1
+
+			# NOTE: All configuration settings are enforced.  If a
+			# connection is closed because of "idle_timeout",
+			# "uses", or "lifetime", then the total number of
+			# connections MAY fall below "min".  When that
+			# happens, it will open a new connection.  It will
+			# also log a WARNING message.
+			#
+			# The solution is to either lower the "min" connections,
+			# or increase lifetime/idle_timeout.
+		}
+
+	}
+
 
 	passchange {
 		# This support MS-CHAPv2 (not v1) password change

--- a/raddb/mods-available/mschap
+++ b/raddb/mods-available/mschap
@@ -41,6 +41,9 @@ mschap {
 	#   'ntlm_auth_helper' start a pool of ntlm_auth
 	#                      processes and pass authentication
 	#                      data to them
+	#   'winbind' make a direct connection to winbind to
+	#             authenticate users. This option is
+	#             experimental.
 	#
 	# The default method is "internal", unless the ntlm_auth
 	# option below is uncommented, in which case "ntlm_auth"

--- a/raddb/mods-available/mschap
+++ b/raddb/mods-available/mschap
@@ -29,21 +29,28 @@ mschap {
 #	require_strong = yes
 
 	# The module can perform authentication itself, OR
-	# use a Windows Domain Controller.  This configuration
-	# directive tells the module to call the ntlm_auth
-	# program, which will do the authentication, and return
-	# the NT-Key.  Note that you MUST have "winbindd" and
-	# "nmbd" running on the local machine for ntlm_auth
-	# to work.  See the ntlm_auth program documentation
-	# for details.
+	# use a Windows Domain Controller. This configuration
+	# directive tells the module which authentication method
+	# to use.
 	#
-	# If ntlm_auth is configured below, then the mschap
-	# module will call ntlm_auth for every MS-CHAP
-	# authentication request.  If there is a cleartext
-	# or NT hashed password available, you can set
-	# "MS-CHAP-Use-NTLM-Auth := No" in the control items,
-	# and the mschap module will do the authentication itself,
-	# without calling ntlm_auth.
+	# Valid options are 'internal' or 'ntlm_auth'.
+	#
+#	auth_method = internal
+
+	# This configuration directive gives the ntlm_auth command
+	# to use when the auth method is 'ntlm_auth'. This will do
+	# the authentication against a Windows Domain Controller
+	# and return the NT-Key. Note that you MUST have
+	# "winbindd" and "nmbd" running on the local machine for
+	# ntlm_auth to work. See the ntlm_auth program
+	# documentation for details.
+	#
+	# When using this method the mschap module will call
+	# ntlm_auth for every MS-CHAP authentication request. If
+	# there is a cleartext or NT hashed password available,
+	# you can set "MS-CHAP-Use-NTLM-Auth := No" in the control
+	# items, and the mschap module will do the authentication
+	# itself, without calling ntlm_auth.
 	#
 	# Be VERY careful when editing the following line!
 	#

--- a/src/modules/rlm_mschap/auth_wbclient.c
+++ b/src/modules/rlm_mschap/auth_wbclient.c
@@ -1,0 +1,145 @@
+/*
+ *   This program is is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License, version 2 if the
+ *   License as published by the Free Software Foundation.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/**
+ * $Id$
+ * @file auth_wbclient.c
+ * @brief NTLM authentication against the wbclient library
+ *
+ * @copyright 2014  Matthew Newton
+ */
+
+RCSID("$Id$")
+
+#include <freeradius-devel/radiusd.h>
+
+#include <wbclient.h>
+
+#include "rlm_mschap.h"
+#include "mschap.h"
+#include "auth_wbclient.h"
+
+#define NT_LENGTH 24
+
+/*
+ *	Check NTLM authentication using ntlm_auth server via a socket
+ *	Returns -1 for failure and 0 on auth success
+ */
+int do_auth_wbclient(rlm_mschap_t *inst, REQUEST *request,
+		     uint8_t const *challenge, uint8_t const *response,
+		     uint8_t nthashhash[NT_DIGEST_LENGTH])
+{
+	int rcode = -1;
+	struct wbcAuthUserParams authparams;
+	wbcErr err;
+	int len;
+	struct wbcAuthUserInfo *info = NULL;
+	struct wbcAuthErrorInfo *error = NULL;
+	char user_name[500];
+	char domain_name[500];
+	uint8_t resp[NT_LENGTH];
+
+	/*
+	 * Clear the auth parameters - this is important, as
+	 * there are options that will cause wbcAuthenticateUserEx
+	 * to bomb out if not zero.
+	 */
+	memset(&authparams, 0, sizeof(authparams));
+
+
+	/*
+	 * Get the username and domain from the configuration
+	 */
+	len = radius_xlat(user_name, sizeof(user_name), request, inst->ntlm_username, NULL, NULL);
+	if (len < 0) goto done;
+
+	authparams.account_name = user_name;
+
+	if (inst->ntlm_domain) {
+		len = radius_xlat(domain_name, sizeof(domain_name), request, inst->ntlm_domain, NULL, NULL);
+		if (len < 0) goto done;
+
+		authparams.domain_name = domain_name;
+	} else {
+		RDEBUG("no domain specified; authentication may fail because of this");
+	}
+
+
+	/*
+	 * Build the wbcAuthUserParams structure with what we know
+	 */
+	//authparams.workstation_name = NULL;
+	//authparams.flags = 0;
+	//authparams.parameter_control = 0;
+	authparams.level = WBC_AUTH_USER_LEVEL_RESPONSE;
+	//authparams.password.response.lm_length = 0;
+	authparams.password.response.nt_length = NT_LENGTH;
+
+	memcpy(resp, response, NT_LENGTH);
+	authparams.password.response.nt_data = resp;
+
+	memcpy(authparams.password.response.challenge, challenge,
+	       sizeof(authparams.password.response.challenge));
+
+
+	/*
+	 * Send auth request across to winbind
+	 */
+	RDEBUG("sending authentication request user='%s' domain='%s'", authparams.account_name,
+								       authparams.domain_name);
+
+	err = wbcAuthenticateUserEx(&authparams, &info, &error);
+
+
+	/*
+	 * Try and give some useful feedback on what happened
+	 */
+	switch (err) {
+	case WBC_ERR_SUCCESS:
+		rcode = 0;
+		RDEBUG("Authenticated successfully");
+		/* Grab the nthashhash from the result */
+		memcpy(nthashhash, info->user_session_key, NT_DIGEST_LENGTH);
+		break;
+	case WBC_ERR_WINBIND_NOT_AVAILABLE:
+		RERROR("Check that winbind is running and that FreeRADIUS");
+		RERROR("has permission to connect to the winbind socket!");
+		break;
+	case WBC_ERR_DOMAIN_NOT_FOUND:
+		RERROR("domain not found");
+		break;
+	case WBC_ERR_AUTH_ERROR:
+		RDEBUG("authentication failed (check domain is correct)");
+		break;
+	default:
+		RDEBUG("other error %d", err);
+		break;
+	}
+
+	if (err != WBC_ERR_SUCCESS) {
+		RDEBUG("authentication failed: wbcErr %d", err);
+		if (error && error->display_string) {
+			RDEBUG("wbcErr %s", error->display_string);
+		}
+	}
+
+
+done:
+	if (info) wbcFreeMemory(info);
+	if (error) wbcFreeMemory(error);
+
+	return rcode;
+}
+

--- a/src/modules/rlm_mschap/auth_wbclient.h
+++ b/src/modules/rlm_mschap/auth_wbclient.h
@@ -1,0 +1,13 @@
+/* Copyright 2014 The FreeRADIUS server project */
+
+#ifndef _AUTH_WBCLIENT_H
+#define _AUTH_WBCLIENT_H
+
+RCSIDH(auth_wbclient_h, "$Id$")
+
+int do_auth_wbclient(rlm_mschap_t *inst, REQUEST *request,
+		     uint8_t const *challenge, uint8_t const *response,
+		     uint8_t nthashhash[NT_DIGEST_LENGTH]);
+
+
+#endif /*_AUTH_WBCLIENT_H*/

--- a/src/modules/rlm_mschap/config.h.in
+++ b/src/modules/rlm_mschap/config.h.in
@@ -3,6 +3,9 @@
 /* Build with Apple Open Directory support */
 #undef HAVE_OPEN_DIRECTORY
 
+/* Build with direct winbind auth support */
+#undef HAVE_WBCLIENT_H
+
 /* Define to the address where bug reports for this package should be sent. */
 #undef PACKAGE_BUGREPORT
 

--- a/src/modules/rlm_mschap/configure
+++ b/src/modules/rlm_mschap/configure
@@ -638,6 +638,9 @@ SHELL'
 ac_subst_files=''
 ac_user_opts='
 enable_option_checking
+with_winbind_include_dir
+with_winbind_lib_dir
+with_winbind_dir
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1251,6 +1254,15 @@ if test -n "$ac_init_help"; then
 
   cat <<\_ACEOF
 
+Optional Packages:
+  --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
+  --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
+  --with-winbind-include-dir=DIR
+                          Directory where the winbind includes may be found
+  --with-winbind-lib-dir=DIR
+                          Directory where the winbind libraries may be found
+  --with-winbind-dir=DIR  Base directory where winbind is installed
+
 Some influential environment variables:
   CC          C compiler command
   CFLAGS      C compiler flags
@@ -1415,6 +1427,52 @@ fi
   as_fn_set_status $ac_retval
 
 } # ac_fn_c_try_cpp
+
+# ac_fn_c_try_link LINENO
+# -----------------------
+# Try to link conftest.$ac_ext, and return whether this succeeded.
+ac_fn_c_try_link ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  rm -f conftest.$ac_objext conftest$ac_exeext
+  if { { ac_try="$ac_link"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+$as_echo "$ac_try_echo"; } >&5
+  (eval "$ac_link") 2>conftest.err
+  ac_status=$?
+  if test -s conftest.err; then
+    grep -v '^ *+' conftest.err >conftest.er1
+    cat conftest.er1 >&5
+    mv -f conftest.er1 conftest.err
+  fi
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; } && {
+	 test -z "$ac_c_werror_flag" ||
+	 test ! -s conftest.err
+       } && test -s conftest$ac_exeext && {
+	 test "$cross_compiling" = yes ||
+	 test -x conftest$ac_exeext
+       }; then :
+  ac_retval=0
+else
+  $as_echo "$as_me: failed program was:" >&5
+sed 's/^/| /' conftest.$ac_ext >&5
+
+	ac_retval=1
+fi
+  # Delete the IPA/IPO (Inter Procedural Analysis/Optimization) information
+  # created by the PGI compiler (conftest_ipa8_conftest.oo), as it would
+  # interfere with the next link command; also delete a directory that is
+  # left behind by Apple's compiler.  We do this before executing the actions.
+  rm -rf conftest.dSYM conftest_ipa8_conftest.oo
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+  as_fn_set_status $ac_retval
+
+} # ac_fn_c_try_link
 cat >config.log <<_ACEOF
 This file contains any messages produced by compilers while
 running configure, to aid debugging if configure makes a mistake.
@@ -1772,7 +1830,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 if test x$with_rlm_mschap != xno; then
 
-	ac_ext=c
+    ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
@@ -2561,7 +2619,7 @@ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
-	ac_ext=c
+    ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
@@ -2699,6 +2757,61 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
+
+        winbind_include_dir=
+
+# Check whether --with-winbind-include-dir was given.
+if test "${with_winbind_include_dir+set}" = set; then :
+  withval=$with_winbind_include_dir; case "$withval" in
+	    no)
+		as_fn_error $? "Need winbind-include-dir" "$LINENO" 5
+		;;
+	    yes)
+		;;
+	    *)
+		winbind_include_dir="$withval"
+		;;
+	esac
+fi
+
+
+        winbind_lib_dir=
+
+# Check whether --with-winbind-lib-dir was given.
+if test "${with_winbind_lib_dir+set}" = set; then :
+  withval=$with_winbind_lib_dir; case "$withval" in
+	    no)
+		as_fn_error $? "Need winbind-lib-dir" "$LINENO" 5
+		;;
+	    yes)
+		;;
+	    *)
+		winbind_lib_dir="$withval"
+		;;
+	esac
+fi
+
+
+
+# Check whether --with-winbind-dir was given.
+if test "${with_winbind_dir+set}" = set; then :
+  withval=$with_winbind_dir; case "$withval" in
+	    no)
+		as_fn_error $? "Need winbind-dir" "$LINENO" 5
+		;;
+	    yes)
+		;;
+	    *)
+		winbind_lib_dir="$withval/lib"
+		winbind_include_dir="$withval/include"
+		;;
+	esac
+fi
+
+
+
+
+    mschap_sources=
 
 
 
@@ -2926,17 +3039,444 @@ fi
 
 smart_prefix=
 
-	if test "x$ac_cv_header_membership_h" = "xyes"; then
+    if test "x$ac_cv_header_membership_h" = "xyes"; then
 
 $as_echo "#define HAVE_MEMBERSHIP_H 1" >>confdefs.h
 
-		mschap_sources="opendir.c"
-		mod_ldflags="-framework DirectoryService"
-	fi
-	targetname=rlm_mschap
+        mschap_sources="$mschap_sources opendir.c"
+        mod_ldflags="-framework DirectoryService"
+    fi
+
+    smart_try_dir="$winbind_include_dir"
+
+
+ac_safe=`echo "wbclient.h" | sed 'y%./+-%__pm%'`
+old_CPPFLAGS="$CPPFLAGS"
+smart_include=
+smart_include_dir="/usr/local/include /opt/include"
+
+_smart_try_dir=
+_smart_include_dir=
+
+for _prefix in $smart_prefix ""; do
+  for _dir in $smart_try_dir; do
+    _smart_try_dir="${_smart_try_dir} ${_dir}/${_prefix}"
+  done
+
+  for _dir in $smart_include_dir; do
+    _smart_include_dir="${_smart_include_dir} ${_dir}/${_prefix}"
+  done
+done
+
+if test "x$_smart_try_dir" != "x"; then
+  for try in $_smart_try_dir; do
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for wbclient.h in $try" >&5
+$as_echo_n "checking for wbclient.h in $try... " >&6; }
+    CPPFLAGS="-isystem $try $old_CPPFLAGS"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdint.h>
+					#include <stdbool.h>
+		    #include <wbclient.h>
+int
+main ()
+{
+int a = 1;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+		     smart_include="-isystem $try"
+		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+		     break
+
 else
-	targetname=
-	echo \*\*\* module rlm_mschap is disabled.
+
+		     smart_include=
+		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  done
+  CPPFLAGS="$old_CPPFLAGS"
+fi
+
+if test "x$smart_include" = "x"; then
+  for _prefix in $smart_prefix; do
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${_prefix}/wbclient.h" >&5
+$as_echo_n "checking for ${_prefix}/wbclient.h... " >&6; }
+
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdint.h>
+					#include <stdbool.h>
+		    #include <wbclient.h>
+int
+main ()
+{
+int a = 1;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+		     smart_include="-isystem ${_prefix}/"
+		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+		     break
+
+else
+
+		     smart_include=
+		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  done
+fi
+
+if test "x$smart_include" = "x"; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for wbclient.h" >&5
+$as_echo_n "checking for wbclient.h... " >&6; }
+
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdint.h>
+					#include <stdbool.h>
+		    #include <wbclient.h>
+int
+main ()
+{
+int a = 1;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+		     smart_include=" "
+		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+		     break
+
+else
+
+		     smart_include=
+		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+
+if test "x$smart_include" = "x"; then
+
+  for prefix in $smart_prefix; do
+
+
+if test "x$LOCATE" != "x"; then
+        DIRS=
+  file="${_prefix}/${1}"
+
+  for x in `${LOCATE} $file 2>/dev/null`; do
+                                        base=`echo $x | sed "s%/${file}%%"`
+    if test "x$x" = "x$base"; then
+      continue;
+    fi
+
+    dir=`${DIRNAME} $x 2>/dev/null`
+                exclude=`echo ${dir} | ${GREP} /home`
+    if test "x$exclude" != "x"; then
+      continue
+    fi
+
+                    already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
+    if test "x$already" = "x"; then
+      DIRS="$DIRS $dir"
+    fi
+  done
+fi
+
+eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
+
+  done
+
+
+if test "x$LOCATE" != "x"; then
+        DIRS=
+  file=wbclient.h
+
+  for x in `${LOCATE} $file 2>/dev/null`; do
+                                        base=`echo $x | sed "s%/${file}%%"`
+    if test "x$x" = "x$base"; then
+      continue;
+    fi
+
+    dir=`${DIRNAME} $x 2>/dev/null`
+                exclude=`echo ${dir} | ${GREP} /home`
+    if test "x$exclude" != "x"; then
+      continue
+    fi
+
+                    already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
+    if test "x$already" = "x"; then
+      DIRS="$DIRS $dir"
+    fi
+  done
+fi
+
+eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
+
+
+  for try in $_smart_include_dir; do
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for wbclient.h in $try" >&5
+$as_echo_n "checking for wbclient.h in $try... " >&6; }
+    CPPFLAGS="-isystem $try $old_CPPFLAGS"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdint.h>
+					#include <stdbool.h>
+		    #include <wbclient.h>
+int
+main ()
+{
+int a = 1;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+		     smart_include="-isystem $try"
+		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+		     break
+
+else
+
+		     smart_include=
+		     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+  done
+  CPPFLAGS="$old_CPPFLAGS"
+fi
+
+if test "x$smart_include" != "x"; then
+  eval "ac_cv_header_$ac_safe=yes"
+  CPPFLAGS="$smart_include $old_CPPFLAGS"
+  SMART_CPPFLAGS="$smart_include $SMART_CPPFLAGS"
+fi
+
+smart_prefix=
+
+    if test "x$ac_cv_header_wbclient_h" = "xyes"; then
+
+$as_echo "#define HAVE_WBCLIENT_H 1" >>confdefs.h
+
+        mschap_sources="$mschap_sources auth_wbclient.c"
+    else
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: wbclient.h not found. Use --with-winbind-include-dir=<path>." >&5
+$as_echo "$as_me: WARNING: wbclient.h not found. Use --with-winbind-include-dir=<path>." >&2;}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: silently building without support for direct authentication via winbind. requires: libwbclient" >&5
+$as_echo "$as_me: WARNING: silently building without support for direct authentication via winbind. requires: libwbclient" >&2;}
+    fi
+
+
+
+    smart_try_dir="$winbind_lib_dir"
+
+
+sm_lib_safe=`echo "wbclient" | sed 'y%./+-%__p_%'`
+sm_func_safe=`echo "wbcAuthenticateUserEx" | sed 'y%./+-%__p_%'`
+
+old_LIBS="$LIBS"
+old_CPPFLAGS="$CPPFLAGS"
+smart_lib=
+smart_ldflags=
+smart_lib_dir=
+
+if test "x$smart_try_dir" != "x"; then
+  for try in $smart_try_dir; do
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for wbcAuthenticateUserEx in -lwbclient in $try" >&5
+$as_echo_n "checking for wbcAuthenticateUserEx in -lwbclient in $try... " >&6; }
+    LIBS="-lwbclient $old_LIBS"
+    CPPFLAGS="-L$try -Wl,-rpath,$try $old_CPPFLAGS"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+extern char wbcAuthenticateUserEx();
+int
+main ()
+{
+wbcAuthenticateUserEx()
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+
+		 smart_lib="-lwbclient"
+		 smart_ldflags="-L$try -Wl,-rpath,$try"
+		 { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+		 break
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+  done
+  LIBS="$old_LIBS"
+  CPPFLAGS="$old_CPPFLAGS"
+fi
+
+if test "x$smart_lib" = "x"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for wbcAuthenticateUserEx in -lwbclient" >&5
+$as_echo_n "checking for wbcAuthenticateUserEx in -lwbclient... " >&6; }
+  LIBS="-lwbclient $old_LIBS"
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+extern char wbcAuthenticateUserEx();
+int
+main ()
+{
+wbcAuthenticateUserEx()
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+
+	        smart_lib="-lwbclient"
+	        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+  LIBS="$old_LIBS"
+fi
+
+if test "x$smart_lib" = "x"; then
+
+
+if test "x$LOCATE" != "x"; then
+        DIRS=
+  file=libwbclient${libltdl_cv_shlibext}
+
+  for x in `${LOCATE} $file 2>/dev/null`; do
+                                        base=`echo $x | sed "s%/${file}%%"`
+    if test "x$x" = "x$base"; then
+      continue;
+    fi
+
+    dir=`${DIRNAME} $x 2>/dev/null`
+                exclude=`echo ${dir} | ${GREP} /home`
+    if test "x$exclude" != "x"; then
+      continue
+    fi
+
+                    already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
+    if test "x$already" = "x"; then
+      DIRS="$DIRS $dir"
+    fi
+  done
+fi
+
+eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
+
+
+
+if test "x$LOCATE" != "x"; then
+        DIRS=
+  file=libwbclient.a
+
+  for x in `${LOCATE} $file 2>/dev/null`; do
+                                        base=`echo $x | sed "s%/${file}%%"`
+    if test "x$x" = "x$base"; then
+      continue;
+    fi
+
+    dir=`${DIRNAME} $x 2>/dev/null`
+                exclude=`echo ${dir} | ${GREP} /home`
+    if test "x$exclude" != "x"; then
+      continue
+    fi
+
+                    already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
+    if test "x$already" = "x"; then
+      DIRS="$DIRS $dir"
+    fi
+  done
+fi
+
+eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
+
+
+  for try in $smart_lib_dir /usr/local/lib /opt/lib; do
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for wbcAuthenticateUserEx in -lwbclient in $try" >&5
+$as_echo_n "checking for wbcAuthenticateUserEx in -lwbclient in $try... " >&6; }
+    LIBS="-lwbclient $old_LIBS"
+    CPPFLAGS="-L$try -Wl,-rpath,$try $old_CPPFLAGS"
+    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+extern char wbcAuthenticateUserEx();
+int
+main ()
+{
+wbcAuthenticateUserEx()
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+
+		  smart_lib="-lwbclient"
+		  smart_ldflags="-L$try -Wl,-rpath,$try"
+		  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+		  break
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+  done
+  LIBS="$old_LIBS"
+  CPPFLAGS="$old_CPPFLAGS"
+fi
+
+if test "x$smart_lib" != "x"; then
+  eval "ac_cv_lib_${sm_lib_safe}_${sm_func_safe}=yes"
+  LIBS="$smart_ldflags $smart_lib $old_LIBS"
+  SMART_LIBS="$smart_ldflags $smart_lib $SMART_LIBS"
+fi
+
+    if test "x$ac_cv_lib_wbclient_wbcAuthenticateUserEx" != "xyes"
+    then
+      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: winbind libraries not found. Use --with-winbind-lib-dir=<path>." >&5
+$as_echo "$as_me: WARNING: winbind libraries not found. Use --with-winbind-lib-dir=<path>." >&2;}
+    fi
+
+    targetname=rlm_mschap
+else
+    targetname=
+    echo \*\*\* module rlm_mschap is disabled.
 fi
 
 if test x"$fail" != x""; then
@@ -2951,6 +3491,8 @@ $as_echo "$as_me: WARNING: FAILURE: rlm_mschap requires: $fail." >&2;};
 	fi
 fi
 
+mod_ldflags="$mod_ldflags $SMART_LIBS"
+mod_cflags="$SMART_CPPFLAGS"
 
 
 

--- a/src/modules/rlm_mschap/configure.ac
+++ b/src/modules/rlm_mschap/configure.ac
@@ -3,20 +3,102 @@ AC_REVISION($Revision$)
 AC_DEFUN(modname,[rlm_mschap])
 
 if test x$with_[]modname != xno; then
+    
+    AC_PROG_CC
+    AC_PROG_CPP
 
-	AC_PROG_CC
-	AC_PROG_CPP
+    dnl ############################################################
+    dnl # Check for command line options
+    dnl ############################################################
 
-	FR_SMART_CHECK_INCLUDE(membership.h)
-	if test "x$ac_cv_header_membership_h" = "xyes"; then
-		AC_DEFINE([HAVE_MEMBERSHIP_H],[1],[Build with Apple Open Directory support])
-		mschap_sources="opendir.c"
-		mod_ldflags="-framework DirectoryService"
-	fi
-	targetname=modname
+    dnl extra argument: --with-winbind-include-dir=DIR
+    winbind_include_dir=
+    AC_ARG_WITH(winbind-include-dir,
+	[AS_HELP_STRING([--with-winbind-include-dir=DIR],
+		[Directory where the winbind includes may be found])],
+	[case "$withval" in
+	    no)
+		AC_MSG_ERROR(Need winbind-include-dir)
+		;;
+	    yes)
+		;;
+	    *)
+		winbind_include_dir="$withval"
+		;;
+	esac])
+
+    dnl extra argument: --with-winbind-lib-dir=DIR
+    winbind_lib_dir=
+    AC_ARG_WITH(winbind-lib-dir,
+	[AS_HELP_STRING([--with-winbind-lib-dir=DIR],
+		[Directory where the winbind libraries may be found])],
+	[case "$withval" in
+	    no)
+		AC_MSG_ERROR(Need winbind-lib-dir)
+		;;
+	    yes)
+		;;
+	    *)
+		winbind_lib_dir="$withval"
+		;;
+	esac])
+
+    dnl extra argument: --with-winbind-dir=DIR
+    AC_ARG_WITH(winbind-dir,
+	[AS_HELP_STRING([--with-winbind-dir=DIR],
+		[Base directory where winbind is installed])],
+	[case "$withval" in
+	    no)
+		AC_MSG_ERROR(Need winbind-dir)
+		;;
+	    yes)
+		;;
+	    *)
+		winbind_lib_dir="$withval/lib"
+		winbind_include_dir="$withval/include"
+		;;
+	esac])
+
+
+    dnl ############################################################
+    dnl # Check for header files
+    dnl ############################################################
+
+    mschap_sources=
+    FR_SMART_CHECK_INCLUDE(membership.h)
+    if test "x$ac_cv_header_membership_h" = "xyes"; then
+        AC_DEFINE([HAVE_MEMBERSHIP_H],[1],[Build with Apple Open Directory support])
+        mschap_sources="$mschap_sources opendir.c"
+        mod_ldflags="-framework DirectoryService"
+    fi
+
+    smart_try_dir="$winbind_include_dir"
+    FR_SMART_CHECK_INCLUDE(wbclient.h, [#include <stdint.h>
+					#include <stdbool.h>])
+    if test "x$ac_cv_header_wbclient_h" = "xyes"; then
+        AC_DEFINE([HAVE_WBCLIENT_H],[1],[Build with direct winbind auth support])
+        mschap_sources="$mschap_sources auth_wbclient.c"
+    else
+	AC_MSG_WARN([wbclient.h not found. Use --with-winbind-include-dir=<path>.])
+	AC_MSG_WARN([silently building without support for direct authentication via winbind. requires: libwbclient])
+    fi
+
+
+    dnl ############################################################
+    dnl # Check for libraries
+    dnl ############################################################
+
+    smart_try_dir="$winbind_lib_dir"
+    FR_SMART_CHECK_LIB(wbclient, wbcAuthenticateUserEx)
+    if test "x$ac_cv_lib_wbclient_wbcAuthenticateUserEx" != "xyes"
+    then
+      AC_MSG_WARN([winbind libraries not found. Use --with-winbind-lib-dir=<path>.])
+    fi
+
+    targetname=modname
 else
-	targetname=
-	echo \*\*\* module modname is disabled.
+    targetname=
+    echo \*\*\* module modname is disabled.
 fi
 
 if test x"$fail" != x""; then
@@ -29,6 +111,8 @@ if test x"$fail" != x""; then
 	fi
 fi
 
+mod_ldflags="$mod_ldflags $SMART_LIBS"
+mod_cflags="$SMART_CPPFLAGS"
 AC_SUBST(mschap_sources)
 AC_SUBST(mod_ldflags)
 AC_SUBST(mod_cflags)

--- a/src/modules/rlm_mschap/rlm_mschap.c
+++ b/src/modules/rlm_mschap/rlm_mschap.c
@@ -32,6 +32,7 @@ RCSID("$Id$")
 
 #include 	<ctype.h>
 
+#include	"rlm_mschap.h"
 #include	"mschap.h"
 #include	"smbdes.h"
 
@@ -43,11 +44,6 @@ USES_APPLE_DEPRECATED_API	/* OpenSSL API has been deprecated by Apple */
 #ifdef WITH_OPEN_DIRECTORY
 int od_mschap_auth(REQUEST *request, VALUE_PAIR *challenge, VALUE_PAIR * usernamepair);
 #endif
-
-typedef enum {
-        AUTH_INTERNAL = 0,
-        AUTH_NTLMAUTH_EXEC = 1
-} MSCHAP_AUTH_METHOD;
 
 /* Allowable account control bits */
 #define ACB_DISABLED	0x00010000	//!< User account disabled.
@@ -140,29 +136,6 @@ static int pdb_decode_acct_ctrl(char const *p)
 
 	return acct_ctrl;
 }
-
-
-typedef struct rlm_mschap_t {
-	bool			use_mppe;
-	bool			require_encryption;
-	bool			require_strong;
-	bool			with_ntdomain_hack;	/* this should be in another module */
-	char const		*xlat_name;
-	char const		*ntlm_auth;
-	uint32_t		ntlm_auth_timeout;
-	char const		*ntlm_cpw;
-	char const		*ntlm_cpw_username;
-	char const		*ntlm_cpw_domain;
-	char const		*local_cpw;
-	char const		*auth_type;
-	bool			allow_retry;
-	char const		*retry_msg;
-	char const		*method_s;
-	MSCHAP_AUTH_METHOD	method;
-#ifdef WITH_OPEN_DIRECTORY
-	bool		open_directory;
-#endif
-} rlm_mschap_t;
 
 
 /*

--- a/src/modules/rlm_mschap/rlm_mschap.h
+++ b/src/modules/rlm_mschap/rlm_mschap.h
@@ -1,0 +1,37 @@
+/* Copyright 2006-2014 The FreeRADIUS server project */
+
+#ifndef _RLM_MSCHAP_H
+#define _RLM_MSCHAP_H
+
+RCSIDH(rlm_mschap_h, "$Id$")
+
+typedef enum {
+	AUTH_INTERNAL		= 0,
+	AUTH_NTLMAUTH_EXEC	= 1
+} MSCHAP_AUTH_METHOD;
+
+typedef struct rlm_mschap_t {
+	bool			use_mppe;
+	bool			require_encryption;
+	bool			require_strong;
+	bool			with_ntdomain_hack;	/* this should be in another module */
+	char const		*xlat_name;
+	char const		*ntlm_auth;
+	uint32_t		ntlm_auth_timeout;
+	char const		*ntlm_cpw;
+	char const		*ntlm_cpw_username;
+	char const		*ntlm_cpw_domain;
+	char const		*local_cpw;
+	char const		*auth_type;
+	bool			allow_retry;
+	char const		*retry_msg;
+	char const		*method_s;
+	MSCHAP_AUTH_METHOD	method;
+	fr_connection_pool_t	*ntlm_auth_pool;
+#ifdef WITH_OPEN_DIRECTORY
+	bool		open_directory;
+#endif
+} rlm_mschap_t;
+
+#endif
+

--- a/src/modules/rlm_mschap/rlm_mschap.h
+++ b/src/modules/rlm_mschap/rlm_mschap.h
@@ -5,10 +5,19 @@
 
 RCSIDH(rlm_mschap_h, "$Id$")
 
+#include "config.h"
+
+#ifdef HAVE_WBCLIENT_H
+#define WITH_AUTH_WINBIND
+#endif
+
 typedef enum {
 	AUTH_INTERNAL		= 0,
 	AUTH_NTLMAUTH_EXEC	= 1,
 	AUTH_NTLMAUTH_HELPER	= 2
+#ifdef WITH_AUTH_WINBIND
+	,AUTH_WBCLIENT       	= 3
+#endif
 } MSCHAP_AUTH_METHOD;
 
 typedef struct rlm_mschap_t {

--- a/src/modules/rlm_mschap/rlm_mschap.h
+++ b/src/modules/rlm_mschap/rlm_mschap.h
@@ -7,7 +7,8 @@ RCSIDH(rlm_mschap_h, "$Id$")
 
 typedef enum {
 	AUTH_INTERNAL		= 0,
-	AUTH_NTLMAUTH_EXEC	= 1
+	AUTH_NTLMAUTH_EXEC	= 1,
+	AUTH_NTLMAUTH_HELPER	= 2
 } MSCHAP_AUTH_METHOD;
 
 typedef struct rlm_mschap_t {
@@ -18,6 +19,9 @@ typedef struct rlm_mschap_t {
 	char const		*xlat_name;
 	char const		*ntlm_auth;
 	uint32_t		ntlm_auth_timeout;
+	char const		*ntlm_helper;
+	char const		*ntlm_username;
+	char const		*ntlm_domain;
 	char const		*ntlm_cpw;
 	char const		*ntlm_cpw_username;
 	char const		*ntlm_cpw_domain;
@@ -32,6 +36,12 @@ typedef struct rlm_mschap_t {
 	bool		open_directory;
 #endif
 } rlm_mschap_t;
+
+typedef struct ntlmauth_child_t {
+	pid_t			pid;
+	int			outfd;
+	int			infd;
+} ntlmauth_child_t;
 
 #endif
 


### PR DESCRIPTION
Using inetd, ntlm_auth can listen on a UNIX socket. This enables the mschap module to talk to this socket for auth, saving an exec. This *seems* to make things faster...