### PR TITLE
Remove warning for ${raddbdir}/mods-available/cache_eap

### DIFF
--- a/raddb/mods-available/cache_eap
+++ b/raddb/mods-available/cache_eap
@@ -8,6 +8,6 @@ cache cache_eap {
 
 	update reply {
 		reply: += &reply:
-		control:State := &request:State
+		&control:State := &request:State
 	}
 }


### PR DESCRIPTION
Hi @arr2036 ,

This a simple fix for warning during starting of cache_eap.

e.g:

Thu May 14 14:12:25 2015 : Warning: /opt/prefix-dev/freeradius/mods-enabled/cache_eap[11]: Please change attribute reference to '&control:State := ...'
