### PR TITLE
Fixing missing 'port' in home_server_cs_afrom_client()

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -17,6 +17,7 @@ FreeRADIUS 3.0.11 Mon 05 Oct 2015 15:00:00 EDT urgency=medium
 	* Use correct talloc context in rlm_exec.  Fixes #1338.
 	* Fixed bug with coa/acct stats value #1339. Based on patch from
 	  Jorge Pereira.
+	* Fix the default port in auto home_servers loaded from a client.
 
 FreeRADIUS 3.0.10 Mon 05 Oct 2015 15:00:00 EDT urgency=medium
 	Feature improvements

--- a/src/main/realms.c
+++ b/src/main/realms.c
@@ -933,6 +933,28 @@ CONF_SECTION *home_server_cs_afrom_client(CONF_SECTION *client)
 		return NULL;
 	}
 
+	if (!cs || !cf_pair_find(cs, "port")) {
+		const char *type = cf_section_value_find(server, "type");
+		uint16_t port = 0;
+
+		if (type) {
+			if (!strcmp(type, "auth") || !strcmp(type, "auth+acct")) {
+				port = PW_AUTH_UDP_PORT;
+			} else if (!strcmp(type, "acct")) {
+				port = PW_ACCT_UDP_PORT;
+			} else if (!strcmp(type, "coa")) {
+				port = PW_COA_UDP_PORT;
+			}
+		}
+
+		if (port != 0) {
+			char buf[5+1];
+			snprintf(buf, sizeof(buf), "%d", port);
+			cp = cf_pair_alloc(server, "port", buf, T_OP_EQ, T_BARE_WORD, T_SINGLE_QUOTED_STRING);
+			if (cp) cf_pair_add(server, cf_pair_dup(server, cp));
+		}
+	}
+
 	return server;
 }
 


### PR DESCRIPTION
to avoid the field 'port' with value 0

```
Sun Oct 25 03:27:08 2015 : Debug:   home_server client-vpn {
Sun Oct 25 03:27:08 2015 : Debug:       ipaddr = 10.1.1.248
Sun Oct 25 03:27:08 2015 : Debug:       port = 0
Sun Oct 25 03:27:08 2015 : Debug:       type = "coa"
Sun Oct 25 03:27:08 2015 : Debug:       secret = "testing123"
Sun Oct 25 03:27:08 2015 : Debug:       response_window = 30.000000
Sun Oct 25 03:27:08 2015 : Debug:       response_timeouts = 1
Sun Oct 25 03:27:08 2015 : Debug:       max_outstanding = 65536
Sun Oct 25 03:27:08 2015 : Debug:       zombie_period = 40
Sun Oct 25 03:27:08 2015 : Debug:       status_check = "none"
Sun Oct 25 03:27:08 2015 : Debug:       ping_interval = 30
Sun Oct 25 03:27:08 2015 : Debug:       check_timeout = 4
Sun Oct 25 03:27:08 2015 : Debug:       num_answers_to_alive = 3
Sun Oct 25 03:27:08 2015 : Debug:       revive_interval = 300
Sun Oct 25 03:27:08 2015 : Debug:   limit {
Sun Oct 25 03:27:08 2015 : Debug:       max_connections = 16
Sun Oct 25 03:27:08 2015 : Debug:       max_requests = 0
Sun Oct 25 03:27:08 2015 : Debug:       lifetime = 0
Sun Oct 25 03:27:08 2015 : Debug:       idle_timeout = 30
Sun Oct 25 03:27:08 2015 : Debug:   }
Sun Oct 25 03:27:08 2015 : Debug:    coa {
Sun Oct 25 03:27:08 2015 : Debug:       irt = 2
Sun Oct 25 03:27:08 2015 : Debug:       mrt = 16
Sun Oct 25 03:27:08 2015 : Debug:       mrc = 5
Sun Oct 25 03:27:08 2015 : Debug:       mrd = 30
Sun Oct 25 03:27:08 2015 : Debug:    }
Sun Oct 25 03:27:08 2015 : Debug:   }
```

now is filled with default coa port.

```
Sun Oct 25 03:27:08 2015 : Debug:   home_server client-vpn {
Sun Oct 25 03:27:08 2015 : Debug:       ipaddr = 10.1.1.248
Sun Oct 25 03:27:08 2015 : Debug:       port = 3799
Sun Oct 25 03:27:08 2015 : Debug:       type = "coa"
Sun Oct 25 03:27:08 2015 : Debug:       secret = "testing123"
Sun Oct 25 03:27:08 2015 : Debug:       response_window = 30.000000
Sun Oct 25 03:27:08 2015 : Debug:       response_timeouts = 1
Sun Oct 25 03:27:08 2015 : Debug:       max_outstanding = 65536
Sun Oct 25 03:27:08 2015 : Debug:       zombie_period = 40
Sun Oct 25 03:27:08 2015 : Debug:       status_check = "none"
Sun Oct 25 03:27:08 2015 : Debug:       ping_interval = 30
Sun Oct 25 03:27:08 2015 : Debug:       check_timeout = 4
Sun Oct 25 03:27:08 2015 : Debug:       num_answers_to_alive = 3
Sun Oct 25 03:27:08 2015 : Debug:       revive_interval = 300
Sun Oct 25 03:27:08 2015 : Debug:   limit {
Sun Oct 25 03:27:08 2015 : Debug:       max_connections = 16
Sun Oct 25 03:27:08 2015 : Debug:       max_requests = 0
Sun Oct 25 03:27:08 2015 : Debug:       lifetime = 0
Sun Oct 25 03:27:08 2015 : Debug:       idle_timeout = 30
Sun Oct 25 03:27:08 2015 : Debug:   }
Sun Oct 25 03:27:08 2015 : Debug:    coa {
Sun Oct 25 03:27:08 2015 : Debug:       irt = 2
Sun Oct 25 03:27:08 2015 : Debug:       mrt = 16
Sun Oct 25 03:27:08 2015 : Debug:       mrc = 5
Sun Oct 25 03:27:08 2015 : Debug:       mrd = 30
Sun Oct 25 03:27:08 2015 : Debug:    }
Sun Oct 25 03:27:08 2015 : Debug:   }
```