### PR TITLE
Fix problem with Packet-Dst-Port and proxy-request list #1298

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -90,6 +90,8 @@ FreeRADIUS 3.0.10 Wed 08 Jul 2015 12:00:00 EDT urgency=medium
 	* Fix off by one error that caused some MSCHAP-Error messages to
 	  be sent without the password change version (V=3) and the textual
 	  message component (M=).
+	* Fix proxy to Packet-Dst-Port, so that it uses the correct
+	  destination port. Patch from Jorge Pereira
 
 FreeRADIUS 3.0.9 Wed 08 Jul 2015 12:00:00 EDT urgency=medium
 	Feature improvements

--- a/src/main/process.c
+++ b/src/main/process.c
@@ -2178,6 +2178,7 @@ static int insert_into_proxy_hash(REQUEST *request)
 	int tries;
 	bool success = false;
 	void *proxy_listener;
+	VALUE_PAIR *vp;
 
 	VERIFY_REQUEST(request);
 
@@ -2190,6 +2191,14 @@ static int insert_into_proxy_hash(REQUEST *request)
 	proxy_listener = NULL;
 	request->num_proxied_requests = 1;
 	request->num_proxied_responses = 0;
+
+	vp = fr_pair_find_by_num(request->proxy->vps, PW_PACKET_DST_PORT, 0, TAG_ANY);
+	if (vp) {
+		RDEBUG3("proxy: Found 'Packet-Dst-Port', Overriding the destination port %d by %d",
+						request->proxy->dst_port,
+						vp->vp_integer);
+		request->proxy->dst_port = vp->vp_integer;
+	}
 
 	for (tries = 0; tries < 2; tries++) {
 		rad_listen_t *this;


### PR DESCRIPTION
Hi,

Fix the question about the Packet-Dst-Port in proxy-request list. below, some evidences about that.

The setting...
```
.......................
server mcare-nas-radius-wifilabs {
     pre-proxy {
          update proxy-request {
              &Packet-Dst-Port := 1812
          }
     }
}
....................
```

if 'Packet-Dst-Port' exist in proxy-request, we will have a new message.
```
Sun Oct  4 23:58:06 2015 : Debug: (0) proxy: Found 'Packet-Dst-Port = 1812' in &proxy-request
Sun Oct  4 23:58:06 2015 : Debug: (0) proxy: Replacing the destination port 3799 by 1812
```

```
Sun Oct  4 23:58:06 2015 : Debug: (0) proxy: Trying to allocate ID (0/2)
Sun Oct  4 23:58:06 2015 : Debug: (0) proxy: request is now in proxy hash
Sun Oct  4 23:58:06 2015 : Debug: (0) proxy: allocating destination 10.11.19.2 port 1812 - Id 252
Sun Oct  4 23:58:06 2015 : Debug: (0) Proxying request to home server 10.11.19.2 port 1812 timeout 30.000000
Sun Oct  4 23:58:06 2015 : Debug: (0) Sent CoA-Request Id 252 from 0.0.0.0:54946 to 10.11.19.2:1812 length 38
Sun Oct  4 23:58:06 2015 : Debug: (0)   Acct-Session-Id = "12345"
Sun Oct  4 23:58:06 2015 : Debug: (0)   Session-Timeout = 180
Sun Oct  4 23:58:06 2015 : Debug: (0)   Proxy-State = 0x313338
Sun Oct  4 23:58:06 2015 : Debug: Waking up in 0.3 seconds.
Sun Oct  4 23:58:07 2015 : Proxy: (0) Marking home server 10.11.19.2 port 1812 alive
Sun Oct  4 23:58:07 2015 : Debug: (0) Clearing existing &reply: attributes
Sun Oct  4 23:58:07 2015 : Debug: (0) Received CoA-ACK Id 252 from 10.11.19.2:1812 to 192.168.56.90:54946 length 80
Sun Oct  4 23:58:07 2015 : Debug: (0)   Reply-Message = "AAA->NOKIA() listen::type=coa pack-type=(CoA-Request)"
Sun Oct  4 23:58:07 2015 : Debug: (0)   Proxy-State = 0x313338
Sun Oct  4 23:58:07 2015 : Debug: (0) server mcare-nas-radius-wifilabs {
Sun Oct  4 23:58:07 2015 : Debug: (0)   Empty post-proxy section in virtual server "mcare-nas-radius-wifilabs".  Using default return values.
Sun Oct  4 23:58:07 2015 : Debug: (0) }
Sun Oct  4 23:58:07 2015 : Debug: (0) Empty send-coa section in virtual server "mcare-nas-test".  Using default return values.
Sun Oct  4 23:58:07 2015 : Debug: (0) Sent CoA-ACK Id 138 from 192.168.56.90:3799 to 10.1.2.128:40378 length 0
Sun Oct  4 23:58:07 2015 : Debug: (0)   Reply-Message = "AAA->NOKIA() listen::type=coa pack-type=(CoA-Request)"
Sun Oct  4 23:58:07 2015 : Debug: (0) Finished request
Sun Oct  4 23:58:07 2015 : Debug: Waking up in 4.9 seconds.
```

Works very well and will help a lot the integrations with other Radius vendors that is out of standards! :+1: 