### PR TITLE
Make do_python to return the indicated code even when there is no request

### DIFF
--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -546,9 +546,6 @@ static rlm_rcode_t do_python(rlm_python_t *inst, REQUEST *request, PyObject *pFu
 		goto finish;
 	}
 
-	if (!request)
-		goto finish;
-
 	/*
 	 *	The function returns either:
 	 *  1. (returnvalue, replyTuple, configTuple), where
@@ -562,7 +559,7 @@ static rlm_rcode_t do_python(rlm_python_t *inst, REQUEST *request, PyObject *pFu
 	 *
 	 * xxx This code is messy!
 	 */
-	if (PyTuple_CheckExact(pRet)) {
+	if (PyTuple_CheckExact(pRet) && request != NULL) {
 		PyObject *pTupleInt;
 
 		if (PyTuple_GET_SIZE(pRet) != 3) {


### PR DESCRIPTION
current implementation of do_python() always returns SUCESS when there is no request. Such is the case of instantiate(). Since the
```
if (!request)		
		goto finish;
```
code seems to be there to protect the access to request-> elements later, we add the protection in 
```
if (PyTuple_CheckExact(pRet) && request != NULL) {
 		PyObject *pTupleInt;		 		PyObject *pTupleInt;
```
that is the only place in the remaining code of the method request is used. 