### PR TITLE
Add --disable-openssl-version-check option

### DIFF
--- a/configure
+++ b/configure
@@ -808,6 +808,7 @@ RUSERS
 SNMPWALK
 SNMPGET
 PERL
+openssl_version_check_config
 raddbdir
 radacctdir
 logdir
@@ -921,6 +922,7 @@ with_experimental_modules
 with_openssl
 with_openssl_includes
 with_openssl_libraries
+enable_openssl_version_check
 with_rlm_FOO_lib_dir
 with_rlm_FOO_include_dir
 with_udpfromto
@@ -1560,6 +1562,8 @@ Optional Features:
   --disable-libtool-lock  avoid locking (might break parallel builds)
   --enable-strict-dependencies  Fail configure on lack of module dependancy.
   --enable-developer               Enables features of interest to developers.
+  --disable-openssl-version-check  Disable vulnerable OpenSSL version check.
+
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -19755,6 +19759,30 @@ if test "${with_openssl_libraries+set}" = set; then :
 	;;
   esac
 
+fi
+
+
+# Check whether --enable-openssl-version-check was given.
+if test "${enable_openssl_version_check+set}" = set; then :
+  enableval=$enable_openssl_version_check;
+fi
+
+if test "x$enable_openssl_version_check" != "xno"; then
+
+$as_echo "#define ENABLE_OPENSSL_VERSION_CHECK 1" >>confdefs.h
+
+  openssl_version_check_config="\
+	#
+	#  allow_vulnerable_openssl: Allow the server to start with
+	#  versions of OpenSSL known to have critical vulnerabilities.
+	#
+	#  This check is based on the version number reported by libssl
+	#  and may not reflect patches applied to libssl by
+	#  distribution maintainers.
+	#
+	allow_vulnerable_openssl = no"
+else
+  openssl_version_check_config=
 fi
 
 

--- a/configure.in
+++ b/configure.in
@@ -403,6 +403,30 @@ AC_ARG_WITH(openssl-libraries,
 )
 
 dnl #
+dnl #  extra argument: --disable-openssl-version-check
+dnl #
+AC_ARG_ENABLE(openssl-version-check,
+[  --disable-openssl-version-check  Disable vulnerable OpenSSL version check.]
+)
+if test "x$enable_openssl_version_check" != "xno"; then
+  AC_DEFINE(ENABLE_OPENSSL_VERSION_CHECK, [1],
+            [Define to 1 to have OpenSSL version check enabled])
+  openssl_version_check_config="\
+	#
+	#  allow_vulnerable_openssl: Allow the server to start with
+	#  versions of OpenSSL known to have critical vulnerabilities.
+	#
+	#  This check is based on the version number reported by libssl
+	#  and may not reflect patches applied to libssl by
+	#  distribution maintainers.
+	#
+	allow_vulnerable_openssl = no"
+else
+  openssl_version_check_config=
+fi
+AC_SUBST([openssl_version_check_config])
+
+dnl #
 dnl #  These next two arguments don't actually do anything.  They're
 dnl #  place holders so that the top-level configure script can tell
 dnl #  the user how to configure lower-level modules

--- a/raddb/radiusd.conf.in
+++ b/raddb/radiusd.conf.in
@@ -557,15 +557,7 @@ security {
 	#
 	status_server = yes
 
-	#
-	#  allow_vulnerable_openssl: Allow the server to start with
-	#  versions of OpenSSL known to have critical vulnerabilities.
-	#
-	#  This check is based on the version number reported by libssl
-	#  and may not reflect patches applied to libssl by
-	#  distribution maintainers.
-	#
-	allow_vulnerable_openssl = no
+@openssl_version_check_config@
 }
 
 # PROXY CONFIGURATION

--- a/src/include/autoconf.h.in
+++ b/src/include/autoconf.h.in
@@ -12,6 +12,9 @@
 /* style of ctime_r function */
 #undef CTIMERSTYLE
 
+/* Define to 1 to have OpenSSL version check enabled */
+#undef ENABLE_OPENSSL_VERSION_CHECK
+
 /* style of gethostbyaddr_r functions */
 #undef GETHOSTBYADDRRSTYLE
 

--- a/src/include/radiusd.h
+++ b/src/include/radiusd.h
@@ -360,7 +360,9 @@ typedef struct main_config_t {
 	int		proxy_requests;
 	int		reject_delay;
 	int		status_server;
+#ifdef ENABLE_OPENSSL_VERSION_CHECK
 	int		allow_vulnerable_openssl;
+#endif
 	int		max_request_time;
 	int		cleanup_delay;
 	int		max_requests;

--- a/src/main/mainconfig.c
+++ b/src/main/mainconfig.c
@@ -172,7 +172,9 @@ static const CONF_PARSER security_config[] = {
 	{ "max_attributes",  PW_TYPE_INTEGER, 0, &fr_max_attributes, Stringify(0) },
 	{ "reject_delay",  PW_TYPE_INTEGER, 0, &mainconfig.reject_delay, Stringify(0) },
 	{ "status_server", PW_TYPE_BOOLEAN, 0, &mainconfig.status_server, "no"},
+#ifdef ENABLE_OPENSSL_VERSION_CHECK
 	{ "allow_vulnerable_openssl", PW_TYPE_BOOLEAN, 0, &mainconfig.allow_vulnerable_openssl, "no"},
+#endif
 	{ NULL, -1, 0, NULL, NULL }
 };
 

--- a/src/main/radiusd.c
+++ b/src/main/radiusd.c
@@ -281,9 +281,11 @@ int main(int argc, char *argv[])
 	 *	Mismatch between build time OpenSSL and linked SSL,
 	 *	better to die here than segfault later.
 	 */
+#ifdef ENABLE_OPENSSL_VERSION_CHECK
 	if (ssl_check_version(mainconfig.allow_vulnerable_openssl) < 0) {
 		exit(1);
 	}
+#endif
 
 	/*  Load the modules AFTER doing SSL checks */
 	if (setup_modules(FALSE, mainconfig.config) < 0) {

--- a/src/main/version.c
+++ b/src/main/version.c
@@ -34,6 +34,22 @@ RCSID("$Id$")
 
 static long ssl_built = OPENSSL_VERSION_NUMBER;
 
+/** Print the current linked version of Openssl
+ *
+ * Print the currently linked version of the OpenSSL library.
+ */
+const char *ssl_version(void)
+{
+	return SSLeay_version(SSLEAY_VERSION);
+}
+#else
+const char *ssl_version()
+{
+	return "not linked";
+}
+#endif
+
+
 /** Check built and linked versions of OpenSSL match
  *
  * OpenSSL version number consists of:
@@ -46,6 +62,7 @@ static long ssl_built = OPENSSL_VERSION_NUMBER;
  *
  * @return 0 if ok, else -1
  */
+#if defined(HAVE_OPENSSL_CRYPTO_H) && defined(ENABLE_OPENSSL_VERSION_CHECK)
 int ssl_check_version(int allow_vulnerable)
 {
 	long ssl_linked;
@@ -97,25 +114,6 @@ int ssl_check_version(int allow_vulnerable)
 	}
 
 	return 0;
-}
-
-/** Print the current linked version of Openssl
- *
- * Print the currently linked version of the OpenSSL library.
- */
-const char *ssl_version(void)
-{
-	return SSLeay_version(SSLEAY_VERSION);
-}
-#else
-int ssl_check_version(UNUSED int allow_vulnerable)
-{
-	return 0;
-}
-
-const char *ssl_version()
-{
-	return "not linked";
 }
 #endif
 


### PR DESCRIPTION
This adds the --disable-openssl-version-check, similarly to v3.0.x, to solve the same problem.
We need this to smooth the RHEL6 upgrade to v2.2.6.
