### PR TITLE
Fixing bug in the scripts 'radtee'

### DIFF
--- a/scripts/radtee
+++ b/scripts/radtee
@@ -92,6 +92,7 @@ THREADS = 32
 # For example:
 #     '127.0.0.1': 'test',
 CLIENTS = {
+#     '127.0.0.1': 'test'
 }
 
 # Ignore any sniffed requests from these IP addresses.
@@ -416,10 +417,10 @@ class RadiusComparer(Thread):
 			if pkt.code == packet.AccessRequest:
 				auth = packet.AuthPacket(data[42:])
 				auth.authenticator = pkt.authenticator
-				auth.secret = clients.CLIENTS.get(ip.get_ip_src(), None)
+				auth.secret = CLIENTS.get(ip.get_ip_src(), None)
 				if not auth.secret:
 					# No configuration for this client.
-					sys.stdout.write('C=%s' % ip.get_ip_src())
+					sys.stdout.write('C=%s (client not authorize)\n' % ip.get_ip_src())
 					sys.stdout.flush()
 					continue
 				passwd = None


### PR DESCRIPTION
Fixing bug

[root@jpereira-desktop scripts]# ./radtee lo
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "./radtee", line 419, in run
    auth.secret = clients.CLIENTS.get(ip.get_ip_src(), None)
NameError: global name 'clients' is not defined

^C^Z
[1]+  Stopped                 ./radtee lo
:(
[root@jpereira-desktop scripts]# kill %1 
