### PR TITLE
Update proxy.conf

### DIFF
--- a/raddb/proxy.conf
+++ b/raddb/proxy.conf
@@ -82,6 +82,9 @@ proxy server {
 #
 #  Configuration for the proxy realms.
 #
+#  As of 2.0. the old-style "realms" file is deprecated, and is not
+#  used by FreeRADIUS.
+#
 #  As of 2.0, the "realm" configuration has changed.  Instead of
 #  specifying "authhost" and "accthost" in a realm section, the home
 #  servers are specified separately in a "home_server" section.  For
@@ -108,9 +111,6 @@ proxy server {
 #  home servers.  Multiple realms can point to one server pool.  One
 #  server pool can point to multiple home servers.  Each home server
 #  can appear in one or more pools.
-#
-#  See sites-available/tls for an example of configuring home servers,
-#  pools, and realms with TLS.
 #
 
 ######################################################################
@@ -657,11 +657,20 @@ home_server_pool my_auth_failover {
 #  Automatic proxying is done via the "realms" module (see "man
 #  rlm_realm").  To manually proxy the request put this entry in the
 #  "users" file:
-
-#
 #
 #DEFAULT	Proxy-To-Realm := "realm_name"
 #
+
+#
+#  The below realms are assumed to be classic UDP-based realms.
+#
+#  To define TLS-based realms, you should:
+#	- Open sites-available/tls and study it carefully
+#	- Define your TLS-based realm entries there
+#
+#  The authhost and accthost entries are obsolete and should no longer 
+#  be used.
+
 #
 realm example.com {
 	#


### PR DESCRIPTION
Add a reference to the proxy.conf to tell people to look at the sites-available/tls file for TLS-based realm definitions.