### PR TITLE
Include headers for OpenSSL init

### DIFF
--- a/src/main/radiusd.c
+++ b/src/main/radiusd.c
@@ -53,6 +53,10 @@ RCSID("$Id$")
 #	define WIFEXITED(stat_val) (((stat_val) & 255) == 0)
 #endif
 
+#ifdef HAVE_OPENSSL_CRYPTO_H
+#include <openssl/ssl.h>
+#endif
+
 /*
  *  Global variables.
  */


### PR DESCRIPTION
Inlude OpenSSL headers into radiusd.c for OpenSSL init.
This fixes "implicit declaration of function" warnings concerning
SSL_library_init and SSL_load_error_strings.

This was a silly omission on my part.