### PR TITLE
Clarify sqlippool operation and queries, change defaults

### DIFF
--- a/raddb/mods-config/sql/ippool/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mysql/queries.conf
@@ -3,9 +3,43 @@
 #  ippool/mysql/queries.conf -- MySQL queries for rlm_sqlippool
 #
 #  $Id$
+#
+#  sqlippool (rlm_sqlippool) is called in the postauth section to allocate an IP address:
+#
+#    * If Framed-IP-Address already set, do nothing
+#    * If no Pool-Name defined, do nothing
+#    * Run allocate_clear (if defined, runs at most once/second) to clean stale pool entries
+#      * Don't define this if you want users to keep old addresses after outages
+#    * Run allocate_find to get an ip address
+#    * If not found, run pool_check (if defined)
+#      * If pool exists, assume full and return notfound
+#      * If pool does not exist, or pool_check not defined, return noop
+#      * Unnecessary if not running redundant pool modules as otherwise
+#        failure only has one meaning (pool is full)
+#    * We have an address, run allocate_update
+#
+#  Everything else happens in the accounting section:
+#    * Accounting start: run start_update
+#    * Accounting alive (Interim-Update): run alive_update
+#    * Accounting stop: run stop_update
+#    * Accounting on: run on_clear (if defined)
+#      * Typically sent on nas startup, don't use to clear table if you want
+#        users to keep old addresses after outages
+#    * Accounting off: run off_clear (if defined)
+#      * Typically sent on nas shutdown, don't use to clear table if you want
+#        users to keep old addresses after outages
+#
 
 #
-#  This series of queries allocates an IP address
+#  allocate_clear clears stale IP addresses before processing a new request
+#
+#  The first version clears based on pool_key and thus will only
+#  clear previous entries for the user requesting and address.
+#
+#  The second version clears all stale allocations for the requesting NAS
+#
+#  Comment both out if you want users to generally keep old addresses
+#  after outages
 #
 #allocate_clear = "\
 #	UPDATE ${ippool_table} \
@@ -18,30 +52,39 @@
 #	WHERE pool_key = '${pool_key}'"
 
 #
-#  This series of queries allocates an IP address
 #  (Note: If your pool_key is set to Calling-Station-Id and not NAS-Port
 #  then you may wish to delete the "AND nasipaddress = '%{Nas-IP-Address}'
 #  from the WHERE clause)
 #
-allocate_clear = "\
-	UPDATE ${ippool_table} \
-	SET \
-		nasipaddress = '', \
-		pool_key = 0, \
-		callingstationid = '', \
-		username = '', \
-		expiry_time = NULL \
-	WHERE expiry_time <= NOW() - INTERVAL 1 SECOND \
-	AND nasipaddress = '%{Nas-IP-Address}'"
+#allocate_clear = "\
+#	UPDATE ${ippool_table} \
+#	SET \
+#		nasipaddress = '', \
+#		pool_key = 0, \
+#		callingstationid = '', \
+#		username = '', \
+#		expiry_time = NULL \
+#	WHERE expiry_time <= NOW() - INTERVAL 1 SECOND \
+#	AND nasipaddress = '%{Nas-IP-Address}'"
+
 
 #
+#  allocate_find obtains a free ip address to satisfy a new request
+#
 #  The ORDER BY clause of this query tries to allocate the same IP-address
-#  which user had last session...
+#  that the user had last session:
+#
+#    username <> User-Name returns 0 on a match and 1 on a mismatch,
+#    thus a match sorts first
+#    Ths same is true for callingstationid
+#    If nothing else, return oldest expiry time
+#
+#  Limit 1 to ensure only one result is returned
 #
 allocate_find = "\
 	SELECT framedipaddress FROM ${ippool_table} \
 	WHERE pool_name = '%{control:Pool-Name}' \
-	AND (expiry_time < NOW() OR expiry_time IS NULL) \
+	AND (expiry_time < NOW() OR expiry_time IS NULL or expiry_time = 0) \
 	ORDER BY \
 		(username <> '%{User-Name}'), \
 		(callingstationid <> '%{Calling-Station-Id}'), \
@@ -61,11 +104,15 @@ allocate_find = "\
 #	LIMIT 1 \
 #	FOR UPDATE"
 
+
 #
-#  If an IP could not be allocated, check to see if the pool exists or not
-#  This allows the module to differentiate between a full pool and no pool
+#  pool_check allows the module to differentiate between a full pool
+#  and no pool when an IP address could not be allocated so an appropriate
+#  error message can be returned.
+#
 #  Note: If you are not running redundant pool modules this query may be
-#  commented out to save running this query every time an ip is not allocated.
+#  left commented out to save running this query every time an IP address
+#  fails to be allocated.
 #
 pool_check = "\
 	SELECT id \
@@ -74,7 +121,12 @@ pool_check = "\
 	LIMIT 1"
 
 #
-#  This is the final IP Allocation query, which saves the allocated ip details.
+#  allocate_update is the final IP Allocation query, which saves the
+#  allocated IP details, officially allocating the IP address to the user.
+#
+#  WARNING: "WHERE framedipaddress = '%I'" MUST use %I instead of %{Framed-IP-Address}
+#           (because Framed-IP-Address hasn't been set yet, that's what we're in the
+#            process of doing)
 #
 allocate_update = "\
 	UPDATE ${ippool_table} \
@@ -82,11 +134,10 @@ allocate_update = "\
 		nasipaddress = '%{NAS-IP-Address}', pool_key = '${pool_key}', \
 		callingstationid = '%{Calling-Station-Id}', \
 		username = '%{User-Name}', expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
-	WHERE framedipaddress = '%I' \
-	AND expiry_time IS NULL"
+	WHERE framedipaddress = '%I'
 
 #
-#  This series of queries frees an IP number when an accounting START record arrives.
+#  start_update updates allocation info when an accounting START record arrives.
 #
 start_update = "\
 	UPDATE ${ippool_table} \
@@ -99,24 +150,40 @@ start_update = "\
 	AND framedipaddress = '%{Framed-IP-Address}'"
 
 #
-#  This series of queries frees an IP number when an accounting STOP record arrives.
+#  stop_clear frees an IP address when an accounting STOP record arrives.
+#
+#  The first version only clears the expiration time so that the user
+#  has a chance of getting the same ip address the next time they request one
+#
+#  The second version clears everything
 #
 stop_clear = "\
-	UPDATE ${ippool_table} \
-	SET \
-		nasipaddress = '', \
-		pool_key = 0, \
-		callingstationid = '', \
-		username = '', \
-		expiry_time = NULL \
-	WHERE nasipaddress = '%{Nas-IP-Address}' \
-	AND pool_key = '${pool_key}' \
-	AND username = '%{User-Name}' \
-	AND callingstationid = '%{Calling-Station-Id}' \
-	AND framedipaddress = '%{Framed-IP-Address}'"
+        UPDATE ${ippool_table} \
+        SET \
+                expiry_time = NULL \
+        WHERE nasipaddress = '%{Nas-IP-Address}' \
+        AND pool_key = '${pool_key}' \
+        AND username = '%{User-Name}' \
+        AND callingstationid = '%{Calling-Station-Id}' \
+        AND framedipaddress = '%{Framed-IP-Address}'"
+
+# stop_clear = "\
+# 	UPDATE ${ippool_table} \
+# 	SET \
+# 		nasipaddress = '', \
+# 		pool_key = 0, \
+# 		callingstationid = '', \
+# 		username = '', \
+# 		expiry_time = NULL \
+# 	WHERE nasipaddress = '%{Nas-IP-Address}' \
+# 	AND pool_key = '${pool_key}' \
+# 	AND username = '%{User-Name}' \
+# 	AND callingstationid = '%{Calling-Station-Id}' \
+# 	AND framedipaddress = '%{Framed-IP-Address}'"
 
 #
-#  This series of queries frees an IP number when an accounting ALIVE record arrives.
+#  alive_update updates allocation info when an accounting ALIVE (Interim-Update)
+#  record arrives.
 #
 alive_update = "\
 	UPDATE ${ippool_table} \
@@ -129,29 +196,33 @@ alive_update = "\
 	AND framedipaddress = '%{Framed-IP-Address}'"
 
 #
-#  This series of queries frees the IP numbers allocate to a
-#  NAS when an accounting ON record arrives
+#  on_clear clears the IP addresses allocated to a NAS when
+#  an accounting ON record arrives (i.e. the NAS is starting up)
+#  Leave commented out if you want users to be able to obtain
+#  their same address after an outage.
 #
-on_clear = "\
-	UPDATE ${ippool_table} \
-	SET \
-		nasipaddress = '', \
-		pool_key = 0, \
-		callingstationid = '', \
-		username = '', \
-		expiry_time = NULL \
-	WHERE nasipaddress = '%{Nas-IP-Address}'"
+# on_clear = "\
+# 	UPDATE ${ippool_table} \
+# 	SET \
+# 		nasipaddress = '', \
+# 		pool_key = 0, \
+# 		callingstationid = '', \
+# 		username = '', \
+# 		expiry_time = NULL \
+# 	WHERE nasipaddress = '%{Nas-IP-Address}'"
 
 #
-#  This series of queries frees the IP numbers allocate to a
-#  NAS when an accounting OFF record arrives
+#  off_clear clears the IP addresses allocated to a NAS when
+#  an accounting OFF record arrives (i.e. the NAS is shutting down)
+#  Leave commented out if you want users to be able to obtain
+#  their same address after an outage.
 #
-off_clear = "\
-	UPDATE ${ippool_table} \
-	SET \
-		nasipaddress = '', \
-		pool_key = 0, \
-		callingstationid = '', \
-		username = '', \
-		expiry_time = NULL \
-	WHERE nasipaddress = '%{Nas-IP-Address}'"
+# off_clear = "\
+# 	UPDATE ${ippool_table} \
+# 	SET \
+# 		nasipaddress = '', \
+# 		pool_key = 0, \
+# 		callingstationid = '', \
+# 		username = '', \
+# 		expiry_time = NULL \
+# 	WHERE nasipaddress = '%{Nas-IP-Address}'"

--- a/raddb/mods-config/sql/ippool/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mysql/queries.conf
@@ -111,7 +111,7 @@ allocate_find = "\
 #  error message can be returned.
 #
 #  Note: If you are not running redundant pool modules this query may be
-#  left commented out to save running this query every time an IP address
+#  commented out to save running this query every time an IP address
 #  fails to be allocated.
 #
 pool_check = "\


### PR DESCRIPTION
Comments updated to describe operation of sqlippool and the supporting queries.

Also changed default queries to preserve user info, allowing reuse of ip addresses after disconnects or outages.
