### PR TITLE
Correctly copy vendor specific attributes in copy_request_to_tunnel

### DIFF
--- a/src/modules/rlm_eap/types/rlm_eap_peap/peap.c
+++ b/src/modules/rlm_eap/types/rlm_eap_peap/peap.c
@@ -1242,7 +1242,7 @@ static int CC_HINT(nonnull) setup_fake_request(REQUEST *request, REQUEST *fake, 
 			case PW_MESSAGE_AUTHENTICATOR:
 			case PW_EAP_MESSAGE:
 			case PW_STATE:
-				continue;
+				if (!vp->da->vendor) continue;
 
 				/*
 				 *	By default, copy it over.

--- a/src/modules/rlm_eap/types/rlm_eap_ttls/ttls.c
+++ b/src/modules/rlm_eap/types/rlm_eap_ttls/ttls.c
@@ -1002,7 +1002,7 @@ PW_CODE eap_ttls_process(eap_session_t *eap_session, tls_session_t *tls_session)
 			case PW_MESSAGE_AUTHENTICATOR:
 			case PW_EAP_MESSAGE:
 			case PW_STATE:
-				continue;
+				if (!vp->da->vendor) continue;
 
 			/*
 			 *	By default, copy it over.


### PR DESCRIPTION
Checking just vp->da->attr is not enough; we also need to ensure that a vendor is not set. Specifically Cisco-AVPair is attribute 1, the same as User-Name...