### PR TITLE
First include the macro, so should be called

### DIFF
--- a/src/include/libradius.h
+++ b/src/include/libradius.h
@@ -23,13 +23,14 @@
  *
  * @copyright 1999-2014 The FreeRADIUS server project
  */
-RCSIDH(libradius_h, "$Id$")
 
 /*
  *  Compiler hinting macros.  Included here for 3rd party consumers
  *  of libradius.h.
  */
 #include <freeradius-devel/build.h>
+
+RCSIDH(libradius_h, "$Id$")
 
 /*
  *  Let any external program building against the library know what


### PR DESCRIPTION
In my sample.

```
[jpereira@jpereira-desktop sample]$ head -5 radius-sample1.c | cat -n
     1  #include <freeradius/libradius.h>
     2  #include <freeradius/radpaths.h>
     3  #include <freeradius/conf.h>
     4  
     5  static char     const *radius_dir = RADDBDIR;
[jpereira@jpereira-desktop sample]$
```

I get the below error related to the order of called the macro X include

```
[jpereira@jpereira-desktop sample]$ make 2>&1 | head -5
cc -I/opt/radius-3.1.x/include -DHAVE_PTHREAD_H -o radius-sample1 radius-sample1.c -L/opt/radius-3.1.x/lib -Wl,-R/opt/radius-3.1.x/lib -L/opt/radius-3.1.x/lib/freeradius -Wl,-R/opt/radius-3.1.x/lib/freeradius -lfreeradius-radius 
In file included from radius-sample1.c:1:0:
/opt/radius-3.1.x/include/freeradius/libradius.h:22:21: error: expected ‘)’ before string constant
 RCSIDH(libradius_h, "$Id: d356b97f983fba4421176d6b637bdd907ad36279 $")
                     ^
[jpereira@jpereira-desktop sample]$
```

This change fix that.

