### PR TITLE
Add Arista-User-Priv-Level, Arista-User-Role and Arista-CVP-Role

### DIFF
--- a/share/dictionary.arista
+++ b/share/dictionary.arista
@@ -10,5 +10,8 @@ VENDOR		Arista				30065
 BEGIN-VENDOR	Arista
 
 ATTRIBUTE	Arista-AVPair			1	string
+ATTRIBUTE       Arista-User-Priv-Level          2       integer
+ATTRIBUTE       Arista-User-Role                3       string
+ATTRIBUTE       Arista-CVP-Role                 4       string
 
 END-VENDOR   Arista


### PR DESCRIPTION
This change adds a few more RADIUS VSA's for Arista Networks. A couple of months ago I submitted this dictionary which contains only the generic AVPair attribute, and here is an attempt to define more specific attributes based on the feedback I got.