### PR TITLE
Freeradius Debian packaging improvements (freeradius-config and freeradius-dhcp)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -58,7 +58,7 @@ Description: FreeRADIUS common files
 
 Package: freeradius-config
 Architecture: any
-Depends: freeradius-common (>= 3), ${misc:Depends}
+Depends: freeradius-common (>= 3), ${misc:Depends}, make
 Breaks: freeradius-config
 Description: FreeRADIUS default config files
   This package should be used as a base for a site local packages

--- a/debian/control
+++ b/debian/control
@@ -101,6 +101,13 @@ Description: FreeRADIUS shared library development files
  .
  This package contains the development headers and static library version.
 
+Package: freeradius-dhcp
+Architecture: any
+Depends: freeradius (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends}
+Description: DHCP module for FreeRADIUS server
+ The FreeRADIUS server can act as a DHCP server, and this module
+ is necessary for that.
+
 Package: freeradius-krb5
 Architecture: any
 Depends: freeradius (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends}

--- a/debian/freeradius-dhcp.install
+++ b/debian/freeradius-dhcp.install
@@ -1,0 +1,2 @@
+usr/lib/freeradius/rlm_dhcp*.so
+usr/lib/freeradius/proto_dhcp*.so

--- a/debian/freeradius-dhcp.postinst
+++ b/debian/freeradius-dhcp.postinst
@@ -1,0 +1,22 @@
+#! /bin/sh
+
+set -e
+
+case "$1" in
+  configure)
+        if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
+          invoke-rc.d freeradius force-reload
+        else
+          /etc/init.d/freeradius force-reload
+        fi
+        ;;
+  abort-upgrade)
+        ;;
+  abort-remove)
+        ;;
+  abort-deconfigure)
+        ;;
+esac
+
+#DEBHELPER#
+

--- a/debian/rules
+++ b/debian/rules
@@ -26,7 +26,7 @@ logdir          = /var/log/$(package)
 pkgdocdir       = /usr/share/doc/$(package)
 raddbdir        = /etc/$(package)
 
-modulelist=krb5 ldap sql_mysql sql_iodbc sql_postgresql rest
+modulelist=krb5 ldap sql_mysql sql_iodbc sql_postgresql rest dhcp
 pkgs=$(shell dh_listpackages)
 
 # This has to be exported to make some magic below work.


### PR DESCRIPTION
This PR adds an additional freeradius-dhcp package for Debian that allows the Freeradius3 DHCP module to be easily installed on Debian-based distros.

I've also made a minor tweak to the freeradius-config dependency list to include make.