### PR TITLE
Fix build on wheezy

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -27,7 +27,7 @@ Build-Depends: debhelper (>= 9),
  libmemcached-dev,
  libhiredis-dev,
  python-dev,
- samba-dev
+ samba-dev | samba4-dev
 Section: net
 Priority: optional
 Maintainer: Josip Rodin <joy-packages@debian.org>


### PR DESCRIPTION
ntstatus.h file is present in samba-dev, however before jessie it
was called samba4-dev. Ubuntu precise 12.04LTS is another derived
distribution release with this package name.