### PR TITLE
Removed option winbind_allow_mschapv2 in rlm_mschap

### DIFF
--- a/raddb/mods-available/mschap
+++ b/raddb/mods-available/mschap
@@ -78,14 +78,6 @@ mschap {
 #	winbind_username = "%{mschap:User-Name}"
 #	winbind_domain = "%{mschap:NT-Domain}"
 
-	# When using the winbind daemon directly, it is possible to
-	# force accepting MSCHAPv2 authentication. This makes it
-	# possible to authenticate to an Active Directory that uses
-	# the local security policy 'Network Security: LAN Manager
-	# authentication level' setting was changed to 'Send NTLMv2
-	# Response Only. Refuse LM & NTLM'
-#	winbind_allow_mschapv2 = no
-
 	#
 	#  Information for the winbind connection pool.  The configuration
 	#  items below are the same for all modules which use the new

--- a/src/modules/rlm_mschap/auth_wbclient.c
+++ b/src/modules/rlm_mschap/auth_wbclient.c
@@ -105,8 +105,7 @@ int do_auth_wbclient(rlm_mschap_t *inst, REQUEST *request,
 	memcpy(authparams.password.response.challenge, challenge,
 	       sizeof(authparams.password.response.challenge));
 
-	if (inst->winbind_allow_mschapv2)
-		authparams.parameter_control |= WBC_MSV1_0_ALLOW_MSVCHAPV2;
+	authparams.parameter_control |= WBC_MSV1_0_ALLOW_MSVCHAPV2;
 
 
 	/*

--- a/src/modules/rlm_mschap/rlm_mschap.c
+++ b/src/modules/rlm_mschap/rlm_mschap.c
@@ -560,7 +560,6 @@ static const CONF_PARSER module_config[] = {
 	{ "retry_msg", FR_CONF_OFFSET(PW_TYPE_STRING, rlm_mschap_t, retry_msg), NULL },
 	{ "winbind_username", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_TMPL, rlm_mschap_t, wb_username), NULL },
 	{ "winbind_domain", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_TMPL, rlm_mschap_t, wb_domain), NULL },
-	{ "winbind_allow_mschapv2", FR_CONF_OFFSET(PW_TYPE_BOOLEAN, rlm_mschap_t, winbind_allow_mschapv2), "no" },
 #ifdef __APPLE__
 	{ "use_open_directory", FR_CONF_OFFSET(PW_TYPE_BOOLEAN, rlm_mschap_t, open_directory), "yes" },
 #endif

--- a/src/modules/rlm_mschap/rlm_mschap.h
+++ b/src/modules/rlm_mschap/rlm_mschap.h
@@ -39,7 +39,6 @@ typedef struct rlm_mschap_t {
 	vp_tmpl_t		*wb_username;
 	vp_tmpl_t		*wb_domain;
 	fr_connection_pool_t    *wb_pool;
-	bool			winbind_allow_mschapv2;
 #ifdef __APPLE__
 	bool			open_directory;
 #endif


### PR DESCRIPTION
See the discussion at https://github.com/FreeRADIUS/freeradius-server/commit/37f2f6d8e09bdebdf3031e419c00a0d3193b074a for more information