### PR TITLE
Move OpenSSL init out of version check

### DIFF
--- a/src/main/radiusd.c
+++ b/src/main/radiusd.c
@@ -277,6 +277,14 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
+#ifdef HAVE_OPENSSL_CRYPTO_H
+	/*
+	 *	Initialize the OpenSSL library before calling any of its
+	 *	functions.
+	 */
+	SSL_library_init();
+	SSL_load_error_strings();
+
 	/*
 	 *	Mismatch between build time OpenSSL and linked SSL,
 	 *	better to die here than segfault later.
@@ -285,6 +293,7 @@ int main(int argc, char *argv[])
 	if (ssl_check_version(mainconfig.allow_vulnerable_openssl) < 0) {
 		exit(1);
 	}
+#endif
 #endif
 
 	/*  Load the modules AFTER doing SSL checks */

--- a/src/main/version.c
+++ b/src/main/version.c
@@ -67,13 +67,6 @@ int ssl_check_version(int allow_vulnerable)
 {
 	long ssl_linked;
 
-	/*
-	 *	Initialize the library before calling any library
-	 *	functions.
-	 */
-	SSL_library_init();
-	SSL_load_error_strings();
-
 	ssl_linked = SSLeay();
 
 	/*


### PR DESCRIPTION
Initialize OpenSSL outside ssl_version_check() to execute even with
disabled version check. Otherwise SSL_CTX_new() returns zero and
FreeRADIUS segfaults in init_tls_ctx with version check disabled.