### PR TITLE
Update abfab-tr-idp

### DIFF
--- a/raddb/sites-available/abfab-tr-idp
+++ b/raddb/sites-available/abfab-tr-idp
@@ -52,6 +52,19 @@ authenticate {
 #  Once we KNOW that the user has been authenticated, there are
 #  additional steps we can take.
 post-auth {
+	#
+	#  For EAP-TTLS and PEAP, add the cached attributes to the reply.
+	#  The "session-state" attributes are automatically cached when
+	#  an Access-Challenge is sent, and automatically retrieved
+	#  when an Access-Request is received.
+	#
+	#  The session-state attributes are automatically deleted after
+	#  an Access-Reject or Access-Accept is sent.
+	#
+	update {
+		&reply: += &session-state:
+	}
+
 	#  Create the CUI value and add the attribute to Access-Accept.
 	#  Uncomment the line below if *returning* the CUI.
 #	cui


### PR DESCRIPTION
Add the 'new' session-state stuff to the ABFAB server too. This keeps the ABFAB server in sync with the improved attribute transfer from the inner-tunnel server.

Can we have this in 3.0.9 too please?