### PR TITLE
Fix problem with REGEX: xlat and strvalue

### DIFF
--- a/src/lib/pair.c
+++ b/src/lib/pair.c
@@ -1985,7 +1985,7 @@ int fr_pair_cmp(VALUE_PAIR *a, VALUE_PAIR *b)
 
 			if (!fr_assert(a->da->type == PW_TYPE_STRING)) return -1;
 
-			slen = regex_compile(NULL, &preg, a->vp_strvalue, a->vp_length, false, false, false, true);
+			slen = regex_compile(NULL, &preg, a->value.xlat, strlen(a->value.xlat), false, false, false, true);
 			if (slen <= 0) {
 				fr_strerror_printf("Error at offset %zu compiling regex for %s: %s",
 						   -slen, a->da->name, fr_strerror());

--- a/src/lib/print.c
+++ b/src/lib/print.c
@@ -434,8 +434,30 @@ size_t vp_prints_value(char *out, size_t outlen, VALUE_PAIR const *vp, char quot
  */
 char *vp_aprints_value(TALLOC_CTX *ctx, VALUE_PAIR const *vp, char quote)
 {
+	size_t len, ret, inlen;
+	char *p = NULL;
+
 	VERIFY_VP(vp);
 
+	if(vp->type == VT_XLAT){
+		inlen = strlen(vp->value.xlat);
+		if (!quote) {
+			p = talloc_bstrndup(ctx, vp->value.xlat, inlen);
+			if (!p) return NULL;
+			talloc_set_type(p, char);
+			return p;
+		}
+		len = fr_prints_len(vp->value.xlat, inlen, quote);
+		p = talloc_array(ctx, char, len);
+		if (!p) return NULL;
+
+		ret = fr_prints(p, len, vp->value.xlat, inlen, quote);
+		if (!fr_assert(ret == (len - 1))) {
+			talloc_free(p);
+			return NULL;
+		}
+		return p;
+	}
 	return value_data_aprints(ctx, vp->da->type, vp->da, &vp->data, vp->vp_length, quote);
 }
 


### PR DESCRIPTION
This PR cause problem of radclient:
If you want send request from file and validate response by REGEX (=~ or !~) all checks will fail
for example
```
$ radclient -x 127.0.0.1 auth testRad -f test_ok.req:test_ok.res
Sent Access-Request Id 227 from 0.0.0.0:37328 to 127.0.0.1:1812 length 44
	User-Name = "5f27e8f3a41c:3108-3131"
Received Access-Accept Id 227 from 127.0.0.1:1812 to 0.0.0.0:0 length 26
	Reply-Message = "good"
(0) test_ok.req: Response for failed filter: Attribute value "good" didn't match filter: Reply-Message =~ ""
```
test_ok.res:
```
Response-Packet-Type == Access-Accept,
Reply-Message =~ 'good'

```
As you can see Reply-Message has value "good", regex should check same (Reply-Message =~ 'good') but validation fails...
After changes we have:
```
$ radclient -x 127.0.0.1 auth testRad -f test_ok.req:test_ok.res
Sent Access-Request Id 81 from 0.0.0.0:57126 to 127.0.0.1:1812 length 44
	User-Name = "5f27e8f3a41c:3108-3131"
Received Access-Accept Id 81 from 127.0.0.1:1812 to 0.0.0.0:0 length 26
	Reply-Message = "good"
(0) test_ok.req: Response passed filter
```

