### PR TITLE
fixed radclient.c compile error

### DIFF
--- a/src/main/radclient.c
+++ b/src/main/radclient.c
@@ -934,7 +934,7 @@ int main(int argc, char **argv)
 			timeout = atof(optarg);
 			break;
 		case 'v':
-			printf(radclient_version);
+			printf("%s", radclient_version);
 			exit(0);
 			break;
 		case 'x':


### PR DESCRIPTION
gcc with -Werror=format-security doesn't like printf without string literal