### PR TITLE
Replaced array function parameters with pointers

### DIFF
--- a/src/modules/rlm_mschap/auth_wbclient.c
+++ b/src/modules/rlm_mschap/auth_wbclient.c
@@ -46,7 +46,7 @@ RCSID("$Id$")
  */
 int do_auth_wbclient(rlm_mschap_t *inst, REQUEST *request,
 		     uint8_t const *challenge, uint8_t const *response,
-		     uint8_t nthashhash[NT_DIGEST_LENGTH])
+		     uint8_t *nthashhash)
 {
 	int rcode = -1;
 	struct wbcContext *wb_ctx;

--- a/src/modules/rlm_mschap/auth_wbclient.h
+++ b/src/modules/rlm_mschap/auth_wbclient.h
@@ -9,6 +9,6 @@ RCSIDH(auth_wbclient_h, "$Id$")
 
 int do_auth_wbclient(rlm_mschap_t *inst, REQUEST *request,
 		     uint8_t const *challenge, uint8_t const *response,
-		     uint8_t nthashhash[NT_DIGEST_LENGTH]);
+		     uint8_t *nthashhash);
 
 #endif /*_AUTH_WBCLIENT_H*/

--- a/src/modules/rlm_mschap/rlm_mschap.c
+++ b/src/modules/rlm_mschap/rlm_mschap.c
@@ -1103,7 +1103,7 @@ ntlm_auth_err:
  */
 static int CC_HINT(nonnull (1, 2, 4, 5 ,6)) do_mschap(rlm_mschap_t *inst, REQUEST *request, VALUE_PAIR *password,
 						      uint8_t const *challenge, uint8_t const *response,
-						      uint8_t nthashhash[NT_DIGEST_LENGTH], MSCHAP_AUTH_METHOD method)
+						      uint8_t *nthashhash, MSCHAP_AUTH_METHOD method)
 {
 	uint8_t	calculated[24];
 


### PR DESCRIPTION
This was already done implicitely, but writing it as an array suggests that it is passed by value instead, and that you can call things like `sizeof` on it. Some explanation and arguments can be found at https://lkml.org/lkml/2015/9/3/428 (although you have to read between the rants, as usual with texts of Linus).

I've only tested it with a local users backend, not with the winbind-client (I don't have a build system with samba 4.2 at hand)