### PR TITLE
remove redundant "name" config option

### DIFF
--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -376,16 +376,6 @@ eap {
 			enable = yes
 
 			#
-			#  Internal "name" of the session cache. Used to distinguish which
-			#  TLS context sessions belong to.
-			#
-			#  The server will generate a random value if unset. This will change
-			#  across server restart so you MUST set the "name" if you want to
-			#  persist sessions (see below).
-			#
-		#	name = "EAP module"
-
-			#
 			#  Lifetime of the cached entries, in hours. The sessions will be
 			#  deleted/invalidated after this time.
 			#
@@ -401,14 +391,13 @@ eap {
 			max_entries = 255
 
 			#
-			#  Internal "name" of the session cache.
-			#  Used to distinguish which TLS context
-			#  sessions belong to.
+			#  Internal "name" of the session cache. Used to
+			#  distinguish which TLS context sessions belong to.
 			#
-			#  The server will generate a random value
-			#  if unset. This will change across server
-			#  restart so you MUST set the "name" if you
-			#  want to persist sessions (see below).
+			#  The server will generate a random value if unset.
+			#  This will change across server restart so you MUST
+			#  set the "name" if you want to persist sessions (see
+			#  below).
 			#
 			#name = "EAP module"
 


### PR DESCRIPTION
note also that "name" has vanished from the config in 3.1.x, but isn't marked deprecated in the code, so not sure if the config needs re-adding or the code updating (in which case the config should list it as deprecated as with the other options).