### PR TITLE
Add the vsa 'Alc-Wlan-SSID-VLAN' for Alcatel 7750

### DIFF
--- a/share/dictionary.alcatel.sr
+++ b/share/dictionary.alcatel.sr
@@ -350,4 +350,8 @@ ATTRIBUTE   Alc-Portal-Url                            177 string
 # names longer than the allowed maximum are treated as host setup failures
 ATTRIBUTE   Alc-SLAAC-IPv6-Pool                       181 string
 
+# The VLAN is transparently taken from the UE’s Ethernet layer and can be reflected
+# in both authentication and accounting
+ATTRIBUTE   Alc-Wlan-SSID-VLAN                        206 string
+
 END-VENDOR	Alcatel-Lucent-Service-Router


### PR DESCRIPTION
following the document https://infoproducts.alcatel-lucent.com/html/0_add-h-f/93-0088-HTML/7750_SR_RADIUS_Attributes_Reference_Guide/SROS_RADIUS_Attrib.html

@arr2036 Please, replicate in the v3.0.x