### PR TITLE
Don't leak memory on fr_syserror()

### DIFF
--- a/src/lib/log.c
+++ b/src/lib/log.c
@@ -142,6 +142,7 @@ char const *fr_syserror(int num)
 	}
 
 	if (!num) {
+		free(buffer);
 		return "No error";
 	}
 


### PR DESCRIPTION
Don't leak memory on each 'No error' messages.