### PR TITLE
Prototype string escaping API for rlm_sql

### DIFF
--- a/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c
@@ -712,7 +712,7 @@ static int sql_affected_rows(rlm_sql_handle_t *handle, UNUSED rlm_sql_config_t *
 
 static size_t sql_escape_string(rlm_sql_handle_t *handle,
 			UNUSED rlm_sql_config_t *config, char *out, size_t outlen,
-			char const *in, UNUSED void *arg)
+			char const *in)
 {
 	size_t qlen;
 	rlm_sql_mysql_conn_t *conn = handle->conn;
@@ -720,6 +720,8 @@ static size_t sql_escape_string(rlm_sql_handle_t *handle,
 	/* Check for potential buffer overflow */
 	qlen = strlen(in);
 	if ((qlen * 2 + 1) > outlen) return 0;
+	/* Prevent integer overflow */
+	if ((qlen * 2 + 1) <= qlen) return 0;
 	return mysql_real_escape_string(conn->sock, out, in, qlen);
 }
 

--- a/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c
@@ -710,6 +710,19 @@ static int sql_affected_rows(rlm_sql_handle_t *handle, UNUSED rlm_sql_config_t *
 	return mysql_affected_rows(conn->sock);
 }
 
+static size_t sql_escape_string(rlm_sql_handle_t *handle,
+			UNUSED rlm_sql_config_t *config, char *out, size_t outlen,
+			char const *in, UNUSED void *arg)
+{
+	size_t qlen;
+	rlm_sql_mysql_conn_t *conn = handle->conn;
+
+	/* Check for potential buffer overflow */
+	qlen = strlen(in);
+	if ((qlen * 2 + 1) > outlen) return 0;
+	return mysql_real_escape_string(conn->sock, out, in, qlen);
+}
+
 
 /* Exported to rlm_sql */
 extern rlm_sql_module_t rlm_sql_mysql;
@@ -729,5 +742,6 @@ rlm_sql_module_t rlm_sql_mysql = {
 	.sql_free_result		= sql_free_result,
 	.sql_error			= sql_error,
 	.sql_finish_query		= sql_finish_query,
-	.sql_finish_select_query	= sql_finish_query
+	.sql_finish_select_query	= sql_finish_query,
+	.sql_escape_string		= sql_escape_string
 };

--- a/src/modules/rlm_sql/drivers/rlm_sql_postgresql/rlm_sql_postgresql.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_postgresql/rlm_sql_postgresql.c
@@ -507,7 +507,7 @@ static int sql_affected_rows(rlm_sql_handle_t * handle, UNUSED rlm_sql_config_t 
 
 static size_t sql_escape_string(rlm_sql_handle_t *handle,
 			UNUSED rlm_sql_config_t *config, char *out, size_t outlen,
-			char const *in, UNUSED void *arg)
+			char const *in)
 {
 	int err;
 	size_t qlen;
@@ -516,6 +516,8 @@ static size_t sql_escape_string(rlm_sql_handle_t *handle,
 	/* Check for potential buffer overflow */
 	qlen = strlen(in);
 	if ((qlen * 2 + 1) > outlen) return 0;
+	/* Prevent integer overflow */
+	if ((qlen * 2 + 1) <= qlen) return 0;
 	qlen = PQescapeStringConn(conn->db, out, in, qlen, &err);
 	if (err) return 0;
 	return qlen;

--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -618,7 +618,7 @@ static size_t sql_string_escape_func(UNUSED REQUEST *request, char *out,
 	rlm_sql_handle_t *handle = arg;
 	rlm_sql_t *inst = handle->inst;
 
-	rc = inst->module->sql_escape_string(handle, inst->config, out, outlen, in, arg);
+	rc = inst->module->sql_escape_string(handle, inst->config, out, outlen, in);
 	out[rc] = '\0';
 	return rc;
 }

--- a/src/modules/rlm_sql/rlm_sql.h
+++ b/src/modules/rlm_sql/rlm_sql.h
@@ -212,7 +212,7 @@ typedef struct rlm_sql_module_t {
 	sql_rcode_t (*sql_finish_query)(rlm_sql_handle_t *handle, rlm_sql_config_t *config);
 	sql_rcode_t (*sql_finish_select_query)(rlm_sql_handle_t *handle, rlm_sql_config_t *config);
 
-	size_t (*sql_escape_string)(rlm_sql_handle_t *handle, rlm_sql_config_t *config, char *out, size_t outlen, char const *in, void *arg);
+	size_t (*sql_escape_string)(rlm_sql_handle_t *handle, rlm_sql_config_t *config, char *out, size_t outlen, char const *in);
 } rlm_sql_module_t;
 
 struct sql_inst {

--- a/src/modules/rlm_sql/rlm_sql.h
+++ b/src/modules/rlm_sql/rlm_sql.h
@@ -211,6 +211,8 @@ typedef struct rlm_sql_module_t {
 
 	sql_rcode_t (*sql_finish_query)(rlm_sql_handle_t *handle, rlm_sql_config_t *config);
 	sql_rcode_t (*sql_finish_select_query)(rlm_sql_handle_t *handle, rlm_sql_config_t *config);
+
+	size_t (*sql_escape_string)(rlm_sql_handle_t *handle, rlm_sql_config_t *config, char *out, size_t outlen, char const *in, void *arg);
 } rlm_sql_module_t;
 
 struct sql_inst {
@@ -228,6 +230,7 @@ struct sql_inst {
 
 	int (*sql_set_user)(rlm_sql_t *inst, REQUEST *request, char const *username);
 	size_t (*sql_escape_func)(REQUEST *, char *out, size_t outlen, char const *in, void *arg);
+	size_t (*sql_string_escape_func)(REQUEST *, char *out, size_t outlen, char const *in, void *arg);
 	sql_rcode_t (*sql_query)(rlm_sql_t *inst, REQUEST *request, rlm_sql_handle_t **handle, char const *query);
 	sql_rcode_t (*sql_select_query)(rlm_sql_t *inst, REQUEST *request, rlm_sql_handle_t **handle, char const *query);
 	sql_rcode_t (*sql_fetch_row)(rlm_sql_row_t *out, rlm_sql_t *inst, REQUEST *request, rlm_sql_handle_t **handle);

--- a/src/modules/rlm_sqlippool/rlm_sqlippool.c
+++ b/src/modules/rlm_sqlippool/rlm_sqlippool.c
@@ -284,7 +284,7 @@ static int sqlippool_command(char const * fmt, rlm_sql_handle_t * handle, rlm_sq
 	 */
 	sqlippool_expand(query, sizeof(query), fmt, data, param, param_len);
 
-	if (radius_axlat(&expanded, request, query, data->sql_inst->sql_escape_func, data->sql_inst) < 0) {
+	if (radius_axlat(&expanded, request, query, data->sql_inst->sql_string_escape_func, handle) < 0) {
 		return -1;
 	}
 
@@ -329,7 +329,7 @@ static int CC_HINT(nonnull (1, 3, 4, 5)) sqlippool_query1(char *out, int outlen,
 	/*
 	 *	Do an xlat on the provided string
 	 */
-	if (radius_axlat(&expanded, request, query, data->sql_inst->sql_escape_func, data->sql_inst) < 0) {
+	if (radius_axlat(&expanded, request, query, data->sql_inst->sql_string_escape_func, handle) < 0) {
 		return 0;
 	}
 	retval = data->sql_inst->sql_select_query(data->sql_inst, request, &handle, expanded);


### PR DESCRIPTION
I'm currently trying to port our custom GPL'ed FreeRADIUS module to 3.x. In addition to updating it to work on newer versions I tried to convert it from using our own half-assed SQL abstraction layer to rlm_sql's (using rlm_sqlhpwippool as an inspiration). While doing that I noticed that there are no DB-specific mechanisms to escape strings for use in DB queries (sql_escape_func is too strict and doesn't know about DB escaping rules).

So my question is - is it ok for me to extend rlm_sql with DB-specific string escaping API, and if so, what are your suggestions and requirements for such an API?

One thing to consider is that data-string-escaping and identifier-string-escaping follow different rules in several DBs.

This pull request is a prototype implementation of such an API. It consists of:
* New function pointer in ```rlm_sql``` module instance (```sql_string_escape_func```). It has the same signature as ```sql_escape_func```, so it can be used as an xlat escape.
* It defaults to ```sql_escape_func```.
* If a driver implements ```sql_escape_string``` method, it gets used instead.

Please send comments, criticism and flames my way. Thanks.