### PR TITLE
Fixing problem with radmin> stats detail <filename>

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -17,6 +17,7 @@ FreeRADIUS 3.0.11 Mon 05 Oct 2015 15:00:00 EDT urgency=medium
 	* Use correct talloc context in rlm_exec.  Fixes #1338.
 	* Fixed bug with coa/acct stats value #1339. Based on patch from
 	  Jorge Pereira.
+	* Fixed bug with radmin related to the option "stats detail <filename>"
 
 FreeRADIUS 3.0.10 Mon 05 Oct 2015 15:00:00 EDT urgency=medium
 	Feature improvements

--- a/src/main/command.c
+++ b/src/main/command.c
@@ -2252,7 +2252,7 @@ static FR_NAME_NUMBER state_names[] = {
 static int command_stats_detail(rad_listen_t *listener, int argc, char *argv[])
 {
 	rad_listen_t *this;
-	listen_detail_t *data;
+	listen_detail_t *data, *needle;
 	struct stat buf;
 
 	if (argc == 0) {
@@ -2264,10 +2264,11 @@ static int command_stats_detail(rad_listen_t *listener, int argc, char *argv[])
 	for (this = main_config.listen; this != NULL; this = this->next) {
 		if (this->type != RAD_LISTEN_DETAIL) continue;
 
-		data = this->data;
-		if (strcmp(argv[1], data->filename) != 0) continue;
-
-		break;
+		needle = this->data;
+		if (!strcmp(argv[0], needle->filename)) {
+			data = needle;
+			break;
+		}
 	}
 
 	if (!data) {


### PR DESCRIPTION
Current problem.
```
Tue Nov 24 00:50:53 2015 : Debug:  ... new connection request on command socket
Tue Nov 24 00:50:53 2015 : Debug: Listening on command file /opt/radius/var/run/freeradius/freeradius.sock
Tue Nov 24 00:50:53 2015 : Info: Ready to process requests
Tue Nov 24 00:50:57 2015 : Debug: radmin> stats detail /somewhere/detail
Segmentation fault (core dumped)
```

After patch
```
radmin> stats detail /somewhere/detail
ERROR: No detail file listener
radmin> stats detail /var/log/freeradius/radacct/buffered/detail
state	no-reply
packets	1
tries	15
offset	213
size	852
radmin> 
```