### PR TITLE
raddb: Move trigger.conf INCLUDE before modules

### DIFF
--- a/raddb/radiusd.conf.in
+++ b/raddb/radiusd.conf.in
@@ -648,6 +648,14 @@ thread pool {
 	auto_limit_acct = no
 }
 
+######################################################################
+#
+#  SNMP notifications.  Uncomment the following line to enable
+#  snmptraps.  Note that you MUST also configure the full path
+#  to the "snmptrap" command in the "trigger.conf" file.
+#
+#$INCLUDE trigger.conf
+
 # MODULE CONFIGURATION
 #
 #  The names and configuration of each module is located in this section.
@@ -777,14 +785,6 @@ instantiate {
 policy {
 	$INCLUDE policy.d/
 }
-
-######################################################################
-#
-#  SNMP notifications.  Uncomment the following line to enable
-#  snmptraps.  Note that you MUST also configure the full path
-#  to the "snmptrap" command in the "trigger.conf" file.
-#
-#$INCLUDE trigger.conf
 
 ######################################################################
 #


### PR DESCRIPTION
Move "$INCLUDE trigger.conf" chunk before module section in
"radiusd.conf.in". This makes it possible to reference "snmptrap" and
related trigger variables under "pool.trigger" in module configurations,
simplifying them.

E.g. like this (in raddb/mods-enabled/ldap):

```
ldap ldap_instance {
    pool {
        trigger {
            args = "radiusdModuleName s '${...:name}' radiusdModuleInstance s '${...:instance}'"
            open = "${snmptrap}::serverModuleConnectionUp ${args}"
            close = "${snmptrap}::serverModuleConnectionDown ${args}"
        }
    }
}
```
