### PR TITLE
rlm_replicate: Added support for the list 'accounting'

### DIFF
--- a/src/modules/rlm_replicate/rlm_replicate.c
+++ b/src/modules/rlm_replicate/rlm_replicate.c
@@ -225,6 +225,11 @@ static rlm_rcode_t CC_HINT(nonnull) mod_authorize(void *instance, REQUEST *reque
 	return replicate_packet(instance, request, PAIR_LIST_REQUEST, request->packet->code);
 }
 
+static rlm_rcode_t CC_HINT(nonnull) mod_accounting(void *instance, REQUEST *request)
+{
+	return replicate_packet(instance, request, PAIR_LIST_REQUEST, request->packet->code);
+}
+
 static rlm_rcode_t CC_HINT(nonnull) mod_preaccounting(void *instance, REQUEST *request)
 {
 	return replicate_packet(instance, request, PAIR_LIST_REQUEST, request->packet->code);
@@ -260,6 +265,7 @@ module_t rlm_replicate = {
 	.type		= RLM_TYPE_THREAD_SAFE,
 	.methods = {
 		[MOD_AUTHORIZE]		= mod_authorize,
+		[MOD_ACCOUNTING]	= mod_accounting,
 		[MOD_PREACCT]		= mod_preaccounting,
 #ifdef WITH_PROXY
 		[MOD_PRE_PROXY]		= mod_pre_proxy,


### PR DESCRIPTION
Hi,

The current documentation /etc/freeradius/mods-available/replicate says:

```
#  To use this module, list "replicate" in the "authorize" or
#  "accounting" section.  Then, ensure that Replicate-To-Realm is set.
#  The contents of the "packet" attribute list will be sent to the
#  home server.  The usual load-balancing, etc. features of the home
#  server will be used.
```

but, when I try..

```
Mon Jun 15 13:58:19 2015 : Error: /etc/freeradius/sites-enabled/default-jorge[104]: "replicate" modules aren't allowed in 'accounting' sections -- they have no such method.
Mon Jun 15 13:58:19 2015 : Error: /etc/freeradius/sites-enabled/default-jorge[96]: Errors parsing accounting section.
```

But, isn't possible to use in the accounting. My patch just added the capability and works fine when have some situation like the below example.

```
    #### ACCOUNTING
    listen {
        ipaddr = *
        port = 0
        type = acct
        limit {
        }
    }

    preacct {
        update control {                                                                                                                                             
            &Replicate-To-Realm := "TESTE"
            &Proxy-To-Realm := "TESTE"
        }
        updated
    }

    accounting {
        detail
    }

    session {

    }

    ##### PROXY
    pre-proxy {

    }

    post-proxy {
        update {
            &request:Acct-Status-Type := Interim-Update
        }
        updated

        replicate.accounting
    }
```

works perfect, below some evidence after the patch.

```
Mon Jun 15 15:52:31 2015 : Debug: (0) Received Accounting-Request Id 216 from 127.0.0.1:55836 to 127.0.0.1:1813 length 118
Mon Jun 15 15:52:31 2015 : Debug: (0)   Acct-Status-Type = Start
Mon Jun 15 15:52:31 2015 : Debug: (0)   NAS-IP-Address = 127.0.0.1
Mon Jun 15 15:52:31 2015 : Debug: (0)   User-Name = 'jorge'
Mon Jun 15 15:52:31 2015 : Debug: (0)   Framed-IP-Address = 10.1.1.2
Mon Jun 15 15:52:31 2015 : Debug: (0)   Calling-Station-Id = 'ca:fe:ca:fe:00:69'
Mon Jun 15 15:52:31 2015 : Debug: (0)   Acct-Session-Id = 'B3017602744702545CE421'
Mon Jun 15 15:52:31 2015 : Debug: (0)   Acct-Multi-Session-Id = 'B3017602744702545CE421'
Mon Jun 15 15:52:31 2015 : Debug: (0)   Event-Timestamp = 'Jun 15 2015 15:52:31 BRT'
Mon Jun 15 15:52:31 2015 : Debug: (0) Empty preacct section.  Using default return values.
Mon Jun 15 15:52:31 2015 : Debug: (0) # Executing section accounting from file /etc/freeradius/sites-enabled/default
Mon Jun 15 15:52:31 2015 : Debug: (0)   accounting {
Mon Jun 15 15:52:31 2015 : Debug: (0)     update control {
Mon Jun 15 15:52:31 2015 : Debug: (0)       &Replicate-To-Realm := "TESTE"
Mon Jun 15 15:52:31 2015 : Debug: (0)       &Proxy-To-Realm := "TESTE"
Mon Jun 15 15:52:31 2015 : Debug: (0)     } # update control = noop
Mon Jun 15 15:52:31 2015 : Debug: (0)     modsingle[accounting]: calling updated (rlm_always) for request 0
Mon Jun 15 15:52:31 2015 : Debug: (0)     modsingle[accounting]: returned from updated (rlm_always) for request 0
Mon Jun 15 15:52:31 2015 : Debug: (0)     [updated] = updated
Mon Jun 15 15:52:31 2015 : Debug: (0)     modsingle[accounting]: calling detail (rlm_detail) for request 0
Mon Jun 15 15:52:31 2015 : Debug: /var/log/freeradius/radacct/%{%{Packet-Src-IP-Address}:-%{Packet-Src-IPv6-Address}}/detail-%Y%m%d
Mon Jun 15 15:52:31 2015 : Debug: Parsed xlat tree:
Mon Jun 15 15:52:31 2015 : Debug: literal --> /var/log/freeradius/radacct/
Mon Jun 15 15:52:31 2015 : Debug: if {
Mon Jun 15 15:52:31 2015 : Debug:       attribute --> Packet-Src-IP-Address
Mon Jun 15 15:52:31 2015 : Debug: }
Mon Jun 15 15:52:31 2015 : Debug: else {
Mon Jun 15 15:52:31 2015 : Debug:       attribute --> Packet-Src-IPv6-Address
Mon Jun 15 15:52:31 2015 : Debug: }
Mon Jun 15 15:52:31 2015 : Debug: literal --> /detail-
Mon Jun 15 15:52:31 2015 : Debug: percent --> Y
Mon Jun 15 15:52:31 2015 : Debug: percent --> m
Mon Jun 15 15:52:31 2015 : Debug: percent --> d
Mon Jun 15 15:52:31 2015 : Debug: (0) detail: EXPAND /var/log/freeradius/radacct/%{%{Packet-Src-IP-Address}:-%{Packet-Src-IPv6-Address}}/detail-%Y%m%d
Mon Jun 15 15:52:31 2015 : Debug: (0) detail:    --> /var/log/freeradius/radacct/127.0.0.1/detail-20150615
Mon Jun 15 15:52:31 2015 : Debug: (0) detail: /var/log/freeradius/radacct/%{%{Packet-Src-IP-Address}:-%{Packet-Src-IPv6-Address}}/detail-%Y%m%d expands to /var/log/freeradius/radacct/127.0.0.1/detail-20150615
Mon Jun 15 15:52:31 2015 : Debug: %t
Mon Jun 15 15:52:31 2015 : Debug: Parsed xlat tree:
Mon Jun 15 15:52:31 2015 : Debug: percent --> t
Mon Jun 15 15:52:31 2015 : Debug: (0) detail: EXPAND %t
Mon Jun 15 15:52:31 2015 : Debug: (0) detail:    --> Mon Jun 15 15:52:31 2015
Mon Jun 15 15:52:31 2015 : Debug: (0)     modsingle[accounting]: returned from detail (rlm_detail) for request 0
Mon Jun 15 15:52:31 2015 : Debug: (0)     [detail] = ok
Mon Jun 15 15:52:31 2015 : Debug: (0)   } # accounting = updated
Mon Jun 15 15:52:31 2015 : Debug: (0) Empty pre-proxy section.  Using default return values.
Mon Jun 15 15:52:31 2015 : Debug: (0) proxy: Trying to allocate ID (0/2)
Mon Jun 15 15:52:31 2015 : Debug: (0) proxy: Trying to open a new listener to the home server
Mon Jun 15 15:52:31 2015 : Debug: Opening new proxy socket 'proxy address * port 0'
Mon Jun 15 15:52:31 2015 : Debug: Listening on proxy address * port 50575
Mon Jun 15 15:52:31 2015 : Debug: (0) proxy: Trying to allocate ID (1/2)
Mon Jun 15 15:52:31 2015 : Debug: (0) proxy: request is now in proxy hash
Mon Jun 15 15:52:31 2015 : Debug: (0) proxy: allocating destination 10.1.2.176 port 1813 - Id 183
Mon Jun 15 15:52:31 2015 : Debug: (0) Proxying request to home server 10.1.2.176 port 1813 timeout 30.000000
Mon Jun 15 15:52:31 2015 : Debug: (0) Sent Accounting-Request Id 183 from 0.0.0.0:50575 to 10.1.2.176:1813 length 123
Mon Jun 15 15:52:31 2015 : Debug: (0)   Acct-Status-Type = Start
Mon Jun 15 15:52:31 2015 : Debug: (0)   NAS-IP-Address = 127.0.0.1
Mon Jun 15 15:52:31 2015 : Debug: (0)   User-Name = 'jorge'
Mon Jun 15 15:52:31 2015 : Debug: (0)   Framed-IP-Address = 10.1.1.2
Mon Jun 15 15:52:31 2015 : Debug: (0)   Calling-Station-Id = 'ca:fe:ca:fe:00:69'
Mon Jun 15 15:52:31 2015 : Debug: (0)   Acct-Session-Id = 'B3017602744702545CE421'
Mon Jun 15 15:52:31 2015 : Debug: (0)   Acct-Multi-Session-Id = 'B3017602744702545CE421'
Mon Jun 15 15:52:31 2015 : Debug: (0)   Event-Timestamp = 'Jun 15 2015 15:52:31 BRT'
Mon Jun 15 15:52:31 2015 : Debug: (0)   Proxy-State = 0x323136
Mon Jun 15 15:52:31 2015 : Debug: Waking up in 0.3 seconds.
Mon Jun 15 15:52:31 2015 : Debug: (0) Clearing existing &reply: attributes
Mon Jun 15 15:52:31 2015 : Debug: (0) Received Accounting-Response Id 183 from 10.1.2.176:1813 to 10.1.2.128:50575 length 70
Mon Jun 15 15:52:31 2015 : Debug: (0)   Reply-Message = 'AAA->NOKIA() Recebido pacote type OK'
Mon Jun 15 15:52:31 2015 : Debug: (0)   Proxy-State = 0x323136
Mon Jun 15 15:52:31 2015 : Debug: (0) proxy: request is no longer in proxy hash
Mon Jun 15 15:52:31 2015 : Debug: (0) # Executing section post-proxy from file /etc/freeradius/sites-enabled/default
Mon Jun 15 15:52:31 2015 : Debug: (0)   post-proxy {
Mon Jun 15 15:52:31 2015 : Debug: (0)     update {
Mon Jun 15 15:52:31 2015 : Debug: (0)       &request:Acct-Status-Type := Interim-Update
Mon Jun 15 15:52:31 2015 : Debug: (0)       Overwriting value "Start" with "Interim-Update"
Mon Jun 15 15:52:31 2015 : Debug: (0)     } # update = noop
Mon Jun 15 15:52:31 2015 : Debug: (0)     modsingle[post-proxy]: calling updated (rlm_always) for request 0
Mon Jun 15 15:52:31 2015 : Debug: (0)     modsingle[post-proxy]: returned from updated (rlm_always) for request 0
Mon Jun 15 15:52:31 2015 : Debug: (0)     [updated] = updated
Mon Jun 15 15:52:31 2015 : Debug: (0)     modsingle[accounting]: calling replicate (rlm_replicate) for request 0
Mon Jun 15 15:52:31 2015 : Debug: (0) replicate: Replicating list 'request' to Realm 'TESTE'
Mon Jun 15 15:52:31 2015 : Debug: (0)     modsingle[accounting]: returned from replicate (rlm_replicate) for request 0
Mon Jun 15 15:52:31 2015 : Debug: (0)     [replicate.accounting] = ok
Mon Jun 15 15:52:31 2015 : Debug: (0)   } # post-proxy = updated
Mon Jun 15 15:52:31 2015 : Debug: (0) Sent Accounting-Response Id 216 from 127.0.0.1:1813 to 127.0.0.1:55836 length 0
Mon Jun 15 15:52:31 2015 : Debug: (0)   Reply-Message = 'AAA->NOKIA() Recebido pacote OK'
Mon Jun 15 15:52:31 2015 : Debug: (0) Finished request
Mon Jun 15 15:52:31 2015 : Debug: (0) <done>: Cleaning up request packet ID 216 with timestamp +3
Mon Jun 15 15:52:31 2015 : Info: Ready to process requests
```