### PR TITLE
Fix compile error with GCC 4.8 and higher

### DIFF
--- a/src/modules/rlm_yubikey/validate.c
+++ b/src/modules/rlm_yubikey/validate.c
@@ -34,7 +34,7 @@ static int _mod_conn_free(ykclient_handle_t **yandle)
  * @see fr_connection_create_t
  * @see connection.c
  */
-static void *mod_conn_create(TALLOC_CTX *ctx, void *instance, UNUSED struct const timeval *timeout)
+static void *mod_conn_create(TALLOC_CTX *ctx, void *instance, UNUSED struct timeval const *timeout)
 {
 	rlm_yubikey_t *inst = instance;
 	ykclient_rc status;


### PR DESCRIPTION
```
src/modules/rlm_yubikey/validate.c:37:77: error: expected ‘{’ before ‘const’
 static void *mod_conn_create(TALLOC_CTX *ctx, void *instance, UNUSED struct const timeval *timeout)
                                                                             ^
src/modules/rlm_yubikey/validate.c: In function ‘rlm_yubikey_ykclient_init’:
src/modules/rlm_yubikey/validate.c:135:58: error: ‘mod_conn_create’ undeclared (first use in this function)
  inst->pool = fr_connection_pool_module_init(conf, inst, mod_conn_create, NULL, prefix);
                                                          ^
src/modules/rlm_yubikey/validate.c:135:58: note: each undeclared identifier is reported only once for each function it appears in
src/modules/rlm_yubikey/validate.c: At top level:
src/modules/rlm_yubikey/validate.c:20:12: warning: ‘_mod_conn_free’ defined but not used [-Wunused-function]
 static int _mod_conn_free(ykclient_handle_t **yandle)
            ^
scripts/boiler.mk:630: recipe for target 'build/objs/src/modules/rlm_yubikey/validate.lo' failed
make: *** [build/objs/src/modules/rlm_yubikey/validate.lo] Error 1
```