### PR TITLE
debian packaging updates

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,8 @@ Build-Depends: debhelper (>= 9),
  libtalloc-dev,
  libwbclient-dev,
  libyubikey-dev,
+ libmemcached-dev,
+ libhiredis-dev,
  python-dev
 Section: net
 Priority: optional
@@ -148,6 +150,20 @@ Depends: freeradius (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}, $
 Description: iODBC module for FreeRADIUS server
  The FreeRADIUS server can use iODBC to access databases to authenticate users
  and do accounting, and this module is necessary for that.
+
+Package: freeradius-redis
+Architecture: any
+Depends: freeradius (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends}
+Description: Redis module for FreeRADIUS server
+ This module is required to enable the FreeRADIUS server to access
+ Redis databases.
+
+Package: freeradius-memcached
+Architecture: any
+Depends: freeradius (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends}
+Description: Memcached module for FreeRADIUS server
+ The FreeRADIUS server can cache data in memcached and this package
+ contains the required module.
 
 Package: freeradius-dbg
 Architecture: any

--- a/debian/control
+++ b/debian/control
@@ -57,7 +57,7 @@ Description: FreeRADIUS common files
 
 Package: freeradius-config
 Architecture: any
-Depends: freeradius-common (>= 3), ${misc:Depends}
+Depends: freeradius-common (>= 3), ${misc:Depends}, openssl
 Breaks: freeradius-config
 Description: FreeRADIUS default config files
  This package should be used as a base for a site local packages

--- a/debian/control
+++ b/debian/control
@@ -38,13 +38,14 @@ Architecture: any
 Depends: lsb-base (>= 3.1-23.2), ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends}, freeradius-common, freeradius-config, libfreeradius3 (= ${binary:Version}), ssl-cert, adduser
 Provides: radius-server
 Recommends: freeradius-utils
-Suggests: freeradius-ldap, freeradius-postgresql, freeradius-mysql, freeradius-krb5
+Suggests: freeradius-ldap, freeradius-postgresql, freeradius-mysql, freeradius-krb5, snmp
 Description: high-performance and highly configurable RADIUS server
  FreeRADIUS is a high-performance RADIUS server with support for:
-  - Many vendor-specific attributes.
+  - Authentication by local files, SQL, Kerberos, LDAP, PAM, and more.
+  - Powerful policy configuration language.
   - Proxying and replicating requests by any criteria.
-  - Authentication on system passwd, SQL, Kerberos, LDAP, users file, or PAM.
-  - Multiple DEFAULT configurations.
+  - Support for many EAP types; TLS, PEAP, TTLS, etc.
+  - Many vendor-specific attributes.
   - Regexp matching in string attributes.
  and lots more.
 

--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Build-Depends: debhelper (>= 9),
  libtalloc-dev,
  libwbclient-dev,
  libyubikey-dev,
+ libykclient-dev,
  libmemcached-dev,
  libhiredis-dev,
  python-dev
@@ -165,6 +166,13 @@ Depends: freeradius (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}, $
 Description: Memcached module for FreeRADIUS server
  The FreeRADIUS server can cache data in memcached and this package
  contains the required module.
+
+Package: freeradius-yubikey
+Architecture: any
+Depends: freeradius (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends}
+Description: Yubikey module for FreeRADIUS server
+ This package is required to add Yubikey functionality to the
+ FreeRADIUS server.
 
 Package: freeradius-dbg
 Architecture: any

--- a/debian/freeradius-memcached.install
+++ b/debian/freeradius-memcached.install
@@ -1,0 +1,1 @@
+usr/lib/freeradius/rlm_cache_memcached.so

--- a/debian/freeradius-memcached.lintian-overrides
+++ b/debian/freeradius-memcached.lintian-overrides
@@ -1,0 +1,1 @@
+freeradius-dhcp: binary-or-shlib-defines-rpath

--- a/debian/freeradius-memcached.postinst
+++ b/debian/freeradius-memcached.postinst
@@ -1,0 +1,19 @@
+#! /bin/sh
+
+set -e
+
+case "$1" in
+  configure)
+        if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
+          invoke-rc.d freeradius force-reload
+        else
+          /etc/init.d/freeradius force-reload
+        fi
+	;;
+esac
+
+#DEBHELPER#
+
+exit 0
+
+

--- a/debian/freeradius-redis.install
+++ b/debian/freeradius-redis.install
@@ -1,0 +1,1 @@
+usr/lib/freeradius/rlm_redis*.so

--- a/debian/freeradius-redis.lintian-overrides
+++ b/debian/freeradius-redis.lintian-overrides
@@ -1,0 +1,1 @@
+freeradius-dhcp: binary-or-shlib-defines-rpath

--- a/debian/freeradius-redis.postinst
+++ b/debian/freeradius-redis.postinst
@@ -1,0 +1,19 @@
+#! /bin/sh
+
+set -e
+
+case "$1" in
+  configure)
+        if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
+          invoke-rc.d freeradius force-reload
+        else
+          /etc/init.d/freeradius force-reload
+        fi
+	;;
+esac
+
+#DEBHELPER#
+
+exit 0
+
+

--- a/debian/freeradius-yubikey.install
+++ b/debian/freeradius-yubikey.install
@@ -1,0 +1,1 @@
+usr/lib/freeradius/rlm_yubikey.so

--- a/debian/freeradius-yubikey.lintian-overrides
+++ b/debian/freeradius-yubikey.lintian-overrides
@@ -1,0 +1,1 @@
+freeradius-dhcp: binary-or-shlib-defines-rpath

--- a/debian/freeradius-yubikey.postinst
+++ b/debian/freeradius-yubikey.postinst
@@ -1,0 +1,19 @@
+#! /bin/sh
+
+set -e
+
+case "$1" in
+  configure)
+        if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
+          invoke-rc.d freeradius force-reload
+        else
+          /etc/init.d/freeradius force-reload
+        fi
+	;;
+esac
+
+#DEBHELPER#
+
+exit 0
+
+

--- a/debian/rules
+++ b/debian/rules
@@ -29,7 +29,7 @@ logdir          = /var/log/$(package)
 pkgdocdir       = /usr/share/doc/$(package)
 raddbdir        = /etc/$(package)
 
-modulelist=krb5 ldap sql_mysql sql_iodbc sql_postgresql dhcp redis
+modulelist=krb5 ldap sql_mysql sql_iodbc sql_postgresql dhcp redis yubikey
 pkgs=$(shell dh_listpackages)
 
 # This has to be exported to make some magic below work.

--- a/debian/rules
+++ b/debian/rules
@@ -29,7 +29,7 @@ logdir          = /var/log/$(package)
 pkgdocdir       = /usr/share/doc/$(package)
 raddbdir        = /etc/$(package)
 
-modulelist=krb5 ldap sql_mysql sql_iodbc sql_postgresql dhcp
+modulelist=krb5 ldap sql_mysql sql_iodbc sql_postgresql dhcp redis
 pkgs=$(shell dh_listpackages)
 
 # This has to be exported to make some magic below work.
@@ -165,6 +165,9 @@ install-arch: build-arch-stamp
 	  dh_install --sourcedir=$(freeradius_dir) -p freeradius-$$pkg ; \
 	  rm -f $(freeradius_dir)/usr/lib/freeradius/rlm_$$mod*.so ; \
 	done
+
+	dh_install --sourcedir=$(freeradius_dir) -p freeradius-memcached
+	rm -f $(freeradius_dir)/usr/lib/freeradius/rlm_cache_memcached.so
 
 	dh_install --sourcedir=$(freeradius_dir) -p freeradius-utils
 	dh_install --sourcedir=$(freeradius_dir) -p freeradius

--- a/src/modules/rlm_cache/rlm_cache.c
+++ b/src/modules/rlm_cache/rlm_cache.c
@@ -715,7 +715,7 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 	if (!inst->handle) {
 		cf_log_err_cs(conf, "Could not link driver %s: %s", inst->driver_name, dlerror());
 		cf_log_err_cs(conf, "Make sure it (and all its dependent libraries!) are in the search path"
-			      "of your system's ld");
+			      " of your system's ld");
 		return -1;
 	}
 

--- a/src/modules/rlm_sql/drivers/rlm_sql_iodbc/configure
+++ b/src/modules/rlm_sql/drivers/rlm_sql_iodbc/configure
@@ -2812,7 +2812,7 @@ fi
 		fail="$fail libiodbc"
 	fi
 
-		smart_try_dir="$iodbc_include_dir /usr/local/iodbc/include"
+		smart_try_dir="$iodbc_include_dir /usr/include /usr/include/iodbc /usr/local/iodbc/include"
 
 
 ac_safe=`echo "isql.h" | sed 'y%./+-%__pm%'`

--- a/src/modules/rlm_sql/drivers/rlm_sql_iodbc/configure.ac
+++ b/src/modules/rlm_sql/drivers/rlm_sql_iodbc/configure.ac
@@ -64,7 +64,7 @@ if test x$with_[]modname != xno; then
 	fi
 
 	dnl Check for isql.h
-	smart_try_dir="$iodbc_include_dir /usr/local/iodbc/include"
+	smart_try_dir="$iodbc_include_dir /usr/include /usr/include/iodbc /usr/local/iodbc/include"
 	FR_SMART_CHECK_INCLUDE(isql.h)
 	if test "x$ac_cv_header_isql_h" != xyes; then
 		fail="$fail isql.h"


### PR DESCRIPTION
* build redis and memcached packages
* rlm_sql_iodbc is broken in jessie as isql.h moved - fixed
* add snmp as a suggests to freeradius pkg because the build suggests it
* add openssl as a depends on freeradius-config so it will install on its own
* move yubikey to separate package and build with ybclient

tested build, install and run successfully on wheezy, jessie and sid using sbuild.
