### PR TITLE
SoH isn't very useful without attributes

### DIFF
--- a/src/modules/rlm_eap/types/rlm_eap_peap/peap.c
+++ b/src/modules/rlm_eap/types/rlm_eap_peap/peap.c
@@ -811,7 +811,7 @@ rlm_rcode_t eap_peap_process(eap_session_t *eap_session, tls_session_t *tls_sess
 	case PEAP_STATUS_WAIT_FOR_SOH_RESPONSE:
 		fake = request_alloc_fake(request);
 		rad_assert(!fake->packet->vps);
-		eap_peap_soh_verify(request, fake->packet, data, data_len);
+		eap_peap_soh_verify(fake, fake->packet, data, data_len);
 		setup_fake_request(request, fake, t);
 
 		if (t->soh_virtual_server) {


### PR DESCRIPTION
Broken in c11e3d8454 by no longer setting fake->packet->vps.

eap_peap_soh_verify has no need to see the original request as
long as it's got access to the data to parse, so just pass in the
fake request and get the attributes created there directly.