### PR TITLE
Restore trailing curly brace

### DIFF
--- a/raddb/sites-available/abfab-tr-idp
+++ b/raddb/sites-available/abfab-tr-idp
@@ -183,4 +183,4 @@ post-proxy {
 	#
 	eap
 }
-
+}


### PR DESCRIPTION
Looks like it was accidentally removed in 73847d34f5a59a7deb60259c2b35ca5b02a9c62d