### PR TITLE
sql: use sql.acct_table1 instead of radacct

### DIFF
--- a/raddb/mods-config/sql/counter/mysql/dailycounter.conf
+++ b/raddb/mods-config/sql/counter/mysql/dailycounter.conf
@@ -6,7 +6,7 @@
 #
 query = "\
 	SELECT SUM(acctsessiontime - GREATEST((%%b - UNIX_TIMESTAMP(acctstarttime)), 0)) \
-	FROM radacct \
+	FROM ${modules.sql.acct_table1} \
 	WHERE username = '%{${key}}' \
 	AND UNIX_TIMESTAMP(acctstarttime) + acctsessiontime > '%%b'"
 
@@ -17,7 +17,7 @@ query = "\
 #
 #query = "\
 #	SELECT SUM(acctsessiontime) \
-#	FROM radacct \
+#	FROM ${modules.sql.acct_table1} \
 #	WHERE username = '%{${key}}' \
 #	AND acctstarttime > FROM_UNIXTIME('%%b')"
 
@@ -28,6 +28,6 @@ query = "\
 #
 #query = "\
 #	SELECT SUM(acctsessiontime) \
-#	FROM radacct \
+#	FROM ${modules.sql.acct_table1} \
 #	WHERE username = '%{${key}}' \
 #	AND acctstarttime BETWEEN FROM_UNIXTIME('%%b') AND FROM_UNIXTIME('%%e')"

--- a/raddb/mods-config/sql/counter/mysql/expire_on_login.conf
+++ b/raddb/mods-config/sql/counter/mysql/expire_on_login.conf
@@ -1,6 +1,6 @@
 query = "\
 	SELECT IFNULL( MAX(TIME_TO_SEC(TIMEDIFF(NOW(), acctstarttime))),0) \
-	FROM radacct \
+	FROM ${modules.sql.acct_table1} \
 	WHERE UserName='%{${key}}' \
 	ORDER BY acctstarttime \
 	LIMIT 1;"

--- a/raddb/mods-config/sql/counter/mysql/monthlycounter.conf
+++ b/raddb/mods-config/sql/counter/mysql/monthlycounter.conf
@@ -6,7 +6,7 @@
 #
 query = "\
 	SELECT SUM(acctsessiontime - GREATEST((%%b - UNIX_TIMESTAMP(acctstarttime)), 0)) \
-	FROM radacct \
+	FROM ${modules.sql.acct_table1} \
 	WHERE username='%{${key}}' \
 	AND UNIX_TIMESTAMP(acctstarttime) + acctsessiontime > '%%b'"
 
@@ -17,7 +17,7 @@ query = "\
 #
 #query = "\
 #	SELECT SUM(acctsessiontime) \
-#	FROM radacct\
+#	FROM ${modules.sql.acct_table1}\
 #	WHERE username='%{${key}}' \
 #	AND acctstarttime > FROM_UNIXTIME('%%b')"
 
@@ -28,7 +28,7 @@ query = "\
 #
 #query = "\
 #	SELECT SUM(acctsessiontime) \
-#	FROM radacct \
+#	FROM ${modules.sql.acct_table1} \
 #	WHERE username='%{${key}}' \
 #	AND acctstarttime BETWEEN FROM_UNIXTIME('%%b') \
 #	AND FROM_UNIXTIME('%%e')"

--- a/raddb/mods-config/sql/counter/mysql/noresetcounter.conf
+++ b/raddb/mods-config/sql/counter/mysql/noresetcounter.conf
@@ -1,4 +1,4 @@
 query = "\
 	SELECT IFNULL(SUM(AcctSessionTime),0) \
-	FROM radacct \
+	FROM ${modules.sql.acct_table1} \
 	WHERE UserName='%{${key}}'"

--- a/raddb/mods-config/sql/counter/postgresql/dailycounter.conf
+++ b/raddb/mods-config/sql/counter/postgresql/dailycounter.conf
@@ -6,7 +6,7 @@
 #
 query = "\
 	SELECT SUM(AcctSessionTime - GREATER((%%b - AcctStartTime::ABSTIME::INT4), 0)) \
-	FROM radacct \
+	FROM ${modules.sql.acct_table1} \
 	WHERE UserName='%{${key}}' \
 	AND AcctStartTime::ABSTIME::INT4 + AcctSessionTime > '%%b'"
 
@@ -17,7 +17,7 @@ query = "\
 #
 #query = "\
 #	SELECT SUM(AcctSessionTime) \
-#	FROM radacct \
+#	FROM ${modules.sql.acct_table1} \
 #	WHERE UserName='%{${key}}' \
 #	AND AcctStartTime::ABSTIME::INT4 > '%%b'"
 
@@ -28,7 +28,7 @@ query = "\
 #
 #query = "\
 #	SELECT SUM(AcctSessionTime) \
-#	FROM radacct \
+#	FROM ${modules.sql.acct_table1} \
 #	WHERE UserName='%{${key}}' \
 #	AND AcctStartTime::ABSTIME::INT4 BETWEEN '%%b' \
 #	AND '%%e'"

--- a/raddb/mods-config/sql/counter/postgresql/expire_on_login.conf
+++ b/raddb/mods-config/sql/counter/postgresql/expire_on_login.conf
@@ -1,6 +1,6 @@
 query = "\
 	SELECT EXTRACT(EPOCH FROM (NOW() - acctstarttime)) \
-	FROM radacct \
+	FROM ${modules.sql.acct_table1} \
 	WHERE UserName='%{${key}}' \
 	ORDER BY acctstarttime \
 	LIMIT 1;"

--- a/raddb/mods-config/sql/counter/postgresql/monthlycounter.conf
+++ b/raddb/mods-config/sql/counter/postgresql/monthlycounter.conf
@@ -4,7 +4,7 @@
 #  below
 query = "\
 	SELECT SUM(AcctSessionTime - GREATER((%%b - AcctStartTime::ABSTIME::INT4), 0)) \
-	FROM radacct \
+	FROM ${modules.sql.acct_table1} \
 	WHERE UserName='%{${key}}' \
 	AND AcctStartTime::ABSTIME::INT4 + AcctSessionTime > '%%b'"
 
@@ -15,7 +15,7 @@ query = "\
 #
 #query = "\
 #	SELECT SUM(AcctSessionTime) \
-#	FROM radacct \
+#	FROM ${modules.sql.acct_table1} \
 #	WHERE UserName='%{${key}}' \
 #	AND AcctStartTime::ABSTIME::INT4 > '%%b'"
 
@@ -26,6 +26,6 @@ query = "\
 #
 #query = "\
 #	SELECT SUM(AcctSessionTime) \
-#	FROM radacct \
+#	FROM ${modules.sql.acct_table1} \
 #	WHERE UserName='%{${key}}' \
 #	AND AcctStartTime::ABSTIME::INT4 BETWEEN '%%b' AND '%%e'"

--- a/raddb/mods-config/sql/counter/postgresql/noresetcounter.conf
+++ b/raddb/mods-config/sql/counter/postgresql/noresetcounter.conf
@@ -1,4 +1,4 @@
 query = "\
 	SELECT SUM(AcctSessionTime) \
-	FROM radacct \
+	FROM ${modules.sql.acct_table1} \
 	WHERE UserName='%{${key}}'"

--- a/raddb/mods-config/sql/counter/sqlite/dailycounter.conf
+++ b/raddb/mods-config/sql/counter/sqlite/dailycounter.conf
@@ -6,7 +6,7 @@
 #
 query = "\
 	SELECT SUM(acctsessiontime - GREATEST((%%b - strftime('%%s', acctstarttime)), 0)) \
-	FROM radacct \
+	FROM ${modules.sql.acct_table1} \
 	WHERE username = '%{${key}}' \
 	AND (strftime('%%s', acctstarttime) + acctsessiontime) > %%b"
 
@@ -17,7 +17,7 @@ query = "\
 #
 #query = "\
 #	SELECT SUM(acctsessiontime) \
-#	FROM radacct \
+#	FROM ${modules.sql.acct_table1} \
 #	WHERE \username = '%{${key}}' \
 #	AND acctstarttime > %%b"
 
@@ -27,7 +27,7 @@ query = "\
 #  timestamp for the end of the period
 #
 #query = "\
-#	SELECT SUM(acctsessiontime) FROM radacct \
+#	SELECT SUM(acctsessiontime) FROM ${modules.sql.acct_table1} \
 #	WHERE username = '%{${key}}' \
 #	AND acctstarttime BETWEEN %%b \
 #	AND %%e"

--- a/raddb/mods-config/sql/counter/sqlite/expire_on_login.conf
+++ b/raddb/mods-config/sql/counter/sqlite/expire_on_login.conf
@@ -1,6 +1,6 @@
 query = "\
 	SELECT GREATEST(strftime('%%s', NOW()) - strftime('%%s', acctstarttime), 0) AS expires \
-	FROM radacct \
+	FROM ${modules.sql.acct_table1} \
 	WHERE username = '%{${key}}' \
 	ORDER BY acctstarttime \
 	LIMIT 1;"

--- a/raddb/mods-config/sql/counter/sqlite/monthlycounter.conf
+++ b/raddb/mods-config/sql/counter/sqlite/monthlycounter.conf
@@ -6,7 +6,7 @@
 #
 query = "\
 	SELECT SUM(acctsessiontime - GREATEST((%%b - strftime('%%s', acctstarttime)), 0)) \
-	FROM radacct \
+	FROM ${modules.sql.acct_table1} \
 	WHERE username = '%{${key}}' AND \
 	(strftime('%%s', acctstarttime) + acctsessiontime) > %%b"
 
@@ -17,7 +17,7 @@ query = "\
 #
 #query = "\
 #	SELECT SUM(acctsessiontime) \
-#	FROM radacct \
+#	FROM ${modules.sql.acct_table1} \
 #	WHERE username = '%{${key}}' \
 #	AND acctstarttime > %%b"
 
@@ -28,7 +28,7 @@ query = "\
 #
 #query = "\
 #	SELECT SUM(acctsessiontime) \
-#	FROM radacct \
+#	FROM ${modules.sql.acct_table1} \
 #	WHERE username = '%{${key}}' \
 #	AND acctstarttime BETWEEN %%b \
 #	AND %%e"

--- a/raddb/mods-config/sql/counter/sqlite/noresetcounter.conf
+++ b/raddb/mods-config/sql/counter/sqlite/noresetcounter.conf
@@ -1,4 +1,4 @@
 query = "\
 	SELECT IFNULL(SUM(acctsessiontime),0) \
-	FROM radacct \
+	FROM ${modules.sql.acct_table1} \
 	WHERE username = '%{${key}}'"


### PR DESCRIPTION
- So the sqlcounter queries honor the sql configuration.