### PR TITLE
Correctly copy vendor specific attributes in copy_request_to_tunnel

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -20,6 +20,8 @@ FreeRADIUS 3.0.12 Mon 25 Jan 2016 14:00:00 EST urgency=medium
 	* Update aclocal tests for FreeBSD 10.  Patches from
 	  Mathieu Simon.
 	* Remove occasional hang in rlm_linelog.
+	* Correctly copy all vendor specific attributes when
+	  PEAP/TTLS copy_request_to_tunnel is used.
 
 FreeRADIUS 3.0.11 Mon 25 Jan 2016 14:00:00 EST urgency=medium
 	Feature improvements

--- a/src/modules/rlm_eap/types/rlm_eap_peap/peap.c
+++ b/src/modules/rlm_eap/types/rlm_eap_peap/peap.c
@@ -1268,7 +1268,7 @@ static int CC_HINT(nonnull) setup_fake_request(REQUEST *request, REQUEST *fake, 
 			case PW_MESSAGE_AUTHENTICATOR:
 			case PW_EAP_MESSAGE:
 			case PW_STATE:
-				continue;
+				if (!vp->da->vendor) continue;
 
 				/*
 				 *	By default, copy it over.

--- a/src/modules/rlm_eap/types/rlm_eap_ttls/ttls.c
+++ b/src/modules/rlm_eap/types/rlm_eap_ttls/ttls.c
@@ -1131,7 +1131,7 @@ int eapttls_process(eap_handler_t *handler, tls_session_t *tls_session)
 			case PW_MESSAGE_AUTHENTICATOR:
 			case PW_EAP_MESSAGE:
 			case PW_STATE:
-				continue;
+				if (!vp->da->vendor) continue;
 
 			/*
 			 *	By default, copy it over.


### PR DESCRIPTION
Checking just vp->da->attr is not enough; we also need to ensure that a vendor is not set. Specifically Cisco-AVPair is attribute 1, the same as User-Name...