### PR TITLE
New rlm_sqlyubikey module

### DIFF
--- a/raddb/mods-available/sqlyubikey
+++ b/raddb/mods-available/sqlyubikey
@@ -1,0 +1,20 @@
+#
+#  This module updates Yubikey OTP token values in SQL database.
+#  Used in combination with Yubikey module when using decrypt.
+#
+#  This module should be placed in the post-auth section after the logging modules.
+#
+sqlyubikey {
+	sql_module_instance = sql
+
+	#  These attributes available after authentication (if successful):
+	#    * Yubikey-Counter   - The lastest counter value.
+	#    * Yubikey-Timestamp - The lastest timestamp value.
+	#  If these attributes do not exist for the account, they will not be updated
+
+	# These must match SQL module
+	dialect = "sqlite"
+	authcheck_table = "radcheck"
+
+	$INCLUDE ${modconfdir}/sql/yubikey/${dialect}/queries.conf
+}

--- a/raddb/mods-available/yubikey
+++ b/raddb/mods-available/yubikey
@@ -12,7 +12,7 @@ yubikey {
 
 	#
 	#  If true, the authorize method of rlm_yubikey will attempt to split the
-	#  value of User-Password, into the user's password, and the OTP token.
+	#  value of User-Password, into the user's password and the OTP token.
 	#
 	#  If enabled and successful, the value of User-Password will be truncated
 	#  and request:Yubikey-OTP will be added.
@@ -22,32 +22,60 @@ yubikey {
 	#
 	#  Decrypt mode - Tokens will be decrypted and processed locally
 	#
+	#  This module should be placed before the sql for the authorize section and
+	#  the yubikey_authorize_otpkey policy directly after the sql.
+	#  The authenticate section should have the following added 
+	#    Auth-Type yubikey {
+	#   #	pap
+	#    	yubikey
+	#    }
+	#  If two factor authentication (password concatenated with OTP) is to be
+	#  implemented, split should be yes and pap should be uncommented. Each
+	#  account will need a password added (using attribute Cleartext-Password
+	#  or preferably SSHA-Password).
+	#
 	#  The module itself does not provide persistent storage as this
-	#  would be duplicative of functionality already in the server.
+	#  would be duplicative of functionality already in the server (see sql
+	#  module and radcheck table). Updates to the persistant storage after
+	#  authentication is provided by the sqlyubikey module.
 	#
-	#  Yubikey authentication needs two control attributes
-	#  retrieved from persistent storage:
-	#    * Yubikey-Key     - The AES key used to decrypt the OTP data.
-	#                        The Yubikey-Public-Id and/or User-Name
-	#                        attributes may be used to retrieve the key.
-	#    * Yubikey-Counter - This is compared with the counter in the OTP
-	#                        data and used to prevent replay attacks.
-	#                        This attribute will also be available in
-	#                        the request list after successful
-	#                        decryption.
-	#
-	#  Yubikey-Counter isn't strictly required, but the server will
-	#  generate warnings if it's not present when yubikey.authenticate
-	#  is called.
+	#  Yubikey authorization uses the following control attributes.
+	#  If enabled and the Yubikey-Key attribute exists for the user, then
+	#  any password >= 32 + id_length is assumed to incorporate the OTP
+	#  Yubikey authentication uses the following control attributes
+	#  retrieved from persistent storage.
+	#    * Yubikey-Key        - (required, 16-byte binary {or modhex/hex/base64})
+	#                           The AES key used to decrypt the OTP data.
+	#    * Yubikey-Private-ID - (optional, 6-byte binary {or modhex/hex/base64})
+	#                           The hidden ID included in OTP data. Compared
+	#                           with ID in the decoded OTP to validate token.
+	#    * Yubikey-Counter    - (optional, 16-bit session count & 8-bit use
+	#                           count as 24-bit monotonically strictly increasing
+	#                           integer until the invidual count ceiling is hit)
+	#                           This is compared with the counters in the OTP
+	#                           data and used to prevent replay attacks.
+	#    * Yubikey-Timestamp  - (optional, 24-bit increasing integer @ 8 Hz with
+	#                           rollover which is randomly initialized each session)
+	#                           This is not currently used in the authenticate
+	#                           module, but may be incorporated in scripting for a
+	#                           successive relative time estimation between single
+	#                           session OTPs (if under 24 days).
 	#
 	#  These attributes are available after authorization:
-	#    * Yubikey-Public-ID  - The public portion of the OTP string
+	#    * Yubikey-Public-ID  - (if OTP found, usually 6-byte binary {see id_length})
+	#                           The public ID included in the OTP string.
+	#  The Yubikey-Public-Id and/or User-Name attributes may be used to retrieve
+	#  the Yubikey-Key, Yubikey-Private-ID, etc. by modifying the sql module main
+	#  queries like:
+	#   sql_user_name = "%{Yubikey-Public-ID}"
+	#  or
+	#   sql_user_name = "%{%{Yubikey-Public-ID}:-%{User-Name}}"
+	#  If Yubikey-Public-ID is used, place the yubikey_authorize_username policy
+	#  directly after the authorize section sql module and add a User-Name attribute
+	#  for each token.
 	#
 	#  These attributes are available after authentication (if successful):
-	#    * Yubikey-Private-ID - The encrypted ID included in OTP data,
-	#                           must be verified if tokens share keys.
-	#    * Yubikey-Counter    - The last counter value (should be recorded).
-	#    * Yubikey-Timestamp  - Token's internal clock (mainly useful for debugging).
+	#    * Yubikey-Private-ID, Yubikey-Counter, & Yubikey-Timestamp
 	#    * Yubikey-Random     - Randomly generated value from the token.
 	#
 	decrypt = no

--- a/raddb/mods-config/sql/yubikey/mysql/queries.conf
+++ b/raddb/mods-config/sql/yubikey/mysql/queries.conf
@@ -1,0 +1,19 @@
+# -*- text -*-
+#
+#  yubikey/mysql/queries.conf -- Queries to update MySQL Yubikey entries.
+#
+#  $Id$
+
+# Update the counter (session|use).
+query_counter = "\
+	UPDATE ${authcheck_table} SET \
+		value = '%{Yubikey-Counter}' \
+	WHERE username = '%{SQL-User-Name}' \
+	AND attribute = 'Yubikey-Counter'"
+
+# Update the timestamp.
+query_timestamp = "\
+	UPDATE ${authcheck_table} SET \
+		value = '%{Yubikey-Timestamp}' \
+	WHERE username = '%{SQL-User-Name}' \
+	AND attribute = 'Yubikey-Timestamp'"

--- a/raddb/mods-config/sql/yubikey/postgresql/queries.conf
+++ b/raddb/mods-config/sql/yubikey/postgresql/queries.conf
@@ -1,0 +1,19 @@
+# -*- text -*-
+#
+#  yubikey/postgresql/queries.conf -- Queries to update PostgreSQL Yubikey entries.
+#
+#  $Id$
+
+# Update the counter (session|use).
+query_counter = "\
+	UPDATE ${authcheck_table} SET \
+		value = '%{Yubikey-Counter}' \
+	WHERE username = '%{SQL-User-Name}' \
+	AND attribute = 'Yubikey-Counter'"
+
+# Update the timestamp.
+query_timestamp = "\
+	UPDATE ${authcheck_table} SET \
+		value = '%{Yubikey-Timestamp}' \
+	WHERE username = '%{SQL-User-Name}' \
+	AND attribute = 'Yubikey-Timestamp'"

--- a/raddb/mods-config/sql/yubikey/sqlite/queries.conf
+++ b/raddb/mods-config/sql/yubikey/sqlite/queries.conf
@@ -1,0 +1,19 @@
+# -*- text -*-
+#
+#  yubikey/sqlite/queries.conf -- Queries to update SQLite Yubikey entries.
+#
+#  $Id$
+
+# Update the counter (session|use).
+query_counter = "\
+	UPDATE ${authcheck_table} SET \
+		value = '%{Yubikey-Counter}' \
+	WHERE username = '%{SQL-User-Name}' \
+	AND attribute = 'Yubikey-Counter'"
+
+# Update the timestamp.
+query_timestamp = "\
+	UPDATE ${authcheck_table} SET \
+		value = '%{Yubikey-Timestamp}' \
+	WHERE username = '%{SQL-User-Name}' \
+	AND attribute = 'Yubikey-Timestamp'"

--- a/raddb/policy.d/yubikey
+++ b/raddb/policy.d/yubikey
@@ -1,0 +1,29 @@
+#
+#  The following policies are for the Yubikey OTP token configuration.
+#
+
+# Mitigate default PAP authentication by password alone in two factor auth
+yubikey_authorize_otpkey {
+	if (!&request:Yubikey-OTP && &control:Yubikey-Key) {
+		update reply {
+			&Reply-Message += 'Rejected: Require Yubikey OTP'
+		}
+		reject
+	}
+	if (&request:Yubikey-OTP && !&control:Yubikey-Key) {
+		update reply {
+			&Reply-Message += 'Rejected: Missing Yubikey Key'
+		}
+		reject
+	}
+}
+
+# Mitigate valid token use for incorrect account
+yubikey_authorize_username {
+	if (&control:User-Name && !(&control:User-Name == &request:User-Name)) {
+		update reply {
+			&Reply-Message += 'Rejected: Mismatch Yubikey User-Name'
+		}
+		reject
+	}
+}

--- a/src/modules/rlm_sqlyubikey/all.mk.in
+++ b/src/modules/rlm_sqlyubikey/all.mk.in
@@ -1,0 +1,11 @@
+TARGETNAME	:= @targetname@
+
+ifneq "$(TARGETNAME)" ""
+TARGET		:= $(TARGETNAME).a
+endif
+
+SOURCES		:= $(TARGETNAME).c
+
+SRC_CFLAGS	:= @mod_cflags@
+SRC_CFLAGS	+= -I$(top_builddir)/src/modules/rlm_sql
+TGT_LDLIBS	:= @mod_ldflags@

--- a/src/modules/rlm_sqlyubikey/configure.ac
+++ b/src/modules/rlm_sqlyubikey/configure.ac
@@ -1,0 +1,32 @@
+AC_PREREQ([2.53])
+AC_INIT(rlm_sqlyubikey.c)
+AC_REVISION($Revision$)
+AC_DEFUN(modname,[rlm_sqlyubikey])
+
+if test x$with_[]modname != xno; then
+
+	AC_PROG_CC
+	AC_PROG_CPP
+
+	targetname=modname
+else
+	targetname=
+	echo \*\*\* module modname is disabled.
+fi
+
+if test x"$fail" != x""; then
+	if test x"${enable_strict_dependencies}" = x"yes"; then
+		AC_MSG_ERROR([set --without-]modname[ to disable it explicitly.])
+	else
+		AC_MSG_WARN([silently not building ]modname[.])
+		AC_MSG_WARN([FAILURE: ]modname[ requires: $fail.]);
+		targetname=""
+	fi
+fi
+
+mod_ldflags="$SMART_LIBS"
+mod_cflags="$SMART_CPPFLAGS"
+AC_SUBST(mod_ldflags)
+AC_SUBST(mod_cflags)
+AC_SUBST(targetname)
+AC_OUTPUT(all.mk)

--- a/src/modules/rlm_sqlyubikey/rlm_sqlyubikey.c
+++ b/src/modules/rlm_sqlyubikey/rlm_sqlyubikey.c
@@ -1,0 +1,166 @@
+/*
+ *   This program is is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License, version 2 if the
+ *   License as published by the Free Software Foundation.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/**
+ * $Id$
+ * @file rlm_sqlyubikey.c
+ * @brief Update Yubikey OTP token values in SQL database.
+ *
+ * @copyright 2015  The FreeRADIUS server project
+ */
+RCSID("$Id$")
+
+#include <freeradius-devel/radiusd.h>
+#include <freeradius-devel/rad_assert.h>
+
+#include <rlm_sql.h>
+
+/*
+ *	Minimalist structure for our module configuration.
+ */
+typedef struct rlm_sqlyubikey_t {
+	char const *sql_instance_name;
+	rlm_sql_t *sql_inst;
+
+	char const *query_counter;     //!< SQL query to update session counter (16-bits monotonic increasing per plugin) concatenated with use (8-bit monotonic per press during plugin)
+	char const *query_timestamp;   //!< SQL query to update timestamp value (24-bit rollover random start per plugin)
+} rlm_sqlyubikey_t;
+
+/*
+ *	A mapping of configuration file names to internal variables.
+ *
+ *	Note that the string is dynamically allocated, so it MUST
+ *	be freed.  When the configuration file parse re-reads the string,
+ *	it free's the old one, and strdup's the new one, placing the pointer
+ *	to the strdup'd string into 'config.string'.  This gets around
+ *	buffer over-flows.
+ */
+static const CONF_PARSER module_config[] = {
+	{ "sql-instance-name", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_DEPRECATED, rlm_sqlyubikey_t, sql_instance_name), NULL },
+	{ "sql_module_instance", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_REQUIRED, rlm_sqlyubikey_t, sql_instance_name), "sql" },
+
+	{ "query_counter", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_REQUIRED, rlm_sqlyubikey_t, query_counter), NULL },
+	{ "query_timestamp", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_REQUIRED, rlm_sqlyubikey_t, query_timestamp), NULL },
+
+	{ NULL, -1, 0, NULL, NULL }
+};
+
+/*
+ *	Do any per-module initialization that is separate to each
+ *	configured instance of the module.  e.g. set up connections
+ *	to external databases, read configuration files, set up
+ *	dictionary entries, etc.
+ *
+ *	If configuration information is given in the config section
+ *	that must be referenced in later calls, store a handle to it
+ *	in *instance otherwise put a null pointer there.
+ */
+static int mod_instantiate(CONF_SECTION *conf, void *instance)
+{
+	rlm_sqlyubikey_t *inst = instance;
+	module_instance_t *mod_inst;
+
+	rad_assert(inst->query_counter && *inst->query_counter);
+	rad_assert(inst->query_timestamp && *inst->query_timestamp);
+
+	mod_inst = find_module_instance(cf_section_find("modules"),
+		inst->sql_instance_name, true);
+	if (!mod_inst) {
+		cf_log_err_cs(conf, "failed to find sql instance named %s",
+			inst->sql_instance_name);
+		return -1;
+	}
+	inst->sql_inst = (rlm_sql_t *) mod_inst->insthandle;
+
+	return 0;
+}
+
+/*
+ *	Translate and issue SQL query.
+ */
+static rlm_rcode_t sqlyubikey_query(rlm_sqlyubikey_t *inst, REQUEST *request, rlm_sql_handle_t *handle, char const *query)
+{
+	rlm_sql_t *sql_inst = inst->sql_inst;
+	char *expanded = NULL;
+	int ret;
+
+	if (radius_axlat(&expanded, request, query, sql_inst->sql_escape_func, sql_inst) < 0)
+		return RLM_MODULE_FAIL;
+
+	ret = sql_inst->sql_query(&handle, sql_inst, expanded);
+	talloc_free(expanded);
+	if (ret < 0)
+		return RLM_MODULE_NOOP;
+
+	sql_inst->module->sql_finish_query(handle, sql_inst->config);
+
+	return RLM_MODULE_OK;
+}
+
+/*
+ *	Update the attribute-value(s) for this user in the database.
+ */
+static rlm_rcode_t CC_HINT(nonnull) mod_post_auth(void *instance, REQUEST *request)
+{
+	rlm_rcode_t rcode;
+	rlm_sqlyubikey_t *inst = instance;
+	rlm_sql_handle_t *handle;
+
+	handle = fr_connection_get(inst->sql_inst->pool);
+	if (!handle) {
+		REDEBUG("cannot get sql connection");
+		return RLM_MODULE_FAIL;
+	}
+
+	if (inst->sql_inst->sql_set_user(inst->sql_inst, request, NULL) < 0)
+		rcode = RLM_MODULE_FAIL;
+	else if ((rcode = sqlyubikey_query(inst, request, handle, inst->query_counter)) == RLM_MODULE_FAIL)
+		;
+	else
+		rcode = sqlyubikey_query(inst, request, handle, inst->query_timestamp);
+
+	fr_connection_release(inst->sql_inst->pool, handle);
+
+	return rcode;
+}
+
+/*
+ *	The module name should be the only globally exported symbol.
+ *	That is, everything else should be 'static'.
+ *
+ *	If the module needs to temporarily modify it's instantiation
+ *	data, the type should be changed to RLM_TYPE_THREAD_UNSAFE.
+ *	The server will then take care of ensuring that the module
+ *	is single-threaded.
+ */
+module_t rlm_sqlyubikey = {
+	RLM_MODULE_INIT,
+	"sqlyubikey",
+	RLM_TYPE_THREAD_SAFE,		/* type */
+	sizeof(rlm_sqlyubikey_t),
+	module_config,
+	mod_instantiate,	/* instantiation */
+	NULL,				/* detach */
+	{
+		NULL,			/* authentication */
+		NULL,			/* authorization */
+		NULL,			/* preaccounting */
+		NULL,			/* accounting */
+		NULL,			/* checksimul */
+		NULL,			/* pre-proxy */
+		NULL,			/* post-proxy */
+		mod_post_auth	/* post-auth */
+	},
+};

--- a/src/modules/rlm_yubikey/decrypt.c
+++ b/src/modules/rlm_yubikey/decrypt.c
@@ -7,9 +7,12 @@
  * @copyright 2013 The FreeRADIUS server project
  * @copyright 2013 Network RADIUS <info@networkradius.com>
  */
+
 #include "rlm_yubikey.h"
 
 #ifdef HAVE_YUBIKEY
+const uint8_t uid_unused[YUBIKEY_UID_SIZE] = { 0, 0, 0, 0, 0, 0 };
+
 /** Decrypt a Yubikey OTP AES block
  *
  * @param inst Module configuration.
@@ -18,36 +21,37 @@
  */
 rlm_rcode_t rlm_yubikey_decrypt(rlm_yubikey_t *inst, REQUEST *request, char const *passcode)
 {
-	uint32_t counter;
+	uint32_t counter, timestamp;
 	yubikey_token_st token;
-
 	DICT_ATTR const *da;
-
 	char private_id[(YUBIKEY_UID_SIZE * 2) + 1];
-	VALUE_PAIR *key, *vp;
+	VALUE_PAIR *vp;
 
+	/*
+	 * Key control list info must exist
+	 */
 	da = dict_attrbyname("Yubikey-Key");
 	if (!da) {
 		REDEBUG("Dictionary missing entry for 'Yubikey-Key'");
 		return RLM_MODULE_FAIL;
 	}
 
-	key = pair_find_by_da(request->config_items, da, TAG_ANY);
-	if (!key) {
+	vp = pair_find_by_da(request->config_items, da, TAG_ANY);
+	if (!vp) {
 		REDEBUG("Yubikey-Key attribute not found in control list, can't decrypt OTP data");
 		return RLM_MODULE_INVALID;
 	}
 
-	if (key->vp_length != YUBIKEY_KEY_SIZE) {
-		REDEBUG("Yubikey-Key length incorrect, expected %u got %zu", YUBIKEY_KEY_SIZE, key->vp_length);
+	if (inst->normify)
+		rlm_yubikey_normify(request, vp, YUBIKEY_KEY_SIZE);
+
+	if (vp->vp_length != YUBIKEY_KEY_SIZE) {
+		REDEBUG("Yubikey-Key length incorrect, expected %u got %zu", YUBIKEY_KEY_SIZE, vp->vp_length);
 		return RLM_MODULE_INVALID;
 	}
 
-	yubikey_parse((uint8_t const *) passcode + inst->id_len, key->vp_octets, &token);
+	yubikey_parse((uint8_t const *) passcode + inst->id_len, vp->vp_octets, &token);
 
-	/*
-	 *	Apparently this just uses byte offsets...
-	 */
 	if (!yubikey_crc_ok_p((uint8_t *) &token)) {
 		REDEBUG("Decrypting OTP token data failed, rejecting");
 		return RLM_MODULE_REJECT;
@@ -55,81 +59,97 @@ rlm_rcode_t rlm_yubikey_decrypt(rlm_yubikey_t *inst, REQUEST *request, char cons
 
 	RDEBUG("Token data decrypted successfully");
 
+	counter = (yubikey_counter(token.ctr) << 8) | token.use;
+	timestamp = (token.tstph << 16) | token.tstpl;
+
 	if (request->log.lvl && request->log.func) {
-		(void) fr_bin2hex((char *) &private_id, (uint8_t*) &token.uid, YUBIKEY_UID_SIZE);
-		RDEBUG2("Private ID	: 0x%s", private_id);
-		RDEBUG2("Session counter   : %u", yubikey_counter(token.ctr));
-		RDEBUG2("# used in session : %u", token.use);
-		RDEBUG2("Token timestamp    : %u",
-			(token.tstph << 16) | token.tstpl);
-		RDEBUG2("Random data       : %u", token.rnd);
-		RDEBUG2("CRC data          : 0x%x", token.crc);
+		(void) fr_bin2hex(private_id, token.uid, YUBIKEY_UID_SIZE);
+		RDEBUG2("Private ID : 0x%s", private_id);
+		RDEBUG2("Counter    : %u", counter);
+		RDEBUG2("Timestamp  : %u", timestamp);
+		RDEBUG2("Random     : %u", token.rnd);
+		RDEBUG2("CRC        : 0x%x", token.crc);
 	}
 
 	/*
-	 *	Private ID used for validation purposes
+	 * If token Private-ID is non-zero, then compare (if info exists)
+	 */
+	if (memcmp(token.uid, uid_unused, YUBIKEY_UID_SIZE)) {
+		da = dict_attrbyname("Yubikey-Private-ID");
+		if (!da) {
+			REDEBUG("Dictionary missing entry for 'Yubikey-Private-ID'");
+			return RLM_MODULE_FAIL;
+		}
+
+		vp = pair_find_by_da(request->config_items, da, TAG_ANY);
+		if (vp) {
+			if (inst->normify)
+				rlm_yubikey_normify(request, vp, YUBIKEY_UID_SIZE);
+			if (vp->vp_length != YUBIKEY_UID_SIZE) {
+				REDEBUG("Yubikey-Private-ID length incorrect, expected %u got %zu", YUBIKEY_UID_SIZE, vp->vp_length);
+				return RLM_MODULE_INVALID;
+			}
+
+			if (memcmp(token.uid, vp->vp_octets, YUBIKEY_UID_SIZE)) {
+				REDEBUG("Private ID mismatch!");
+				return RLM_MODULE_REJECT;
+			}
+		}
+	}
+
+	/*
+	 * Now check for replay attacks (if info exists)
+	 */
+	da = dict_attrbyname("Yubikey-Counter");
+	if (!da) {
+		REDEBUG("Dictionary missing entry for 'Yubikey-Counter'");
+		return RLM_MODULE_FAIL;
+	}
+
+	vp = pair_find_by_da(request->config_items, da, TAG_ANY);
+	if (vp) {
+		if (counter <= vp->vp_integer) {
+			REDEBUG("Replay attack detected! Counter value %u, is lt or eq to last known counter value %u",
+				counter, vp->vp_integer);
+			return RLM_MODULE_REJECT;
+		}
+	}
+
+	/* 
+	 * Record attributes for further validation and optional SQL storage
 	 */
 	vp = pairmake(request, &request->packet->vps, "Yubikey-Private-ID", NULL, T_OP_SET);
 	if (!vp) {
 		REDEBUG("Failed creating Yubikey-Private-ID");
-
 		return RLM_MODULE_FAIL;
 	}
 	pairmemcpy(vp, token.uid, YUBIKEY_UID_SIZE);
 
-	/*
-	 *	Token timestamp
-	 */
+	vp = pairmake(request, &request->packet->vps, "Yubikey-Counter", NULL, T_OP_SET);
+	if (!vp) {
+		REDEBUG("Failed creating Yubikey-Counter");
+		return RLM_MODULE_FAIL;
+	}
+
+	vp->vp_integer = counter;
+	vp->vp_length = 4;
+
 	vp = pairmake(request, &request->packet->vps, "Yubikey-Timestamp", NULL, T_OP_SET);
 	if (!vp) {
 		REDEBUG("Failed creating Yubikey-Timestamp");
-
 		return RLM_MODULE_FAIL;
 	}
-	vp->vp_integer = (token.tstph << 16) | token.tstpl;
+	vp->vp_integer = timestamp;
 	vp->vp_length = 4;
 
-	/*
-	 *	Token random
-	 */
 	vp = pairmake(request, &request->packet->vps, "Yubikey-Random", NULL, T_OP_SET);
 	if (!vp) {
 		REDEBUG("Failed creating Yubikey-Random");
-
 		return RLM_MODULE_FAIL;
 	}
 	vp->vp_integer = token.rnd;
 	vp->vp_length = 4;
 
-	/*
-	 *	Combine the two counter fields together so we can do
-	 *	replay attack checks.
-	 */
-	counter = (yubikey_counter(token.ctr) << 16) | token.use;
-
-	vp = pairmake(request, &request->packet->vps, "Yubikey-Counter", NULL, T_OP_SET);
-	if (!vp) {
-		REDEBUG("Failed creating Yubikey-Counter");
-
-		return RLM_MODULE_FAIL;
-	}
-	vp->vp_integer = counter;
-	vp->vp_length = 4;
-
-	/*
-	 *	Now we check for replay attacks
-	 */
-	vp = pair_find_by_da(request->config_items, da, TAG_ANY);
-	if (!vp) {
-		RWDEBUG("Yubikey-Counter not found in control list, skipping replay attack checks");
-		return RLM_MODULE_OK;
-	}
-
-	if (counter <= vp->vp_integer) {
-		REDEBUG("Replay attack detected! Counter value %u, is lt or eq to last known counter value %u",
-			counter, vp->vp_integer);
-		return RLM_MODULE_REJECT;
-	}
 
 	return RLM_MODULE_OK;
 }

--- a/src/modules/rlm_yubikey/rlm_yubikey.h
+++ b/src/modules/rlm_yubikey/rlm_yubikey.h
@@ -26,6 +26,7 @@ typedef struct rlm_yubikey_t {
 	int			auth_type;		//!< Our Auth-Type.
 	unsigned int		id_len;			//!< The length of the Public ID portion of the OTP string.
 	bool			split;			//!< Split password string into components.
+	bool			normify;		//!< Auto-convert value
 	bool			decrypt;		//!< Decrypt the OTP string using the yubikey library.
 	bool			validate;		//!< Validate the OTP string using the ykclient library.
 	char const		**uris;			//!< Yubicloud URLs to validate the token against.
@@ -38,6 +39,8 @@ typedef struct rlm_yubikey_t {
 #endif
 } rlm_yubikey_t;
 
+
+void rlm_yubikey_normify(REQUEST *request, VALUE_PAIR *vp, size_t min_length);
 
 /*
  *	decrypt.c - Decryption functions


### PR DESCRIPTION
This is an enhancement to add the ability to update the Yubikey-Counter and/or Yubikey-Timestamp attributes (if they exist). This will hopefully mitigate replay attacks, and lead to session timestamp comparison (where that could be necessary).

Hopefully you'll find these modifications useful and will add them to the upstream. There is also an attendant branch for the rlm_yubikey module which updates some of the capabilities for decrypt.