### PR TITLE
Fix man errors

### DIFF
--- a/man/man5/rlm_passwd.5
+++ b/man/man5/rlm_passwd.5
@@ -75,7 +75,7 @@ added as a control attribute list.
 .PP
 To add an attribute to the RADIUS request (as though it had been sent
 by the NAS), prefix the attribute name in the "format" string with the
-\'~' character.
+\(aq~' character.
 .PP
 To add an attribute to the RADIUS reply (to be sent back to the NAS),
 prefix the attribute name in the "format" string with the '='

--- a/man/man5/unlang.5
+++ b/man/man5/unlang.5
@@ -444,7 +444,7 @@ true.  Valid comparison operators are "==", "!=", "<", "<=", ">",
 ">=", "=~", and "!~", all with their usual meanings.  Invalid
 comparison operators are ":=" and "=".
 .RE
-.IP Attribute Comparisons
+.IP Attribute\ Comparisons
 .DS
 	(&User-Name == "foo")
 .DE
@@ -454,7 +454,7 @@ evaluates to true if the comparison holds true.  The comparison is
 done by printing the attribute to a string, and then doing a string
 comparison of the two sides of the condition.
 .RE
-.IP Inter-Attribute Comparisons
+.IP Inter-Attribute\ Comparisons
 .DS
 	(&User-Name == &Filter-Id)
 .DE

--- a/man/man8/radmin.8
+++ b/man/man8/radmin.8
@@ -77,7 +77,7 @@ enclosed in double-quotes must have back-slashes and the quotation
 marks escaped inside of the string.
 
 Only one debug condition can be active at a time.
-.IP debug\ condition\ '((User-Name\ ==\ "bob")\ ||\ (Packet-Src-IP-Address\ ==\ 192.0.2.22))'
+.IP "debug condition '((User-Name == ""bob"") || (Packet-Src-IP-Address == 192.0.2.22))'"
 A more complex condition that enables debugging output for requests
 containing User-Name "bob", or requests that originate from source IP
 address 192.0.2.22.

--- a/man/man8/radsniff.8
+++ b/man/man8/radsniff.8
@@ -54,9 +54,9 @@ Read packets from filename.
 Print packet headers only, not contents.
 .IP \-p\ \fIport\fP
 \tListen for packets on port.
-.IP \-r\ \fIresponse filter\fP
+.IP \-r\ \fIresponse\ filter\fP
 RADIUS attribute request filter.
-.IP \-R\ \fIrequest filter\fP
+.IP \-R\ \fIrequest\ filter\fP
 RADIUS attribute response filter.
 .IP \-s\ \fIsecret\fP
 RADIUS secret.


### PR DESCRIPTION
Minor fixes to man pages to eliminate groff warnings (and hence lintian warnings)