### PR TITLE
Fix build failure when --disable-openssl-version-check is set.

### DIFF
--- a/src/include/radiusd.h
+++ b/src/include/radiusd.h
@@ -360,7 +360,7 @@ typedef struct main_config_t {
 	int		proxy_requests;
 	int		reject_delay;
 	int		status_server;
-#ifdef ENABLE_OPENSSL_VERSION_CHECK
+#if defined(HAVE_OPENSSL_CRYPTO_H) && defined(ENABLE_OPENSSL_VERSION_CHECK)
 	int		allow_vulnerable_openssl;
 #endif
 	int		max_request_time;
@@ -536,7 +536,8 @@ int		pairlist_read(const char *file, PAIR_LIST **list, int complain);
 void		pairlist_free(PAIR_LIST **);
 
 /* version.c */
-int 		ssl_check_version(int allow_vulnerable);
+int 		ssl_check_version(void);
+int 		ssl_check_vulnerable(void);
 const char	*ssl_version(void);
 void		version(void);
 

--- a/src/main/mainconfig.c
+++ b/src/main/mainconfig.c
@@ -172,7 +172,7 @@ static const CONF_PARSER security_config[] = {
 	{ "max_attributes",  PW_TYPE_INTEGER, 0, &fr_max_attributes, Stringify(0) },
 	{ "reject_delay",  PW_TYPE_INTEGER, 0, &mainconfig.reject_delay, Stringify(0) },
 	{ "status_server", PW_TYPE_BOOLEAN, 0, &mainconfig.status_server, "no"},
-#ifdef ENABLE_OPENSSL_VERSION_CHECK
+#if defined(HAVE_OPENSSL_CRYPTO_H) && defined(ENABLE_OPENSSL_VERSION_CHECK)
 	{ "allow_vulnerable_openssl", PW_TYPE_BOOLEAN, 0, &mainconfig.allow_vulnerable_openssl, "no"},
 #endif
 	{ NULL, -1, 0, NULL, NULL }

--- a/src/main/radiusd.c
+++ b/src/main/radiusd.c
@@ -293,9 +293,22 @@ int main(int argc, char *argv[])
 	 *	Mismatch between build time OpenSSL and linked SSL,
 	 *	better to die here than segfault later.
 	 */
-	if (ssl_check_version(mainconfig.allow_vulnerable_openssl) < 0) {
+	if (ssl_check_version() < 0) {
 		exit(1);
 	}
+
+	/*
+	 *	Check for known vulnerabilities that compromise the 
+	 *	security of the server.
+	 */
+#  ifdef ENABLE_OPENSSL_VERSION_CHECK
+	if (!mainconfig.allow_vulnerable_openssl) {
+		if (ssl_check_vulnerable() < 0) {
+			exit(1);
+		}
+	}
+#  endif
+
 #endif
 
 	/*  Load the modules AFTER doing SSL checks */


### PR DESCRIPTION
Minor fix, as mentioned on the devel list.

4f24d4c mostly corrected the behaviour, however mainconfig.allow_vulnerable_ssl still had a dependency on ENABLE_OPENSSL_VERSION_CHECK.