### PR TITLE
Allow to set source interface (rlm_rest)

### DIFF
--- a/raddb/mods-available/rest
+++ b/raddb/mods-available/rest
@@ -46,6 +46,12 @@ rest {
 #	connect_proxy = "socks://127.0.0.1"
 
 	#
+	#  Set a specific source interface or IP address for outgoing traffic.
+	#  (Refer to libcurl CURLOPT_INTERFACE option.)
+	#
+#	src_interface = ""
+
+	#
 	#  The following config items can be used in each of the sections.
 	#  The sections themselves reflect the sections in the server.
 	#  For example if you list rest in the authorize section of a virtual server,

--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -362,6 +362,7 @@ void *mod_conn_create(TALLOC_CTX *ctx, void *instance, struct timeval const *tim
 		SET_OPTION(CURLOPT_URL, inst->connect_uri);
 		SET_OPTION(CURLOPT_NOSIGNAL, 1);
 		if (inst->connect_proxy) SET_OPTION(CURLOPT_PROXY, inst->connect_proxy);
+		if (inst->src_interface) SET_OPTION(CURLOPT_INTERFACE, inst->src_interface);
 
 		DEBUG("rlm_rest (%s): Connecting to \"%s\"", inst->xlat_name, inst->connect_uri);
 

--- a/src/modules/rlm_rest/rest.h
+++ b/src/modules/rlm_rest/rest.h
@@ -151,6 +151,8 @@ typedef struct rlm_rest_t {
 
 	char const		*connect_proxy;	//!< Send request via this proxy.
 
+	char const		*src_interface;	//!< Source interface or IP address.
+
 	fr_connection_pool_t	*pool;		//!< Pointer to the connection pool.
 
 	rlm_rest_section_t	authorize;	//!< Configuration specific to authorisation.

--- a/src/modules/rlm_rest/rlm_rest.c
+++ b/src/modules/rlm_rest/rlm_rest.c
@@ -82,6 +82,7 @@ static const CONF_PARSER module_config[] = {
 	{ FR_CONF_OFFSET("connect_uri", PW_TYPE_STRING, rlm_rest_t, connect_uri) },
 	{ FR_CONF_DEPRECATED("connect_timeout", PW_TYPE_TIMEVAL, rlm_rest_t, connect_timeout) },
 	{ FR_CONF_OFFSET("connect_proxy", PW_TYPE_STRING, rlm_rest_t, connect_proxy) },
+	{ FR_CONF_OFFSET("src_interface", PW_TYPE_STRING, rlm_rest_t, src_interface) },
 	CONF_PARSER_TERMINATOR
 };
 


### PR DESCRIPTION
Sometimes it is required to be able to set the source interface (or IP
address).
This small patch adds a configuration item and sets the appropriate
libcurl option.