### PR TITLE
Fixed the capability to use libfreeradius-radius with distributed headers

### DIFF
--- a/src/include/all.mk
+++ b/src/include/all.mk
@@ -90,9 +90,11 @@ src/include/%.h: share/dictionary.% share/dictionary.vqp
 #
 src/include/features.h: src/include/features-h src/include/autoconf.h
 	@$(ECHO) HEADER $@
-	@cp $< $@
+	@echo "#ifndef FR_FEATURES_H_ /* auto generated */" > $@
+	@cat $< >> $@
 	@grep "^#define[ ]*WITH_" src/include/autoconf.h >> $@
 	@grep "^#define[ ]*RADIUSD_VERSION" src/include/autoconf.h >> $@
+	@echo "#endif /*FR_FEATURES_H_ */" >> $@
 
 #
 #  Use the SED script we built earlier to make permanent substitutions

--- a/src/include/all.mk
+++ b/src/include/all.mk
@@ -42,6 +42,13 @@ HEADERS	= \
 	base64.h \
 	map.h \
 	udp.h \
+	tcp.h \
+	threads.h \
+	regex.h \
+	inet.h \
+	dict.h \
+	pair.h \
+	proto.h \
 	$(HEADERS_DY)
 
 #

--- a/src/include/build.h
+++ b/src/include/build.h
@@ -10,7 +10,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#include <freeradius-devel/autoconf.h> /* Needed for endian macros */
 
 /*
  *	The ubiquitous stringify macros

--- a/src/include/libradius.h
+++ b/src/include/libradius.h
@@ -87,6 +87,8 @@ RCSIDH(libradius_h, "$Id$")
 #include <freeradius-devel/dict.h>
 #include <freeradius-devel/pair.h>
 #include <freeradius-devel/proto.h>
+#include <freeradius-devel/conf.h>
+#include <freeradius-devel/radpaths.h>
 
 #ifdef SIZEOF_UNSIGNED_INT
 #  if SIZEOF_UNSIGNED_INT != 4

--- a/src/include/libradius.h
+++ b/src/include/libradius.h
@@ -23,13 +23,14 @@
  *
  * @copyright 1999-2014 The FreeRADIUS server project
  */
-RCSIDH(libradius_h, "$Id$")
 
 /*
  *  Compiler hinting macros.  Included here for 3rd party consumers
  *  of libradius.h.
  */
 #include <freeradius-devel/build.h>
+
+RCSIDH(libradius_h, "$Id$")
 
 /*
  *  Let any external program building against the library know what

--- a/src/include/radius.h
+++ b/src/include/radius.h
@@ -5,6 +5,8 @@
  *
  */
 
+#ifndef RADIUS_H_
+#define RADIUS_H_
 /** Internal data types used within libfreeradius
  *
  */
@@ -201,3 +203,5 @@ typedef enum {
 
 #define PW_UKERNA_CHBIND		135
 #define PW_UKERNA_TR_COI 136
+
+#endif /*RADIUS_H_*/


### PR DESCRIPTION
Using the below sample

```
[jpereira@jpereira-desktop sample]$ cat -n radius-sample1.c
     1  #include <freeradius-devel/libradius.h>
     2
     3  static char     const *radius_dir = RADDBDIR;
     4  static char     const *dict_dir = DICTDIR;
     5  fr_dict_t       *dict = NULL;
     6
     7  int main() {
     8          printf("Using libfreeradius-radius.so %s\n", RADIUSD_VERSION_STRING);
     9
    10          if (fr_check_lib_magic(RADIUSD_MAGIC_NUMBER) < 0) {
    11                  fr_perror("radclient");
    12                  return 1;
    13          }
    14
    15          if (fr_dict_init(NULL, &dict, dict_dir, RADIUS_DICTIONARY, "radius") < 0) {
    16                  fr_perror("radclient");
    17                  return 1;
    18          }
    19
    20          if (fr_dict_read(dict, radius_dir, RADIUS_DICTIONARY) == -1) {
    21                  fr_perror("radclient");
    22                  return 1;
    23          }
    24          printf("done\n");
    25          return 0;
    26  }
    27
[jpereira@jpereira-desktop sample]$ make
cc -I/opt/radius-3.1.x/include -DHAVE_PTHREAD_H -o radius-sample1 radius-sample1.c -L/opt/radius-3.1.x/lib -Wl,-R/opt/radius-3.1.x/lib -L/opt/radius-3.1.x/lib/freeradius -Wl,-R/opt/radius-3.1.x/lib/freeradius -lfreeradius-radius
[jpereira@jpereira-desktop sample]$ ./radius-sample1
Using libfreeradius-radius.so 3.1.0
done
[jpereira@jpereira-desktop sample]$
```

p.s: Was necessary to create apply a "duck-tape"

```
# cd /opt/radius-3.1.x/include
# ln -fs freeradius freeradius-devel
```

Because whole os codes have references to

```
#include <freeradius-devel/name.h>
```
