### PR TITLE
Exclude rlm_cache_redis.so from freeradius package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -169,7 +169,7 @@ install-arch: build-arch-stamp
 	done
 
 	dh_install --sourcedir=$(freeradius_dir) -p freeradius-utils
-	dh_install --sourcedir=$(freeradius_dir) -p freeradius
+	dh_install --sourcedir=$(freeradius_dir) -p freeradius -Xusr/lib/freeradius/rlm_cache_redis.so
 
 	dh_strip -a --dbg-package=freeradius-dbg
 


### PR DESCRIPTION
Exclude rlm_cache_redis.so from freeradius package to avoid conflict with freeradius-redis