### PR TITLE
Allow config section in python config

### DIFF
--- a/raddb/mods-available/python
+++ b/raddb/mods-available/python
@@ -50,4 +50,15 @@ python {
 
 	mod_send_coa = ${.module}
 #	func_send_coa = send_coa
+
+	# You can define configuration items (and nested sub-sections) in python "config" section.
+	# These items will be accessible in the python script through radiusd.config dict
+	# For instance: radiusd.config['name'], radiusd.config['sub-config']['name']
+	#
+	#config {
+	#	name = "value"
+	#	sub-config {
+	#		name = "value of name from config.sub-config"
+	#	}
+	#}
 }

--- a/src/modules/rlm_python/example.py
+++ b/src/modules/rlm_python/example.py
@@ -17,6 +17,9 @@ def authorize(p):
   radiusd.radlog(radiusd.L_INFO, '*** radlog call in authorize ***')
   print
   print p
+  print
+  print radiusd.config
+  print
   return radiusd.RLM_MODULE_OK
 
 def preacct(p):


### PR DESCRIPTION
They will recursively be turned into a dict, and added to radiusd.config. Behaviour is identical to the same config option in rlm_perl.

This is the extended version of #1451/#1453. It has *not* been addressed by #1459.

This patch can be backported to v3.0.x, it just adds another attribute to the `radiusd` module, script that don't use it just keep not using it ;)