### PR TITLE
Bugfix - The current example of missing/vdprintf() has a bad behavior.

### DIFF
--- a/src/lib/missing.c
+++ b/src/lib/missing.c
@@ -194,16 +194,11 @@ struct tm *gmtime_r(time_t const *l_clock, struct tm *result)
 #ifndef HAVE_VDPRINTF
 int vdprintf (int fd, const char *format, va_list args)
 {
-	int     ret;
-	FILE    *fp;
+	char buf[8192];
+	int len;
 
-	fp = fdopen(fd, "w");
-	if (!fp) return -1;
-
-	ret = vfprintf(fp, format, args);
-	fclose(fp);
-
-	return ret;
+	len = vsnprintf(buf, 8192, format, ap);
+	return write(d, buf, len);
 }
 #endif
 


### PR DESCRIPTION
Hi,

Below some evidences about the current problem in missing.c/vdprintf

``` C
#define _GNU_SOURCE
#include <stdarg.h>
#include <stdio.h>
#include <unistd.h>
#include <sys/types.h>
#include <sys/stat.h>
#include <fcntl.h>
#include <err.h>

/*
 * current version of missing.c +/ vdprintf() 
 * in https://github.com/FreeRADIUS/freeradius-server/blob/28e6eebdbe053a374dd7dcfffbfc19348872f886/src/lib/missing.c
*/
int test_vdprintf (int fd, const char *format, va_list args) {
    int     ret;
    FILE    *fp;

    fp = fdopen(fd, "w");
    if (!fp) { 
        printf("Problems with fdopen()\n");
        return -1;
    }

    ret = vfprintf(fp, format, args);
    fclose(fp);

    return ret; 
}

void my_test(const char *fmt, ...) {
    int ret;
    int fd;
    va_list args;

    va_start(args, fmt);

    fd = open ("/tmp/caipirinha",  O_WRONLY | O_CREAT, 0644);
    if (fd < 0) {
        printf("Problems with open()\n");
        return;
    }

    printf("fd=%d\n", fd);

    ret = vdprintf(fd, fmt, args);
    printf("1: vdprintf() returns %d\n", ret);

    ret = vdprintf(fd, fmt, args);
    printf("2: vdprintf() returns %d\n", ret);

    ret = vdprintf(fd, fmt, args);
    printf("3: vdprintf() returns %d\n", ret);

    ret = test_vdprintf(fd, fmt, args);
    printf("1: test_vdprintf() returns %d\n", ret);

    ret = test_vdprintf(fd, fmt, args);
    printf("2: test_vdprintf() returns %d\n", ret);

    ret = test_vdprintf(fd, fmt, args);
    printf("3: test_vdprintf() returns %d\n", ret);

    ret = vdprintf(fd, fmt, args);
    printf("1: vdprintf() returns %d\n", ret);

    va_end (args);

    close(fd);
}

int main() {
    my_test("My uid is %d\n", getuid());

    return 0;
}
```

Output 

```
[jpereira@jpereira-desktop Codes]$ !gcc
gcc -W -Wall -o example-vdprintf example-vdprintf.c 
[jpereira@jpereira-desktop Codes]$ ./example-vdprintf 
fd = 3
1: vdprintf() returns 15
2: vdprintf() returns 21
3: vdprintf() returns 21
1: test_vdprintf() returns 21
Problems with fdopen()
2: test_vdprintf() returns -1
Problems with fdopen()
3: test_vdprintf() returns -1
1: vdprintf() returns -1
[jpereira@jpereira-desktop Codes]$ cat /tmp/caipirinha 
My uid is 1000
My uid is 483031640
My uid is -1869534441
My uid is -1866412592
[jpereira@jpereira-desktop Codes]$
```
