### PR TITLE
debian package fails trying to build sqlhpwippool

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -63,6 +63,7 @@ include /usr/share/quilt/quilt.make
 
 config.status: configure
 	dh_testdir
+	dh_testroot
 
 ifeq (config.sub.dist,$(wildcard config.sub.dist))
 	rm config.sub


### PR DESCRIPTION
Fails trying to run "configure" in src/modules/rlm_sqlhpwippool at make time,
but having disabled it in configure, it all builds fine, including sqlhpwippool...

Probably wants reviewing to make sure this is sane - system here is debian wheezy, so maybe it's fine on jessie, but I can't easily test right now.