### PR TITLE
Fix acctinputoctets & acctoutputoctets been reset to 0 when accounting stopped with no attributes of traffic.

### DIFF
--- a/raddb/mods-config/sql/main/mysql/queries.conf
+++ b/raddb/mods-config/sql/main/mysql/queries.conf
@@ -292,10 +292,26 @@ accounting {
 						UNIX_TIMESTAMP(@acctupdatetime_old), \
 					framedipaddress = '%{Framed-IP-Address}', \
 					acctsessiontime = %{%{Acct-Session-Time}:-NULL}, \
-					acctinputoctets = '%{%{Acct-Input-Gigawords}:-0}' \
-						<< 32 | '%{%{Acct-Input-Octets}:-0}', \
-					acctoutputoctets = '%{%{Acct-Output-Gigawords}:-0}' \
-						<< 32 | '%{%{Acct-Output-Octets}:-0}' \
+					acctinputoctets	= \
+						CASE \
+							WHEN '%{Acct-Input-Gigawords}'='' THEN (acctinputoctets >> 32) \
+							ELSE '%{Acct-Input-Gigawords}' \
+						END << 32 \
+						| \
+						CASE \
+							WHEN '%{Acct-Input-Octets}'='' THEN (acctinputoctets & 0xFFFFFFFF) \
+							ELSE '%{Acct-Input-Octets}' \
+						END, \
+					acctoutputoctets = \
+						CASE \
+							WHEN '%{Acct-Output-Gigawords}'='' THEN (acctoutputoctets >> 32) \
+							ELSE '%{Acct-Output-Gigawords}' \
+						END << 32 \
+						| \
+						CASE \
+							WHEN '%{Acct-Output-Octets}'='' THEN (acctoutputoctets & 0xFFFFFFFF) \
+							ELSE '%{Acct-Output-Octets}' \
+						END \
 				WHERE AcctUniqueId = '%{Acct-Unique-Session-Id}'"
 
 			#
@@ -339,10 +355,26 @@ accounting {
 					acctstoptime	= FROM_UNIXTIME(\
 						%{integer:Event-Timestamp}), \
 					acctsessiontime	= %{%{Acct-Session-Time}:-NULL}, \
-					acctinputoctets	= '%{%{Acct-Input-Gigawords}:-0}' \
-						<< 32 | '%{%{Acct-Input-Octets}:-0}', \
-					acctoutputoctets = '%{%{Acct-Output-Gigawords}:-0}' \
-						<< 32 | '%{%{Acct-Output-Octets}:-0}', \
+					acctinputoctets	= \
+						CASE \
+							WHEN '%{Acct-Input-Gigawords}'='' THEN (acctinputoctets >> 32) \
+							ELSE '%{Acct-Input-Gigawords}' \
+						END << 32 \
+						| \
+						CASE \
+							WHEN '%{Acct-Input-Octets}'='' THEN (acctinputoctets & 0xFFFFFFFF) \
+							ELSE '%{Acct-Input-Octets}' \
+						END, \
+					acctoutputoctets = \
+						CASE \
+							WHEN '%{Acct-Output-Gigawords}'='' THEN (acctoutputoctets >> 32) \
+							ELSE '%{Acct-Output-Gigawords}' \
+						END << 32 \
+						| \
+						CASE \
+							WHEN '%{Acct-Output-Octets}'='' THEN (acctoutputoctets & 0xFFFFFFFF) \
+							ELSE '%{Acct-Output-Octets}' \
+						END, \
 					acctterminatecause = '%{Acct-Terminate-Cause}', \
 					connectinfo_stop = '%{Connect-Info}' \
 				WHERE AcctUniqueId = '%{Acct-Unique-Session-Id}'"


### PR DESCRIPTION
An example log of "Acct-Status-Type = Stop" with no attributes of traffic (no Acct-Input-Gigawords, no Acct-Input-Octets, no Acct-Output-Gigawords, no Acct-Output-Octets).

	Fri Dec 18 14:00:12 2015
			Acct-Status-Type = Stop
			Acct-Authentic = RADIUS
			User-Name = "**********"
			Called-Station-Id = "00-0C-43-**-**-**:\\x**\\x**\\x**\\x**\\x**\\x**\\x**\\x**\\x**\\x**\\x**\\x**\\x**\\x**\\x**\\x**\\x**\\x**"
			NAS-Port-Type = Wireless-802.11
			NAS-Port = 4
			Calling-Station-Id = "9C-FC-01-**-**-**"
			Connect-Info = "CONNECT 54Mbps 802.11g"
			Acct-Session-Id = "5670F442-00000330"
			WLAN-Pairwise-Cipher = 1027076
			WLAN-Group-Cipher = 1027076
			WLAN-AKM-Suite = 1027073
			Acct-Session-Time = 811
			Event-Timestamp = "Dec 18 2015 14:00:12 CST"
			NAS-IP-Address = 192.168.201.20
			Acct-Unique-Session-Id = "0c82627b41241813"
			Timestamp = 1450418412


This fix is for v3.0.x, v3.1.x. For v2.x.x, it can be simpler:

	 acctinputoctets    = %{%{Acct-Input-Gigawords}:-(acctinputoctets >> 32)} << 32 | %{%{Acct-Input-Octets}:-(acctinputoctets & 0xFFFFFFFF)}, \
	 acctoutputoctets   = %{%{Acct-Output-Gigawords}:-(acctoutputoctets >> 32)} << 32 | %{%{Acct-Output-Octets}:-(acctoutputoctets & 0xFFFFFFFF)}, \
