### PR TITLE
Show the name of virtual-server

### DIFF
--- a/src/main/modules.c
+++ b/src/main/modules.c
@@ -975,8 +975,14 @@ rlm_rcode_t indexed_modcall(rlm_components_t comp, int idx, REQUEST *request)
 
 	if (idx == 0) {
 		list = server->mc[comp];
-		if (!list) RDEBUG3("Empty %s section.  Using default return values.", section_type_value[comp].section);
-
+		if (!list) {
+			if (server->name) {
+				RDEBUG3("Empty %s section in virtual server \"%s\".  Using default return values.",
+					section_type_value[comp].section, server->name);
+			} else {
+				RDEBUG3("Empty %s section.  Using default return values.", section_type_value[comp].section);
+			}
+		}
 	} else {
 		indexed_modcallable *this;
 


### PR DESCRIPTION
Currently, we don't show the name of virtual-server. It's terrible to troubleshootin.

```
Mon Sep 21 23:25:05 2015 : Debug: (1) Received CoA-Request Id 200 from 10.1.2.128:54283 to 192.168.56.90:3799 length 187
Mon Sep 21 23:25:05 2015 : Debug: (1)   Acct-Session-Id = "AB818B0000132A55FB8749"
Mon Sep 21 23:25:05 2015 : Debug: (1)   Session-Timeout = 180
Mon Sep 21 23:26:53 2015 : Debug: (1) Empty recv-coa section.  Using default return values.
Mon Sep 21 23:26:58 2015 : Debug: (1) Empty send-coa section.  Using default return values.
```

after patch... MUCH better!!

```
Mon Sep 21 23:40:42 2015 : Debug: (0) Received CoA-Request Id 243 from 10.1.2.128:44088 to 192.168.56.90:3799 length 187
Mon Sep 21 23:40:42 2015 : Debug: (0)   Acct-Session-Id = "AB818B0000132A55FB8749"
Mon Sep 21 23:40:42 2015 : Debug: (0)   Session-Timeout = 180
Mon Sep 21 23:40:42 2015 : Debug: (0) Empty recv-coa section in virtual server "mcare-nas-alcatel".  Using default return values.
Mon Sep 21 23:40:42 2015 : Debug: (0) Empty send-coa section in virtual server "mcare-nas-alcatel".  Using default return values.
Mon Sep 21 23:40:42 2015 : Debug: (0) Sent CoA-ACK Id 243 from 192.168.56.90:3799 to 10.1.2.128:44088 length 0
Mon Sep 21 23:40:42 2015 : Debug: (0) Finished request
Mon Sep 21 23:40:42 2015 : Debug: Waking up in 4.9 seconds.
```