### PR TITLE
Fixing issues related to m4 include path

### DIFF
--- a/src/modules/rlm_example/config.h.in
+++ b/src/modules/rlm_example/config.h.in
@@ -1,38 +1,5 @@
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
-/* Define to 1 if you have the <inttypes.h> header file. */
-#undef HAVE_INTTYPES_H
-
-/* Define to 1 if you have the <memory.h> header file. */
-#undef HAVE_MEMORY_H
-
-/* Define to 1 if you have the `printf' function. */
-#undef HAVE_PRINTF
-
-/* Define to 1 if you have the <stdint.h> header file. */
-#undef HAVE_STDINT_H
-
-/* Define to 1 if you have the <stdio.h> header file. */
-#undef HAVE_STDIO_H
-
-/* Define to 1 if you have the <stdlib.h> header file. */
-#undef HAVE_STDLIB_H
-
-/* Define to 1 if you have the <strings.h> header file. */
-#undef HAVE_STRINGS_H
-
-/* Define to 1 if you have the <string.h> header file. */
-#undef HAVE_STRING_H
-
-/* Define to 1 if you have the <sys/stat.h> header file. */
-#undef HAVE_SYS_STAT_H
-
-/* Define to 1 if you have the <sys/types.h> header file. */
-#undef HAVE_SYS_TYPES_H
-
-/* Define to 1 if you have the <unistd.h> header file. */
-#undef HAVE_UNISTD_H
-
 /* Define to the address where bug reports for this package should be sent. */
 #undef PACKAGE_BUGREPORT
 
@@ -45,8 +12,8 @@
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
 
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
-
-/* Define to 1 if you have the ANSI C header files. */
-#undef STDC_HEADERS

--- a/src/modules/rlm_ldap/configure
+++ b/src/modules/rlm_ldap/configure
@@ -3992,7 +3992,7 @@ smart_prefix=
 $as_echo "#define WITH_SASL 1" >>confdefs.h
 
 	    SASL=sasl.c
-          fi
+	  fi
 	fi
 
 	targetname=rlm_ldap

--- a/src/modules/rlm_pam/config.h.in
+++ b/src/modules/rlm_pam/config.h.in
@@ -45,6 +45,9 @@
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
 
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 

--- a/src/modules/rlm_perl/config.h.in
+++ b/src/modules/rlm_perl/config.h.in
@@ -12,5 +12,8 @@
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
 
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION

--- a/src/modules/rlm_perl/configure.ac
+++ b/src/modules/rlm_perl/configure.ac
@@ -3,7 +3,7 @@ AC_INIT(rlm_perl.c)
 AC_REVISION($Revision$)
 AC_DEFUN(modname,[rlm_perl])
 
-m4_include([ax_with_prog.m4])
+m4_include([m4/ax_with_prog.m4])
 
 if test x$with_[]modname != xno; then
 	AC_PROG_CC

--- a/src/modules/rlm_radutmp/config.h.in
+++ b/src/modules/rlm_radutmp/config.h.in
@@ -42,6 +42,9 @@
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
 
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 

--- a/src/modules/rlm_ruby/configure
+++ b/src/modules/rlm_ruby/configure
@@ -1875,6 +1875,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 
+
 # ===========================================================================
 #    http://www.gnu.org/software/autoconf-archive/ax_compare_version.html
 # ===========================================================================

--- a/src/modules/rlm_ruby/configure.ac
+++ b/src/modules/rlm_ruby/configure.ac
@@ -3,15 +3,16 @@ AC_INIT(rlm_ruby.c)
 AC_REVISION($Revision: 1.9 $)
 AC_DEFUN(modname,[rlm_ruby])
 
-m4_include([ax_with_prog.m4])
+m4_include([m4/ax_with_prog.m4])
 
 AC_DEFUN([AX_WITH_RUBY],[
     AX_WITH_PROG([RUBY],[ruby],[not-found],[${PATH}:/usr/bin:/usr/local/bin])
 ])
 
-m4_include([ax_compare_version.m4])
-m4_include([ax_prog_ruby_version.m4])
-m4_include([ax_ruby_devel.m4])
+
+m4_include([m4/ax_compare_version.m4])
+m4_include([m4/ax_prog_ruby_version.m4])
+m4_include([m4/ax_ruby_devel.m4])
 
 targetname=modname
 mod_cflags=

--- a/src/modules/rlm_smsotp/config.h.in
+++ b/src/modules/rlm_smsotp/config.h.in
@@ -42,6 +42,9 @@
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
 
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 

--- a/src/modules/rlm_sql/drivers/rlm_sql_mysql/config.h.in
+++ b/src/modules/rlm_sql/drivers/rlm_sql_mysql/config.h.in
@@ -18,5 +18,8 @@
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
 
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION

--- a/src/modules/rlm_unix/config.h.in
+++ b/src/modules/rlm_unix/config.h.in
@@ -1,5 +1,8 @@
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
+/* Define to 1 if you have the `getpwnam' function. */
+#undef HAVE_GETPWNAM
+
 /* Define to 1 if you have the `getspnam' function. */
 #undef HAVE_GETSPNAM
 
@@ -53,6 +56,9 @@
 
 /* Define to the one symbol short name of this package. */
 #undef PACKAGE_TARNAME
+
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
 
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION


### PR DESCRIPTION
Currently we have some issues when call the script autogen.sh

```
[jpereira@jpereira-desktop freeradius-server.git]$ ./autogen.sh 
libtoolize: putting auxiliary files in `.'.
libtoolize: copying file `./ltmain.sh'
libtoolize: You should add the contents of the following files to `aclocal.m4':
libtoolize:   `/usr/share/aclocal/ltversion.m4'
libtoolize: Remember to add `LT_INIT' to configure.ac.
libtoolize: Consider adding `AC_CONFIG_MACRO_DIR([m4])' to configure.ac and
libtoolize: rerunning libtoolize, to keep the correct libtool macros in-tree.
libtoolize: Consider adding `-I m4' to ACLOCAL_AMFLAGS in Makefile.am.
libtoolize: `AC_PROG_RANLIB' is rendered obsolete by `LT_INIT'
configure.ac:26: warning: AC_INIT: not a literal: $Id$
configure.ac:2284: warning: AC_CONFIG_SUBDIRS: you should use literals
../../lib/autoconf/status.m4:1097: AC_CONFIG_SUBDIRS is expanded from...
configure.ac:2284: the top level
configure.ac:26: warning: AC_INIT: not a literal: $Id$
configure.ac:2284: warning: AC_CONFIG_SUBDIRS: you should use literals
../../lib/autoconf/status.m4:1097: AC_CONFIG_SUBDIRS is expanded from...
configure.ac:2284: the top level
Configuring in src/modules/rlm_krb5...
Configuring in src/modules/rlm_sql...
configure.ac:32: warning: AC_CONFIG_SUBDIRS: you should use literals
../../lib/autoconf/status.m4:1097: AC_CONFIG_SUBDIRS is expanded from...
configure.ac:32: the top level
Configuring in src/modules/rlm_sql/drivers/rlm_sql_oracle...
Configuring in src/modules/rlm_sql/drivers/rlm_sql_cassandra...
Configuring in src/modules/rlm_sql/drivers/rlm_sql_postgresql...
Configuring in src/modules/rlm_sql/drivers/rlm_sql_db2...
Configuring in src/modules/rlm_sql/drivers/rlm_sql_iodbc...
Configuring in src/modules/rlm_sql/drivers/rlm_sql_firebird...
Configuring in src/modules/rlm_sql/drivers/rlm_sql_unixodbc...
Configuring in src/modules/rlm_sql/drivers/rlm_sql_mysql...
Configuring in src/modules/rlm_sql/drivers/rlm_sql_sqlite...
Configuring in src/modules/rlm_sql/drivers/rlm_sql_freetds...
Configuring in src/modules/rlm_eap...
configure.ac:26: warning: AC_CONFIG_SUBDIRS: you should use literals
../../lib/autoconf/status.m4:1097: AC_CONFIG_SUBDIRS is expanded from...
configure.ac:26: the top level
Configuring in src/modules/rlm_eap/types/rlm_eap_pwd...
Configuring in src/modules/rlm_eap/types/rlm_eap_sim...
Configuring in src/modules/rlm_opendirectory...
Configuring in src/modules/rlm_idn...
Configuring in src/modules/rlm_unix...
Configuring in src/modules/rlm_securid...
Configuring in src/modules/rlm_ldap...
Configuring in src/modules/rlm_radutmp...
Configuring in src/modules/rlm_cache...
configure.ac:32: warning: AC_CONFIG_SUBDIRS: you should use literals
../../lib/autoconf/status.m4:1097: AC_CONFIG_SUBDIRS is expanded from...
configure.ac:32: the top level
Configuring in src/modules/rlm_cache/drivers/rlm_cache_memcached...
Configuring in src/modules/rlm_ruby...
/usr/bin/m4:configure.ac:6: cannot open `ax_with_prog.m4': No such file or directory
/usr/bin/m4:configure.ac:12: cannot open `ax_compare_version.m4': No such file or directory
/usr/bin/m4:configure.ac:13: cannot open `ax_prog_ruby_version.m4': No such file or directory
/usr/bin/m4:configure.ac:14: cannot open `ax_ruby_devel.m4': No such file or directory
autom4te: /usr/bin/m4 failed with exit status: 1
[jpereira@jpereira-desktop freeradius-server.git]$ 
```

This patch includes the fix and update of affected files.