### PR TITLE
radeapclient - filters and passwords authentication methods

### DIFF
--- a/src/modules/rlm_eap/radeapclient.mk
+++ b/src/modules/rlm_eap/radeapclient.mk
@@ -1,10 +1,13 @@
 TARGET   := radeapclient
 SOURCES := radeapclient.c
 
+SOURCES += ${top_srcdir}/src/modules/rlm_mschap/smbdes.c \
+		   ${top_srcdir}/src/modules/rlm_mschap/mschap.c
+
 SOURCES += ${top_srcdir}/src/main/files.c \
 	   ${top_srcdir}/src/main/threads.c \
 	   ${top_srcdir}/src/main/version.c
-
+   
 TGT_PREREQS := libfreeradius-radius.a libfreeradius-server.a
 TGT_LDLIBS  := $(LIBS)
 
@@ -21,4 +24,5 @@ endif
 
 SRC_CFLAGS += -DWITH_EAPCLIENT
 SRC_INCDIRS  := ${top_srcdir}/src/modules/rlm_eap/libeap
+SRC_CFLAGS   += -I${top_srcdir}/src/modules/rlm_mschap
 endif


### PR DESCRIPTION

Another set of changes to radeapclient 3.1.x.

These changes do not add "new" features, but rather implement things from radclient that are (were) still missing in radeapclient.

The changes are the following (see each commit log for detail):
- Handle PAP, CHAP and MS-CHAP as in radclient.
- Handle filters as in radclient.

I've copied entire functions from radclient, such as mschapv1_encode. But this should be in a library, I think.

Feel free to yell if things are not as you want them to be :)