### PR TITLE
More helpful message during query executions in the rlm_redis

### DIFF
--- a/src/modules/rlm_redis/rlm_redis.c
+++ b/src/modules/rlm_redis/rlm_redis.c
@@ -220,7 +220,7 @@ int rlm_redis_query(REDISSOCK **dissocket_p, REDIS_INST *inst,
 
 	dissocket = *dissocket_p;
 
-	DEBUG2("executing %s ...", argv[0]);
+	DEBUG2("rlm_redis (%s): executing the query: \"%s\"", inst->xlat_name, query);
 	dissocket->reply = redisCommandArgv(dissocket->conn, argc, argv, NULL);
 	if (!dissocket->reply) {
 		RERROR("%s", dissocket->conn->errstr);


### PR DESCRIPTION
Currently during the query in the rlm_redis we showed:

```
Debug: executing EXPIRE ..
```

Actually, could be more helpful shows the complete query that is executed.

```
Debug: executing the query: EXPIRE 12345 1800
```

@arr2036 agree?
