### PR TITLE
Add new port bounce attribute from Aruba

### DIFF
--- a/share/dictionary.aruba
+++ b/share/dictionary.aruba
@@ -49,6 +49,8 @@ ATTRIBUTE	Aruba-User-Group			36	string
 ATTRIBUTE	Aruba-Network-SSO-Token			37	string
 ATTRIBUTE	Aruba-AirGroup-Version			38	integer
 
+ATTRIBUTE Aruba-Port-Bounce-Host      40  integer
+
 VALUE 		Aruba-AirGroup-Device-Type	Personal-Device	1
 VALUE		Aruba-AirGroup-Device-Type	Shared-Device	2
 


### PR DESCRIPTION
This attribute was added in ArubaOS 7.4.0.3 for the Aruba Mobility Access Switch