### PR TITLE
Fixed bug: It should return CoA-NAK when the home-server is invalid.

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -23,6 +23,8 @@ FreeRADIUS 3.0.10 Wed 08 Jul 2015 12:00:00 EDT urgency=medium
 	* Documentation fixes from Alan Buxey and Matthew Newton.
 
 	Bug fixes
+	* Fix home-server, It should return CoA-NAK when the Home-Server-Pool
+	  is invalid.
 	* Fix rlm_files so that there are no collisions when loading
 	  10's of 1000's of users.
 	* Fix radclient to use our internal v4/v6 parsing functions.

--- a/src/main/listen.c
+++ b/src/main/listen.c
@@ -1771,7 +1771,6 @@ int rad_coa_recv(REQUEST *request)
 		case RLM_MODULE_REJECT:
 		case RLM_MODULE_USERLOCK:
 		default:
-			request->reply->code = nak;
 			break;
 
 		case RLM_MODULE_HANDLED:
@@ -1781,11 +1780,14 @@ int rad_coa_recv(REQUEST *request)
 		case RLM_MODULE_NOTFOUND:
 		case RLM_MODULE_OK:
 		case RLM_MODULE_UPDATED:
-			if (do_proxy(request)) return RLM_MODULE_OK;
-			request->reply->code = ack;
+			if (do_proxy(request)) {
+			    request->reply->code = ack;
+			    return RLM_MODULE_OK;
+			}
 			break;
 		}
 
+		request->reply->code = nak;
 	}
 
 #ifdef WITH_PROXY


### PR DESCRIPTION
When we have a wrong home-server

```
update control {
       &Home-Server-Pool := "coa_pool_wrongset"
}
```

the server currently return

````
Tue Sep 15 19:23:12 2015 : ERROR: (5) Cannot proxy to unknown pool coa_pool_wrongset
Tue Sep 15 19:23:12 2015 : Debug: (5) Empty send-coa section.  Using default return values.
Tue Sep 15 19:23:12 2015 : Debug: (1) Sent CoA-ACK Id 215 from 192.168.1.90:3799 to 10.1.2.128:41165 length 0

```

And after the patch, fix this issue.

```
Tue Sep 15 19:53:35 2015 : ERROR: (1) Cannot proxy to unknown pool coa_pool_wrongset
Tue Sep 15 19:53:35 2015 : Debug: (1) Empty send-coa section.  Using default return values.
Tue Sep 15 19:53:35 2015 : Debug: (1) Sent CoA-NAK Id 225 from 192.168.18.90:3799 to 10.1.2.128:41160 length 0
```