### PR TITLE
Update rlm_python.c

### DIFF
--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -770,7 +770,7 @@ static void python_parse_config(CONF_SECTION *cs, int lvl, PyObject *dict)
 static int mod_instantiate(CONF_SECTION *conf, void *instance)
 {
 	rlm_python_t *inst = instance;
-
+	int code = 0;
 	CONF_SECTION *cs;
 
 	/* parse python configuration sub-section */
@@ -807,9 +807,12 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 
 	/*
 	 *	Call the instantiate function.  No request.  Use the
-	 *	return value.
+	 *	return value if successful. Otherwise, continue to the failed label
 	 */
-	return do_python(inst, NULL, inst->instantiate.function, "instantiate", false);
+	code = do_python(inst, NULL, inst->instantiate.function, "instantiate", false);
+	if (code >= 0) {
+		return code;
+	}
 failed:
 	Pyx_BLOCK_THREADS
 	mod_error();


### PR DESCRIPTION
The mod_instantiate() function just forwards the return code the Python instantiate(p) call gives. But in case of error, the mod_error() and mod_instantiate_clear() functions are not called. 

The immediate consequence of this is that, even in the presence of an error in the module, FR continues executing and therefore, the module can be called again and again, even though it claimed to not being  able to instantiate itself.

The patch makes sure that if the do_python() call returns a value <0, the failed: label is executed.