### PR TITLE
dhcp secs is a short

### DIFF
--- a/src/modules/proto_dhcp/dhcp.c
+++ b/src/modules/proto_dhcp/dhcp.c
@@ -1608,6 +1608,7 @@ int fr_dhcp_encode(RADIUS_PACKET *packet)
 	vp_cursor_t	cursor;
 	VALUE_PAIR	*vp;
 	uint32_t	lvalue;
+	uint16_t	svalue;
 	size_t		dhcp_size;
 	ssize_t		len;
 #ifndef NDEBUG
@@ -1717,8 +1718,8 @@ int fr_dhcp_encode(RADIUS_PACKET *packet)
 
 	/* DHCP-Number-of-Seconds */
 	if ((vp = fr_pair_find_by_num(packet->vps, 261, DHCP_MAGIC_VENDOR, TAG_ANY))) {
-		lvalue = htonl(vp->vp_integer);
-		memcpy(p, &lvalue, 2);
+		svalue = htons(vp->vp_short);
+		memcpy(p, &svalue, 2);
 	}
 	p += 2;
 


### PR DESCRIPTION
Properly encode DHCP field "secs" (using htons instead of htonl).

Also I think in this case using "vp_short" is more correct than
"vp_integer" for a short (even though it still works with "vp_integer").