### PR TITLE
Fixing the missing '%{client:nas_type}' caused by use of old client_afrom_query()

### DIFF
--- a/raddb/mods-available/sql
+++ b/raddb/mods-available/sql
@@ -231,6 +231,45 @@ sql {
 	client_table = "nas"
 
 	#
+	# Table to keep radius client info
+	#
+	client {
+#		id = "myid"
+
+		#  Sets default values (not obtained from SQL) for new client entries
+		#
+		template {
+#			login				= 'test'
+#			password			= 'test'
+#			proto	 			= tcp
+#			require_message_authenticator	= yes
+
+			# Uncomment to add a home_server with the same
+			# attributes as the client.
+#			coa_server {
+#				response_window = 2.0
+#			}
+		}
+
+		#  Client attribute mappings are in the format:
+		#      <client attribute> = <table field name>
+		#
+		#  The following attributes are required:
+		#    * ipaddr - Client IP Address.
+		#    * secret - RADIUS shared secret.
+		#
+		#  All other attributes usually supported in a client
+		#  definition are also supported here.
+		attribute {
+			ipaddr		= "nasname"
+			shortname	= "shortname"
+			nas_type	= "type"
+			secret		= "secret"
+			virtual_server	= "server"
+		}
+	}
+
+	#
 	# The group attribute specific to this instance of rlm_sql
 	#
 

--- a/src/include/clients.h
+++ b/src/include/clients.h
@@ -150,10 +150,6 @@ int		client_map_section(CONF_SECTION *out, CONF_SECTION const *map, client_value
 
 RADCLIENT	*client_afrom_cs(TALLOC_CTX *ctx, CONF_SECTION *cs, bool in_server, bool with_coa);
 
-RADCLIENT	*client_afrom_query(TALLOC_CTX *ctx, char const *identifier, char const *secret, char const *shortname,
-				    char const *type, char const *server, bool require_ma)
-		CC_HINT(nonnull(2, 3));
-
 RADCLIENT	*client_find(RADCLIENT_LIST const *clients, fr_ipaddr_t const *ipaddr, int proto);
 
 RADCLIENT	*client_findbynumber(RADCLIENT_LIST const *clients, int number);

--- a/src/main/client.c
+++ b/src/main/client.c
@@ -1134,55 +1134,6 @@ done_coa:
 	return c;
 }
 
-/** Add a client from a result set (SQL)
- *
- * @todo This function should die. SQL should use client_afrom_cs.
- *
- * @param ctx Talloc context.
- * @param identifier Client IP Address / IPv4 subnet / IPv6 subnet / FQDN.
- * @param secret Client secret.
- * @param shortname Client friendly name.
- * @param type NAS-Type.
- * @param server Virtual-Server to associate clients with.
- * @param require_ma If true all packets from client must include a message-authenticator.
- * @return The new client, or NULL on error.
- */
-RADCLIENT *client_afrom_query(TALLOC_CTX *ctx, char const *identifier, char const *secret,
-			      char const *shortname, char const *type, char const *server, bool require_ma)
-{
-	RADCLIENT *c;
-	char buffer[128];
-
-	rad_assert(identifier);
-	rad_assert(secret);
-
-	c = talloc_zero(ctx, RADCLIENT);
-
-	if (fr_pton(&c->ipaddr, identifier, -1, AF_UNSPEC, true) < 0) {
-		ERROR("%s", fr_strerror());
-		talloc_free(c);
-
-		return NULL;
-	}
-
-#ifdef WITH_DYNAMIC_CLIENTS
-	c->dynamic = true;
-#endif
-	ip_ntoh(&c->ipaddr, buffer, sizeof(buffer));
-	c->longname = talloc_typed_strdup(c, buffer);
-
-	/*
-	 *	Other values (secret, shortname, nas_type, virtual_server)
-	 */
-	c->secret = talloc_typed_strdup(c, secret);
-	if (shortname) c->shortname = talloc_typed_strdup(c, shortname);
-	if (type) c->nas_type = talloc_typed_strdup(c, type);
-	if (server) c->server = talloc_typed_strdup(c, server);
-	c->message_authenticator = require_ma;
-
-	return c;
-}
-
 /** Create a new client, consuming all attributes in the control list of the request
  *
  * @param clients list to add new client to.

--- a/src/modules/rlm_sql/rlm_sql.h
+++ b/src/modules/rlm_sql/rlm_sql.h
@@ -108,6 +108,13 @@ typedef struct sql_config {
 	char const 		*groupmemb_query;		//!< Query to determine group membership.
 
 	bool			do_clients;			//!< Read clients from SQL database.
+	char const 		*client_id;			//!< Client ID from SQL database.
+	char const 		*client_ipaddr;			//!< Client 'ipaddr' from SQL database.
+	char const 		*client_shortname;		//!< Client 'shortname' from SQL database.
+	char const 		*client_nas_type;		//!< Client 'nas_type'  from SQL database.
+	char const 		*client_secret;			//!< Client 'secret' from SQL database.
+	char const 		*client_virtual_server;		//!< Client 'virtual_server' from SQL database.
+
 	bool			read_groups;			//!< Read user groups by default.
 								//!< If false, Fall-Through = yes is required
 								//!< in the previous reply list to process


### PR DESCRIPTION
Hi,

This patch fixes the issue 1108, below some evidence.

1) I added the below peaces in my $raddb/mods-enabled/sql

```
............
  	client_table = "nas"
 
 	#
	# Table to keep radius client info
	#
	client {
#		identifier = "myid"

		#  Sets default values (not obtained from SQL) for new client entries
		#
		template {
#			login				= 'test'
#			password			= 'test'
#			proto	 			= tcp
#			require_message_authenticator	= yes

			# Uncomment to add a home_server with the same
			# attributes as the client.
#			coa_server {
#				response_window = 2.0
#			}
		}

		#  Client attribute mappings are in the format:
		#      <client attribute> = <table field name>
		#
		#  The following attributes are required:
		#    * ipaddr - Client IP Address.
		#    * secret - RADIUS shared secret.
		#
		#  All other attributes usually supported in a client
		#  definition are also supported here.
		attribute {
			ipaddr		= "nasname"
			shortname	= "shortname"
			nas_type	= "type"
			secret		= "secret"
			virtual_server	= "server"
		}
	}
................
```

2) The output of my instance during load of clients from SQL.
```
Tue Jul  7 18:44:59 2015 : Debug: rlm_sql (sql): Executing select query: SELECT id, nasname, shortname, type, secret, server FROM nas
Tue Jul  7 18:44:59 2015 : Debug: rlm_sql (sql): Adding client 10.1.2.128 (client-sql1) to global clients list
Tue Jul  7 18:44:59 2015 : Debug: client client-sql1 {
Tue Jul  7 18:44:59 2015 : Debug: 	ipaddr = 10.1.2.128
Tue Jul  7 18:44:59 2015 : Debug: 	require_message_authenticator = no
Tue Jul  7 18:44:59 2015 : Debug: 	secret = "caiprinha123"
Tue Jul  7 18:44:59 2015 : Debug: 	shortname = "client-sql1"
Tue Jul  7 18:44:59 2015 : Debug: 	nas_type = "alcatel"
Tue Jul  7 18:44:59 2015 : Debug:  limit {
Tue Jul  7 18:44:59 2015 : Debug:  	max_connections = 16
Tue Jul  7 18:44:59 2015 : Debug:  	lifetime = 0
Tue Jul  7 18:44:59 2015 : Debug:  	idle_timeout = 30
Tue Jul  7 18:44:59 2015 : Debug:  }
Tue Jul  7 18:44:59 2015 : Debug: }
Tue Jul  7 18:44:59 2015 : Debug: Adding client 10.1.2.128/32 (10.1.2.128) to prefix tree 32
Tue Jul  7 18:44:59 2015 : Debug: rlm_sql (10.1.2.128): Client "client-sql1" (sql) added
Tue Jul  7 18:44:59 2015 : Debug: rlm_sql (sql): Adding client 10.1.1.86 (client-sql2) to global clients list
Tue Jul  7 18:44:59 2015 : Debug: client client-sql2 {
Tue Jul  7 18:44:59 2015 : Debug: 	ipaddr = 10.1.1.86
Tue Jul  7 18:44:59 2015 : Debug: 	require_message_authenticator = no
Tue Jul  7 18:44:59 2015 : Debug: 	secret = "caipirinha321"
Tue Jul  7 18:44:59 2015 : Debug: 	shortname = "client-sql2"
Tue Jul  7 18:44:59 2015 : Debug: 	nas_type = "aptilo"
Tue Jul  7 18:44:59 2015 : Debug:  limit {
Tue Jul  7 18:44:59 2015 : Debug:  	max_connections = 16
Tue Jul  7 18:44:59 2015 : Debug:  	lifetime = 0
Tue Jul  7 18:44:59 2015 : Debug:  	idle_timeout = 30
Tue Jul  7 18:44:59 2015 : Debug:  }
Tue Jul  7 18:44:59 2015 : Debug: }
Tue Jul  7 18:44:59 2015 : Debug: Adding client 10.1.1.86/32 (10.1.1.86) to prefix tree 32
Tue Jul  7 18:44:59 2015 : Debug: rlm_sql (10.1.1.86): Client "client-sql2" (sql) added
Tue Jul  7 18:44:59 2015 : Debug: rlm_sql (sql): Released connection (0)
Tue Jul  7 18:44:59 2015 : Debug:  } # modules

```

3) I used this approach to testing.
```
update {
   &reply:Reply-Message += "NAS Info: nasname=%{client:ipaddr}, shortname=%{client:shortname}, nas_type=%{client    :nas_type}, secret=%{client:secret}"                                                                                    
}
updated
```

4) And... the result is:

```
$ echo "User-Name = 'bob'" | /opt/prefix/bin/radclient 10.1.2.128 auth caipirinha123 -x
Sent Access-Request Id 29 from 0.0.0.0:55083 to 10.1.2.128:1812 length 25
	User-Name = "bob"
Received Access-Accept Id 29 from 10.1.2.128:1812 to 0.0.0.0:0 length 110
	Reply-Message = "NAS Info: nasname=10.1.2.128, shortname=cliente-sql1 nas_type=alcatel, secret=caipirinha123"
$
```

Fixed! :+1: 