### PR TITLE
Add systemd support for Debian Jessie

### DIFF
--- a/debian/freeradius.default
+++ b/debian/freeradius.default
@@ -1,6 +1,15 @@
-# Options for the FreeRADIUS deamon.
+# Options passed to the FreeRADIUS deamon.
+#
+FREERADIUS_OPTIONS=""
+
+
+# If FreeRADIUS is being used on a SysVinit system
+# and FREERADIUS_OPTIONS has not been set and the
+# following location exists, then it will be used
+# for the config directory rather than the default.
+#
+# This option has no effect when systemd is in
+# use, or if FREERADIUS_OPTIONS is set above.
+#
 FREERADIUS_CONF_LOCAL="/usr/local/etc/freeradius"
 
-if [ -d "$FREERADIUS_CONF_LOCAL" ]; then
-	FREERADIUS_OPTIONS="-d $FREERADIUS_CONF_LOCAL"
-fi

--- a/debian/freeradius.init
+++ b/debian/freeradius.init
@@ -42,6 +42,10 @@ if [ ! -d /var/run/freeradius ]; then
     chown freerad:freerad /var/run/freeradius
 fi
 
+if [ -d "$FREERADIUS_CONF_LOCAL" -a -z "$FREERADIUS_OPTIONS" ]; then
+  FREERADIUS_OPTIONS="-d $FREERADIUS_CONF_LOCAL"
+fi
+
 export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
 
 ret=0

--- a/debian/freeradius.service
+++ b/debian/freeradius.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=FreeRADIUS multi-protocol policy server
+After=syslog.target network.target
+Documentation=man:radiusd(8) man:radiusd.conf(5) http://wiki.freeradius.org/ http://networkradius.com/doc/
+
+[Service]
+Type=forking
+PIDFile=/run/freeradius/freeradius.pid
+EnvironmentFile=-/etc/default/freeradius
+ExecStartPre=/usr/sbin/freeradius $FREERADIUS_OPTIONS -Cxm -lstdout
+ExecStart=/usr/sbin/freeradius $FREERADIUS_OPTIONS
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Apparently it is moving a step forward to break convenience.
So systemd users will have to manually update the system to use
/usr/local/etc/freeradius themselves if that is where their
config is located.

Without this, the freeradius package refuses to start on jessie, and systemd can't cope with shell code in the default file. But this patch doesn't change functionality when building on wheezy.