### PR TITLE
Fixing a memory leak in the rlm_redis

### DIFF
--- a/src/modules/rlm_redis/rlm_redis.c
+++ b/src/modules/rlm_redis/rlm_redis.c
@@ -62,6 +62,8 @@ static void *mod_conn_create(TALLOC_CTX *ctx, void *instance)
 
 	conn = redisConnect(inst->hostname, inst->port);
 	if (conn && conn->err) {
+		ERROR("rlm_redis (%s): Problems with redisConnect('%s', %d), %s",
+				inst->xlat_name, inst->hostname, inst->port, redisReplyReaderGetError(conn));
 		redisFree(conn);
 		return NULL;
 	}

--- a/src/modules/rlm_redis/rlm_redis.c
+++ b/src/modules/rlm_redis/rlm_redis.c
@@ -61,7 +61,10 @@ static void *mod_conn_create(TALLOC_CTX *ctx, void *instance)
 	char buffer[1024];
 
 	conn = redisConnect(inst->hostname, inst->port);
-	if (conn->err) return NULL;
+	if (conn && conn->err) {
+		redisFree(conn);
+		return NULL;
+	}
 
 	if (inst->password) {
 		snprintf(buffer, sizeof(buffer), "AUTH %s", inst->password);


### PR DESCRIPTION
Hi,

  During inspect of rlm_redis, I figured out that we have reference to redisConnect() missing a redisFree().