### PR TITLE
Add samba-dev as build-dependency for debian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,8 @@ Build-Depends: debhelper (>= 9),
  libykclient-dev,
  libmemcached-dev,
  libhiredis-dev,
- python-dev
+ python-dev,
+ samba-dev
 Section: net
 Priority: optional
 Maintainer: Josip Rodin <joy-packages@debian.org>


### PR DESCRIPTION
Needed for "core/ntstatus.h" in rlm_mschap, in addition to libwbclient-dev.