### PR TITLE
Fix policyd filter

### DIFF
--- a/raddb/policy.d/filter
+++ b/raddb/policy.d/filter
@@ -3,27 +3,39 @@
 #	realms.
 #
 deny_realms {
-	if (&User-Name && (&User-Name =~ /@|\\/)) {
+	#
+	#  No User-Name, skip.
+	#
+	if (!&User-Name || &User-Name == "") {
+		noop
+	}
+
+	if (&User-Name =~ /@|\\/) {
+		update reply {
+			&Reply-Message += 'Rejected: User-Name contains a realm'
+		}
 		reject
 	}
 }
 
 #
-#	Filter the username
+#	Filter the User-Name
 #
 #  Force some sanity on User-Name. This helps to avoid issues
 #  issues where the back-end database is "forgiving" about
 #  what constitutes a user name.
 #
 filter_username {
-	if (!&User-Name) {
+	#
+	#  No User-Name, skip.
+	#
+	if (!&User-Name || &User-Name == "") {
 		noop
 	}
 
 	#
 	#  reject mixed case e.g. "UseRNaMe"
 	#
-
 	#if (&User-Name != "%{tolower:%{User-Name}}") {
 	#	reject
 	#}
@@ -34,38 +46,41 @@ filter_username {
 	#
 	if (&User-Name =~ / /) {
 		update reply {
-			&Reply-Message += 'Rejected: Username contains whitespace'
+			&Reply-Message += 'Rejected: User-Name contains whitespace'
 		}
 		reject
 	}
 
 	#
-	#  reject Multiple @'s
+	#  reject multiple realm delimiters
 	#  e.g. "user@site.com@site.com"
+	#  e.g. "site.com\site.com\user"
 	#
-	if (&User-Name =~ /@.*@/ ) {
+	if (&User-Name =~ /[@\][^@\]*[@\]/ ) {
 		update reply {
-			&Reply-Message += 'Rejected: Multiple @ in username'
+			&Reply-Message += 'Rejected: Multiple realm delimiters in User-Name'
 		}
 		reject
 	}
 
 	#
-	#  reject double dots
+	#  reject multiple dots in the realm
 	#  e.g. "user@site..com"
+	#  e.g. "site..com\user"
 	#
-	if (&User-Name =~ /\.\./ ) {
+	if (&User-Name =~ /@[^.]*\.\.|\.\.[^.]*\\/ ) {
 		update reply {
-			&Reply-Message += 'Rejected: Username contains ..s'
+			&Reply-Message += 'Rejected: Realm contains ..s'
 		}
 		reject
 	}
 
 	#
-	#  must have at least 1 string-dot-string after @
-	#  e.g. "user@site.com"
+	#  reject where there is not at least 1 string-dot-string in the realm
+	#  e.g. "user@site"
+	#  e.g. "site\user"
 	#
-	if ((&User-Name =~ /@/) && (&User-Name !~ /@(.+)\.(.+)$/))  {
+	if (&User-Name =~ /@|\\/ && &User-Name !~ /@[^.]+\.[^.]+|[^.]+\.[^.]+\\/)  {
 		update reply {
 			&Reply-Message += 'Rejected: Realm does not have at least one dot separator'
 		}
@@ -73,10 +88,11 @@ filter_username {
 	}
 
 	#
-	#  Realm ends with a dot
+	#  reject realms that end with a dot
 	#  e.g. "user@site.com."
+	#  e.g. "site.com.\user"
 	#
-	if (&User-Name =~ /\.$/)  {
+	if (&User-Name =~ /@.*\.$|.*\.\\/)  {
 		update reply {
 			&Reply-Message += 'Rejected: Realm ends with a dot'
 		}
@@ -84,10 +100,11 @@ filter_username {
 	}
 
 	#
-	#  Realm begins with a dot
+	#  reject realms that begin with a dot
 	#  e.g. "user@.site.com"
+	#  e.g. ".site.com\user"
 	#
-	if (&User-Name =~ /@\./)  {
+	if (&User-Name =~ /@\..*$|\..*\\/)  {
 		update reply {
 			&Reply-Message += 'Rejected: Realm begins with a dot'
 		}
@@ -98,12 +115,18 @@ filter_username {
 #
 #	Filter the User-Password
 #
-#  Some equipment sends passwords with embedded zeros.
-#  This poliocy filters them out.
+#  Some equipment sends passwords with embedded zeroes.
+#  This policy filters them out.
 #
 filter_password {
-	if (&User-Password && \
-	   (&User-Password != "%{string:User-Password}")) {
+	#
+	#  No user password, skip.
+	#
+	if (!&User-Password) {
+		noop
+	}
+	
+	if (&User-Password != "%{string:User-Password}") {
 		update request {
 			&Tmp-String-0 := "%{string:User-Password}"
 			&User-Password := "%{string:Tmp-String-0}"
@@ -111,78 +134,157 @@ filter_password {
 	 }
 }
 
-filter_inner_identity {
+#
+#	Filter the inner and outer identities
+#
+#  Do checks on outer and inner identities so that users
+#  cannot spoof us by using incompatible identities
+#
+filter_inner_outer_identity {
 	#
-	#  No names, reject.
+	#  No inner or outer User-Name? Reject.
 	#
-	if (!&outer.request:User-Name || !&User-Name) {
+	if (!&outer.request:User-Name || &outer.request:User-Name == "" || !&User-Name || &User-Name == "") {
 		update request {
-			Module-Failure-Message = "User-Name is required for tunneled authentication"
+			Module-Failure-Message = 'Rejected: Inner and outer identities are required for tunnelled authentication'
 		}
 		reject
 	}
 
 	#
-	#  If the names are the same, it's OK.
+	#  Do lots of sanity checks.
 	#
-	#  Otherwise, do lots of sanity checks
+	#  Get the outer stripped user name. Look for the outer realm.
 	#
-	if (&outer.request:User-Name != &User-Name) {
-		#
-		#  We require the outer User-Name
-		#  to be "@realm", or "anon...",
-		#  hopefully "anonymous", or "anonymous@realm"
-		#
-		#  The checks for "anonymous" are more relaxed
-		#  because vendors send a variety of names
-		#  instead of following the standards.
-		#
-		if ((&outer.request:User-Name !~ /^@/) && \
-		    (&outer.request:User-Name !~ /^anon/)) {
+	if (&outer.request:User-Name =~ /^([^@\]+)?(@([^@\]+)?)?$/) {
+		#  Case insensitive.
+		update request {
+			Outer-Stripped-User-Name = "%{tolower:%{1}}"
+			Outer-Realm-Name = "%{tolower:%{3}}"
+		}
+		
+		#  Case sensitive.
+		#update request {
+		#	Outer-Stripped-User-Name = "%{1}"
+		#	Outer-Realm-Name = "%{3}"
+		#}
+	}
+	elsif (&outer.request:User-Name =~ /^(([^@\]+)?\\)?([^@\]+)?$/) {
+		#  Case insensitive.
+		update request {
+			Outer-Stripped-User-Name = "%{tolower:%{3}}"	
+			Outer-Realm-Name = "%{tolower:%{1}}"
+		}
+		
+		#  Case sensitive.
+		#update request {
+		#	Outer-Stripped-User-Name = "%{3}"
+		#	Outer-Realm-Name = "%{1}"
+		#}
+	}
+
+	#
+	#  Get the inner stripped user name. Look for the inner realm.
+	#
+	if (&User-Name =~ /^([^@\]+)?(@([^@\]+)?)?$/) {
+		#  Case insensitive.
+		update request {
+			Inner-Stripped-User-Name = "%{tolower:%{1}}"
+			Inner-Realm-Name = "%{tolower:%{3}}"
+		}
+		
+		#  Case sensitive.
+		#update request {
+		#	Inner-Stripped-User-Name = "%{1}"
+		#	Inner-Realm-Name = "%{3}"
+		#}
+	}
+	elsif (&User-Name =~ /^(([^@\]+)?\\)?([^@\]+)?$/) {
+		#  Case insensitive.
+		update request {
+			Inner-Stripped-User-Name = "%{tolower:%{3}}"	
+			Inner-Realm-Name = "%{tolower:%{1}}"
+		}
+		
+		#  Case sensitive.
+		#update request {
+		#	Inner-Stripped-User-Name = "%{3}"
+		#	Inner-Realm-Name = "%{1}"
+		#}
+	}
+
+	#
+	#  We require that the inner User-Name not be
+	#  "@realm", "\realm", "anonymous", "anon"
+	#  "anonymous@realm", "realm\anonymous",
+	#  "anon@realm" or "realm\anon".
+	#
+	#  The check for "anonymous" is more relaxed,
+	#  disallowing "anon" because some vendors
+	#  send this in the outer instead of
+	#  following the standards.
+	#
+	if ((&Inner-Realm-Name == "" && \
+		&Inner-Stripped-User-Name =~ /^anon(ymous)?$/) || \
+		&Inner-Stripped-User-Name =~ /^(anon(ymous)?)?$/) {
+		update request {
+			Module-Failure-Message = 'Rejected: Inner identity cannot be anonymized'
+		}
+		reject
+	}
+
+	if (&Outer-Stripped-User-Name == &Inner-Stripped-User-Name) {
+		#  The stripped inner and outer User-Name are the same.
+		#  Ensure that the inner and outer realms are the same where they are both defined.
+		if (&Outer-Realm-Name != "" && \
+			&Inner-Realm-Name != "" && \
+			&Inner-Realm-Name != &Outer-Realm-Name) {
 			update request {
-				Module-Failure-Message = "User-Name is not correctly anonymized"
+				Module-Failure-Message = 'Rejected: Realm in the inner identity is not the same as the realm in the outer identity'
+			}
+			reject
+		}
+	}
+	else {
+		#
+		#  The stripped inner and outer User-Name are different.
+		#  Perform anonimization checks.
+		#
+		#  We require that the outer User-Name be
+		#  "@realm", "\realm", "anonymous", "anon"
+		#  "anonymous@realm", "realm\anonymous",
+		#  "anon@realm" or "realm\anon".
+		#
+		#  The check for "anonymous" is more relaxed,
+		#  allowing "anon" because some vendors send
+		#  this instead of following the standards.
+		#
+		if ((&Outer-Realm-Name == "" && \
+			&Outer-Stripped-User-Name !~ /^anon(ymous)?$/) || \
+			&Outer-Stripped-User-Name !~ /^(anon(ymous)?)?$/) {
+			update request {
+				Module-Failure-Message = 'Rejected: Outer identity is not anonymized correctly'
 			}
 			reject
 		}
 
 		#
-		#  Now we get complicated.  Look for the outer realm
+		#  It is OK to have outer realm "@example.com" and
+		#  inner User-Name "bob".  We do more detailed checks
+		#  only if an inner and outer realm exists.
 		#
-		if (&outer.request:User-Name =~ /@(.*)$/) {
-			update request {
-				Outer-Realm-Name = "%{1}"
-			}
-		}
-
-		#
-		#  And the inner realm
-		#
-		if (&User-Name =~ /@(.*)$/) {
-			update request {
-				Inner-Realm-Name = "%{1}"
-			}
-		}
-
-		#
-		#  It's OK to have outer "@example.com" and
-		#  inner "bob".  We do more detailed checks
-		#  only if the inner realm exists.
-		#
-		#  It's OK to have the same realm name, or
+		#  It is OK to have the same realm name, or
 		#  the outer one is "example.com" and the inner
 		#  is "secure.example.com"
 		#
-		if (&Inner-Realm-Name && \
-		    (&Inner-Realm-Name != &Outer-Realm-Name) && \
-		    (&Inner-Realm-Name !~ /\.%{Outer-Realm-Name}$/)) {
+		if (&Outer-Realm-Name != "" && \
+			&Inner-Realm-Name != "" && \
+			&Inner-Realm-Name !~ /(\.)?%{Outer-Realm-Name}$/) {
 			update request {
-				Module-Failure-Message = "Inner and outer realms are not compatible"
+				Module-Failure-Message = 'Rejected: Realm in the inner identity is not the same as or a subrealm of the realm in the anonymized outer identity'
 			}
 			reject
 		}
-
-		#
-		#  It's OK to have an outer realm and no inner realm.
-		#
 	}
 }
+

--- a/raddb/policy.d/filter
+++ b/raddb/policy.d/filter
@@ -3,39 +3,27 @@
 #	realms.
 #
 deny_realms {
-	#
-	#  No User-Name, skip.
-	#
-	if (!&User-Name || &User-Name == "") {
-		noop
-	}
-
-	if (&User-Name =~ /@|\\/) {
-		update reply {
-			&Reply-Message += 'Rejected: User-Name contains a realm'
-		}
+	if (&User-Name && (&User-Name =~ /@|\\/)) {
 		reject
 	}
 }
 
 #
-#	Filter the User-Name
+#	Filter the username
 #
 #  Force some sanity on User-Name. This helps to avoid issues
 #  issues where the back-end database is "forgiving" about
 #  what constitutes a user name.
 #
 filter_username {
-	#
-	#  No User-Name, skip.
-	#
-	if (!&User-Name || &User-Name == "") {
+	if (!&User-Name) {
 		noop
 	}
 
 	#
 	#  reject mixed case e.g. "UseRNaMe"
 	#
+
 	#if (&User-Name != "%{tolower:%{User-Name}}") {
 	#	reject
 	#}
@@ -46,41 +34,38 @@ filter_username {
 	#
 	if (&User-Name =~ / /) {
 		update reply {
-			&Reply-Message += 'Rejected: User-Name contains whitespace'
+			&Reply-Message += 'Rejected: Username contains whitespace'
 		}
 		reject
 	}
 
 	#
-	#  reject multiple realm delimiters
+	#  reject Multiple @'s
 	#  e.g. "user@site.com@site.com"
-	#  e.g. "site.com\site.com\user"
 	#
-	if (&User-Name =~ /[@\][^@\]*[@\]/ ) {
+	if (&User-Name =~ /@.*@/ ) {
 		update reply {
-			&Reply-Message += 'Rejected: Multiple realm delimiters in User-Name'
+			&Reply-Message += 'Rejected: Multiple @ in username'
 		}
 		reject
 	}
 
 	#
-	#  reject multiple dots in the realm
+	#  reject double dots
 	#  e.g. "user@site..com"
-	#  e.g. "site..com\user"
 	#
-	if (&User-Name =~ /@[^.]*\.\.|\.\.[^.]*\\/ ) {
+	if (&User-Name =~ /\.\./ ) {
 		update reply {
-			&Reply-Message += 'Rejected: Realm contains ..s'
+			&Reply-Message += 'Rejected: Username contains ..s'
 		}
 		reject
 	}
 
 	#
-	#  reject where there is not at least 1 string-dot-string in the realm
-	#  e.g. "user@site"
-	#  e.g. "site\user"
+	#  must have at least 1 string-dot-string after @
+	#  e.g. "user@site.com"
 	#
-	if (&User-Name =~ /@|\\/ && &User-Name !~ /@[^.]+\.[^.]+|[^.]+\.[^.]+\\/)  {
+	if ((&User-Name =~ /@/) && (&User-Name !~ /@(.+)\.(.+)$/))  {
 		update reply {
 			&Reply-Message += 'Rejected: Realm does not have at least one dot separator'
 		}
@@ -88,11 +73,10 @@ filter_username {
 	}
 
 	#
-	#  reject realms that end with a dot
+	#  Realm ends with a dot
 	#  e.g. "user@site.com."
-	#  e.g. "site.com.\user"
 	#
-	if (&User-Name =~ /@.*\.$|.*\.\\/)  {
+	if (&User-Name =~ /\.$/)  {
 		update reply {
 			&Reply-Message += 'Rejected: Realm ends with a dot'
 		}
@@ -100,11 +84,10 @@ filter_username {
 	}
 
 	#
-	#  reject realms that begin with a dot
+	#  Realm begins with a dot
 	#  e.g. "user@.site.com"
-	#  e.g. ".site.com\user"
 	#
-	if (&User-Name =~ /@\..*$|\..*\\/)  {
+	if (&User-Name =~ /@\./)  {
 		update reply {
 			&Reply-Message += 'Rejected: Realm begins with a dot'
 		}
@@ -115,18 +98,12 @@ filter_username {
 #
 #	Filter the User-Password
 #
-#  Some equipment sends passwords with embedded zeroes.
-#  This policy filters them out.
+#  Some equipment sends passwords with embedded zeros.
+#  This poliocy filters them out.
 #
 filter_password {
-	#
-	#  No user password, skip.
-	#
-	if (!&User-Password) {
-		noop
-	}
-	
-	if (&User-Password != "%{string:User-Password}") {
+	if (&User-Password && \
+	   (&User-Password != "%{string:User-Password}")) {
 		update request {
 			&Tmp-String-0 := "%{string:User-Password}"
 			&User-Password := "%{string:Tmp-String-0}"
@@ -134,157 +111,78 @@ filter_password {
 	 }
 }
 
-#
-#	Filter the inner and outer identities
-#
-#  Do checks on outer and inner identities so that users
-#  cannot spoof us by using incompatible identities
-#
-filter_inner_outer_identity {
+filter_inner_identity {
 	#
-	#  No inner or outer User-Name? Reject.
+	#  No names, reject.
 	#
-	if (!&outer.request:User-Name || &outer.request:User-Name == "" || !&User-Name || &User-Name == "") {
+	if (!&outer.request:User-Name || !&User-Name) {
 		update request {
-			Module-Failure-Message = 'Rejected: Inner and outer identities are required for tunnelled authentication'
+			Module-Failure-Message = "User-Name is required for tunneled authentication"
 		}
 		reject
 	}
 
 	#
-	#  Do lots of sanity checks.
+	#  If the names are the same, it's OK.
 	#
-	#  Get the outer stripped user name. Look for the outer realm.
+	#  Otherwise, do lots of sanity checks
 	#
-	if (&outer.request:User-Name =~ /^([^@\]+)?(@([^@\]+)?)?$/) {
-		#  Case insensitive.
-		update request {
-			Outer-Stripped-User-Name = "%{tolower:%{1}}"
-			Outer-Realm-Name = "%{tolower:%{3}}"
-		}
-		
-		#  Case sensitive.
-		#update request {
-		#	Outer-Stripped-User-Name = "%{1}"
-		#	Outer-Realm-Name = "%{3}"
-		#}
-	}
-	elsif (&outer.request:User-Name =~ /^(([^@\]+)?\\)?([^@\]+)?$/) {
-		#  Case insensitive.
-		update request {
-			Outer-Stripped-User-Name = "%{tolower:%{3}}"	
-			Outer-Realm-Name = "%{tolower:%{1}}"
-		}
-		
-		#  Case sensitive.
-		#update request {
-		#	Outer-Stripped-User-Name = "%{3}"
-		#	Outer-Realm-Name = "%{1}"
-		#}
-	}
-
-	#
-	#  Get the inner stripped user name. Look for the inner realm.
-	#
-	if (&User-Name =~ /^([^@\]+)?(@([^@\]+)?)?$/) {
-		#  Case insensitive.
-		update request {
-			Inner-Stripped-User-Name = "%{tolower:%{1}}"
-			Inner-Realm-Name = "%{tolower:%{3}}"
-		}
-		
-		#  Case sensitive.
-		#update request {
-		#	Inner-Stripped-User-Name = "%{1}"
-		#	Inner-Realm-Name = "%{3}"
-		#}
-	}
-	elsif (&User-Name =~ /^(([^@\]+)?\\)?([^@\]+)?$/) {
-		#  Case insensitive.
-		update request {
-			Inner-Stripped-User-Name = "%{tolower:%{3}}"	
-			Inner-Realm-Name = "%{tolower:%{1}}"
-		}
-		
-		#  Case sensitive.
-		#update request {
-		#	Inner-Stripped-User-Name = "%{3}"
-		#	Inner-Realm-Name = "%{1}"
-		#}
-	}
-
-	#
-	#  We require that the inner User-Name not be
-	#  "@realm", "\realm", "anonymous", "anon"
-	#  "anonymous@realm", "realm\anonymous",
-	#  "anon@realm" or "realm\anon".
-	#
-	#  The check for "anonymous" is more relaxed,
-	#  disallowing "anon" because some vendors
-	#  send this in the outer instead of
-	#  following the standards.
-	#
-	if ((&Inner-Realm-Name == "" && \
-		&Inner-Stripped-User-Name =~ /^anon(ymous)?$/) || \
-		&Inner-Stripped-User-Name =~ /^(anon(ymous)?)?$/) {
-		update request {
-			Module-Failure-Message = 'Rejected: Inner identity cannot be anonymized'
-		}
-		reject
-	}
-
-	if (&Outer-Stripped-User-Name == &Inner-Stripped-User-Name) {
-		#  The stripped inner and outer User-Name are the same.
-		#  Ensure that the inner and outer realms are the same where they are both defined.
-		if (&Outer-Realm-Name != "" && \
-			&Inner-Realm-Name != "" && \
-			&Inner-Realm-Name != &Outer-Realm-Name) {
+	if (&outer.request:User-Name != &User-Name) {
+		#
+		#  We require the outer User-Name
+		#  to be "@realm", or "anon...",
+		#  hopefully "anonymous", or "anonymous@realm"
+		#
+		#  The checks for "anonymous" are more relaxed
+		#  because vendors send a variety of names
+		#  instead of following the standards.
+		#
+		if ((&outer.request:User-Name !~ /^@/) && \
+		    (&outer.request:User-Name !~ /^anon/)) {
 			update request {
-				Module-Failure-Message = 'Rejected: Realm in the inner identity is not the same as the realm in the outer identity'
-			}
-			reject
-		}
-	}
-	else {
-		#
-		#  The stripped inner and outer User-Name are different.
-		#  Perform anonimization checks.
-		#
-		#  We require that the outer User-Name be
-		#  "@realm", "\realm", "anonymous", "anon"
-		#  "anonymous@realm", "realm\anonymous",
-		#  "anon@realm" or "realm\anon".
-		#
-		#  The check for "anonymous" is more relaxed,
-		#  allowing "anon" because some vendors send
-		#  this instead of following the standards.
-		#
-		if ((&Outer-Realm-Name == "" && \
-			&Outer-Stripped-User-Name !~ /^anon(ymous)?$/) || \
-			&Outer-Stripped-User-Name !~ /^(anon(ymous)?)?$/) {
-			update request {
-				Module-Failure-Message = 'Rejected: Outer identity is not anonymized correctly'
+				Module-Failure-Message = "User-Name is not correctly anonymized"
 			}
 			reject
 		}
 
 		#
-		#  It is OK to have outer realm "@example.com" and
-		#  inner User-Name "bob".  We do more detailed checks
-		#  only if an inner and outer realm exists.
+		#  Now we get complicated.  Look for the outer realm
 		#
-		#  It is OK to have the same realm name, or
+		if (&outer.request:User-Name =~ /@(.*)$/) {
+			update request {
+				Outer-Realm-Name = "%{1}"
+			}
+		}
+
+		#
+		#  And the inner realm
+		#
+		if (&User-Name =~ /@(.*)$/) {
+			update request {
+				Inner-Realm-Name = "%{1}"
+			}
+		}
+
+		#
+		#  It's OK to have outer "@example.com" and
+		#  inner "bob".  We do more detailed checks
+		#  only if the inner realm exists.
+		#
+		#  It's OK to have the same realm name, or
 		#  the outer one is "example.com" and the inner
 		#  is "secure.example.com"
 		#
-		if (&Outer-Realm-Name != "" && \
-			&Inner-Realm-Name != "" && \
-			&Inner-Realm-Name !~ /(\.)?%{Outer-Realm-Name}$/) {
+		if (&Inner-Realm-Name && \
+		    (&Inner-Realm-Name != &Outer-Realm-Name) && \
+		    (&Inner-Realm-Name !~ /\.%{Outer-Realm-Name}$/)) {
 			update request {
-				Module-Failure-Message = 'Rejected: Realm in the inner identity is not the same as or a subrealm of the realm in the anonymized outer identity'
+				Module-Failure-Message = "Inner and outer realms are not compatible"
 			}
 			reject
 		}
+
+		#
+		#  It's OK to have an outer realm and no inner realm.
+		#
 	}
 }
-

--- a/raddb/policy.d/filter
+++ b/raddb/policy.d/filter
@@ -34,7 +34,7 @@ filter_username {
 	}
 
 	#
-	#  reject mixed case e.g. "UseRNaMe"
+	#  reject mixed case and upper case e.g. "UseRNaMe", "USERNAME"
 	#
 	#if (&User-Name != "%{tolower:%{User-Name}}") {
 	#	reject

--- a/raddb/policy.d/filter
+++ b/raddb/policy.d/filter
@@ -56,7 +56,7 @@ filter_username {
 	#  e.g. "user@site.com@site.com"
 	#  e.g. "site.com\site.com\user"
 	#
-	if (&User-Name =~ /[@\][^@\]*[@\]/ ) {
+	if (&User-Name =~ /[@\\][^@\\]*[@\\]/ ) {
 		update reply {
 			&Reply-Message += 'Rejected: Multiple realm delimiters in User-Name'
 		}
@@ -156,7 +156,7 @@ filter_inner_outer_identity {
 	#
 	#  Get the outer stripped user name. Look for the outer realm.
 	#
-	if (&outer.request:User-Name =~ /^([^@\]+)?(@([^@\]+)?)?$/) {
+	if (&outer.request:User-Name =~ /^([^@\\]+)?(@([^@\\]+)?)?$/) {
 		#  Case insensitive.
 		update request {
 			Outer-Stripped-User-Name = "%{tolower:%{1}}"
@@ -169,7 +169,7 @@ filter_inner_outer_identity {
 		#	Outer-Realm-Name = "%{3}"
 		#}
 	}
-	elsif (&outer.request:User-Name =~ /^(([^@\]+)?\\)?([^@\]+)?$/) {
+	elsif (&outer.request:User-Name =~ /^(([^@\\]+)?\\)?([^@\\]+)?$/) {
 		#  Case insensitive.
 		update request {
 			Outer-Stripped-User-Name = "%{tolower:%{3}}"	
@@ -186,7 +186,7 @@ filter_inner_outer_identity {
 	#
 	#  Get the inner stripped user name. Look for the inner realm.
 	#
-	if (&User-Name =~ /^([^@\]+)?(@([^@\]+)?)?$/) {
+	if (&User-Name =~ /^([^@\\]+)?(@([^@\\]+)?)?$/) {
 		#  Case insensitive.
 		update request {
 			Inner-Stripped-User-Name = "%{tolower:%{1}}"
@@ -199,7 +199,7 @@ filter_inner_outer_identity {
 		#	Inner-Realm-Name = "%{3}"
 		#}
 	}
-	elsif (&User-Name =~ /^(([^@\]+)?\\)?([^@\]+)?$/) {
+	elsif (&User-Name =~ /^(([^@\\]+)?\\)?([^@\\]+)?$/) {
 		#  Case insensitive.
 		update request {
 			Inner-Stripped-User-Name = "%{tolower:%{3}}"	

--- a/raddb/policy.d/filter
+++ b/raddb/policy.d/filter
@@ -3,27 +3,39 @@
 #	realms.
 #
 deny_realms {
-	if (&User-Name && (&User-Name =~ /@|\\/)) {
+	#
+	#  No User-Name, skip.
+	#
+	if (!&User-Name || &User-Name == "") {
+		noop
+	}
+
+	if (&User-Name =~ /@|\\/) {
+		update reply {
+			&Reply-Message += 'Rejected: User-Name contains a realm'
+		}
 		reject
 	}
 }
 
 #
-#	Filter the username
+#	Filter the User-Name
 #
 #  Force some sanity on User-Name. This helps to avoid issues
 #  issues where the back-end database is "forgiving" about
 #  what constitutes a user name.
 #
 filter_username {
-	if (!&User-Name) {
+	#
+	#  No User-Name, skip.
+	#
+	if (!&User-Name || &User-Name == "") {
 		noop
 	}
 
 	#
 	#  reject mixed case e.g. "UseRNaMe"
 	#
-
 	#if (&User-Name != "%{tolower:%{User-Name}}") {
 	#	reject
 	#}
@@ -34,38 +46,41 @@ filter_username {
 	#
 	if (&User-Name =~ / /) {
 		update reply {
-			&Reply-Message += 'Rejected: Username contains whitespace'
+			&Reply-Message += 'Rejected: User-Name contains whitespace'
 		}
 		reject
 	}
 
 	#
-	#  reject Multiple @'s
+	#  reject multiple realm delimiters
 	#  e.g. "user@site.com@site.com"
+	#  e.g. "site.com\site.com\user"
 	#
-	if (&User-Name =~ /@.*@/ ) {
+	if (&User-Name =~ /[@\][^@\]*[@\]/ ) {
 		update reply {
-			&Reply-Message += 'Rejected: Multiple @ in username'
+			&Reply-Message += 'Rejected: Multiple realm delimiters in User-Name'
 		}
 		reject
 	}
 
 	#
-	#  reject double dots
+	#  reject multiple dots in the realm
 	#  e.g. "user@site..com"
+	#  e.g. "site..com\user"
 	#
-	if (&User-Name =~ /\.\./ ) {
+	if (&User-Name =~ /@[^.]*\.\.|\.\.[^.]*\\/ ) {
 		update reply {
-			&Reply-Message += 'Rejected: Username contains ..s'
+			&Reply-Message += 'Rejected: Realm contains ..s'
 		}
 		reject
 	}
 
 	#
-	#  must have at least 1 string-dot-string after @
-	#  e.g. "user@site.com"
+	#  reject where there is not at least 1 string-dot-string in the realm
+	#  e.g. "user@site"
+	#  e.g. "site\user"
 	#
-	if ((&User-Name =~ /@/) && (&User-Name !~ /@(.+)\.(.+)$/))  {
+	if (&User-Name =~ /@|\\/ && &User-Name !~ /@[^.]+\.[^.]+|[^.]+\.[^.]+\\/)  {
 		update reply {
 			&Reply-Message += 'Rejected: Realm does not have at least one dot separator'
 		}
@@ -73,10 +88,11 @@ filter_username {
 	}
 
 	#
-	#  Realm ends with a dot
+	#  reject realms that end with a dot
 	#  e.g. "user@site.com."
+	#  e.g. "site.com.\user"
 	#
-	if (&User-Name =~ /\.$/)  {
+	if (&User-Name =~ /@.*\.$|.*\.\\/)  {
 		update reply {
 			&Reply-Message += 'Rejected: Realm ends with a dot'
 		}
@@ -84,10 +100,11 @@ filter_username {
 	}
 
 	#
-	#  Realm begins with a dot
+	#  reject realms that begin with a dot
 	#  e.g. "user@.site.com"
+	#  e.g. ".site.com\user"
 	#
-	if (&User-Name =~ /@\./)  {
+	if (&User-Name =~ /@\..*$|\..*\\/)  {
 		update reply {
 			&Reply-Message += 'Rejected: Realm begins with a dot'
 		}
@@ -98,12 +115,18 @@ filter_username {
 #
 #	Filter the User-Password
 #
-#  Some equipment sends passwords with embedded zeros.
-#  This poliocy filters them out.
+#  Some equipment sends passwords with embedded zeroes.
+#  This policy filters them out.
 #
 filter_password {
-	if (&User-Password && \
-	   (&User-Password != "%{string:User-Password}")) {
+	#
+	#  No user password, skip.
+	#
+	if (!&User-Password) {
+		noop
+	}
+	
+	if (&User-Password != "%{string:User-Password}") {
 		update request {
 			&Tmp-String-0 := "%{string:User-Password}"
 			&User-Password := "%{string:Tmp-String-0}"
@@ -111,78 +134,156 @@ filter_password {
 	 }
 }
 
-filter_inner_identity {
+#
+#	Filter the inner and outer identities
+#
+#  Do checks on outer and inner identities so that users
+#  cannot spoof us by using incompatible identities
+#
+filter_inner_outer_identity {
 	#
-	#  No names, reject.
+	#  No inner or outer User-Name? Reject.
 	#
-	if (!&outer.request:User-Name || !&User-Name) {
+	if (!&outer.request:User-Name || &outer.request:User-Name == "" || !&User-Name || &User-Name == "") {
 		update request {
-			Module-Failure-Message = "User-Name is required for tunneled authentication"
+			Module-Failure-Message = 'Rejected: Inner and outer identities are required for tunnelled authentication'
 		}
 		reject
 	}
 
 	#
-	#  If the names are the same, it's OK.
+	#  Do lots of sanity checks.
 	#
-	#  Otherwise, do lots of sanity checks
+	#  Get the outer stripped user name. Look for the outer realm.
 	#
-	if (&outer.request:User-Name != &User-Name) {
-		#
-		#  We require the outer User-Name
-		#  to be "@realm", or "anon...",
-		#  hopefully "anonymous", or "anonymous@realm"
-		#
-		#  The checks for "anonymous" are more relaxed
-		#  because vendors send a variety of names
-		#  instead of following the standards.
-		#
-		if ((&outer.request:User-Name !~ /^@/) && \
-		    (&outer.request:User-Name !~ /^anon/)) {
+	if (&outer.request:User-Name =~ /^([^@\]+)?(@([^@\]+)?)?$/) {
+		#  Case insensitive.
+		update request {
+			Outer-Stripped-User-Name = "%{tolower:%{1}}"
+			Outer-Realm-Name = "%{tolower:%{3}}"
+		}
+		
+		#  Case sensitive.
+		#update request {
+		#	Outer-Stripped-User-Name = "%{1}"
+		#	Outer-Realm-Name = "%{3}"
+		#}
+	}
+	elsif (&outer.request:User-Name =~ /^(([^@\]+)?\\)?([^@\]+)?$/) {
+		#  Case insensitive.
+		update request {
+			Outer-Stripped-User-Name = "%{tolower:%{3}}"	
+			Outer-Realm-Name = "%{tolower:%{1}}"
+		}
+		
+		#  Case sensitive.
+		#update request {
+		#	Outer-Stripped-User-Name = "%{3}"
+		#	Outer-Realm-Name = "%{1}"
+		#}
+	}
+
+	#
+	#  Get the inner stripped user name. Look for the inner realm.
+	#
+	if (&User-Name =~ /^([^@\]+)?(@([^@\]+)?)?$/) {
+		#  Case insensitive.
+		update request {
+			Inner-Stripped-User-Name = "%{tolower:%{1}}"
+			Inner-Realm-Name = "%{tolower:%{3}}"
+		}
+		
+		#  Case sensitive.
+		#update request {
+		#	Inner-Stripped-User-Name = "%{1}"
+		#	Inner-Realm-Name = "%{3}"
+		#}
+	}
+	elsif (&User-Name =~ /^(([^@\]+)?\\)?([^@\]+)?$/) {
+		#  Case insensitive.
+		update request {
+			Inner-Stripped-User-Name = "%{tolower:%{3}}"	
+			Inner-Realm-Name = "%{tolower:%{1}}"
+		}
+		
+		#  Case sensitive.
+		#update request {
+		#	Inner-Stripped-User-Name = "%{3}"
+		#	Inner-Realm-Name = "%{1}"
+		#}
+	}
+
+	#
+	#  We require that the inner User-Name not be
+	#  "@realm", "\realm", "anonymous", "anon"
+	#  "anonymous@realm", "realm\anonymous",
+	#  "anon@realm" or "realm\anon".
+	#
+	#  The check for "anonymous" is more relaxed,
+	#  disallowing "anon" because some vendors
+	#  send this in the outer instead of
+	#  following the standards.
+	#
+	if ((&Inner-Realm-Name == "" && \
+		&Inner-Stripped-User-Name =~ /^anon(ymous)?$/) || \
+		&Inner-Stripped-User-Name =~ /^(anon(ymous)?)?$/) {
+		update request {
+			Module-Failure-Message = 'Rejected: Inner identity cannot be anonymized'
+		}
+		reject
+	}
+
+	if (&Outer-Stripped-User-Name == &Inner-Stripped-User-Name) {
+		#  The stripped inner and outer User-Name are the same.
+		#  Ensure that the inner and outer realms are the same where they are both defined.
+		if (&Outer-Realm-Name != "" && \
+			&Inner-Realm-Name != "" && \
+			&Inner-Realm-Name != &Outer-Realm-Name) {
 			update request {
-				Module-Failure-Message = "User-Name is not correctly anonymized"
+				Module-Failure-Message = 'Rejected: Realm in the inner identity is not the same as the realm in the outer identity'
+			}
+			reject
+		}
+	}
+	else {
+		#
+		#  The stripped inner and outer User-Name are different.
+		#  Perform anonimization checks.
+		#
+		#  We require that the outer User-Name be
+		#  "@realm", "\realm", "anonymous", "anon"
+		#  "anonymous@realm", "realm\anonymous",
+		#  "anon@realm" or "realm\anon".
+		#
+		#  The check for "anonymous" is more relaxed,
+		#  allowing "anon" because some vendors send
+		#  this instead of following the standards.
+		#
+		if ((&Outer-Realm-Name == "" && \
+			&Outer-Stripped-User-Name !~ /^anon(ymous)?$/) || \
+			&Outer-Stripped-User-Name !~ /^(anon(ymous)?)?$/) {
+			update request {
+				Module-Failure-Message = 'Rejected: Outer identity is not anonymized correctly'
 			}
 			reject
 		}
 
 		#
-		#  Now we get complicated.  Look for the outer realm
+		#  It is OK to have outer realm "@example.com" and
+		#  inner User-Name "bob".  We do more detailed checks
+		#  only if an inner and outer realm exists.
 		#
-		if (&outer.request:User-Name =~ /@(.*)$/) {
-			update request {
-				Outer-Realm-Name = "%{1}"
-			}
-		}
-
-		#
-		#  And the inner realm
-		#
-		if (&User-Name =~ /@(.*)$/) {
-			update request {
-				Inner-Realm-Name = "%{1}"
-			}
-		}
-
-		#
-		#  It's OK to have outer "@example.com" and
-		#  inner "bob".  We do more detailed checks
-		#  only if the inner realm exists.
-		#
-		#  It's OK to have the same realm name, or
+		#  It is OK to have the same realm name, or
 		#  the outer one is "example.com" and the inner
 		#  is "secure.example.com"
 		#
-		if (&Inner-Realm-Name && \
-		    (&Inner-Realm-Name != &Outer-Realm-Name) && \
-		    (&Inner-Realm-Name !~ /\.%{Outer-Realm-Name}$/)) {
+		if (&Outer-Realm-Name != "" && \
+			&Inner-Realm-Name != "" && \
+			&Inner-Realm-Name !~ /(\.)?%{Outer-Realm-Name}$/) {
 			update request {
-				Module-Failure-Message = "Inner and outer realms are not compatible"
+				Module-Failure-Message = 'Rejected: Realm in the inner identity is not the same as or a subrealm of the realm in the anonymized outer identity'
 			}
 			reject
 		}
-
-		#
-		#  It's OK to have an outer realm and no inner realm.
-		#
 	}
 }

--- a/raddb/sites-available/inner-tunnel
+++ b/raddb/sites-available/inner-tunnel
@@ -56,10 +56,10 @@ authorize {
 	filter_username
 
 	#
-	#  Do checks on outer and inner identities so that users
-	#  cannot spoof us by using incompatible identities
+	#  Do checks on outer / inner User-Name, so that users
+	#  can't spoof us by using incompatible identities
 	#
-	filter_inner_outer_identity
+	filter_inner_identity
 
 	#
 	#  The chap module will set 'Auth-Type := CHAP' if we are

--- a/raddb/sites-available/inner-tunnel
+++ b/raddb/sites-available/inner-tunnel
@@ -56,10 +56,10 @@ authorize {
 	filter_username
 
 	#
-	#  Do checks on outer / inner User-Name, so that users
-	#  can't spoof us by using incompatible identities
+	#  Do checks on outer and inner identities so that users
+	#  cannot spoof us by using incompatible identities
 	#
-	filter_inner_identity
+	filter_inner_outer_identity
 
 	#
 	#  The chap module will set 'Auth-Type := CHAP' if we are

--- a/share/dictionary.freeradius.internal
+++ b/share/dictionary.freeradius.internal
@@ -345,8 +345,10 @@ VALUE	Listen-Socket-Type		dhcp			6
 VALUE	Listen-Socket-Type		control			7
 VALUE	Listen-Socket-Type		coa			8
 
-ATTRIBUTE	Outer-Realm-Name			1218	string internal
-ATTRIBUTE	Inner-Realm-Name			1219	string internal
+ATTRIBUTE	Inner-Stripped-User-Name		1218	string internal
+ATTRIBUTE	Inner-Stripped-User-Name		1219	string internal
+ATTRIBUTE	Outer-Realm-Name			1220	string internal
+ATTRIBUTE	Inner-Realm-Name			1221	string internal
 
 #
 #	Range:	1280 - 1535

--- a/share/dictionary.freeradius.internal
+++ b/share/dictionary.freeradius.internal
@@ -345,8 +345,10 @@ VALUE	Listen-Socket-Type		dhcp			6
 VALUE	Listen-Socket-Type		control			7
 VALUE	Listen-Socket-Type		coa			8
 
-ATTRIBUTE	Outer-Realm-Name			1218	string internal
-ATTRIBUTE	Inner-Realm-Name			1219	string internal
+ATTRIBUTE	Outer-Stripped-User-Name		1218	string internal
+ATTRIBUTE	Inner-Stripped-User-Name		1219	string internal
+ATTRIBUTE	Outer-Realm-Name			1220	string internal
+ATTRIBUTE	Inner-Realm-Name			1221	string internal
 
 #
 #	Range:	1280 - 1535

--- a/share/dictionary.freeradius.internal
+++ b/share/dictionary.freeradius.internal
@@ -345,10 +345,8 @@ VALUE	Listen-Socket-Type		dhcp			6
 VALUE	Listen-Socket-Type		control			7
 VALUE	Listen-Socket-Type		coa			8
 
-ATTRIBUTE	Inner-Stripped-User-Name		1218	string internal
-ATTRIBUTE	Inner-Stripped-User-Name		1219	string internal
-ATTRIBUTE	Outer-Realm-Name			1220	string internal
-ATTRIBUTE	Inner-Realm-Name			1221	string internal
+ATTRIBUTE	Outer-Realm-Name			1218	string internal
+ATTRIBUTE	Inner-Realm-Name			1219	string internal
 
 #
 #	Range:	1280 - 1535


### PR DESCRIPTION
Update policy.d/filter

Improve the regular expressions in filter_username to mimise the use of .* where possible.

Add support for User-Name values that are realm\user delimited.

Correct the filter_inner_identity implementation to:
1) Permit the case that no realm is given in an anonymous outer identity where the inner identity has a realm.
2) Require the inner identity to not be anonymized.
3) Support case insensitive operation, default to permitting this.
4) Make the check for "anonymous" stricter by requiring anonymous or anon, not just any stripped user-name that begins with anon.
5) Do not allow subrealms in the inner identity where the outer identity is not anonymized.
6) Improve the module failure messages that are returned.