### PR TITLE
Peercred alt autz

### DIFF
--- a/configure
+++ b/configure
@@ -9937,7 +9937,11 @@ for ac_func in \
   getresuid \
   strlcat \
   strlcpy \
-  kqueue
+  kqueue \
+  openat \
+  mkdirat \
+  unlinkat \
+  bindat
 
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`

--- a/configure.ac
+++ b/configure.ac
@@ -1442,7 +1442,11 @@ AC_CHECK_FUNCS( \
   getresuid \
   strlcat \
   strlcpy \
-  kqueue
+  kqueue \
+  openat \
+  mkdirat \
+  unlinkat \
+  bindat
 )
 
 AC_TYPE_SIGNAL

--- a/src/include/autoconf.h.in
+++ b/src/include/autoconf.h.in
@@ -24,6 +24,9 @@
 /* Define to 1 if you have the <arpa/inet.h> header file. */
 #undef HAVE_ARPA_INET_H
 
+/* Define to 1 if you have the `bindat' function. */
+#undef HAVE_BINDAT
+
 /* Define if we have a binary safe regular expression library */
 #undef HAVE_BINSAFE_REGEX
 
@@ -200,6 +203,9 @@
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
 
+/* Define to 1 if you have the `mkdirat' function. */
+#undef HAVE_MKDIRAT
+
 /* Define to 1 if you have the <ndir.h> header file, and it defines `DIR'. */
 #undef HAVE_NDIR_H
 
@@ -211,6 +217,9 @@
 
 /* Define to 1 if you have the <net/if.h> header file. */
 #undef HAVE_NET_IF_H
+
+/* Define to 1 if you have the `openat' function. */
+#undef HAVE_OPENAT
 
 /* Define to 1 if you have the <openssl/crypto.h> header file. */
 #undef HAVE_OPENSSL_CRYPTO_H
@@ -444,6 +453,9 @@
 
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
+
+/* Define to 1 if you have the `unlinkat' function. */
+#undef HAVE_UNLINKAT
 
 /* Define to 1 if you have the <utime.h> header file. */
 #undef HAVE_UTIME_H

--- a/src/include/radiusd.h
+++ b/src/include/radiusd.h
@@ -563,6 +563,8 @@ char const	*rad_default_sbin_dir(void);
 char const	*rad_radacct_dir(void);
 
 void		verify_request(char const *file, int line, REQUEST *request);	/* only for special debug builds */
+void		rad_mode_to_str(char out[10], mode_t mode);
+void		rad_mode_to_oct(char out[5], mode_t mode);
 int		rad_getpwuid(TALLOC_CTX *ctx, struct passwd **out, uid_t uid);
 int		rad_getpwnam(TALLOC_CTX *ctx, struct passwd **out, char const *name);
 int		rad_getgrgid(TALLOC_CTX *ctx, struct group **out, gid_t gid);
@@ -570,6 +572,8 @@ int		rad_getgrnam(TALLOC_CTX *ctx, struct group **out, char const *name);
 int		rad_getgid(TALLOC_CTX *ctx, gid_t *out, char const *name);
 int		rad_prints_uid(TALLOC_CTX *ctx, char *out, size_t outlen, uid_t uid);
 int		rad_prints_gid(TALLOC_CTX *ctx, char *out, size_t outlen, gid_t gid);
+int		rad_seuid(uid_t uid);
+int		rad_segid(gid_t gid);
 
 void		rad_suid_set_down_uid(uid_t uid);
 void		rad_suid_down(void);


### PR DESCRIPTION
Uses file system permissions to manage socket access.

On non-linux systems the permissions set on a bound socket aren't enforced. We can work around that by setting permissions on the directory containing the socket.

Known Issues
-------------------
* We need to do some operations suid_up, which means the code has to be very careful not to make the server complicit in TOCTOU attacks. TOCTOU is mitigated against in multiple ways.
    - Using *at functions to prevent re-traversal of the control socket path, and using O_NOFOLLOW where appropriate.
    - Doing most operations as the user/group set in the control socket config (which could be root, but often won't be).
    - Getting the user to fix some issues manually, instead of stomping on directory ownership and permissions.
* The directory and socket often can't be unlinked when the server exits. They'll usually be owned by a different user/group to the server, and the server suid_downs permanently at some point to stop runtime exploits. This isn't a *huge* issue, as unlike the existing code, the socket is always created with the same user/group (unless the config is changed) meaning if you do ``sudo radiusd -X`` then ``radiusd -f -lstdout`` you won't end up with permissions issues.
* The server will not start unless running under root initially, or if the user/group on the socket happens to match the user starting radiusd. This could be made slightly better by not forcing unspecified uids/gids to root. That would allow someone to start the server if they had the control socket group as a supplementary group

Questions
-------------
* Are the rad_seuid and rad_segid called correctly? I can see the suid_up/down functions are more complex and use non-posix functions. There must be a good reason for this.
* Is the code TOCTOU safe, are there any likely attack vectors remaining? Could they be mitigated against?
* Should we stat the control socket dir on new connections to make sure the permissions haven't changed, and reject users if they have?
* Are there are obvious issues with controlling access this way that i've missed.