### PR TITLE
Use define for Service-Type value check

### DIFF
--- a/src/include/radius.h
+++ b/src/include/radius.h
@@ -130,6 +130,7 @@ typedef enum {
 #define PW_NAS_PROMPT_USER		7
 #define PW_AUTHENTICATE_ONLY		8
 #define PW_CALLBACK_NAS_PROMPT		9
+#define PW_AUTHORIZE_ONLY		17
 
 /*	Framed Protocols	*/
 

--- a/src/main/listen.c
+++ b/src/main/listen.c
@@ -1779,7 +1779,7 @@ int rad_coa_recv(REQUEST *request)
 		 */
 		vp = fr_pair_find_by_num(request->packet->vps, PW_SERVICE_TYPE, 0, TAG_ANY);
 		if (request->packet->code == PW_CODE_COA_REQUEST) {
-			if (vp && (vp->vp_integer == 17)) {
+			if (vp && (vp->vp_integer == PW_AUTHORIZE_ONLY)) {
 				vp = fr_pair_find_by_num(request->packet->vps, PW_STATE, 0, TAG_ANY);
 				if (!vp || (vp->vp_length == 0)) {
 					REDEBUG("CoA-Request with Service-Type = Authorize-Only MUST contain a State attribute");


### PR DESCRIPTION
The value 17 (Authorize-Only) has been added in RFC3576, the other values were already present in RFC 2865, most likely that's the reason the symbolic name was missing.