### PR TITLE
rlm_replicate: The packet->data isn't used, check if was allocated.

### DIFF
--- a/src/modules/rlm_replicate/rlm_replicate.c
+++ b/src/modules/rlm_replicate/rlm_replicate.c
@@ -174,9 +174,12 @@ static int replicate_packet(UNUSED void *instance, REQUEST *request, pair_lists_
 			}
 
 			packet->id++;
-			talloc_free(packet->data);
-			packet->data = NULL;
-			packet->data_len = 0;
+
+			if (packet->data) {
+				talloc_free(packet->data);
+				packet->data = NULL;
+				packet->data_len = 0;
+			}
 		}
 
 		/*


### PR DESCRIPTION
Hi,

 The packet->data isn't used. Could be better check before call the talloc_free.