### PR TITLE
revert recent dh_testroot change

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -63,7 +63,6 @@ include /usr/share/quilt/quilt.make
 
 config.status: configure
 	dh_testdir
-	dh_testroot
 
 ifeq (config.sub.dist,$(wildcard config.sub.dist))
 	rm config.sub


### PR DESCRIPTION
Successfully enforced fakeroot in normal build, but then annoyingly fails in
sbuild which calls each build target separately and doesn't use fakeroot for
the build target.