### PR TITLE
The field 'last_packet' in 'radmin>stats client' now is shown like a date

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -13,6 +13,8 @@ FreeRADIUS 3.0.11 Mon 05 Oct 2015 15:00:00 EDT urgency=medium
 	* Portability fixes for Solaris.
 	* More errors from ntlm_auth gets passed to MS-CHAP.
 	* Update abfab-tr-idp virtual server.
+	* The field 'last_packet' in 'radmin> stats client' now is
+	  shown like a date.
 
 	Bug fixes
 	* Fix issue where field nas_type would not be accessible via

--- a/src/main/command.c
+++ b/src/main/command.c
@@ -2172,7 +2172,18 @@ static int command_print_stats(rad_listen_t *listener, fr_stats_t *stats,
 		cprintf(listener, "timeouts\t" PU "\n", stats->total_timeouts);
 	}
 
-	cprintf(listener, "last_packet\t%" PRId64 "\n", (int64_t) stats->last_packet);
+	if (stats->last_packet > 0) {
+		char str_last_packet[64];
+		struct tm *pts;
+
+		pts = localtime((time_t *)&stats->last_packet);
+		strftime(str_last_packet, sizeof(str_last_packet), "%Y-%m-%d %H:%M:%S", pts);
+
+		cprintf(listener, "last_packet\t%" PRId64 "\t(%s)\n", (int64_t) stats->last_packet, str_last_packet);
+	} else {
+		cprintf(listener, "last_packet\t%" PRId64 "\n", (int64_t) stats->last_packet);
+	}
+
 	for (i = 0; i < 8; i++) {
 		cprintf(listener, "elapsed.%s\t%u\n",
 			elapsed_names[i], stats->elapsed[i]);


### PR DESCRIPTION
Currently the field 'last_packet' is shown like a any number.

```
radmin> stats client acct
requests	116
responses	116
dup		0
invalid		0
malformed	0
bad_authenticator	0
dropped		0
unknown_types	0
last_packet	1448563105
elapsed.1us	0
elapsed.10us	0
elapsed.100us	102
elapsed.1ms	10
elapsed.10ms	3
elapsed.100ms	1
elapsed.1s	0
elapsed.10s	0
radmin> 
```

The value shown like a date is completely more helpful than a simple number!

```
radmin> stats client acct
requests	116
responses	116
dup		0
invalid		0
malformed	0
bad_authenticator	0
dropped		0
unknown_types	0
last_packet	1448563105	(2015-11-26 16:38:25)
elapsed.1us	0
elapsed.10us	0
elapsed.100us	102
elapsed.1ms	10
elapsed.10ms	3
elapsed.100ms	1
elapsed.1s	0
elapsed.10s	0
radmin> 
```