### PR TITLE
if has a wrong client-settings, don't rise!

### DIFF
--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -272,6 +272,7 @@ static int generate_sql_clients(rlm_sql_t *inst)
 	rlm_sql_handle_t *handle;
 	rlm_sql_row_t row;
 	unsigned int i = 0;
+	int ret = 0;
 	RADCLIENT *c;
 
 	DEBUG("rlm_sql (%s): Processing generate_sql_clients",
@@ -340,7 +341,8 @@ static int generate_sql_clients(rlm_sql_t *inst)
 			WARN("Failed to add client, possible duplicate?");
 
 			client_free(c);
-			continue;
+			ret = -1;
+			break;
 		}
 
 		DEBUG("rlm_sql (%s): Client \"%s\" (%s) added", c->longname, c->shortname,
@@ -350,7 +352,7 @@ static int generate_sql_clients(rlm_sql_t *inst)
 	(inst->module->sql_finish_select_query)(handle, inst->config);
 	fr_connection_release(inst->pool, handle);
 
-	return 0;
+	return ret;
 }
 
 


### PR DESCRIPTION
Hi,

if you make a mistake in client-settings, the current code let you start the FreeRadius. this is REALLY BAD.... induce to a error! below a example that a client "nas-portal" was pointed to a wrong server...

```
Thu Sep 17 11:43:19 2015 : Debug: rlm_sql (sql): Adding client 192.168.22.11 (nas-portal) to mcare-portal-auth+acct clients list
Thu Sep 17 11:43:19 2015 : Debug: Adding client 192.168.22.11/32 (192.168.22.11) to prefix tree 32
Thu Sep 17 11:43:19 2015 : Error: Failed to find virtual server mcare-portal-auth+acct
Thu Sep 17 11:43:19 2015 : Warning: Failed to add client, possible duplicate?
```

It is bad... really bad if happens in production setup. if something wrong, don't rise! let me know that has something wrong. :)

after patch... more easy to "discover" a wrong set.
```
Thu Sep 17 12:37:56 2015 : Debug: Adding client 192.168.22.11/32 (192.168.22.11) to prefix tree 32
Thu Sep 17 12:37:56 2015 : Error: Failed to find virtual server mcare-portal-auth+acct
Thu Sep 17 12:37:56 2015 : Warning: Failed to add client, possible duplicate?
Thu Sep 17 12:37:56 2015 : Debug: rlm_sql (sql): Released connection (0)
Thu Sep 17 12:37:56 2015 : Error: Failed to load clients from SQL
Thu Sep 17 12:37:56 2015 : Error: /etc/freeradius/mods-enabled/sql[20]: Instantiation failed for module "sql"