### PR TITLE
Optionally send rejects without a delay

### DIFF
--- a/src/main/process.c
+++ b/src/main/process.c
@@ -1160,8 +1160,6 @@ static void request_response_delay(REQUEST *request, int action)
 	case FR_ACTION_TIMER:
 		fr_event_now(el, &now);
 
-		rad_assert(request->response_delay.tv_sec > 0);
-
 		/*
 		 *	See if it's time to send the reply.  If not,
 		 *	we wait some more.


### PR DESCRIPTION
Currently there is only one global option to set a delay to every Access-Reject packet: reject_delay. There are use cases where you want certain rejects to have no delay, while others should have a delay. An example might be using 802.1X on Cisco LAN Devices: If a client tries MAC authentication an Access-Reject can force it to switch to 802.1X, this is a reject you want to send without any delay. On the other hand, if the client tries 802.1X with a wrong password, you still want the reject to be delayed.

The config option reject_delay can be bypassed by adding the attribute No-Reject-Delay to control, and setting it to a value larger than 0. Setting it to 0 or not adding it results in the old behaviour.

The implementation is the simplest version I could think of. A more advanced version could read the delay time from the VP, instead of using it as a boolean. This would require that all the sanity checks that are currently in mainconfig.c should be copied here as well (or made more generic).