### PR TITLE
SoH isn't very useful without attributes

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -34,6 +34,7 @@ FreeRADIUS 3.0.11 Mon 05 Oct 2015 15:00:00 EDT urgency=medium
 	* Fixed bug with radmin related to the option "stats detail <filename>"
 	* Complain if the detail file reader does not have permission
 	  to read the "detail.work" file.  Fixes #1398
+	* Fixed SoH. Attributes were not being copied to the virtual server.
 
 FreeRADIUS 3.0.10 Mon 05 Oct 2015 15:00:00 EDT urgency=medium
 	Feature improvements

--- a/src/modules/rlm_eap/types/rlm_eap_peap/peap.c
+++ b/src/modules/rlm_eap/types/rlm_eap_peap/peap.c
@@ -804,7 +804,7 @@ rlm_rcode_t eappeap_process(eap_handler_t *handler, tls_session_t *tls_session)
 	case PEAP_STATUS_WAIT_FOR_SOH_RESPONSE:
 		fake = request_alloc_fake(request);
 		rad_assert(!fake->packet->vps);
-		eapsoh_verify(request, fake->packet, data, data_len);
+		eapsoh_verify(fake, fake->packet, data, data_len);
 		setup_fake_request(request, fake, t);
 
 		if (t->soh_virtual_server) {


### PR DESCRIPTION
Broken in c11e3d8454 by no longer setting fake->packet->vps.

eapsoh_verify has no need to see the original request as long
as it's got access to the data to parse, so just pass in the
fake request and get the attributes created there directly.