### PR TITLE
Updated comment about default fragment_size

### DIFF
--- a/src/include/tls-h
+++ b/src/include/tls-h
@@ -351,7 +351,7 @@ struct fr_tls_server_conf_t {
 	bool		disable_tlsv1_2;
 
 	/*
-	 *	Always < 4096 (due to radius limit), 0 by default = 2048
+	 *	Always < 4096 (due to radius limit), 0 by default = 1024
 	 */
 	uint32_t	fragment_size;
 	bool		check_crl;


### PR DESCRIPTION
The default is 1024, as can be seen in tls.c:

    ./src/main/tls.c: { "fragment_size", FR_CONF_OFFSET(PW_TYPE_INTEGER, fr_tls_server_conf_t, fragment_size), "1024" }