### PR TITLE
Rlm python fixes

### DIFF
--- a/src/modules/rlm_python/prepaid.py
+++ b/src/modules/rlm_python/prepaid.py
@@ -161,15 +161,14 @@ def authorize(authData):
   # If you want to use different operators
   # you can do
   # return (radiusd.RLM_MODULE_UPDATED,
-  #         radiusd.resolve(
-  #            'Session-Timeout := %s' % str(sessionTimeout),
-  #            'Some-other-option -= Value',
+  #         (
+  #            ('Session-Timeout', ':=', str(sessionTimeout)),
+  #            ('Some-other-option', '-=', Value'),
   #         ),
-  #         radiusd.resolve(
-  #            'Auth-Type := python'
-  #         )
+  #         (
+  #            ('Auth-Type', ':=', 'python'),
+  #         ),
   #        )
-  # Edit operators you need in OP_TRY in radiusd.py
 
 def authenticate(p):
   p = p

--- a/src/modules/rlm_python/radiusd.py
+++ b/src/modules/rlm_python/radiusd.py
@@ -32,22 +32,6 @@ L_ERR = 4
 L_PROXY = 5
 L_CONS = 128
 
-OP={       '{':2,   '}':3,   '(':4,   ')':5,   ',':6,   ';':7,  '+=':8,  '-=':9,  ':=':10,
-  '=':11, '!=':12, '>=':13,  '>':14, '<=':15,  '<':16, '=~':17, '!~':18, '=*':19, '!*':20,
- '==':21 , '#':22 }
-
-OP_TRY = (':=', '+=', '-=', '=' )
-
-def resolve(*lines):
-    tuples = []
-    for line in lines:
-	for op in OP_TRY:
-	    arr = line.rsplit(op)
-	    if len(arr)==2:
-		tuples.append((str(arr[0].strip()),OP[op],str(arr[1].strip())))
-		break
-    return tuple(tuples)
-
 # log function
 def radlog(level, msg):
     import sys

--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -364,9 +364,9 @@ static void mod_vptuple(TALLOC_CTX *ctx, REQUEST *request, VALUE_PAIR **vps, PyO
 
 		vp->op = op;
 		if (fr_pair_value_from_str(vp, s2, -1) < 0) {
-			DEBUG("rlm_python:%s: Failed: '%s:%s' = '%s'", funcname, list_name, s1, s2);
+			DEBUG("rlm_python:%s: Failed: '%s:%s' %s '%s'", funcname, list_name, s1, fr_int2str(fr_tokens_table, op, "="), s2);
 		} else {
-			DEBUG("rlm_python:%s: '%s:%s' = '%s'", funcname, list_name, s1, s2);
+			DEBUG("rlm_python:%s: '%s:%s' %s '%s'", funcname, list_name, s1, fr_int2str(fr_tokens_table, op, "="), s2);
 		}
 
 		radius_pairmove(current, vps, vp, false);


### PR DESCRIPTION
A number of changes to the python module to make it a lot more usable than it was. It started when I was trying to understand how rlm_python works due to https://github.com/FreeRADIUS/freeradius-server/issues/1451#issuecomment-164894510, and there were a lot of easy fixes to make it more mature than it is now. All these fixes can be backported to 3.0.10, because they preserve backwards compatibility. It was mainly as an excercise for myself to get some experience with embedding python.

As a bonus, I also updated the (almost completely empty) wiki page at http://wiki.freeradius.org/modules/Rlm_python.