### PR TITLE
Added example of multi-value attributes in rlm_perl

### DIFF
--- a/raddb/mods-config/perl/example.pl
+++ b/raddb/mods-config/perl/example.pl
@@ -45,6 +45,19 @@ our (%RAD_REQUEST, %RAD_REPLY, %RAD_CONFIG);
 # This is configuration items from "config" perl module configuration section
 #my %RAD_PERLCONF;
 
+# Multi-value attributes are mapped to perl arrayrefs.
+#
+#  update request {
+#    Filter-Id := 'foo'
+#    Filter-Id += 'bar'
+#  }
+#
+# This results to the following entry in %RAD_REQUEST:
+#
+#  $RAD_REQUEST{'Filter-Id'} = [ 'foo', 'bar' ];
+#
+# Likewise, you can assign an arrayref to return multi-value attributes
+
 #
 # This the remapping of return values
 #


### PR DESCRIPTION
As seen on the mailing list today (subject: "How to Pass multiple Attribute Value Pair of Same Name"), this isn't always clear to the users.