### PR TITLE
Parsing error on debian/control: Fixes #1442

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -61,7 +61,7 @@ Description: FreeRADIUS common files
 
 Package: freeradius-config
 Architecture: any
-Depends: freeradius-common (>= 3), ${misc:Depends}, openssl make
+Depends: freeradius-common (>= 3), ${misc:Depends}, openssl, make
 Breaks: freeradius-config
 Description: FreeRADIUS default config files
  This package should be used as a base for a site local packages


### PR DESCRIPTION
Without the comma dpkg-buildpackage doesn't like the conrol file.