### PR TITLE
DHCP-Client-FQDN is not a string

### DIFF
--- a/share/dictionary.dhcp
+++ b/share/dictionary.dhcp
@@ -225,7 +225,7 @@ ATTRIBUTE	DHCP-Service-Scope			79	octets
 # Rapid Commit
 ATTRIBUTE	DHCP-Rapid-Commit			80	octets
 # Fully Qualified Domain Name
-ATTRIBUTE	DHCP-Client-FQDN			81	string
+ATTRIBUTE	DHCP-Client-FQDN			81	octets
 # Relay Agent Information
 ATTRIBUTE	DHCP-Relay-Agent-Information		82	tlv
 


### PR DESCRIPTION
See RFC 4702.
DHCP-Client-FQDN (DHCP option 81) is actually a record composed of:
- first octet: "Flags"
- second octet: "RCODE1"
- third octet: "RCODE2"
- and then "Domain Name" (which is a string)

But I don't think that FreeRADIUS dictionaries support encoding /
decoding such a format, so octets is the best option we have.