### PR TITLE
make sure rlm_python does not segfault when using 2 instances and second is called first in a Thread

### DIFF
--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -134,12 +134,6 @@ static struct {
 };
 
 /*
- *	This allows us to initialise PyThreadState on a per thread basis
- */
-fr_thread_local_setup(PyThreadState *, local_thread_state)	/* macro */
-
-
-/*
  *	Let assume that radiusd module is only one since we have only
  *	one intepreter
  */


### PR DESCRIPTION
First commit is about initializing all instances correctly. I had to make main_thread_state global. Note that only 1 interpreter is used, that means 2 instances are not in separate envs...

Second commit is cleaning of the code as I believe (https://docs.python.org/2/c-api/init.html#non-python-created-threads) PyGILState_* should take care of thread states. This simplifies a bit the code
