### PR TITLE
Abfab policy and trust router changes

### DIFF
--- a/raddb/mods-config/attr_filter/access_reject
+++ b/raddb/mods-config/attr_filter/access_reject
@@ -15,4 +15,5 @@ DEFAULT
 	Error-Cause =* ANY,
 	Reply-Message =* ANY,
 	MS-CHAP-Error =* ANY,
-	Proxy-State =* ANY
+	Proxy-State =* ANY,
+	Error-Cause =* ANY

--- a/raddb/policy.d/abfab-tr
+++ b/raddb/policy.d/abfab-tr
@@ -15,29 +15,35 @@ psk_authorize {
 			# do things here
 		}
 		else {
+		update reply {
+			Reply-Message = "RP not authorized for this ABFAB request"
+			}
 			reject
 		}
 	}
 }
 
-abfab_pre_proxy {
+abfab_client_check {
 	# check that the acceptor host name is correct
 	if ("%{client:gss_acceptor_host_name}" && "%{gss-acceptor-host-name}") {
 		if ("%{client:gss_acceptor_host_name}" != "%{gss-acceptor-host-name}") {
+			update reply {
+			        Reply-Message = "GSS-Acceptor-Host-Name incorrect"
+				}
 			reject
 		}
 	}
 
 	# set trust-router-coi attribute from the client configuration
 	if ("%{client:trust_router_coi}") {
-		update proxy-request {
+		update request {
 			Trust-Router-COI := "%{client:trust_router_coi}"
 		}
 	}
 
 	# set gss-acceptor-realm-name attribute from the client configuration
 	if ("%{client:gss_acceptor_realm_name}") {
-		update proxy-request {
+		update request {
 			GSS-Acceptor-Realm-Name := "%{client:gss_acceptor_realm_name}"
 		}
 	}

--- a/raddb/sites-available/abfab-tls
+++ b/raddb/sites-available/abfab-tls
@@ -42,9 +42,36 @@ listen {
 clients radsec-abfab {
 	#
 	#  Allow all clients, but require TLS.
+	#  This client stanza will match other RP proxies from other
+	#  realms  established via the trustrouter.  In general
+	#  additional client stanzas are also required for local services.
 	#
         client default {
 	        ipaddr = 0.0.0.0/0
 		proto = tls
 	}
+
+	#  An example local service
+	#  client service_1 {
+	#  	ipaddr = 192.0.2.20
+	#  	#  You should either set gss_acceptor_host_name below
+	#  	#  or set up policy to confirm that a client claims
+	#  	#  the right acceptor hostname when using ABFAB.  If
+	#  	#  set,  the RADIUS server will confirm that all
+	#  	#  requests have this value for the acceptor host name
+	#  	gss_acceptor_host_name = "server.example.com"
+	#  	#  If set, this acceptor realm name will be included.
+	#  Foreign realms will typically reject a request if this is not
+	#  	#  properly set.
+	#  	gss_acceptor_realm_name = "example.com"
+	#  	#  Additionally, trust_router_coi can be set; if set
+	#  	#  it will override the default_community in the realm
+ 	#  	#  module
+	#  	# trust_router_coi =  "community1.example.net"
+	#  	#  In production depployments it is important to set
+	#  	#  	up certificate verification  so that even if
+	#  	#  clients spoof IP addresses, one client cannot
+	#  	#  impersonate another.
+	#  }
+
 }

--- a/raddb/sites-available/abfab-tr-idp
+++ b/raddb/sites-available/abfab-tr-idp
@@ -13,6 +13,7 @@
 server abfab-idp {
 authorize {
         psk_authorize
+	abfab_client_check
 	filter_username
 	preprocess
 
@@ -95,8 +96,12 @@ post-auth {
 
 		# Insert EAP-Failure message if the request was
 		# rejected by policy instead of because of an
-		# authentication failure
-		eap
+		# authentication failure And already has an EAP message
+		# For non-ABFAB, we insert the failure all the time, but for ABFAB
+		# It's more desirable to preserve reply-message when we can
+if &reply:Eap-Message {
+			eap
+			}
 
 		#  Remove reply message if the response contains an EAP-Message
 		remove_reply_message_if_eap
@@ -116,7 +121,6 @@ pre-proxy {
 	# No need to uncomment this if you have already enabled this in
 	# the authorize section.
 #	operator-name
-	abfab_pre_proxy
 
 	#  The client requests the CUI by sending a CUI attribute
 	#  containing one zero byte.

--- a/src/include/radius.h
+++ b/src/include/radius.h
@@ -237,3 +237,4 @@ typedef enum {
  */
 
 #define PW_UKERNA_CHBIND		135
+#define PW_UKERNA_TR_COI 136

--- a/src/main/realms.c
+++ b/src/main/realms.c
@@ -491,7 +491,7 @@ bool realm_home_server_add(home_server_t *home)
 	 *	the server.
 	 */
 	if (event_loop_started && !realm_config->dynamic) {
-		ERROR("Failed to add dynamic home server, \"dynamic = true\" must be set in proxy.conf");
+		ERROR("Failed to add dynamic home server, \"dynamic = yes\" must be set in proxy.conf");
 		return false;
 	}
 

--- a/src/modules/rlm_realm/rlm_realm.c
+++ b/src/modules/rlm_realm/rlm_realm.c
@@ -173,7 +173,7 @@ static int check_for_realm(void *instance, REQUEST *request, REALM **returnrealm
 	 *	Try querying for the dynamic realm.
 	 */
 	if (!realm)
-		realm = tr_query_realm(realmname, inst->default_community, inst->rp_realm, inst->trust_router, inst->tr_port);
+	  realm = tr_query_realm(request, realmname, inst->default_community, inst->rp_realm, inst->trust_router, inst->tr_port);
 #endif
 	if (!realm) {
 		RDEBUG2("No such realm \"%s\"", (!realmname) ? "NULL" : realmname);

--- a/src/modules/rlm_realm/trustrouter.c
+++ b/src/modules/rlm_realm/trustrouter.c
@@ -342,7 +342,7 @@ static bool update_required(REALM const *r)
 
     
 
-REALM *tr_query_realm(char const *realm,
+REALM *tr_query_realm(REQUEST *request, char const *realm,
 		      char const  *community,
 		      char const *rprealm,
 		      char const *trustrouter,
@@ -350,6 +350,7 @@ REALM *tr_query_realm(char const *realm,
 {
 	int conn = 0;
 	int rcode;
+	VALUE_PAIR *vp;
 	gss_ctx_id_t gssctx;
 	struct resp_opaque cookie;
 
@@ -357,6 +358,12 @@ REALM *tr_query_realm(char const *realm,
 
 	/* clear the cookie structure */
 	memset (&cookie, 0, sizeof(cookie));
+
+	/* See if the request overrides the community*/
+	vp = pairfind(request->packet->vps, PW_UKERNA_TR_COI, VENDORPEC_UKERNA, TAG_ANY);
+	if (vp)
+		community = vp->vp_strvalue;
+	else pairmake_packet("Trust-Router-COI", community, T_OP_SET);
 
 	cookie.fr_realm_name = talloc_asprintf(NULL,
 					       "%s%%%s",
@@ -387,6 +394,13 @@ REALM *tr_query_realm(char const *realm,
 		/* Handle error */
 		DEBUG2("Error in tidc_send_request, rc = %d.\n", rcode);
 		goto cleanup;
+	}
+	if (cookie.result != TID_SUCCESS) {
+		DEBUG2("TID response is error, rc = %d: %s.\n", cookie.result,
+		       cookie.err_msg?cookie.err_msg:"(NO ERROR TEXT)");
+		if (cookie.err_msg) 
+			pairmake_reply("Reply-Message", cookie.err_msg, T_OP_SET);
+		pairmake_reply("Error-Cause", "502", T_OP_SET); /*proxy unroutable*/
 	}
 
 cleanup:

--- a/src/modules/rlm_realm/trustrouter.h
+++ b/src/modules/rlm_realm/trustrouter.h
@@ -27,7 +27,7 @@
 #include <freeradius-devel/radiusd.h>
 #include <freeradius-devel/modules.h>
 
-REALM *tr_query_realm(char const *realm,
+REALM *tr_query_realm(REQUEST *request, char const *realm,
 		      char const *community,
 		      char const *rprealm,
 		      char const *trustrouter,

--- a/src/modules/rlm_sql/drivers/rlm_sql_sqlite/rlm_sql_sqlite.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_sqlite/rlm_sql_sqlite.c
@@ -403,7 +403,9 @@ static sql_rcode_t sql_socket_init(rlm_sql_handle_t *handle, rlm_sql_config_t *c
 	INFO("rlm_sql_sqlite: Opening SQLite database \"%s\"", driver->filename);
 #ifdef HAVE_SQLITE3_OPEN_V2
 	status = sqlite3_open_v2(driver->filename, &(conn->db), SQLITE_OPEN_READWRITE | SQLITE_OPEN_NOMUTEX, NULL);
+	sqlite3_busy_timeout( conn->db, 200); /*wait up to 200 ms for db locks*/
 #else
+	
 	status = sqlite3_open(driver->filename, &(conn->db));
 #endif
 	if (!conn->db) {


### PR DESCRIPTION
Hi.  I'd appreciate it if these changes could be integrated.  This updates the trust router code for exposing errors to the NAS as well as allowing unlang configuration to override the community.  In addition there are significant improvements to the sample abfab configuration to provide better error handling and more functionality.

A bug fix is provided to the sqlite driver.  Currently any database contetion at all will cause a request to fail.  In practice we've found that even under very moderate load this is a significant problem, so sqlite is permitted to use a small busy-wait.