### PR TITLE
Added some null checks after talloc_zero

### DIFF
--- a/src/main/process.c
+++ b/src/main/process.c
@@ -1816,6 +1816,10 @@ static REQUEST *request_setup(rad_listen_t *listener, RADIUS_PACKET *packet,
 	 *	Create and initialize the new request.
 	 */
 	request = request_alloc(NULL);
+	if (!request) {
+		ERROR("No memory");
+		return NULL;
+	}
 	request->reply = rad_alloc(request, false);
 	if (!request->reply) {
 		ERROR("No memory");
@@ -3239,6 +3243,7 @@ static void ping_home_server(void *ctx)
 
 
 	request = request_alloc(NULL);
+	if (!request) return;
 	request->number = request_num_counter++;
 	NO_CHILD_THREAD;
 

--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -308,7 +308,10 @@ tls_session_t *tls_new_session(TALLOC_CTX *ctx, fr_tls_server_conf_t *conf, REQU
 	/* We use the SSL's "app_data" to indicate a call-back */
 	SSL_set_app_data(new_tls, NULL);
 
-	state = talloc_zero(ctx, tls_session_t);
+	if ((state = talloc_zero(ctx, tls_session_t)) == NULL) {
+		ERROR("SSL: Error allocating memory for SSL state");
+		return NULL;
+	}
 	session_init(state);
 	talloc_set_destructor(state, _tls_session_free);
 

--- a/src/main/util.c
+++ b/src/main/util.c
@@ -517,6 +517,7 @@ REQUEST *request_alloc(TALLOC_CTX *ctx)
 	REQUEST *request;
 
 	request = talloc_zero(ctx, REQUEST);
+	if (!request) return NULL;
 	talloc_set_destructor(request, _request_free);
 #ifndef NDEBUG
 	request->magic = REQUEST_MAGIC;
@@ -553,6 +554,7 @@ REQUEST *request_alloc_fake(REQUEST *request)
 	REQUEST *fake;
 
 	fake = request_alloc(request);
+	if (!fake) return NULL;
 
 	fake->number = request->number;
 #ifdef HAVE_PTHREAD_H

--- a/src/modules/rlm_eap/mem.c
+++ b/src/modules/rlm_eap/mem.c
@@ -115,7 +115,10 @@ eap_handler_t *eap_handler_alloc(rlm_eap_t *inst)
 	eap_handler_t	*handler;
 
 	PTHREAD_MUTEX_LOCK(&(inst->handler_mutex));
-	handler = talloc_zero(NULL, eap_handler_t);
+	if ((handler = talloc_zero(NULL, eap_handler_t)) == NULL) {
+		ERROR("Failed allocating handler");
+		return NULL;
+	}
 	if (inst->handler_tree) {
 		if (!rbtree_insert(inst->handler_tree, handler)) {
 			ERROR("Failed inserting EAP handler into handler tree");


### PR DESCRIPTION
We've seen the scenario with proxy-inner-tunnel as virtual server for PEAP, and a backend that is unreachable. With a storm of requests this did lead to segfaults in `session_init` (`src/main/tls.c`). From there, it's just turtles all the way down.
