### PR TITLE
Fix boilerplates after valuepair.c split in 2de33b8.

### DIFF
--- a/src/lib/pair.c
+++ b/src/lib/pair.c
@@ -1,5 +1,5 @@
 /*
- * valuepair.c	Functions to handle VALUE_PAIRs
+ * pair.c	Functions to handle VALUE_PAIRs
  *
  * Version:	$Id$
  *

--- a/src/lib/value.c
+++ b/src/lib/value.c
@@ -1,5 +1,5 @@
 /*
- * valuepair.c	Functions to handle value_data_t
+ * value.c	Functions to handle value_data_t
  *
  * Version:	$Id$
  *


### PR DESCRIPTION
This is a cosmetic code change, and has no functional impact.