### PR TITLE
Include missing headers

### DIFF
--- a/src/include/libradius.h
+++ b/src/include/libradius.h
@@ -86,6 +86,8 @@ RCSIDH(libradius_h, "$Id$")
 #include <freeradius-devel/dict.h>
 #include <freeradius-devel/pair.h>
 #include <freeradius-devel/proto.h>
+#include <freeradius-devel/conf.h>
+#include <freeradius-devel/radpaths.h>
 
 #ifdef SIZEOF_UNSIGNED_INT
 #  if SIZEOF_UNSIGNED_INT != 4


### PR DESCRIPTION
It's good to use the libfreeradius-radius.so with a single header ```#include <freeradius/libradius.h>```