### PR TITLE
Link libfreeradius-server against openssl to that linker can include ver...

### DIFF
--- a/src/main/libfreeradius-server.mk
+++ b/src/main/libfreeradius-server.mk
@@ -13,3 +13,6 @@ SOURCES	:=	conffile.c \
 		version.c \
 		pair.c \
 		xlat.c
+
+# This lets the linker determine which version of the SSLeay functions to use.
+TGT_LDLIBS      := $(OPENSSL_LIBS)


### PR DESCRIPTION
...sion of SSLeay functions to use.
Since version.c was moved to libfreeradius-server, the wrong version was being used on RadHat.