### PR TITLE
Fixing conflict between 'MAX_STRING_LEN' and the found in apache2 API

### DIFF
--- a/src/include/libradius.h
+++ b/src/include/libradius.h
@@ -117,7 +117,7 @@ typedef void (*sig_t)(int);
 
 #define AUTH_VECTOR_LEN		16
 #define CHAP_VALUE_LENGTH       16
-#define MAX_STRING_LEN		254	/* RFC2138: string 0-253 octets */
+#define FR_MAX_STRING_LEN		254	/* RFC2138: string 0-253 octets */
 
 #ifdef _LIBRADIUS
 #  define RADIUS_HDR_LEN	20

--- a/src/lib/radius_encode.c
+++ b/src/lib/radius_encode.c
@@ -52,7 +52,7 @@ int fr_radius_encode_chap_password(uint8_t *output, RADIUS_PACKET *packet, int i
 {
 	int		i;
 	uint8_t		*ptr;
-	uint8_t		string[MAX_STRING_LEN * 2 + 1];
+	uint8_t		string[FR_MAX_STRING_LEN * 2 + 1];
 	VALUE_PAIR	*challenge;
 
 	/*
@@ -105,7 +105,7 @@ int fr_radius_encode_chap_password(uint8_t *output, RADIUS_PACKET *packet, int i
  */
 int fr_radius_encode_tunnel_password(char *passwd, size_t *pwlen, char const *secret, uint8_t const *vector)
 {
-	uint8_t		buffer[AUTH_VECTOR_LEN + MAX_STRING_LEN + 3];
+	uint8_t		buffer[AUTH_VECTOR_LEN + FR_MAX_STRING_LEN + 3];
 	unsigned char	digest[AUTH_VECTOR_LEN];
 	char		*salt;
 	int		i, n, secretlen;
@@ -179,7 +179,7 @@ int fr_radius_encode_tunnel_password(char *passwd, size_t *pwlen, char const *se
  * We assume that the passwd buffer passed is big enough.
  * RFC2138 says the password is max 128 chars, so the size
  * of the passwd buffer must be at least 129 characters.
- * Preferably it's just MAX_STRING_LEN.
+ * Preferably it's just FR_MAX_STRING_LEN.
  *
  * int *pwlen is updated to the new length of the encrypted
  * password - a multiple of 16 bytes.

--- a/src/main/auth.c
+++ b/src/main/auth.c
@@ -447,7 +447,7 @@ autz_redo:
 	case RLM_MODULE_USERLOCK:
 	default:
 		if ((module_msg = fr_pair_find_by_num(request->packet->vps, 0, PW_MODULE_FAILURE_MESSAGE, TAG_ANY)) != NULL) {
-			char msg[MAX_STRING_LEN + 16];
+			char msg[FR_MAX_STRING_LEN + 16];
 			snprintf(msg, sizeof(msg), "Invalid user (%s)",
 				 module_msg->vp_strvalue);
 			rad_authlog(msg,request,0);
@@ -532,7 +532,7 @@ authenticate:
 		request->reply->code = PW_CODE_ACCESS_REJECT;
 
 		if ((module_msg = fr_pair_find_by_num(request->packet->vps, 0, PW_MODULE_FAILURE_MESSAGE, TAG_ANY)) != NULL){
-			char msg[MAX_STRING_LEN+19];
+			char msg[FR_MAX_STRING_LEN+19];
 
 			snprintf(msg, sizeof(msg), "Login incorrect (%s)",
 				 module_msg->vp_strvalue);
@@ -568,7 +568,7 @@ authenticate:
 	    (check_item = fr_pair_find_by_num(request->config, 0, PW_SIMULTANEOUS_USE, TAG_ANY)) != NULL) {
 		int r, session_type = 0;
 		char		logstr[1024];
-		char		umsg[MAX_STRING_LEN + 1];
+		char		umsg[FR_MAX_STRING_LEN + 1];
 
 		tmp = fr_pair_find_by_num(request->config, 0, PW_SESSION_TYPE, TAG_ANY);
 		if (tmp) {
@@ -640,7 +640,7 @@ authenticate:
 	  request->reply->code = PW_CODE_ACCESS_ACCEPT;
 
 	if ((module_msg = fr_pair_find_by_num(request->packet->vps, 0, PW_MODULE_SUCCESS_MESSAGE, TAG_ANY)) != NULL){
-		char msg[MAX_STRING_LEN+12];
+		char msg[FR_MAX_STRING_LEN+12];
 
 		snprintf(msg, sizeof(msg), "Login OK (%s)",
 			 module_msg->vp_strvalue);

--- a/src/main/map_proc.c
+++ b/src/main/map_proc.c
@@ -36,7 +36,7 @@ static rbtree_t *map_proc_root = NULL;
  */
 struct map_proc {
 	void			*mod_inst;		//!< Module instance.
-	char			name[MAX_STRING_LEN];	//!< Name of the map function.
+	char			name[FR_MAX_STRING_LEN];	//!< Name of the map function.
 	int			length;			//!< Length of name.
 
 	map_proc_func_t		evaluate;		//!< Module's map processor function.

--- a/src/main/xlat.c
+++ b/src/main/xlat.c
@@ -34,7 +34,7 @@ RCSID("$Id$")
 #include <ctype.h>
 
 typedef struct xlat_t {
-	char			name[MAX_STRING_LEN];	//!< Name of the xlat expansion.
+	char			name[FR_MAX_STRING_LEN];	//!< Name of the xlat expansion.
 	int			length;			//!< Length of name.
 	void			*mod_inst;		//!< Module instance passed to xlat and escape functions.
 	xlat_func_t		func;			//!< xlat function.

--- a/src/modules/proto_vmps/vqp.c
+++ b/src/modules/proto_vmps/vqp.c
@@ -27,7 +27,7 @@ RCSID("$Id$")
 
 #include	"vqp.h"
 
-#define MAX_VMPS_LEN (MAX_STRING_LEN - 1)
+#define MAX_VMPS_LEN (FR_MAX_STRING_LEN - 1)
 
 /* @todo: this is a hack */
 #  define debug_pair(vp)	do { if (fr_debug_lvl && fr_log_fp) { \

--- a/src/modules/rlm_chap/rlm_chap.c
+++ b/src/modules/rlm_chap/rlm_chap.c
@@ -57,7 +57,7 @@ static rlm_rcode_t CC_HINT(nonnull) mod_authenticate(UNUSED void *instance,
 				     REQUEST *request)
 {
 	VALUE_PAIR *password, *chap;
-	uint8_t pass_str[MAX_STRING_LEN];
+	uint8_t pass_str[FR_MAX_STRING_LEN];
 
 	if (!request->username) {
 		RWDEBUG("&request:User-Name attribute is required for authentication");

--- a/src/modules/rlm_digest/rlm_digest.c
+++ b/src/modules/rlm_digest/rlm_digest.c
@@ -199,9 +199,9 @@ static rlm_rcode_t CC_HINT(nonnull) mod_authenticate(UNUSED void *instance, REQU
 {
 	int i;
 	size_t a1_len, a2_len, kd_len;
-	uint8_t a1[(MAX_STRING_LEN + 1) * 5]; /* can be 5 attributes */
-	uint8_t a2[(MAX_STRING_LEN + 1) * 3]; /* can be 3 attributes */
-	uint8_t kd[(MAX_STRING_LEN + 1) * 5];
+	uint8_t a1[(FR_MAX_STRING_LEN + 1) * 5]; /* can be 5 attributes */
+	uint8_t a2[(FR_MAX_STRING_LEN + 1) * 3]; /* can be 3 attributes */
+	uint8_t kd[(FR_MAX_STRING_LEN + 1) * 5];
 	uint8_t hash[16];	/* MD5 output */
 	VALUE_PAIR *vp, *passwd, *algo;
 	VALUE_PAIR *qop, *nonce;

--- a/src/modules/rlm_eap/eap.c
+++ b/src/modules/rlm_eap/eap.c
@@ -1301,7 +1301,7 @@ eap_session_t *eap_session_continue(eap_packet_raw_t **eap_packet_p, rlm_eap_t *
 		*      request as the NAS is doing something
 		*      funny.
 		*/
-	       if (strncmp(eap_session->identity, vp->vp_strvalue, MAX_STRING_LEN) != 0) {
+	       if (strncmp(eap_session->identity, vp->vp_strvalue, FR_MAX_STRING_LEN) != 0) {
 		       RDEBUG("Identity does not match User-Name.  Authentication failed");
 		       goto error;
 	       }

--- a/src/modules/rlm_eap/libeap/eap_sim.h
+++ b/src/modules/rlm_eap/libeap/eap_sim.h
@@ -85,13 +85,13 @@ int unmap_eapsim_basictypes(RADIUS_PACKET *r, uint8_t *attr, unsigned int attrle
 
 struct eapsim_keys {
 	/* inputs */
-	uint8_t identity[MAX_STRING_LEN];
+	uint8_t identity[FR_MAX_STRING_LEN];
 	unsigned int  identitylen;
 	uint8_t nonce_mt[EAPSIM_NONCEMT_SIZE];
 	uint8_t rand[3][EAPSIM_RAND_SIZE];
 	uint8_t sres[3][EAPSIM_SRES_SIZE];
 	uint8_t Kc[3][EAPSIM_KC_SIZE];
-	uint8_t versionlist[MAX_STRING_LEN];
+	uint8_t versionlist[FR_MAX_STRING_LEN];
 	uint8_t versionlistlen;
 	uint8_t versionselect[2];
 

--- a/src/modules/rlm_eap/libeap/eapsimlib.c
+++ b/src/modules/rlm_eap/libeap/eapsimlib.c
@@ -326,8 +326,8 @@ int unmap_eapsim_basictypes(RADIUS_PACKET *r,
 			return 0;
 		}
 
-		if (eapsim_len > MAX_STRING_LEN) {
-			eapsim_len = MAX_STRING_LEN;
+		if (eapsim_len > FR_MAX_STRING_LEN) {
+			eapsim_len = FR_MAX_STRING_LEN;
 		}
 		if (eapsim_len < 2) {
 			ERROR("eap: EAP-Sim attribute %d (no.%d) has length too small", eapsim_attribute,

--- a/src/modules/rlm_eap/radeapclient.c
+++ b/src/modules/rlm_eap/radeapclient.c
@@ -2547,8 +2547,8 @@ static void rc_unmap_eap_methods(RADIUS_PACKET *rep)
 		type += PW_EAP_TYPE_BASE;
 		len -= 5;
 
-		if (len > MAX_STRING_LEN) {
-			len = MAX_STRING_LEN;
+		if (len > FR_MAX_STRING_LEN) {
+			len = FR_MAX_STRING_LEN;
 		}
 
 		eap1 = fr_pair_afrom_num(rep, 0, type);

--- a/src/modules/rlm_eap/types/rlm_eap_md5/eap_md5.c
+++ b/src/modules/rlm_eap/types/rlm_eap_md5/eap_md5.c
@@ -131,7 +131,7 @@ int eapmd5_verify(MD5_PACKET *packet, VALUE_PAIR* password,
 		  uint8_t *challenge)
 {
 	char	*ptr;
-	char	string[1 + MAX_STRING_LEN*2];
+	char	string[1 + FR_MAX_STRING_LEN*2];
 	uint8_t digest[16];
 	unsigned short len;
 

--- a/src/modules/rlm_eap/types/rlm_eap_pwd/eap_pwd.h
+++ b/src/modules/rlm_eap/types/rlm_eap_pwd/eap_pwd.h
@@ -81,7 +81,7 @@ typedef struct _pwd_session_t {
     uint16_t group_num;
     uint32_t ciphersuite;
     uint32_t token;
-    char peer_id[MAX_STRING_LEN];
+    char peer_id[FR_MAX_STRING_LEN];
     size_t peer_id_len;
     size_t mtu;
     uint8_t *in;      /* reassembled fragments */

--- a/src/modules/rlm_eap/types/rlm_eap_sim/rlm_eap_sim.c
+++ b/src/modules/rlm_eap/types/rlm_eap_sim/rlm_eap_sim.c
@@ -329,7 +329,7 @@ static int eap_sim_sendchallenge(eap_session_t *eap_session)
 
 		memcpy(&len, newvp->vp_octets, sizeof(uint16_t));
 		len = ntohs(len);
-		if (len <= newvp->vp_length - 2 && len <= MAX_STRING_LEN) {
+		if (len <= newvp->vp_length - 2 && len <= FR_MAX_STRING_LEN) {
 			ess->keys.identitylen = len;
 			memcpy(ess->keys.identity, newvp->vp_octets + 2, ess->keys.identitylen);
 		}

--- a/src/modules/rlm_expr/paircmp.c
+++ b/src/modules/rlm_expr/paircmp.c
@@ -64,7 +64,7 @@ static int presufcmp(UNUSED void *instance,
 {
 	VALUE_PAIR *vp;
 	char const *name;
-	char rest[MAX_STRING_LEN];
+	char rest[FR_MAX_STRING_LEN];
 	int len, namelen;
 	int ret = -1;
 

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -1839,7 +1839,7 @@ static rlm_rcode_t user_modify(rlm_ldap_t *inst, REQUEST *request, ldap_acct_sec
 	CONF_PAIR	*cp;
 	CONF_SECTION 	*cs;
 	FR_TOKEN	op;
-	char		path[MAX_STRING_LEN];
+	char		path[FR_MAX_STRING_LEN];
 
 	char		*p = path;
 

--- a/src/modules/rlm_pap/rlm_pap.c
+++ b/src/modules/rlm_pap/rlm_pap.c
@@ -886,8 +886,8 @@ static rlm_rcode_t CC_HINT(nonnull) pap_auth_ns_mta_md5(UNUSED rlm_pap_t *inst, 
 {
 	FR_MD5_CTX md5_context;
 	uint8_t digest[128];
-	uint8_t buff[MAX_STRING_LEN];
-	char buff2[MAX_STRING_LEN + 50];
+	uint8_t buff[FR_MAX_STRING_LEN];
+	char buff2[FR_MAX_STRING_LEN + 50];
 
 	RDEBUG("Using NT-MTA-MD5-Password");
 

--- a/src/modules/rlm_preprocess/rlm_preprocess.c
+++ b/src/modules/rlm_preprocess/rlm_preprocess.c
@@ -106,7 +106,7 @@ static void cisco_vsa_hack(REQUEST *request)
 {
 	int		vendorcode;
 	char		*ptr;
-	char		newattr[MAX_STRING_LEN];
+	char		newattr[FR_MAX_STRING_LEN];
 	VALUE_PAIR	*vp;
 	vp_cursor_t	cursor;
 	for (vp = fr_cursor_init(&cursor, &request->packet->vps);
@@ -276,7 +276,7 @@ static void rad_mangle(rlm_preprocess_t *inst, REQUEST *request)
 
 	if (inst->with_ntdomain_hack) {
 		char *ptr;
-		char newname[MAX_STRING_LEN];
+		char newname[FR_MAX_STRING_LEN];
 
 		/*
 		 *	Windows NT machines often authenticate themselves as

--- a/src/modules/rlm_securid/rlm_securid.c
+++ b/src/modules/rlm_securid/rlm_securid.c
@@ -455,7 +455,7 @@ static rlm_rcode_t CC_HINT(nonnull) mod_authenticate(void *instance, REQUEST *re
 {
 	int rcode;
 	rlm_securid_t *inst = instance;
-	char  buffer[MAX_STRING_LEN]="";
+	char  buffer[FR_MAX_STRING_LEN]="";
 	char const *username=NULL, *password=NULL;
 	VALUE_PAIR *vp;
 

--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -1467,7 +1467,7 @@ static int acct_redundant(rlm_sql_t *inst, REQUEST *request, sql_acct_section_t 
 	char const		*attr = NULL;
 	char const		*value;
 
-	char			path[MAX_STRING_LEN];
+	char			path[FR_MAX_STRING_LEN];
 	char			*p = path;
 	char			*expanded = NULL;
 

--- a/src/modules/rlm_sql/sql.c
+++ b/src/modules/rlm_sql/sql.c
@@ -129,7 +129,7 @@ int sql_fr_pair_list_afrom_str(TALLOC_CTX *ctx, REQUEST *request, VALUE_PAIR **h
 {
 	VALUE_PAIR *vp;
 	char const *ptr, *value;
-	char buf[MAX_STRING_LEN];
+	char buf[FR_MAX_STRING_LEN];
 	char do_xlat = 0;
 	FR_TOKEN token, operator = T_EOL;
 

--- a/src/modules/rlm_sqlippool/rlm_sqlippool.c
+++ b/src/modules/rlm_sqlippool/rlm_sqlippool.c
@@ -445,7 +445,7 @@ static int do_logging(REQUEST *request, char const *str, int rcode)
 static rlm_rcode_t CC_HINT(nonnull) mod_post_auth(void *instance, REQUEST *request)
 {
 	rlm_sqlippool_t *inst = (rlm_sqlippool_t *) instance;
-	char allocation[MAX_STRING_LEN];
+	char allocation[FR_MAX_STRING_LEN];
 	int allocation_len;
 	VALUE_PAIR *vp;
 	rlm_sql_handle_t *handle;


### PR DESCRIPTION
Exist the same macro in apache2 SDK

```
[jpereira@jpereira-desktop mod_auth_radius.git]$ grep MAX_STRING_LEN -r /usr/include/apr-1.0/ /usr/include/apache2/ 
/usr/include/apache2/mpm_common.h:AP_DECLARE_DATA extern char ap_coredump_dir[MAX_STRING_LEN];
/usr/include/apache2/httpd.h:#define MAX_STRING_LEN HUGE_STRING_LEN
[jpereira@jpereira-desktop mod_auth_radius.git]$ 
```