### PR TITLE
Remove second entry of Error-Cause in Access-Reject filter

### DIFF
--- a/raddb/mods-config/attr_filter/access_reject
+++ b/raddb/mods-config/attr_filter/access_reject
@@ -17,5 +17,4 @@ DEFAULT
 	MS-CHAP-Error =* ANY,
 	Proxy-State =* ANY,
 	FreeRADIUS-Response-Delay =* ANY,
-	FreeRADIUS-Response-Delay-USec =* ANY,
-	Error-Cause =* ANY
+	FreeRADIUS-Response-Delay-USec =* ANY


### PR DESCRIPTION
This is effectively a revert of commit caaca8da2eede537270a711742cc99f0ba854eb1.