### PR TITLE
Bugfix - Possible segfault/assertion error on else without if

### DIFF
--- a/src/main/modcall.c
+++ b/src/main/modcall.c
@@ -2863,7 +2863,13 @@ static modcallable *do_compile_modgroup(modcallable *parent,
 			rad_assert(parent != NULL);
 			p = mod_callabletogroup(parent);
 
-			rad_assert(p->tail != NULL);
+			rad_assert(p != NULL);
+
+			if (!p->tail) {
+				cf_log_err_cs(g->cs, "Invalid location for 'else'.  There is no preceding 'if' statement");
+				talloc_free(g);
+				return NULL;
+			}
 
 			f = mod_callabletogroup(p->tail);
 			if ((f->mc.type != MOD_IF) &&


### PR DESCRIPTION
Bugfix - Possible segfault/assertion error on else without if #1355 

When use the

``` 
authorize {
    else {

   }
}
```

results in

```
Tue Oct 27 13:37:51 2015 : Error: ASSERT FAILED src/main/modcall.c[2866]: p->tail != NULL
CAUGHT SIGNAL: Aborted
Backtrace of last 12 frames:
/opt/radius/lib/libfreeradius-radius.so(fr_fault+0x12d)[0x7febc813297a]
/opt/radius/lib/libfreeradius-server.so(rad_assert_fail+0x46)[0x7febc839812d]
/opt/radius/sbin/radiusd[0x42f839]
/opt/radius/sbin/radiusd[0x42e69d]
/opt/radius/sbin/radiusd(compile_modsingle+0x15c)[0x42f341]
/opt/radius/sbin/radiusd[0x4282bf]
/opt/radius/sbin/radiusd[0x42874a]
/opt/radius/sbin/radiusd(virtual_servers_load+0x1a7)[0x428cc8]
/opt/radius/sbin/radiusd(modules_init+0x992)[0x429fb8]
/opt/radius/sbin/radiusd(main+0x94e)[0x432f19]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7febc6ecea40]
/opt/radius/sbin/radiusd(_start+0x29)[0x40e8b9]
```

After the the patch:

```
Tue Oct 27 13:47:07 2015 : Error: /opt/radius/etc/raddb/sites-enabled/default[258]: Invalid location for 'else'. There is no preceding 'if' statement
Tue Oct 27 13:47:07 2015 : Error: /opt/radius/etc/raddb/sites-enabled/default[254]: Errors parsing authorize section. 
```