### PR TITLE
Fix bug in the parse of VERSION file in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,9 +34,9 @@ dnl #  Custom hackery to discover version at configure time
 dnl #
 dnl #############################################################
 
-RADIUSD_MAJOR_VERSION=`cat VERSION | sed 's/\..*//'`
-RADIUSD_MINOR_VERSION=`cat VERSION | sed 's/^[[^\.]]*\.//' | sed 's/\..*$//'`
-RADIUSD_INCRM_VERSION=`cat VERSION | sed 's/^.*\..*\.//' | sed 's/[[\.-]].*$//'`
+RADIUSD_MAJOR_VERSION=`cat VERSION | cut -f1 -d.`
+RADIUSD_MINOR_VERSION=`cat VERSION | cut -f2 -d.`
+RADIUSD_INCRM_VERSION=`cat VERSION | cut -f3 -d.`
 
 RADIUSD_VERSION=`echo | awk -v major="$RADIUSD_MAJOR_VERSION" \
 -v minor="$RADIUSD_MINOR_VERSION" \


### PR DESCRIPTION
Hi @arr2036,

We have a bug in the configure.ac, has a wrong parse of VERSION file. below the example.

```
[jpereira@jpereira-desktop freeradius-server.git]$ grep "^RADIUSD_.*_VERSION=" configure.ac
RADIUSD_MAJOR_VERSION=`cat VERSION | sed 's/\..*//'`
RADIUSD_MINOR_VERSION=`cat VERSION | sed 's/^[[^\.]]*\.//' | sed 's/\..*$//'`
RADIUSD_INCRM_VERSION=`cat VERSION | sed 's/^.*\..*\.//' | sed 's/[[\.-]].*$//'`
[jpereira@jpereira-desktop freeradius-server.git]$ RADIUSD_MAJOR_VERSION=`cat VERSION | sed 's/\..*//'`
[jpereira@jpereira-desktop freeradius-server.git]$ RADIUSD_MINOR_VERSION=`cat VERSION | sed 's/^[[^\.]]*\.//' | sed 's/\..*$//'`
[jpereira@jpereira-desktop freeradius-server.git]$ RADIUSD_INCRM_VERSION=`cat VERSION | sed 's/^.*\..*\.//' | sed 's/[[\.-]].*$//'`
[jpereira@jpereira-desktop freeradius-server.git]$ echo $RADIUSD_MAJOR_VERSION
3
[jpereira@jpereira-desktop freeradius-server.git]$ echo $RADIUSD_MINOR_VERSION
3
[jpereira@jpereira-desktop freeradius-server.git]$ echo $RADIUSD_INCRM_VERSION
0
[jpereira@jpereira-desktop freeradius-server.git]$ cat VERSION 
3.1.0
[jpereira@jpereira-desktop freeradius-server.git]$ 
```