### PR TITLE
some adjustments for a better error messages.

### DIFF
--- a/src/main/conffile.c
+++ b/src/main/conffile.c
@@ -305,7 +305,6 @@ static FILE *cf_file_open(CONF_SECTION *cs, char const *filename)
 	CONF_DATA *cd;
 	CONF_SECTION *top;
 	rbtree_t *tree;
-	int fd;
 	FILE *fp;
 
 	top = cf_top_section(cs);
@@ -321,8 +320,6 @@ static FILE *cf_file_open(CONF_SECTION *cs, char const *filename)
 		return NULL;
 	}
 
-	fd = fileno(fp);
-
 	file = talloc(tree, cf_file_t);
 	if (!file) {
 		fclose(fp);
@@ -333,7 +330,7 @@ static FILE *cf_file_open(CONF_SECTION *cs, char const *filename)
 	file->cs = cs;
 	file->input = true;
 
-	if (fstat(fd, &file->buf) == 0) {
+	if (stat(filename, &file->buf) < 0) {
 #ifdef S_IWOTH
 		if ((file->buf.st_mode & S_IWOTH) != 0) {
 			fclose(fp);
@@ -373,7 +370,6 @@ static bool cf_file_input(CONF_SECTION *cs, char const *filename)
 	if (!cd) return false;
 
 	tree = cd->data;
-
 	file = talloc(tree, cf_file_t);
 	if (!file) return false;
 

--- a/src/main/conffile.c
+++ b/src/main/conffile.c
@@ -1366,6 +1366,7 @@ int cf_item_parse(CONF_SECTION *cs, char const *name, unsigned int type, void *d
 	CONF_PAIR *cp = NULL;
 	fr_ipaddr_t *ipaddr;
 	char buffer[8192];
+	CONF_ITEM *c_item = &cs->item;
 
 	if (!cs) return -1;
 
@@ -1385,7 +1386,7 @@ int cf_item_parse(CONF_SECTION *cs, char const *name, unsigned int type, void *d
 	 *	Everything except templates must have a base type.
 	 */
 	if (!(type & 0xff) && !tmpl) {
-		cf_log_err(&(cs->item), "Configuration item '%s' must have a data type", name);
+		cf_log_err(c_item, "Configuration item '%s' must have a data type", name);
 		return -1;
 	}
 
@@ -1409,6 +1410,7 @@ int cf_item_parse(CONF_SECTION *cs, char const *name, unsigned int type, void *d
 		CONF_PAIR *next = cp;
 		value = cp->value;
 		cp->parsed = true;
+		c_item = &cp->item;
 
 		/*
 		 *	@fixme We should actually validate
@@ -1422,11 +1424,8 @@ int cf_item_parse(CONF_SECTION *cs, char const *name, unsigned int type, void *d
 	if (!value) {
 		if (required) {
 		is_required:
-			if (!cp) {
-				cf_log_err(&(cs->item), "Configuration item '%s' must have a value", name);
-			} else {
-				cf_log_err(&(cp->item), "Configuration item '%s' must have a value", name);
-			}
+			cf_log_err(c_item, "Configuration item '%s' must have a value", name);
+
 			return -1;
 		}
 		return rcode;
@@ -1434,18 +1433,16 @@ int cf_item_parse(CONF_SECTION *cs, char const *name, unsigned int type, void *d
 
 	if ((value[0] == '\0') && cant_be_empty) {
 	cant_be_empty:
-		if (!cp) {
-			cf_log_err(&(cs->item), "Configuration item '%s' must not be empty (zero length)", name);
-			if (!required) cf_log_err(&(cs->item), "Comment item to silence this message");
-		} else {
-			cf_log_err(&(cp->item), "Configuration item '%s' must not be empty (zero length)", name);
-			if (!required) cf_log_err(&(cp->item), "Comment item to silence this message");
-		}
+		cf_log_err(c_item, "Configuration item '%s' must not be empty (zero length)", name);
+
+		if (!required)
+			cf_log_err(c_item, "Comment item to silence this message");
+
 		return -1;
 	}
 
 	if (deprecated) {
-		cf_log_err(&(cs->item), "Configuration item \"%s\" is deprecated", name);
+		cf_log_err(c_item, "Configuration item \"%s\" is deprecated", name);
 
 		return -2;
 	}

--- a/src/main/conffile.c
+++ b/src/main/conffile.c
@@ -378,8 +378,7 @@ static bool cf_file_input(CONF_SECTION *cs, char const *filename)
 	file->input = true;
 
 	if (stat(filename, &file->buf) < 0) {
-		ERROR("Unable to open file \"%s\": %s",
-		      filename, fr_strerror());
+		ERROR("Unable to open file \"%s\": %s", filename, fr_syserror(errno));
 		talloc_free(file);
 		return false;
 	}


### PR DESCRIPTION
Hi @arr2036!

Today I had the situation that was necessary to call the 'radiusd' using a directory that the user 'freerad' don't had permissions to read... and was terrible to find  the problem like the below message.

```
......
Wed Jun 24 01:00:55 2015 : Debug:   # Loading module "files" from file /root/teste/mods-enabled/files
Wed Jun 24 01:00:55 2015 : Debug:   files {
Wed Jun 24 01:00:55 2015 : Debug:   	filename = "/root/teste/mods-config/files/authorize"
Wed Jun 24 01:00:55 2015 : Error: Unable to open file "/root/teste/mods-config/files/authorize": 
Wed Jun 24 01:00:55 2015 : Debug:   }
Wed Jun 24 01:00:55 2015 : Error: /root/teste/mods-enabled/files[9]: Invalid configuration for module "files"
......
```

after the adjustments...

```
......
Wed Jun 24 01:00:55 2015 : Debug:   # Loading module "files" from file /root/teste/mods-enabled/files
Wed Jun 24 01:00:55 2015 : Debug:   files {
Wed Jun 24 01:00:55 2015 : Debug:   	filename = "/root/teste/mods-config/files/authorize"
Wed Jun 24 01:00:55 2015 : Error: Unable to open file "/root/teste/mods-config/files/authorize": Permission denied
Wed Jun 24 01:00:55 2015 : Debug:   }
Wed Jun 24 01:00:55 2015 : Error: /root/teste/mods-enabled/files[9]: Invalid configuration for module "files"
......
```

more useful! :+1: 

And I made some others adjustments.