### PR TITLE
Include session-state in rlm_perl

### DIFF
--- a/raddb/mods-config/perl/example.pl
+++ b/raddb/mods-config/perl/example.pl
@@ -34,7 +34,7 @@ use warnings;
 use Data::Dumper;
 
 # Bring the global hashes into the package scope
-our (%RAD_REQUEST, %RAD_REPLY, %RAD_CONFIG);
+our (%RAD_REQUEST, %RAD_REPLY, %RAD_CONFIG, %RAD_STATE);
 
 # This is hash wich hold original request from radius
 #my %RAD_REQUEST;
@@ -42,6 +42,8 @@ our (%RAD_REQUEST, %RAD_REPLY, %RAD_CONFIG);
 #my %RAD_REPLY;
 #This is for config items (was %RAD_CHECK in earlier versions)
 #my %RAD_CONFIG;
+# This is the session-sate
+#my %RAD_STATE;
 # This is configuration items from "config" perl module configuration section
 #my %RAD_PERLCONF;
 

--- a/src/modules/rlm_perl/rlm_perl.c
+++ b/src/modules/rlm_perl/rlm_perl.c
@@ -792,6 +792,7 @@ static int do_perl(void *instance, REQUEST *request, char const *function_name)
 	HV		*rad_reply_hv;
 	HV		*rad_config_hv;
 	HV		*rad_request_hv;
+	HV		*rad_state_hv;
 #ifdef WITH_PROXY
 	HV		*rad_request_proxy_hv;
 	HV		*rad_request_proxy_reply_hv;
@@ -828,10 +829,12 @@ static int do_perl(void *instance, REQUEST *request, char const *function_name)
 		rad_reply_hv = get_hv("RAD_REPLY", 1);
 		rad_config_hv = get_hv("RAD_CONFIG", 1);
 		rad_request_hv = get_hv("RAD_REQUEST", 1);
+		rad_state_hv = get_hv("RAD_STATE", 1);
 
 		perl_store_vps(request->packet, request, &request->packet->vps, rad_request_hv, "RAD_REQUEST", "request");
 		perl_store_vps(request->reply, request, &request->reply->vps, rad_reply_hv, "RAD_REPLY", "reply");
 		perl_store_vps(request, request, &request->config, rad_config_hv, "RAD_CONFIG", "control");
+		perl_store_vps(request, request, &request->state, rad_state_hv, "RAD_STATE", "session-state");
 
 #ifdef WITH_PROXY
 		rad_request_proxy_hv = get_hv("RAD_REQUEST_PROXY",1);
@@ -907,6 +910,12 @@ static int do_perl(void *instance, REQUEST *request, char const *function_name)
 		if ((get_hv_content(request, request, rad_config_hv, &vp, "RAD_CONFIG", "control")) == 0) {
 			fr_pair_list_free(&request->config);
 			request->config = vp;
+			vp = NULL;
+		}
+
+		if ((get_hv_content(request, request, rad_state_hv, &vp, "RAD_STATE", "session-state")) == 0) {
+			fr_pair_list_free(&request->state);
+			request->state = vp;
 			vp = NULL;
 		}
 


### PR DESCRIPTION
Via the new variable %RAD_STATE.

We already copied request, reply and control to the perl script, so why not include session-state as well.