### PR TITLE
Add ALLOW_MSVCHAPV2 flag to mschap/libwbclient

### DIFF
--- a/raddb/mods-available/mschap
+++ b/raddb/mods-available/mschap
@@ -78,6 +78,14 @@ mschap {
 #	winbind_username = "%{mschap:User-Name}"
 #	winbind_domain = "%{mschap:NT-Domain}"
 
+	# When using the winbind daemon directly, it is possible to
+	# force accepting MSCHAPv2 authentication. This makes it
+	# possible to authenticate to an Active Directory that uses
+	# the local security policy 'Network Security: LAN Manager
+	# authentication level' setting was changed to 'Send NTLMv2
+	# Response Only. Refuse LM & NTLM'
+#	winbind_allow_mschapv2 = no
+
 	#
 	#  Information for the winbind connection pool.  The configuration
 	#  items below are the same for all modules which use the new

--- a/src/modules/rlm_mschap/auth_wbclient.c
+++ b/src/modules/rlm_mschap/auth_wbclient.c
@@ -105,6 +105,9 @@ int do_auth_wbclient(rlm_mschap_t *inst, REQUEST *request,
 	memcpy(authparams.password.response.challenge, challenge,
 	       sizeof(authparams.password.response.challenge));
 
+	if (inst->winbind_allow_mschapv2)
+		authparams.parameter_control |= WBC_MSV1_0_ALLOW_MSVCHAPV2;
+
 
 	/*
 	 * Send auth request across to winbind

--- a/src/modules/rlm_mschap/auth_wbclient.h
+++ b/src/modules/rlm_mschap/auth_wbclient.h
@@ -7,6 +7,11 @@ RCSIDH(auth_wbclient_h, "$Id$")
 
 #include <wbclient.h>
 
+/* Samba does not export this constant yet */
+#ifndef WBC_MSV1_0_ALLOW_MSVCHAPV2
+#define WBC_MSV1_0_ALLOW_MSVCHAPV2 0x00010000
+#endif
+
 int do_auth_wbclient(rlm_mschap_t *inst, REQUEST *request,
 		     uint8_t const *challenge, uint8_t const *response,
 		     uint8_t nthashhash[NT_DIGEST_LENGTH]);

--- a/src/modules/rlm_mschap/rlm_mschap.c
+++ b/src/modules/rlm_mschap/rlm_mschap.c
@@ -560,6 +560,7 @@ static const CONF_PARSER module_config[] = {
 	{ "retry_msg", FR_CONF_OFFSET(PW_TYPE_STRING, rlm_mschap_t, retry_msg), NULL },
 	{ "winbind_username", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_TMPL, rlm_mschap_t, wb_username), NULL },
 	{ "winbind_domain", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_TMPL, rlm_mschap_t, wb_domain), NULL },
+	{ "winbind_allow_mschapv2", FR_CONF_OFFSET(PW_TYPE_BOOLEAN, rlm_mschap_t, winbind_allow_mschapv2), "no" },
 #ifdef __APPLE__
 	{ "use_open_directory", FR_CONF_OFFSET(PW_TYPE_BOOLEAN, rlm_mschap_t, open_directory), "yes" },
 #endif

--- a/src/modules/rlm_mschap/rlm_mschap.h
+++ b/src/modules/rlm_mschap/rlm_mschap.h
@@ -39,6 +39,7 @@ typedef struct rlm_mschap_t {
 	vp_tmpl_t		*wb_username;
 	vp_tmpl_t		*wb_domain;
 	fr_connection_pool_t    *wb_pool;
+	bool			winbind_allow_mschapv2;
 #ifdef __APPLE__
 	bool			open_directory;
 #endif


### PR DESCRIPTION
The functionality is the same as https://github.com/samba-team/samba/pull/45: allow authentication via winbind when the AD has a higher security level.