### PR TITLE
Regex fr_pair_make fix

### DIFF
--- a/src/lib/pair.c
+++ b/src/lib/pair.c
@@ -1519,8 +1519,8 @@ VALUE_PAIR *fr_pair_make(TALLOC_CTX *ctx, VALUE_PAIR **vps,
 			talloc_free(vp);
 			return NULL;
 		}
-
-		value = NULL;	/* ignore it */
+		/* Ignore? But what about radclient checking oO We use strvalue but if we ignore it - all checks fails!*/
+		//value = NULL;	/* ignore it */
 		break;
 #endif
 	}


### PR DESCRIPTION
Why we ignore value when expecting regex? If value ignored then fr_pair_cmp() will fail in line 1988 because a->vp_strvalue has NULL value