### PR TITLE
Make instantiate() return -1 when an exception occurs

### DIFF
--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -816,7 +816,7 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 	 *	return value if successful. Otherwise, continue to the failed label
 	 */
 	code = do_python(inst, NULL, inst->instantiate.function, "instantiate", false);
-	if (code >= 0) {
+	if (code == RLM_MODULE_OK) {
 		return code;
 	}
 failed:


### PR DESCRIPTION
As do_python returns RLM_MODULE_FAIL when an exception occurs, and RLM_MODULE_OK in any other situation, just compare the code value and return RLM_MODULE_OK (in any case != -1) when success, and reach the failuer label when RLM_MODULE_FAIL (that makes -1 be returned)