### PR TITLE
raddb: Comment on ipaddr/ipv4addr/ipv6addr use

### DIFF
--- a/raddb/sites-available/default
+++ b/raddb/sites-available/default
@@ -84,16 +84,21 @@ listen {
 	#  source IP address for packets sent to a home server, the
 	#  proxy listeners are automatically created.
 
-	#  IP address on which to listen.
+	#  ipaddr/ipv4addr/ipv6addr - IP address on which to listen.
+	#  Out of several options the first one will be used.
+	#
 	#  Allowed values are:
-	#	dotted quad (1.2.3.4)
-	#       hostname    (radius.example.com)
-	#       wildcard    (*)
+	#	IPv4 address (e.g. 1.2.3.4, for ipv4addr/ipaddr)
+	#	IPv6 address (e.g. 2001:db8::1, for ipv6addr/ipaddr)
+	#	hostname     (radius.example.com,
+	#			A record for ipv4addr,
+	#       		AAAA record for ipv6addr,
+	#			A or AAAA record for ipaddr)
+	#       wildcard     (*)
+	#
+	# ipv4addr = *
+	# ipv6addr = *
 	ipaddr = *
-
-	#  OR, you can use an IPv6 address, but not both
-	#  at the same time.
-#	ipv6addr = ::	# any.  ::1 == localhost
 
 	#  Port on which to listen.
 	#  Allowed values are:


### PR DESCRIPTION
I've attempted to summarize combined ipaddr/ipv4addr/ipv6addr use in raddb/sitest-available/default.
However, I might have got it wrong, sorry.

Also, our QE noticed that the following ChangeLog entry:

```
* "ipaddr" will now use v6 if no v4 address is present.  You should
  use "ipv4addr" or "ipv6addr" to force v4/v6 addresses.
```

doesn't seem to be true WRT "ipaddr" v6 usage. It doesn't try to use IPv6, if there is no IPv4, it just aborts with "ip_hton: No address associated with hostname". I'm not sure if this is intended, and if not I'm not sure how to fix it. The comments attempt to describe the current state of affairs, but I'm ready to fix it if the behavior changes.

Thank you.
