### PR TITLE
Cisco ASA dictionary fixes

### DIFF
--- a/share/dictionary.cisco.asa
+++ b/share/dictionary.cisco.asa
@@ -13,10 +13,10 @@ VENDOR		Cisco-ASA			3076
 BEGIN-VENDOR	Cisco-ASA
 
 ATTRIBUTE	ASA-Simultaneous-Logins			2	integer
-ATTRIBUTE	ASA-Primary-DNS				5	string
-ATTRIBUTE	ASA-Secondary-DNS			6	string
-ATTRIBUTE	ASA-Primary-WINS			7	string
-ATTRIBUTE	ASA-Secondary-WINS			8	string
+ATTRIBUTE	ASA-Primary-DNS				5	ipaddr
+ATTRIBUTE	ASA-Secondary-DNS			6	ipaddr
+ATTRIBUTE	ASA-Primary-WINS			7	ipaddr
+ATTRIBUTE	ASA-Secondary-WINS			8	ipaddr
 ATTRIBUTE	ASA-SEP-Card-Assignment			9	integer
 ATTRIBUTE	ASA-Tunneling-Protocols			11	integer
 ATTRIBUTE	ASA-IPsec-Sec-Association		12	string
@@ -54,9 +54,9 @@ ATTRIBUTE	ASA-IPsec-Client-Firewall-Filter-Name	57	string
 ATTRIBUTE	ASA-IPsec-Client-Firewall-Filter-Optional 58	integer
 ATTRIBUTE	ASA-IPsec-Backup-Servers		59	integer
 ATTRIBUTE	ASA-IPsec-Backup-Server-List		60	string
-ATTRIBUTE	ASA-DHCP-Network-Scope			61	string
+ATTRIBUTE	ASA-DHCP-Network-Scope			61	ipaddr
 ATTRIBUTE	ASA-Intercept-DHCP-Configure-Msg	62	integer
-ATTRIBUTE	ASA-MS-Client-Subnet-Mask		63	integer
+ATTRIBUTE	ASA-MS-Client-Subnet-Mask		63	ipaddr
 ATTRIBUTE	ASA-Allow-Network-Extension-Mode	64	integer
 ATTRIBUTE	ASA-Authorization-Type			65	integer
 ATTRIBUTE	ASA-Authorization-Required		66	integer

--- a/src/modules/proto_dhcp/dhcp.c
+++ b/src/modules/proto_dhcp/dhcp.c
@@ -1015,7 +1015,7 @@ static VALUE_PAIR *fr_dhcp_vp2suboption(TALLOC_CTX *ctx, vp_cursor_t *cursor)
 {
 	ssize_t length;
 	unsigned int parent; 	/* Parent attribute of suboption */
-	uint8_t attr;
+	uint8_t attr = 0;
 	uint8_t *p, *opt_len;
 	vp_cursor_t to_pack;
 	VALUE_PAIR *vp, *tlv;
@@ -1090,7 +1090,7 @@ static VALUE_PAIR *fr_dhcp_vp2suboption(TALLOC_CTX *ctx, vp_cursor_t *cursor)
  * @param outlen Length of out buffer.
  * @param ctx to use for any allocated memory.
  * @param cursor with current VP set to the option to be encoded. Will be advanced to the next option to encode.
- * @return > 0 length of data written, < 0 out of buffer, 0 not valid option (skipping).
+ * @return > 0 length of data written, < 0 error, 0 not valid option (skipping).
  */
 ssize_t fr_dhcp_encode_option(uint8_t *out, size_t outlen, TALLOC_CTX *ctx, vp_cursor_t *cursor)
 {
@@ -1101,6 +1101,7 @@ ssize_t fr_dhcp_encode_option(uint8_t *out, size_t outlen, TALLOC_CTX *ctx, vp_c
 	ssize_t len;
 
 	vp = fr_cursor_current(cursor);
+	if (!vp) return -1;
 
 	if (vp->da->vendor != DHCP_MAGIC_VENDOR) goto next; /* not a DHCP option */
 	if (vp->da->attr == 53) goto next; /* already done */
@@ -1117,11 +1118,12 @@ ssize_t fr_dhcp_encode_option(uint8_t *out, size_t outlen, TALLOC_CTX *ctx, vp_c
 	*(p++) = vp->da->attr & 0xff;
 
 	/* Pointer to the length field of the option */
-	opt_len = p;
+	opt_len = p++;
 
 	/* Zero out the option's length field */
-	*(p++) = 0;
+	*opt_len = 0;
 
+	/* We just consumed two bytes for the header */
 	freespace -= 2;
 
 	/* DHCP options with the same number get coalesced into a single option */
@@ -1469,9 +1471,11 @@ int fr_dhcp_encode(RADIUS_PACKET *packet)
 	 *  and sub options.
 	 */
 	do {
-		p += len = fr_dhcp_encode_option(p, packet->data_len - (p - packet->data), packet, &cursor);
+		len = fr_dhcp_encode_option(p, packet->data_len - (p - packet->data), packet, &cursor);
+		if (len < 0) break;
 		if (len > 0) debug_pair(vp);
-	} while (len >= 0);
+		p += len;
+	} while (fr_cursor_current(&cursor));
 
 	p[0] = 0xff;		/* end of option option */
 	p[1] = 0x00;


### PR DESCRIPTION
I have no idea why the dhcp.c file is being included in this pull request since I only changed dictionary.cisco.asa. Several of the attributes should have been ipaddr instead of string/integer. These changes worked for ASA-Primary-DNS and ASA-Secondary-DNS, I have not tested the rest, but I have the DNS attributes.