### PR TITLE
Removing restrictions on vendor attributes with numbers > 255

### DIFF
--- a/src/lib/dict.c
+++ b/src/lib/dict.c
@@ -815,15 +815,6 @@ int dict_addattr(char const *name, int attr, unsigned int vendor, PW_TYPE type,
 		}
 
 		/*
-		 *	FIXME: Switch over dv->type, and limit things
-		 *	properly.
-		 */
-		if ((dv->type == 1) && (attr >= 256) && !flags.is_tlv) {
-			fr_strerror_printf("dict_addattr: ATTRIBUTE has invalid number (larger than 255)");
-			return -1;
-		} /* else 256..65535 are allowed */
-
-		/*
 		 *	If the attribute is in the standard space, AND
 		 *	has a sub-type (e.g. 241.1 or 255.3), then its
 		 *	number is placed into the upper 8 bits of the
@@ -2923,11 +2914,6 @@ int dict_unknown_from_str(DICT_ATTR *da, char const *name)
 
 		p = q;
 	}
-
-	/*
-	 *	Enforce a maximum value on the attribute number.
-	 */
-	if (attr >= (unsigned) (1 << (dv_type << 3))) goto invalid;
 
 	if (*p == '.') {
 		if (dict_str2oid(p + 1, &attr, &vendor, 1) < 0) {

--- a/src/lib/radius.c
+++ b/src/lib/radius.c
@@ -1771,8 +1771,7 @@ int rad_encode(RADIUS_PACKET *packet, RADIUS_PACKET const *original,
 		 *	Ignore non-wire attributes, but allow extended
 		 *	attributes.
 		 */
-		if ((reply->da->vendor == 0) &&
-		    ((reply->da->attr & 0xFFFF) >= 256) &&
+		if (((reply->da->attr & 0xFFFF) >= 256) &&
 		    !reply->da->flags.extended && !reply->da->flags.long_extended) {
 #ifndef NDEBUG
 			/*

--- a/src/tests/unit/errors.txt
+++ b/src/tests/unit/errors.txt
@@ -7,8 +7,8 @@ data rad_attr2vp: Insufficient data
 decode 01 01 00
 data rad_attr2vp: Insufficient data
 
-encode Attr-26.1.256 = 0x00000001
-data Invalid OID
+#encode Attr-26.1.256 = 0x00000001
+#data rad_vp2vsa called with non-protocol attribute 256
 
 encode Attr-240.1 = 0x01
 data Standard attributes cannot use OIDs


### PR DESCRIPTION
Need review/feedback on these changes.

FreeRADIUS attributes should be between 0-UINT_MAX. I don't see much point in putting restrictions on attribute numbers in the dictionary, and it's useful for organisations to be able to define non protocol attributes > 255 for internal use within the server.

The RADIUS encoder should be smart and ignore attributes with numbers above protocol maximum, for both RFC attributes and VSA attributes.  Maybe it would be smarter to have a separate check for vendor attribtues, re-use the one from the dictionary code  ``if (attr >= (unsigned) (1 << (dv_type << 3)))``?