### PR TITLE
Bug fix - When coa_server aren't specified, create the home_server with same name of client section.

### DIFF
--- a/src/main/realms.c
+++ b/src/main/realms.c
@@ -903,7 +903,7 @@ CONF_SECTION *home_server_cs_afrom_client(CONF_SECTION *client)
 	if (cs) {
 		server = cf_section_dup(client, cs, "home_server", NULL, true);
 	} else {
-		server = cf_section_alloc(client, "home_server", NULL);
+		server = cf_section_alloc(client, "home_server", cf_section_name2(client));
 	}
 
 	if (!cs || (!cf_pair_find(cs, "ipaddr") && !cf_pair_find(cs, "ipv4addr") && !cf_pair_find(cs, "ipv6addr"))) {


### PR DESCRIPTION
Hi,

We fix the creation of empty home_servers when is based on client section.

e.g:
```
Wed Oct 14 02:20:14 2015 : Debug: radiusd: #### Loading Clients ####
Wed Oct 14 02:20:14 2015 : Debug:  client jorge-nas {
Wed Oct 14 02:20:14 2015 : Debug:       ipaddr = 10.1.2.128
Wed Oct 14 02:20:14 2015 : Debug:       require_message_authenticator = no
Wed Oct 14 02:20:14 2015 : Debug:       secret = "testing123"
Wed Oct 14 02:20:14 2015 : Debug:       nas_type = "salinas"
Wed Oct 14 02:20:14 2015 : Debug:       proto = "*"
Wed Oct 14 02:20:14 2015 : Debug:   limit {
Wed Oct 14 02:20:14 2015 : Debug:       max_connections = 16
Wed Oct 14 02:20:14 2015 : Debug:       lifetime = 0
Wed Oct 14 02:20:14 2015 : Debug:       idle_timeout = 30
Wed Oct 14 02:20:14 2015 : Debug:   }
Wed Oct 14 02:20:14 2015 : Debug:  }
Wed Oct 14 02:20:14 2015 : Debug:   home_server {
Wed Oct 14 02:20:14 2015 : Debug:       ipaddr = 10.1.2.128
............................
............................
Wed Oct 14 02:20:14 2015 : Debug:   }
Wed Oct 14 02:20:14 2015 : Debug: Adding client 10.1.2.128/32 (10.1.2.128) to prefix tree 32
```

after the fix.
```
Wed Oct 14 02:20:14 2015 : Debug: radiusd: #### Loading Clients ####
Wed Oct 14 02:20:14 2015 : Debug:  client jorge-nas {
Wed Oct 14 02:20:14 2015 : Debug:       ipaddr = 10.1.2.128
Wed Oct 14 02:20:14 2015 : Debug:       require_message_authenticator = no
Wed Oct 14 02:20:14 2015 : Debug:       secret = "testing123"
Wed Oct 14 02:20:14 2015 : Debug:       nas_type = "salinas"
Wed Oct 14 02:20:14 2015 : Debug:       proto = "*"
Wed Oct 14 02:20:14 2015 : Debug:   limit {
Wed Oct 14 02:20:14 2015 : Debug:       max_connections = 16
Wed Oct 14 02:20:14 2015 : Debug:       lifetime = 0
Wed Oct 14 02:20:14 2015 : Debug:       idle_timeout = 30
Wed Oct 14 02:20:14 2015 : Debug:   }
Wed Oct 14 02:20:14 2015 : Debug:  }
Wed Oct 14 02:20:14 2015 : Debug:   home_server jorge-nas {
Wed Oct 14 02:20:14 2015 : Debug:       ipaddr = 10.1.2.128
............................
............................
Wed Oct 14 02:20:14 2015 : Debug:   }
Wed Oct 14 02:20:14 2015 : Debug: Adding client 10.1.2.128/32 (10.1.2.128) to prefix tree 32
```
