### PR TITLE
Update rlm_yubikey to better support decrypt

### DIFF
--- a/raddb/mods-available/yubikey
+++ b/raddb/mods-available/yubikey
@@ -12,7 +12,7 @@ yubikey {
 
 	#
 	#  If true, the authorize method of rlm_yubikey will attempt to split the
-	#  value of User-Password, into the user's password, and the OTP token.
+	#  value of User-Password, into the user's password and the OTP token.
 	#
 	#  If enabled and successful, the value of User-Password will be truncated
 	#  and request:Yubikey-OTP will be added.
@@ -22,32 +22,60 @@ yubikey {
 	#
 	#  Decrypt mode - Tokens will be decrypted and processed locally
 	#
+	#  This module should be placed before the sql for the authorize section and
+	#  the yubikey_authorize_otpkey policy directly after the sql.
+	#  The authenticate section should have the following added 
+	#    Auth-Type yubikey {
+	#   #	pap
+	#    	yubikey
+	#    }
+	#  If two factor authentication (password concatenated with OTP) is to be
+	#  implemented, split should be yes and pap should be uncommented. Each
+	#  account will need a password added (using attribute Cleartext-Password
+	#  or preferably SSHA-Password).
+	#
 	#  The module itself does not provide persistent storage as this
-	#  would be duplicative of functionality already in the server.
+	#  would be duplicative of functionality already in the server (see sql
+	#  module and radcheck table). Updates to the persistant storage after
+	#  authentication is provided by the sqlyubikey module.
 	#
-	#  Yubikey authentication needs two control attributes
-	#  retrieved from persistent storage:
-	#    * Yubikey-Key     - The AES key used to decrypt the OTP data.
-	#                        The Yubikey-Public-Id and/or User-Name
-	#                        attributes may be used to retrieve the key.
-	#    * Yubikey-Counter - This is compared with the counter in the OTP
-	#                        data and used to prevent replay attacks.
-	#                        This attribute will also be available in
-	#                        the request list after successful
-	#                        decryption.
-	#
-	#  Yubikey-Counter isn't strictly required, but the server will
-	#  generate warnings if it's not present when yubikey.authenticate
-	#  is called.
+	#  Yubikey authorization uses the following control attributes.
+	#  If enabled and the Yubikey-Key attribute exists for the user, then
+	#  any password >= 32 + id_length is assumed to incorporate the OTP
+	#  Yubikey authentication uses the following control attributes
+	#  retrieved from persistent storage.
+	#    * Yubikey-Key        - (required, 16-byte binary {or modhex/hex/base64})
+	#                           The AES key used to decrypt the OTP data.
+	#    * Yubikey-Private-ID - (optional, 6-byte binary {or modhex/hex/base64})
+	#                           The hidden ID included in OTP data. Compared
+	#                           with ID in the decoded OTP to validate token.
+	#    * Yubikey-Counter    - (optional, 16-bit session count & 8-bit use
+	#                           count as 24-bit monotonically strictly increasing
+	#                           integer until the invidual count ceiling is hit)
+	#                           This is compared with the counters in the OTP
+	#                           data and used to prevent replay attacks.
+	#    * Yubikey-Timestamp  - (optional, 24-bit increasing integer @ 8 Hz with
+	#                           rollover which is randomly initialized each session)
+	#                           This is not currently used in the authenticate
+	#                           module, but may be incorporated in scripting for a
+	#                           successive relative time estimation between single
+	#                           session OTPs (if under 24 days).
 	#
 	#  These attributes are available after authorization:
-	#    * Yubikey-Public-ID  - The public portion of the OTP string
+	#    * Yubikey-Public-ID  - (if OTP found, usually 6-byte binary {see id_length})
+	#                           The public ID included in the OTP string.
+	#  The Yubikey-Public-Id and/or User-Name attributes may be used to retrieve
+	#  the Yubikey-Key, Yubikey-Private-ID, etc. by modifying the sql module main
+	#  queries like:
+	#   sql_user_name = "%{Yubikey-Public-ID}"
+	#  or
+	#   sql_user_name = "%{%{Yubikey-Public-ID}:-%{User-Name}}"
+	#  If Yubikey-Public-ID is used, place the yubikey_authorize_username policy
+	#  directly after the authorize section sql module and add a User-Name attribute
+	#  for each token.
 	#
 	#  These attributes are available after authentication (if successful):
-	#    * Yubikey-Private-ID - The encrypted ID included in OTP data,
-	#                           must be verified if tokens share keys.
-	#    * Yubikey-Counter    - The last counter value (should be recorded).
-	#    * Yubikey-Timestamp  - Token's internal clock (mainly useful for debugging).
+	#    * Yubikey-Private-ID, Yubikey-Counter, & Yubikey-Timestamp
 	#    * Yubikey-Random     - Randomly generated value from the token.
 	#
 	decrypt = no

--- a/raddb/policy.d/yubikey
+++ b/raddb/policy.d/yubikey
@@ -1,0 +1,29 @@
+#
+#  The following policies are for the Yubikey OTP token configuration.
+#
+
+# Mitigate default PAP authentication by password alone in two factor auth
+yubikey_authorize_otpkey {
+	if (!&request:Yubikey-OTP && &control:Yubikey-Key) {
+		update reply {
+			&Reply-Message += 'Rejected: Require Yubikey OTP'
+		}
+		reject
+	}
+	if (&request:Yubikey-OTP && !&control:Yubikey-Key) {
+		update reply {
+			&Reply-Message += 'Rejected: Missing Yubikey Key'
+		}
+		reject
+	}
+}
+
+# Mitigate valid token use for incorrect account
+yubikey_authorize_username {
+	if (&control:User-Name && !(&control:User-Name == &request:User-Name)) {
+		update reply {
+			&Reply-Message += 'Rejected: Mismatch Yubikey User-Name'
+		}
+		reject
+	}
+}

--- a/src/modules/rlm_yubikey/decrypt.c
+++ b/src/modules/rlm_yubikey/decrypt.c
@@ -7,9 +7,12 @@
  * @copyright 2013 The FreeRADIUS server project
  * @copyright 2013 Network RADIUS <info@networkradius.com>
  */
+
 #include "rlm_yubikey.h"
 
 #ifdef HAVE_YUBIKEY
+const uint8_t uid_unused[YUBIKEY_UID_SIZE] = { 0, 0, 0, 0, 0, 0 };
+
 /** Decrypt a Yubikey OTP AES block
  *
  * @param inst Module configuration.
@@ -18,36 +21,37 @@
  */
 rlm_rcode_t rlm_yubikey_decrypt(rlm_yubikey_t *inst, REQUEST *request, char const *passcode)
 {
-	uint32_t counter;
+	uint32_t counter, timestamp;
 	yubikey_token_st token;
-
 	DICT_ATTR const *da;
-
 	char private_id[(YUBIKEY_UID_SIZE * 2) + 1];
-	VALUE_PAIR *key, *vp;
+	VALUE_PAIR *vp;
 
+	/*
+	 * Key control list info must exist
+	 */
 	da = dict_attrbyname("Yubikey-Key");
 	if (!da) {
 		REDEBUG("Dictionary missing entry for 'Yubikey-Key'");
 		return RLM_MODULE_FAIL;
 	}
 
-	key = pair_find_by_da(request->config_items, da, TAG_ANY);
-	if (!key) {
+	vp = pair_find_by_da(request->config_items, da, TAG_ANY);
+	if (!vp) {
 		REDEBUG("Yubikey-Key attribute not found in control list, can't decrypt OTP data");
 		return RLM_MODULE_INVALID;
 	}
 
-	if (key->vp_length != YUBIKEY_KEY_SIZE) {
-		REDEBUG("Yubikey-Key length incorrect, expected %u got %zu", YUBIKEY_KEY_SIZE, key->vp_length);
+	if (inst->normify)
+		rlm_yubikey_normify(request, vp, YUBIKEY_KEY_SIZE);
+
+	if (vp->vp_length != YUBIKEY_KEY_SIZE) {
+		REDEBUG("Yubikey-Key length incorrect, expected %u got %zu", YUBIKEY_KEY_SIZE, vp->vp_length);
 		return RLM_MODULE_INVALID;
 	}
 
-	yubikey_parse((uint8_t const *) passcode + inst->id_len, key->vp_octets, &token);
+	yubikey_parse((uint8_t const *) passcode + inst->id_len, vp->vp_octets, &token);
 
-	/*
-	 *	Apparently this just uses byte offsets...
-	 */
 	if (!yubikey_crc_ok_p((uint8_t *) &token)) {
 		REDEBUG("Decrypting OTP token data failed, rejecting");
 		return RLM_MODULE_REJECT;
@@ -55,81 +59,97 @@ rlm_rcode_t rlm_yubikey_decrypt(rlm_yubikey_t *inst, REQUEST *request, char cons
 
 	RDEBUG("Token data decrypted successfully");
 
+	counter = (yubikey_counter(token.ctr) << 8) | token.use;
+	timestamp = (token.tstph << 16) | token.tstpl;
+
 	if (request->log.lvl && request->log.func) {
-		(void) fr_bin2hex((char *) &private_id, (uint8_t*) &token.uid, YUBIKEY_UID_SIZE);
-		RDEBUG2("Private ID	: 0x%s", private_id);
-		RDEBUG2("Session counter   : %u", yubikey_counter(token.ctr));
-		RDEBUG2("# used in session : %u", token.use);
-		RDEBUG2("Token timestamp    : %u",
-			(token.tstph << 16) | token.tstpl);
-		RDEBUG2("Random data       : %u", token.rnd);
-		RDEBUG2("CRC data          : 0x%x", token.crc);
+		(void) fr_bin2hex(private_id, token.uid, YUBIKEY_UID_SIZE);
+		RDEBUG2("Private ID : 0x%s", private_id);
+		RDEBUG2("Counter    : %u", counter);
+		RDEBUG2("Timestamp  : %u", timestamp);
+		RDEBUG2("Random     : %u", token.rnd);
+		RDEBUG2("CRC        : 0x%x", token.crc);
 	}
 
 	/*
-	 *	Private ID used for validation purposes
+	 * If token Private-ID is non-zero, then compare (if info exists)
+	 */
+	if (memcmp(token.uid, uid_unused, YUBIKEY_UID_SIZE)) {
+		da = dict_attrbyname("Yubikey-Private-ID");
+		if (!da) {
+			REDEBUG("Dictionary missing entry for 'Yubikey-Private-ID'");
+			return RLM_MODULE_FAIL;
+		}
+
+		vp = pair_find_by_da(request->config_items, da, TAG_ANY);
+		if (vp) {
+			if (inst->normify)
+				rlm_yubikey_normify(request, vp, YUBIKEY_UID_SIZE);
+			if (vp->vp_length != YUBIKEY_UID_SIZE) {
+				REDEBUG("Yubikey-Private-ID length incorrect, expected %u got %zu", YUBIKEY_UID_SIZE, vp->vp_length);
+				return RLM_MODULE_INVALID;
+			}
+
+			if (memcmp(token.uid, vp->vp_octets, YUBIKEY_UID_SIZE)) {
+				REDEBUG("Private ID mismatch!");
+				return RLM_MODULE_REJECT;
+			}
+		}
+	}
+
+	/*
+	 * Now check for replay attacks (if info exists)
+	 */
+	da = dict_attrbyname("Yubikey-Counter");
+	if (!da) {
+		REDEBUG("Dictionary missing entry for 'Yubikey-Counter'");
+		return RLM_MODULE_FAIL;
+	}
+
+	vp = pair_find_by_da(request->config_items, da, TAG_ANY);
+	if (vp) {
+		if (counter <= vp->vp_integer) {
+			REDEBUG("Replay attack detected! Counter value %u, is lt or eq to last known counter value %u",
+				counter, vp->vp_integer);
+			return RLM_MODULE_REJECT;
+		}
+	}
+
+	/* 
+	 * Record attributes for further validation and optional SQL storage
 	 */
 	vp = pairmake(request, &request->packet->vps, "Yubikey-Private-ID", NULL, T_OP_SET);
 	if (!vp) {
 		REDEBUG("Failed creating Yubikey-Private-ID");
-
 		return RLM_MODULE_FAIL;
 	}
 	pairmemcpy(vp, token.uid, YUBIKEY_UID_SIZE);
 
-	/*
-	 *	Token timestamp
-	 */
+	vp = pairmake(request, &request->packet->vps, "Yubikey-Counter", NULL, T_OP_SET);
+	if (!vp) {
+		REDEBUG("Failed creating Yubikey-Counter");
+		return RLM_MODULE_FAIL;
+	}
+
+	vp->vp_integer = counter;
+	vp->vp_length = 4;
+
 	vp = pairmake(request, &request->packet->vps, "Yubikey-Timestamp", NULL, T_OP_SET);
 	if (!vp) {
 		REDEBUG("Failed creating Yubikey-Timestamp");
-
 		return RLM_MODULE_FAIL;
 	}
-	vp->vp_integer = (token.tstph << 16) | token.tstpl;
+	vp->vp_integer = timestamp;
 	vp->vp_length = 4;
 
-	/*
-	 *	Token random
-	 */
 	vp = pairmake(request, &request->packet->vps, "Yubikey-Random", NULL, T_OP_SET);
 	if (!vp) {
 		REDEBUG("Failed creating Yubikey-Random");
-
 		return RLM_MODULE_FAIL;
 	}
 	vp->vp_integer = token.rnd;
 	vp->vp_length = 4;
 
-	/*
-	 *	Combine the two counter fields together so we can do
-	 *	replay attack checks.
-	 */
-	counter = (yubikey_counter(token.ctr) << 16) | token.use;
-
-	vp = pairmake(request, &request->packet->vps, "Yubikey-Counter", NULL, T_OP_SET);
-	if (!vp) {
-		REDEBUG("Failed creating Yubikey-Counter");
-
-		return RLM_MODULE_FAIL;
-	}
-	vp->vp_integer = counter;
-	vp->vp_length = 4;
-
-	/*
-	 *	Now we check for replay attacks
-	 */
-	vp = pair_find_by_da(request->config_items, da, TAG_ANY);
-	if (!vp) {
-		RWDEBUG("Yubikey-Counter not found in control list, skipping replay attack checks");
-		return RLM_MODULE_OK;
-	}
-
-	if (counter <= vp->vp_integer) {
-		REDEBUG("Replay attack detected! Counter value %u, is lt or eq to last known counter value %u",
-			counter, vp->vp_integer);
-		return RLM_MODULE_REJECT;
-	}
 
 	return RLM_MODULE_OK;
 }

--- a/src/modules/rlm_yubikey/rlm_yubikey.h
+++ b/src/modules/rlm_yubikey/rlm_yubikey.h
@@ -26,6 +26,7 @@ typedef struct rlm_yubikey_t {
 	int			auth_type;		//!< Our Auth-Type.
 	unsigned int		id_len;			//!< The length of the Public ID portion of the OTP string.
 	bool			split;			//!< Split password string into components.
+	bool			normify;		//!< Auto-convert value
 	bool			decrypt;		//!< Decrypt the OTP string using the yubikey library.
 	bool			validate;		//!< Validate the OTP string using the ykclient library.
 	char const		**uris;			//!< Yubicloud URLs to validate the token against.
@@ -38,6 +39,8 @@ typedef struct rlm_yubikey_t {
 #endif
 } rlm_yubikey_t;
 
+
+void rlm_yubikey_normify(REQUEST *request, VALUE_PAIR *vp, size_t min_length);
 
 /*
  *	decrypt.c - Decryption functions


### PR DESCRIPTION
This is an enhancement to clarify some of rlm_yubikey setup and code (for people who need things explicitly spelled out like me), add a little support policy, and add "normifying" to the Yubikey-Key / Yubikey-Private-ID attributes.

Specifically:
* The split code now creates the Yubikey-OTP pair if it passes, even if password is zero length.
* If the optional Yubikey-Private-ID and/or Yubikey-Counter attributes exist, then they are checked.
* If the checks pass, then the pairs are created.
* If configuration has normalise set to yes (the default), then the Yubikey-Key and Yubikey-Private-ID values can be stored as a modhex string / hexadecimal string / base64 string / binary blob. Sort of like rlm_pap and passwords.
* The Yubikey-Counter was changed to a 32-bit to a 24-bit value: 16-bits session counter immediately concatenated with the 8-bit use counter.
* As it would seem the in order to reach the authenticate code, the OTP should have already been verified by the authorize code, redoing this check seemed redundant and so I marked it with an #if 0 for potential elimination (it's up to you).
* The suggested policy handles in authorize (after the SQL query) some potential mismatches.

Hopefully you'll find these modifications useful and will add them to the upstream. There is also an attendant branch for a new module rlm_sqlyubikey which updates some of the attributes post-authentication.