### PR TITLE
After removing a vp, if removed element was cursor->found it should b…

### DIFF
--- a/src/lib/cursor.c
+++ b/src/lib/cursor.c
@@ -469,7 +469,7 @@ fixup:
 	/*
 	 *	Fixup cursor->found if we removed the VP it was referring to
 	 */
-	if (vp == cursor->found) cursor->found = cursor->current;
+	if (vp == cursor->found) cursor->found = NULL;
 
 	/*
 	 *	Fixup cursor->last if we removed the VP it was referring to


### PR DESCRIPTION
…e set to null, not current