### PR TITLE
ability to fetch attributes from sql module to control list

### DIFF
--- a/share/dictionary.rfc4072
+++ b/share/dictionary.rfc4072
@@ -2,7 +2,7 @@
 # Copyright (C) 2015 The FreeRADIUS Server project and contributors
 #
 #	Attributes and values defined in RFC 4072
-#	http://www.ietf.org/rfc/4072.txt
+#	http://www.ietf.org/rfc/rfc4072.txt
 #
 #	$Id$
 #

--- a/share/dictionary.rfc4372
+++ b/share/dictionary.rfc4372
@@ -2,7 +2,7 @@
 # Copyright (C) 2015 The FreeRADIUS Server project and contributors
 #
 #	Attributes and values defined in RFC 4372.
-#	http://www.ietf.org/rfc/4372.txt
+#	http://www.ietf.org/rfc/rfc4372.txt
 #
 #	$Id$
 #

--- a/share/dictionary.rfc4675
+++ b/share/dictionary.rfc4675
@@ -2,7 +2,7 @@
 # Copyright (C) 2015 The FreeRADIUS Server project and contributors
 #
 #	Attributes and values defined in RFC 4675.
-#	http://www.ietf.org/rfc/4675.txt
+#	http://www.ietf.org/rfc/rfc4675.txt
 #
 #	$Id$
 #

--- a/share/dictionary.rfc4679
+++ b/share/dictionary.rfc4679
@@ -2,7 +2,7 @@
 # Copyright (C) 2015 The FreeRADIUS Server project and contributors
 #
 #	Attributes and values defined in RFC 4679.
-#	http://www.ietf.org/rfc/4679.txt
+#	http://www.ietf.org/rfc/rfc4679.txt
 #
 #	$Id$
 #

--- a/src/include/libradius.h
+++ b/src/include/libradius.h
@@ -23,13 +23,15 @@
  *
  * @copyright 1999-2014 The FreeRADIUS server project
  */
-RCSIDH(libradius_h, "$Id$")
 
 /*
  *  Compiler hinting macros.  Included here for 3rd party consumers
  *  of libradius.h.
+ *
+ *  @note Defines RCSIDH.
  */
 #include <freeradius-devel/build.h>
+RCSIDH(libradius_h, "$Id$")
 
 /*
  *  Let any external program building against the library know what
@@ -86,6 +88,8 @@ RCSIDH(libradius_h, "$Id$")
 #include <freeradius-devel/dict.h>
 #include <freeradius-devel/pair.h>
 #include <freeradius-devel/proto.h>
+#include <freeradius-devel/conf.h>
+#include <freeradius-devel/radpaths.h>
 
 #ifdef SIZEOF_UNSIGNED_INT
 #  if SIZEOF_UNSIGNED_INT != 4

--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -61,6 +61,7 @@ static const CONF_PARSER type_config[] = {
 };
 
 static const CONF_PARSER acct_config[] = {
+	{ FR_CONF_OFFSET("fetchattrs", PW_TYPE_STRING| PW_TYPE_XLAT, rlm_sql_config_t, accounting.fetchattrs) },
 	{ FR_CONF_OFFSET("reference", PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sql_config_t, accounting.reference), .dflt = ".query" },
 	{ FR_CONF_OFFSET("logfile", PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sql_config_t, accounting.logfile) },
 
@@ -1618,6 +1619,76 @@ finish:
 
 #ifdef WITH_ACCOUNTING
 
+static rlm_rcode_t acct_fetchattrs(void *instance, REQUEST *request, sql_acct_section_t *section)
+{
+	rlm_rcode_t rcode = RLM_MODULE_NOOP;
+
+	rlm_sql_t *inst = instance;
+	rlm_sql_handle_t  *handle;
+
+	VALUE_PAIR		*reply_tmp = NULL;
+	
+	int	rows;
+	
+	char			*expanded = NULL;
+
+	if ( ! section->fetchattrs ) {
+		RDEBUG("Ignoring null query");
+	}
+	
+	handle = fr_connection_get(inst->pool);
+	if (!handle) {
+		rcode = RLM_MODULE_FAIL;
+		
+		goto error;
+	}
+
+	if (radius_axlat(&expanded, request, section->fetchattrs, inst->sql_escape_func, handle) < 0) {
+		rcode = RLM_MODULE_FAIL;
+
+		goto error;
+	}
+
+	if (!*expanded) {
+		RDEBUG("Ignoring null query");
+		rcode = RLM_MODULE_NOOP;
+		talloc_free(expanded);
+
+		goto error;
+	}
+
+	rlm_sql_query_log(inst, request, section, expanded);
+		
+	rows = sql_getvpdata(request, inst, request, &handle, &reply_tmp, expanded);
+	TALLOC_FREE(expanded);
+	if (rows < 0) {
+		REDEBUG("SQL query error getting CoA attributes");
+		rcode = RLM_MODULE_FAIL;
+		goto error;
+	}
+
+	if (rows == 0) goto error;
+
+	rdebug_pair_list(L_DBG_LVL_2, request, reply_tmp, NULL);
+
+	radius_pairmove(request, &request->config, reply_tmp, true);
+
+	rcode = RLM_MODULE_OK;
+	
+	reply_tmp = NULL;
+
+	fr_connection_release(inst->pool, request);
+
+	return rcode;
+
+error:
+	fr_pair_list_free(&reply_tmp);
+
+	fr_connection_release(inst->pool, request);
+
+	return rcode;
+}
+
 /*
  *	Accounting: Insert or update session data in our sql table
  */
@@ -1625,6 +1696,10 @@ static rlm_rcode_t mod_accounting(void *instance, REQUEST *request) CC_HINT(nonn
 static rlm_rcode_t mod_accounting(void *instance, REQUEST *request)
 {
 	rlm_sql_t *inst = instance;
+
+	if (inst->config->accounting.fetchattrs) {
+		acct_fetchattrs(inst, request, &inst->config->accounting);
+	}
 
 	if (inst->config->accounting.reference_cp) {
 		return acct_redundant(inst, request, &inst->config->accounting);

--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -1619,6 +1619,10 @@ finish:
 
 #ifdef WITH_ACCOUNTING
 
+/* 
+ * Fetch attributes from sql server and places it to control list
+ * Using fetchattrs query of accounting section of sql config
+ */
 static rlm_rcode_t acct_fetchattrs(void *instance, REQUEST *request, sql_acct_section_t *section)
 {
 	rlm_rcode_t rcode = RLM_MODULE_NOOP;

--- a/src/modules/rlm_sql/rlm_sql.h
+++ b/src/modules/rlm_sql/rlm_sql.h
@@ -70,6 +70,7 @@ typedef struct sql_log_entry {
 typedef struct sql_acct_section {
 	CONF_SECTION		*cs;				//!< The CONF_SECTION representing the group
 								//!< of queries to process.
+
 	char const		*fetchattrs;	//!< query for fetch attributes from database to control list
 	char const		*reference;			//!< Reference string, expanded to point to
 								//!< a group of queries.

--- a/src/modules/rlm_sql/rlm_sql.h
+++ b/src/modules/rlm_sql/rlm_sql.h
@@ -70,7 +70,7 @@ typedef struct sql_log_entry {
 typedef struct sql_acct_section {
 	CONF_SECTION		*cs;				//!< The CONF_SECTION representing the group
 								//!< of queries to process.
-
+	char const		*fetchattrs;	//!< query for fetch attributes from database to control list
 	char const		*reference;			//!< Reference string, expanded to point to
 								//!< a group of queries.
 	bool			reference_cp;


### PR DESCRIPTION
I have cisco ASR1000 for PPPoE subscriber termination.
I need automatic service activation/deactivation, so I need CoA queries, maybe on accounting update.
This patch allows fetch on some cases (maybe dependent on check in database logic) attributes from sql server and place in control list.
After that freeradius check flag and build CoA request.
This patch tested on Cisco ASR1000 version 15.5, after some time I will test this functionality on Mikrotik RouterOS >= 6.33.

Example in attached file.

[configs.zip](https://github.com/FreeRADIUS/freeradius-server/files/75163/configs.zip)
