### PR TITLE
log: Check message buffer length to avoid overflow

### DIFF
--- a/src/main/log.c
+++ b/src/main/log.c
@@ -311,6 +311,8 @@ void radlog_request(int lvl, int priority, REQUEST *request, const char *msg, ..
 
 		if (len < sizeof(buffer)) {
 			len += strlcpy(buffer + len, fr_int2str(levels, (lvl & ~L_CONS), ": "), sizeof(buffer) - len);
+			if (len >= sizeof(buffer))
+				len = sizeof(buffer) - 1;
 		}
 	}
 	


### PR DESCRIPTION
This commit is trying to fix what I noted in my 0824dd5 comment.
Alternatively, that commit can simply be reverted.