### PR TITLE
Added option 'show home_server list full', now we can see the name of server

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -7,6 +7,8 @@ FreeRADIUS 3.0.11 Mon 05 Oct 2015 15:00:00 EDT urgency=medium
 	  subsection.  This allows the disablign of OpenSSL
 	  auto-chaining of certificates.  Which it can get wrong.
 	* Added printing of coa and disconnect stats (radmin).
+	* Added option "show home_server list full" in radmin. Now
+	  we can see also the name of home_server.
 
 	Bug fixes
 	* Fix issue where field nas_type would not be accessible via

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -9,6 +9,8 @@ FreeRADIUS 3.0.11 Mon 05 Oct 2015 15:00:00 EDT urgency=medium
 	* Added printing of coa and disconnect stats (radmin).
 	* Added option "show home_server list full" in radmin. Now
 	  we can see also the name of home_server.
+	* Added option "show client list full" in radmin. Now is possible
+	  to see shortname,nas_type and server.
 
 	Bug fixes
 	* Fix issue where field nas_type would not be accessible via

--- a/src/main/command.c
+++ b/src/main/command.c
@@ -1182,6 +1182,7 @@ static int command_show_clients(rad_listen_t *listener, UNUSED int argc, UNUSED 
 	int i;
 	RADCLIENT *client;
 	char buffer[256];
+	char ipaddr[256];
 
 	for (i = 0; i < 256; i++) {
 		client = client_findbynumber(NULL, i);
@@ -1193,9 +1194,18 @@ static int command_show_clients(rad_listen_t *listener, UNUSED int argc, UNUSED 
 		     (client->ipaddr.prefix != 32)) ||
 		    ((client->ipaddr.af == AF_INET6) &&
 		     (client->ipaddr.prefix != 128))) {
-			cprintf(listener, "%s/%d\n", buffer, client->ipaddr.prefix);
+			snprintf(ipaddr, sizeof(ipaddr), "%s/%d", buffer, client->ipaddr.prefix);
 		} else {
-			cprintf(listener, "%s\n", buffer);
+			snprintf(ipaddr, sizeof(ipaddr), "%s", buffer);
+		}
+
+		if (argc && !strcmp(argv[0], "full")) {
+			cprintf(listener, "%s\t(%s)\t%s\t%s\n", ipaddr,
+				client->shortname ? client->shortname : "no_shortname",
+				client->nas_type  ? client->nas_type  : "no_type",
+				client->server    ? client->server    : "no_server");
+		} else {
+			cprintf(listener, "%s\n", ipaddr);
 		}
 	}
 
@@ -1953,7 +1963,7 @@ static fr_command_table_t command_table_show_module[] = {
 
 static fr_command_table_t command_table_show_client[] = {
 	{ "list", FR_READ,
-	  "show client list - shows list of global clients",
+	  "show client list [full] - shows list of global clients",
 	  command_show_clients, NULL },
 
 	{ NULL, 0, NULL, NULL, NULL }

--- a/src/main/command.c
+++ b/src/main/command.c
@@ -1160,10 +1160,17 @@ static int command_show_home_servers(rad_listen_t *listener, UNUSED int argc, UN
 
 		} else continue;
 
-		cprintf(listener, "%s\t%d\t%s\t%s\t%s\t%d\n",
-			ip_ntoh(&home->ipaddr, buffer, sizeof(buffer)),
-			home->port, proto, type, state,
-			home->currently_outstanding);
+		if (argc > 0 && !strcmp(argv[0], "full")) {
+			cprintf(listener, "%s\t(%s)\t%d\t%s\t%s\t%s\t%d\n",
+				ip_ntoh(&home->ipaddr, buffer, sizeof(buffer)),
+				home->name, home->port, proto, type, state,
+				home->currently_outstanding);
+		} else {
+			cprintf(listener, "%s\t%d\t%s\t%s\t%s\t%d\n",
+				ip_ntoh(&home->ipaddr, buffer, sizeof(buffer)),
+				home->port, proto, type, state,
+				home->currently_outstanding);
+		}
 	}
 
 	return CMD_OK;
@@ -1955,7 +1962,7 @@ static fr_command_table_t command_table_show_client[] = {
 #ifdef WITH_PROXY
 static fr_command_table_t command_table_show_home[] = {
 	{ "list", FR_READ,
-	  "show home_server list - shows list of home servers",
+	  "show home_server list [full] - shows list of home servers",
 	  command_show_home_servers, NULL },
 	{ "state", FR_READ,
 	  "show home_server state <ipaddr> <port> [udp|tcp] - shows state of given home server",


### PR DESCRIPTION
Hi,

When you have tens of home_servers, It's too hard to know 'who' is by the ipaddr.

```
radmin> show home_server list
127.0.0.1    1812    udp     auth    unknown 0
10.15.21.13  1812    udp     auth    unknown 0
10.16.11.19  1812    udp     auth    unknown 0
............
10.19.51.1   1812    udp     auth    unknown 0
radmin>
```

With this patch, we can see the name used in ```home_server <name> { ...}```  section. more helpful!

```
radmin> show home_server list full
127.0.0.1    1812    udp     auth    unknown 0  partner_east02
10.15.21.13  1812    udp     auth    unknown 0  partner_east04
10.16.11.19  1812    udp     auth    unknown 0  lab_03
............
10.19.51.1   1812    udp     auth    unknown 0  partner_east01
radmin>
```
