### PR TITLE
bugfix a SIGSEGV during 'show debug condition' in radmin

### DIFF
--- a/src/main/parser.c
+++ b/src/main/parser.c
@@ -54,7 +54,14 @@ size_t fr_cond_sprint(char *buffer, size_t bufsize, fr_cond_t const *in)
 	char *end = buffer + bufsize - 1;
 	fr_cond_t const *c = in;
 
+	rad_assert(buffsize > 0);
+
 next:
+	if (!c) {
+		buffer[0] = '\0';
+		return 0;
+	}
+
 	if (c->negate) {
 		*(p++) = '!';	/* FIXME: only allow for child? */
 	}


### PR DESCRIPTION
Hi @arr2036 / @alandekok ,

I have found a bug during "show debug condition" in the radmin like below example. 

```
hu May 28 19:02:14 2015 : Debug: radmin> show debug condition

Program received signal SIGSEGV, Segmentation fault.
0x00007ffff7bb2052 in fr_cond_sprint (
    buffer=0x7fffffffdd90 "command file /home/jpereira/Devel/github-jpereira/freeradius/prefix-3.0.x/var/run/radiusd/radiusd.sock", bufsize=0x400, in=0x0) at src/main/parser.c:58
58		if (c->negate) {
(gdb) bt
#0  0x00007ffff7bb2052 in fr_cond_sprint (
    buffer=0x7fffffffdd90 "command file /home/jpereira/Devel/github-jpereira/freeradius/prefix-3.0.x/var/run/radiusd/radiusd.sock", bufsize=0x400, in=0x0) at src/main/parser.c:58
#1  0x000000000041ce4e in command_show_debug_condition (listener=0x927920, argc=0x0, argv=0x7fffffffe218)
    at src/main/command.c:1349
#2  0x0000000000420197 in command_domain_recv_co (listener=0x927920, co=0x927bf8) at src/main/command.c:2912
#3  0x000000000042068c in command_domain_recv (listener=0x927920) at src/main/command.c:3048
#4  0x0000000000446022 in event_socket_handler (xel=0x8c5bf0, fd=0xb, ctx=0x927920) at src/main/process.c:4459
#5  0x00007ffff7984f56 in fr_event_loop (el=0x8c5bf0) at src/lib/event.c:642
#6  0x0000000000447e32 in radius_event_process () at src/main/process.c:5406
#7  0x0000000000431bcd in main (argc=0x2, argv=0x7fffffffe6c8) at src/main/radiusd.c:581
(gdb) p c
$1 = (const fr_cond_t *) 0x0
(gdb) 

```