### PR TITLE
Fixed some NULL checks in EAP memory

### DIFF
--- a/src/modules/rlm_eap/mem.c
+++ b/src/modules/rlm_eap/mem.c
@@ -42,13 +42,14 @@ EAP_DS *eap_ds_alloc(eap_handler_t *handler)
 	EAP_DS	*eap_ds;
 
 	eap_ds = talloc_zero(handler, EAP_DS);
+	if (!eap_ds) return NULL;
 	eap_ds->response = talloc_zero(eap_ds, eap_packet_t);
 	if (!eap_ds->response) {
 		eap_ds_free(&eap_ds);
 		return NULL;
 	}
 	eap_ds->request = talloc_zero(eap_ds, eap_packet_t);
-	if (!eap_ds->response) {
+	if (!eap_ds->request) {
 		eap_ds_free(&eap_ds);
 		return NULL;
 	}


### PR DESCRIPTION
- Add a NULL check after the first talloc call
- Fix the check after allocating eap_ds->request

Furthermore, I guess the code in eap_ds_free could be simplified, the talloc library should be able to free the response and request automatically.
