### PR TITLE
Fixed build for systems without support for 128 bit integers

### DIFF
--- a/src/include/missing-h
+++ b/src/include/missing-h
@@ -438,7 +438,8 @@ typedef struct int128_t {
 			uint64_t l;
 #endif
 		};
-	} int128_t;
+	};
+} int128_t;
 #  endif
 #else
 #  define HAVE_128BIT_INTEGERS


### PR DESCRIPTION
The build still fails, but at least it's a step in the right direction.