### PR TITLE
Add NULL check in originate-coa

### DIFF
--- a/src/main/map.c
+++ b/src/main/map.c
@@ -1075,7 +1075,10 @@ int map_to_request(REQUEST *request, vp_map_t const *map, radius_map_getvalue_t 
 	 */
 	if (((map->lhs->tmpl_list == PAIR_LIST_COA) ||
 	     (map->lhs->tmpl_list == PAIR_LIST_DM)) && !request->coa) {
-		request_alloc_coa(context);
+		if (!request_alloc_coa(context)) {
+			REDEBUG("Failed to create a CoA/Disconnect Request message");
+			return -2;
+		}
 		context->coa->proxy->code = (map->lhs->tmpl_list == PAIR_LIST_COA) ?
 					    PW_CODE_COA_REQUEST :
 					    PW_CODE_DISCONNECT_REQUEST;


### PR DESCRIPTION
This prevents segfaults that may occur when the COA list could not be created, either by a lack of memory, or a request that is not an Access-Request/Accounting-Request.

Easiest way to reproduce:

Create a CoA request from the coa virtual server
```
server coa {
  recv-coa {
    update coa {
      &NAS-IP-Address = '127.0.0.1'
    }
  }
}
```

Then, send some CoA packet to this server
```
echo 'User-Name = test' | radclient 127.0.0.1:3799 coa testing123
```

The segfault occurs because creating CoA packets is only supported for {Access,Accounting}-Request messages (which is also documented). It may also happen when there is a lack of memory and the talloc call fails, but that is harder to test.