### PR TITLE
Fix ${..base_dn} expansion in LDAP config.

### DIFF
--- a/raddb/mods-available/ldap
+++ b/raddb/mods-available/ldap
@@ -121,7 +121,7 @@ ldap {
 	#
 	user {
 		#  Where to start searching in the tree for users
-		base_dn = '${..base_dn}'
+		base_dn = "${..base_dn}"
 
 		#  Filter for user objects, should be specific enough
 		#  to identify a single user object.
@@ -181,7 +181,7 @@ ldap {
 	#
 	group {
 		#  Where to start searching in the tree for groups
-		base_dn = '${..base_dn}'
+		base_dn = "${..base_dn}"
 
 		#  Filter for group objects, should match all available
 		#  group objects a user might be a member of.
@@ -255,7 +255,7 @@ ldap {
 	#
 	client {
 		#   Where to start searching in the tree for clients
-		base_dn = '${..base_dn}'
+		base_dn = "${..base_dn}"
 
 		#
 		#  Filter to match client objects


### PR DESCRIPTION
Change single quotes for double quotes to permit expansion in ldap module config.
Partially reverts 34b35e5.