### PR TITLE
Re-shape SSL_CTL storage, force OpenSSL to reload CApath contents periodically

### DIFF
--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -283,6 +283,16 @@ eap {
 
 		ca_path = ${cadir}
 
+		# OpenSSL does not reload contents of ca_path dir over time.
+		# That means that if check_crl is enabled and CRLs are loaded
+		# from ca_path dir, at some point CRLs will expire and
+		# RADIUSd will stop authenticating users.
+		# If ca_path_reload_interval is non-zero, it will force OpenSSL
+		# to reload all data from ca_path periodically
+		#
+		# Flush ca_path each hour
+		ca_path_reload_interval = 3600
+
 		#
 		#  If check_cert_issuer is set, the value will be checked
 		#  against the DN of the issuer in the client certificate.  If

--- a/raddb/sites-available/tls
+++ b/raddb/sites-available/tls
@@ -162,6 +162,16 @@ listen {
 	#	check_crl = yes
 		ca_path = ${cadir}
 
+		# OpenSSL does not reload contents of ca_path dir over time.
+		# That means that if check_crl is enabled and CRLs are loaded
+		# from ca_path dir, at some point CRLs will expire and
+		# RADIUSd will stop authenticating NASes.
+		# If ca_path_reload_interval is non-zero, it will force OpenSSL
+		# to reload all data from ca_path periodically
+		#
+		# Flush ca_path each hour
+		ca_path_reload_interval = 3600
+
 		#
 		#  If check_cert_issuer is set, the value will
 		#  be checked against the DN of the issuer in

--- a/src/include/tls-h
+++ b/src/include/tls-h
@@ -180,6 +180,12 @@ typedef struct _tls_session_t {
 	} handshake_alert;
 } tls_session_t;
 
+/** Provides a storage for TLS context and hardwired structures
+ */
+typedef	struct _ssl_ctx_pool_t {
+	SSL_CTX		*ctx;				//!< TLS context itself
+} ssl_ctx_pool_t;
+
 #ifdef HAVE_OPENSSL_OCSP_H
 /** OCSP Configuration
  *
@@ -200,7 +206,7 @@ typedef struct ft_tls_ocsp_conf {
 
 /* configured values goes right here */
 struct fr_tls_conf_t {
-	SSL_CTX		**ctx;				//!< We use an array of contexts to reduce contention.
+	ssl_ctx_pool_t	*ctx_pool;			//!< We use an array of contexts to reduce contention.
 							//!< Each context may only be used by a single thread
 							//!< concurrently.
 	uint32_t	ctx_count;			//!< Number of contexts we created.

--- a/src/include/tls-h
+++ b/src/include/tls-h
@@ -180,12 +180,6 @@ typedef struct _tls_session_t {
 	} handshake_alert;
 } tls_session_t;
 
-/** Provides a storage for TLS context and hardwired structures
- */
-typedef	struct _ssl_ctx_pool_t {
-	SSL_CTX		*ctx;				//!< TLS context itself
-} ssl_ctx_pool_t;
-
 #ifdef HAVE_OPENSSL_OCSP_H
 /** OCSP Configuration
  *
@@ -204,6 +198,15 @@ typedef struct ft_tls_ocsp_conf {
 } fr_tls_ocsp_conf_t;
 #endif
 
+/** Provides a storage for TLS context and hardwired structures
+ */
+typedef	struct _ssl_ctx_pool_t {
+	SSL_CTX		*ctx;				//!< TLS context itself
+	pthread_mutex_t mtx;				//!< Context-based mutex
+	uint32_t	ca_path_last_reload;		//!< Timestamp of last ca_path reload event
+	X509_STORE	*old_x509_store;		//!< Old X509 store
+} ssl_ctx_pool_t;
+
 /* configured values goes right here */
 struct fr_tls_conf_t {
 	ssl_ctx_pool_t	*ctx_pool;			//!< We use an array of contexts to reduce contention.
@@ -211,6 +214,7 @@ struct fr_tls_conf_t {
 							//!< concurrently.
 	uint32_t	ctx_count;			//!< Number of contexts we created.
 	uint32_t	ctx_next;			//!< Next context to use.
+	uint32_t	ca_path_reload_interval;	//!< Interval for reloading ca_path contents
 
 	CONF_SECTION	*cs;
 
@@ -411,6 +415,8 @@ void		tls_cache_init(SSL_CTX *ctx, bool enabled, char const *session_context, ui
 fr_tls_conf_t	*tls_conf_parse_server(CONF_SECTION *cs);
 
 fr_tls_conf_t	*tls_conf_parse_client(CONF_SECTION *cs);
+
+X509_STORE	*tls_conf_init_x509_store(fr_tls_conf_t const *conf);
 
 /*
  *	tls/ctx.c

--- a/src/main/tls/conf.c
+++ b/src/main/tls/conf.c
@@ -271,7 +271,7 @@ static int _conf_server_free(fr_tls_conf_t *conf)
 {
 	uint32_t i;
 
-	for (i = 0; i < conf->ctx_count; i++) SSL_CTX_free(conf->ctx[i]);
+	for (i = 0; i < conf->ctx_count; i++) SSL_CTX_free(conf->ctx_pool[i].ctx);
 
 #ifdef HAVE_OPENSSL_OCSP_H
 	if (conf->ocsp.store) X509_STORE_free(conf->ocsp.store);
@@ -359,10 +359,10 @@ fr_tls_conf_t *tls_conf_parse_server(CONF_SECTION *cs)
 	/*
 	 *	Initialize TLS
 	 */
-	conf->ctx = talloc_array(conf, SSL_CTX *, conf->ctx_count);
+	conf->ctx_pool = talloc_array(conf, ssl_ctx_pool_t, conf->ctx_count);
 	for (i = 0; i < conf->ctx_count; i++) {
-		conf->ctx[i] = tls_ctx_alloc(conf, false);
-		if (conf->ctx[i] == NULL) goto error;
+		conf->ctx_pool[i].ctx = tls_ctx_alloc(conf, false);
+		if (conf->ctx_pool[i].ctx == NULL) goto error;
 	}
 
 #ifdef HAVE_OPENSSL_OCSP_H
@@ -475,10 +475,10 @@ fr_tls_conf_t *tls_conf_parse_client(CONF_SECTION *cs)
 	if (conf_cert_admin_password(conf) < 0) goto error;
 #endif
 
-	conf->ctx = talloc_array(conf, SSL_CTX *, conf->ctx_count);
+	conf->ctx_pool = talloc_array(conf, ssl_ctx_pool_t, conf->ctx_count);
 	for (i = 0; i < conf->ctx_count; i++) {
-		conf->ctx[i] = tls_ctx_alloc(conf, true);
-		if (conf->ctx[i] == NULL) goto error;
+		conf->ctx_pool[i].ctx = tls_ctx_alloc(conf, true);
+		if (conf->ctx_pool[i].ctx == NULL) goto error;
 	}
 
 	cf_data_add(cs, "tls-conf", conf, NULL);

--- a/src/main/tls/session.c
+++ b/src/main/tls/session.c
@@ -1447,7 +1447,7 @@ tls_session_t *tls_session_init_client(TALLOC_CTX *ctx, fr_tls_conf_t *conf)
 
 	talloc_set_destructor(session, _tls_session_free);
 
-	session->ctx = conf->ctx[(conf->ctx_count == 1) ? 0 : conf->ctx_next++ % conf->ctx_count];	/* mutex not needed */
+	session->ctx = conf->ctx_pool[(conf->ctx_count == 1) ? 0 : conf->ctx_next++ % conf->ctx_count].ctx;	/* mutex not needed */
 	rad_assert(session->ctx);
 
 	SSL_CTX_set_mode(session->ctx, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER | SSL_MODE_AUTO_RETRY);
@@ -1519,7 +1519,7 @@ tls_session_t *tls_session_init_server(TALLOC_CTX *ctx, fr_tls_conf_t *conf, REQ
 
 	RDEBUG2("Initiating new TLS session");
 
-	ssl_ctx = conf->ctx[(conf->ctx_count == 1) ? 0 : conf->ctx_next++ % conf->ctx_count];	/* mutex not needed */
+	ssl_ctx = conf->ctx_pool[(conf->ctx_count == 1) ? 0 : conf->ctx_next++ % conf->ctx_count].ctx;	/* mutex not needed */
 	rad_assert(ssl_ctx);
 
 	new_tls = SSL_new(ssl_ctx);

--- a/src/main/tls/session.c
+++ b/src/main/tls/session.c
@@ -1424,6 +1424,61 @@ static void session_init(tls_session_t *session)
 	session->opaque = NULL;
 }
 
+
+/*
+ * Return SSL context addressed by ctx_num. Check and flush X509 store for
+ * this context if it is time do do that
+ *
+ * @param conf		TLS configuration
+ * @param ctx_num	SSL contex id to check and return
+ * @param request	request being processed (used in debug/error outpu)
+ * @return
+ *  pointer to SSL context with up-to-date X509 store
+ */
+static SSL_CTX	*tls_session_retrieve_ssl_context(fr_tls_conf_t *conf, int ctx_num, REQUEST *request)
+{
+	X509_STORE	*new_cert_store;
+	ssl_ctx_pool_t	*data;
+	time_t		now;
+
+	now = ((request) ? request->timestamp.tv_sec : time(NULL));
+
+	data = &conf->ctx_pool[ctx_num];
+	/*
+	 *	Replace X509 store if it is time to update CRLs/certs in ca_path
+	*/
+	if (conf->ca_path_reload_interval > 0 && data->ca_path_last_reload + conf->ca_path_reload_interval <= now) {
+		pthread_mutex_lock(&data->mtx);
+		/* recheck data->ca_path_last_reload because it may be inaccurate without mutex */
+		if (data->ca_path_last_reload + conf->ca_path_reload_interval <= now) {
+			if (request) {
+				RDEBUG2("Flushing X509 store to re-read data from ca_path dir");
+			} else {
+				DEBUG2("Flushing X509 store to re-read data from ca_path dir");
+			}
+
+			if ((new_cert_store = tls_conf_init_x509_store(conf)) == NULL) {
+				tls_log_error(request, "Error replacing X509 store, out of memory (?)");
+			} else {
+				/*
+				 * Swap empty store with the old one.
+				 * We do not use SSL_CTX_set_cert_store() call here because
+				 * we are not sure that old X509 store is not in the use by some
+				 * thread (i.e. cert check in progress).
+				 * Keep it allocated till next store replacement.
+				 */
+				if (data->old_x509_store) X509_STORE_free(data->old_x509_store);
+				data->old_x509_store = data->ctx->cert_store;
+				data->ctx->cert_store = new_cert_store;
+				data->ca_path_last_reload = now;
+			}
+		}
+		pthread_mutex_unlock(&data->mtx);
+	}
+	return data->ctx;
+}
+
+
 /** Create a new client TLS session
  *
  * Configures a new client TLS session, configuring options, setting callbacks etc...
@@ -1439,6 +1494,7 @@ tls_session_t *tls_session_init_client(TALLOC_CTX *ctx, fr_tls_conf_t *conf)
 {
 	int		ret;
 	int		verify_mode;
+	int		ctx_num;
 	tls_session_t	*session = NULL;
 	REQUEST		*request;
 
@@ -1447,7 +1503,8 @@ tls_session_t *tls_session_init_client(TALLOC_CTX *ctx, fr_tls_conf_t *conf)
 
 	talloc_set_destructor(session, _tls_session_free);
 
-	session->ctx = conf->ctx_pool[(conf->ctx_count == 1) ? 0 : conf->ctx_next++ % conf->ctx_count].ctx;	/* mutex not needed */
+	ctx_num = ((conf->ctx_count == 1) ? 0 : conf->ctx_next++ % conf->ctx_count); /* mutex not needed */
+	session->ctx = tls_session_retrieve_ssl_context(conf, ctx_num, NULL);
 	rad_assert(session->ctx);
 
 	SSL_CTX_set_mode(session->ctx, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER | SSL_MODE_AUTO_RETRY);
@@ -1513,13 +1570,15 @@ tls_session_t *tls_session_init_server(TALLOC_CTX *ctx, fr_tls_conf_t *conf, REQ
 	int		verify_mode = 0;
 	VALUE_PAIR	*vp;
 	SSL_CTX		*ssl_ctx;
+	int		ctx_num;
 
 	rad_assert(request != NULL);
 	rad_assert(conf->ctx_count > 0);
 
 	RDEBUG2("Initiating new TLS session");
 
-	ssl_ctx = conf->ctx_pool[(conf->ctx_count == 1) ? 0 : conf->ctx_next++ % conf->ctx_count].ctx;	/* mutex not needed */
+	ctx_num = ((conf->ctx_count == 1) ? 0 : conf->ctx_next++ % conf->ctx_count); /* mutex not needed */
+	ssl_ctx = tls_session_retrieve_ssl_context(conf, ctx_num, request);
 	rad_assert(ssl_ctx);
 
 	new_tls = SSL_new(ssl_ctx);


### PR DESCRIPTION
OpenSSL does not reload contents of ca_path dir over time.
That means that if check_crl is enabled and CRLs are loaded from ca_path dir, at some point CRLs will expire and RADIUSd will stop authenticating users. If ca_path_reload_interval is non-zero, it will force OpenSSL to reload all data from ca_path periodically.

Commit  9bca727 replaces SSL_CTL *\* with a struct that can hold all per-context additional fields.
Commit  062f066 actually adds CA path reloading feature
