### PR TITLE
Fix wrong inner EAP type in src/tests/eapol_test/peap-eap-gtc.conf.

### DIFF
--- a/src/tests/eapol_test/peap-eap-gtc.conf
+++ b/src/tests/eapol_test/peap-eap-gtc.conf
@@ -8,6 +8,6 @@ network={
 	identity="bob"
 	anonymous_identity="anonymous"
 	password="bob"
-	phase2="autheap=MSCHAPV2"
+	phase2="auth=GTC"
 	phase1="peapver=0"
 }


### PR DESCRIPTION
Inner EAP type should be GTC for PEAPv0/EAP-GTC, and phase2 param
field should be "auth" for EAP-PEAP while "autheap" is for EAP-TTLS
as mentioned in the example of wpa_supplicant.conf.