### PR TITLE
Fixed correct strip of #include <freeradius-devel

### DIFF
--- a/src/include/all.mk
+++ b/src/include/all.mk
@@ -141,7 +141,7 @@ $(SRC_INCLUDE_DIR):
 ${SRC_INCLUDE_DIR}/%.h: src/include/%.h | $(SRC_INCLUDE_DIR)
 	@echo INSTALL $(notdir $<)
 	@$(INSTALL) -d -m 755 `echo $(dir $@) | sed 's/\/$$//'`
-	@sed 's/^#include <freeradius-devel/#include <freeradius/' < $< > $@
+	@sed -e 's/^#\(\s*\)include <freeradius-devel/#\1include <freeradius/' < $< > $@
 	@chmod 644 $@
 
 install.src.include: $(addprefix ${SRC_INCLUDE_DIR}/,${HEADERS})


### PR DESCRIPTION
The current regex doesn't works with spaces.

```
[jpereira@jpereira-desktop sample]$ grep ".*devel" -r /opt/radius-3.1.x/include/
/opt/radius-3.1.x/include/freeradius/libradius.h:#  include <freeradius-devel/tcp.h>
/opt/radius-3.1.x/include/freeradius/radiusd.h:#  include <freeradius-devel/tls.h>
[jpereira@jpereira-desktop sample]$
```

Keep some headers with -devel