### PR TITLE
Correct SIGINT and SIGQUIT termination in debug mode

### DIFF
--- a/src/main/radiusd.c
+++ b/src/main/radiusd.c
@@ -476,15 +476,13 @@ int main(int argc, char *argv[])
 	 *  immediately.  Use SIGTERM to shut down the server cleanly in
 	 *  that case.
 	 */
-	if (main_config.debug_memory || (rad_debug_lvl == 0)) {
-		if ((fr_set_signal(SIGINT, sig_fatal) < 0)
+	if ((fr_set_signal(SIGINT, sig_fatal) < 0)
 #ifdef SIGQUIT
-		|| (fr_set_signal(SIGQUIT, sig_fatal) < 0)
+	|| (fr_set_signal(SIGQUIT, sig_fatal) < 0)
 #endif
-		) {
-			ERROR("%s", fr_strerror());
-			exit(EXIT_FAILURE);
-		}
+	) {
+		ERROR("%s", fr_strerror());
+		exit(EXIT_FAILURE);
 	}
 
 	/*


### PR DESCRIPTION
If server starts without -m  option, then SIGINT and SIGQUIT signal handlers doesn't init.

The -m option for memory cleanup then correctly processed in sig_fatal function.
