### PR TITLE
Feature: maximum FD count & idle timeout for file logging facilities can be configured

### DIFF
--- a/raddb/mods-available/detail
+++ b/raddb/mods-available/detail
@@ -97,4 +97,14 @@ detail {
 		# User-Password
 	#}
 
+	limit {
+		# By default FreeRADIUS will allow to open upto 64 log files
+		# Change it if it is not enough (capped at 2048)
+		# max_files = 64
+
+		# A log file that is not being used to write into will be
+		# closed after idle_timeout seconds (default 30)
+		# idle_timeout = 30
+	}
+
 }

--- a/raddb/mods-available/linelog
+++ b/raddb/mods-available/linelog
@@ -93,6 +93,16 @@ linelog {
 		#  set this to "yes".
 		#
 		escape_filenames = no
+
+		limit {
+			# By default FreeRADIUS will allow to open upto 64 log files
+			# Change it if it is not enough (capped at 2048)
+			# max_files = 64
+
+			# A log file that is not being used to write into will be
+			# closed after idle_timeout seconds (default 30)
+			# idle_timeout = 30
+		}
 	}
 
 	#

--- a/raddb/mods-config/sql/main/mssql/queries.conf
+++ b/raddb/mods-config/sql/main/mssql/queries.conf
@@ -83,6 +83,18 @@ group_membership_query = "\
 	ORDER BY priority"
 
 #######################################################################
+# Logfile fine tuning
+#######################################################################
+	# By default FreeRADIUS will allow to open upto 64 log files
+	# Change it if it is not enough (capped at 2048)
+	# max_open_logfiles = 64
+
+	# A log file that is not being used to write into will be
+	# closed after log_idle_timeout seconds (default 30)
+	# log_idle_timeout = 30
+
+
+#######################################################################
 # Accounting and Post-Auth Queries
 #######################################################################
 # These queries insert/update accounting and authentication records.

--- a/raddb/mods-config/sql/main/mssql/queries.conf
+++ b/raddb/mods-config/sql/main/mssql/queries.conf
@@ -85,13 +85,15 @@ group_membership_query = "\
 #######################################################################
 # Logfile fine tuning
 #######################################################################
+limit {
 	# By default FreeRADIUS will allow to open upto 64 log files
 	# Change it if it is not enough (capped at 2048)
-	# max_open_logfiles = 64
+	# max_files = 64
 
 	# A log file that is not being used to write into will be
-	# closed after log_idle_timeout seconds (default 30)
-	# log_idle_timeout = 30
+	# closed after idle_timeout seconds (default 30)
+	# idle_timeout = 30
+}
 
 
 #######################################################################

--- a/raddb/mods-config/sql/main/mysql/queries.conf
+++ b/raddb/mods-config/sql/main/mysql/queries.conf
@@ -180,13 +180,15 @@ simul_verify_query = "\
 #######################################################################
 # Logfile fine tuning
 #######################################################################
+limit {
 	# By default FreeRADIUS will allow to open upto 64 log files
 	# Change it if it is not enough (capped at 2048)
-	# max_open_logfiles = 64
+	# max_files = 64
 
 	# A log file that is not being used to write into will be
-	# closed after log_idle_timeout seconds (default 30)
-	# log_idle_timeout = 30
+	# closed after idle_timeout seconds (default 30)
+	# idle_timeout = 30
+}
 
 
 #######################################################################

--- a/raddb/mods-config/sql/main/mysql/queries.conf
+++ b/raddb/mods-config/sql/main/mysql/queries.conf
@@ -178,6 +178,18 @@ simul_verify_query = "\
 	AND acctstoptime IS NULL"
 
 #######################################################################
+# Logfile fine tuning
+#######################################################################
+	# By default FreeRADIUS will allow to open upto 64 log files
+	# Change it if it is not enough (capped at 2048)
+	# max_open_logfiles = 64
+
+	# A log file that is not being used to write into will be
+	# closed after log_idle_timeout seconds (default 30)
+	# log_idle_timeout = 30
+
+
+#######################################################################
 # Accounting and Post-Auth Queries
 #######################################################################
 # These queries insert/update accounting and authentication records.

--- a/raddb/mods-config/sql/main/oracle/queries.conf
+++ b/raddb/mods-config/sql/main/oracle/queries.conf
@@ -159,6 +159,18 @@ group_membership_query = "\
 	WHERE UserName='%{SQL-User-Name}'"
 
 #######################################################################
+# Logfile fine tuning
+#######################################################################
+	# By default FreeRADIUS will allow to open upto 64 log files
+	# Change it if it is not enough (capped at 2048)
+	# max_open_logfiles = 64
+
+	# A log file that is not being used to write into will be
+	# closed after log_idle_timeout seconds (default 30)
+	# log_idle_timeout = 30
+
+
+#######################################################################
 # Accounting and Post-Auth Queries
 #######################################################################
 # These queries insert/update accounting and authentication records.

--- a/raddb/mods-config/sql/main/oracle/queries.conf
+++ b/raddb/mods-config/sql/main/oracle/queries.conf
@@ -161,13 +161,15 @@ group_membership_query = "\
 #######################################################################
 # Logfile fine tuning
 #######################################################################
+limit {
 	# By default FreeRADIUS will allow to open upto 64 log files
 	# Change it if it is not enough (capped at 2048)
-	# max_open_logfiles = 64
+	# max_files = 64
 
 	# A log file that is not being used to write into will be
-	# closed after log_idle_timeout seconds (default 30)
-	# log_idle_timeout = 30
+	# closed after idle_timeout seconds (default 30)
+	# idle_timeout = 30
+}
 
 
 #######################################################################

--- a/raddb/mods-config/sql/main/postgresql/queries.conf
+++ b/raddb/mods-config/sql/main/postgresql/queries.conf
@@ -201,13 +201,15 @@ group_membership_query = "\
 #######################################################################
 # Logfile fine tuning
 #######################################################################
+limit {
 	# By default FreeRADIUS will allow to open upto 64 log files
 	# Change it if it is not enough (capped at 2048)
-	# max_open_logfiles = 64
+	# max_files = 64
 
 	# A log file that is not being used to write into will be
-	# closed after log_idle_timeout seconds (default 30)
-	# log_idle_timeout = 30
+	# closed after idle_timeout seconds (default 30)
+	# idle_timeout = 30
+}
 
 
 #######################################################################

--- a/raddb/mods-config/sql/main/postgresql/queries.conf
+++ b/raddb/mods-config/sql/main/postgresql/queries.conf
@@ -199,6 +199,18 @@ group_membership_query = "\
 	ORDER BY priority"
 
 #######################################################################
+# Logfile fine tuning
+#######################################################################
+	# By default FreeRADIUS will allow to open upto 64 log files
+	# Change it if it is not enough (capped at 2048)
+	# max_open_logfiles = 64
+
+	# A log file that is not being used to write into will be
+	# closed after log_idle_timeout seconds (default 30)
+	# log_idle_timeout = 30
+
+
+#######################################################################
 # Accounting and Post-Auth Queries
 #######################################################################
 # These queries insert/update accounting and authentication records.

--- a/raddb/mods-config/sql/main/sqlite/queries.conf
+++ b/raddb/mods-config/sql/main/sqlite/queries.conf
@@ -169,13 +169,15 @@ simul_verify_query = "\
 #######################################################################
 # Logfile fine tuning
 #######################################################################
+limit {
 	# By default FreeRADIUS will allow to open upto 64 log files
 	# Change it if it is not enough (capped at 2048)
-	# max_open_logfiles = 64
+	# max_files = 64
 
 	# A log file that is not being used to write into will be
-	# closed after log_idle_timeout seconds (default 30)
-	# log_idle_timeout = 30
+	# closed after idle_timeout seconds (default 30)
+	# idle_timeout = 30
+}
 
 
 #######################################################################

--- a/raddb/mods-config/sql/main/sqlite/queries.conf
+++ b/raddb/mods-config/sql/main/sqlite/queries.conf
@@ -167,6 +167,18 @@ simul_verify_query = "\
 	AND acctstoptime IS NULL"
 
 #######################################################################
+# Logfile fine tuning
+#######################################################################
+	# By default FreeRADIUS will allow to open upto 64 log files
+	# Change it if it is not enough (capped at 2048)
+	# max_open_logfiles = 64
+
+	# A log file that is not being used to write into will be
+	# closed after log_idle_timeout seconds (default 30)
+	# log_idle_timeout = 30
+
+
+#######################################################################
 # Accounting and Post-Auth Queries
 #######################################################################
 # These queries insert/update accounting and authentication records.

--- a/src/main/exfile.c
+++ b/src/main/exfile.c
@@ -299,7 +299,7 @@ int exfile_open(exfile_t *ef, REQUEST *request, char const *filename, mode_t per
 			ef->entries_count += 64;
 			if (ef->entries_count > ef->max_entries)
 				ef->entries_count = ef->max_entries;
-			DEBUG2("Grow number of logfile entries for %s: %d -> %d", "", i, ef->entries_count);
+			RDEBUG2("Grow number of logfile entries: %d -> %d", i, ef->entries_count);
 			tmp = talloc_realloc(ef, ef->entries, exfile_entry_t, ef->entries_count);
 			if (tmp) {
 				ef->entries = tmp;
@@ -316,7 +316,7 @@ int exfile_open(exfile_t *ef, REQUEST *request, char const *filename, mode_t per
 				}
 			}
 			i = unused;
-			DEBUG2("Closing '%s' (last write %lu seconds ago) due to lack of vacant logfile entries", ef->entries[i].filename, now - ef->entries[i].last_used);
+			RDEBUG2("Closing '%s' (last write %lu seconds ago) due to lack of vacant logfile entries", ef->entries[i].filename, now - ef->entries[i].last_used);
 			close(ef->entries[i].fd);
 			/* Issue close trigger *after* we've closed the fd */
 			exfile_trigger_exec(ef, request, &ef->entries[i], "close");

--- a/src/main/exfile.c
+++ b/src/main/exfile.c
@@ -224,12 +224,9 @@ int exfile_open(exfile_t *ef, REQUEST *request, char const *filename, mode_t per
 		if (ef->entries[i].hash != hash) continue;
 
 		/*
-		 *	Same hash but different filename.  Give up.
+		 *	Same hash but different filename.
 		 */
-		if (strcmp(ef->entries[i].filename, filename) != 0) {
-			pthread_mutex_unlock(&ef->mutex);
-			return -1;
-		}
+		if (strcmp(ef->entries[i].filename, filename) != 0) continue;
 
 		found = i;
 		break;

--- a/src/modules/rlm_detail/rlm_detail.c
+++ b/src/modules/rlm_detail/rlm_detail.c
@@ -77,6 +77,12 @@ typedef struct detail_instance {
 	uint32_t	max_idle;		//!< Timeout before closing `unused' log file opened previously
 } rlm_detail_t;
 
+static const CONF_PARSER limit_config[] = {
+	{ FR_CONF_OFFSET("max_files", PW_TYPE_INTEGER, rlm_detail_t, max_entries), .dflt = "64" },
+	{ FR_CONF_OFFSET("idle_timeout", PW_TYPE_INTEGER, rlm_detail_t, max_idle), .dflt = "30" },
+	CONF_PARSER_TERMINATOR
+};
+
 static const CONF_PARSER module_config[] = {
 	{ FR_CONF_OFFSET("filename", PW_TYPE_FILE_OUTPUT | PW_TYPE_REQUIRED | PW_TYPE_XLAT, rlm_detail_t, filename), .dflt = "%A/%{Client-IP-Address}/detail" },
 	{ FR_CONF_OFFSET("header", PW_TYPE_STRING | PW_TYPE_XLAT, rlm_detail_t, header), .dflt = "%t" },
@@ -85,8 +91,9 @@ static const CONF_PARSER module_config[] = {
 	{ FR_CONF_OFFSET("locking", PW_TYPE_BOOLEAN, rlm_detail_t, locking), .dflt = "no" },
 	{ FR_CONF_OFFSET("escape_filenames", PW_TYPE_BOOLEAN, rlm_detail_t, escape), .dflt = "no" },
 	{ FR_CONF_OFFSET("log_packet_header", PW_TYPE_BOOLEAN, rlm_detail_t, log_srcdst), .dflt = "no" },
-	{ FR_CONF_OFFSET("max_open_logfiles", PW_TYPE_INTEGER, rlm_detail_t, max_entries), .dflt = "64" },
-	{ FR_CONF_OFFSET("log_idle_timeout", PW_TYPE_INTEGER, rlm_detail_t, max_idle), .dflt = "30" },
+
+	{ FR_CONF_POINTER("limit", PW_TYPE_SUBSECTION, NULL), .subcs = (void const *) limit_config },
+
 	CONF_PARSER_TERMINATOR
 };
 

--- a/src/modules/rlm_detail/rlm_detail.c
+++ b/src/modules/rlm_detail/rlm_detail.c
@@ -139,7 +139,7 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 	FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->max_entries, >=, 8);
 	FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->max_entries, <=, 2048);
 	FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->max_idle, >=, 1);
-	FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->max_idle, >=, 3600);
+	FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->max_idle, <=, 3600);
 	inst->ef = module_exfile_init(inst, conf, inst->max_entries, inst->max_idle, inst->locking, NULL, NULL);
 	if (!inst->ef) {
 		cf_log_err_cs(conf, "Failed creating log file context");

--- a/src/modules/rlm_detail/rlm_detail.c
+++ b/src/modules/rlm_detail/rlm_detail.c
@@ -136,9 +136,9 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 		inst->escape_func = rad_filename_make_safe;
 	}
 
-	FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->max_entries, >=, 0);
+	FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->max_entries, >=, 8);
 	FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->max_entries, <=, 2048);
-	FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->max_idle, >=, 0);
+	FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->max_idle, >=, 1);
 	FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->max_idle, >=, 3600);
 	inst->ef = module_exfile_init(inst, conf, inst->max_entries, inst->max_idle, inst->locking, NULL, NULL);
 	if (!inst->ef) {

--- a/src/modules/rlm_linelog/rlm_linelog.c
+++ b/src/modules/rlm_linelog/rlm_linelog.c
@@ -350,9 +350,9 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 			return -1;
 		}
 
-		FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->file.max_entries, >=, 0);
+		FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->file.max_entries, >=, 8);
 		FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->file.max_entries, <=, 2048);
-		FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->file.max_idle, >=, 0);
+		FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->file.max_idle, >=, 1);
 		FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->file.max_idle, >=, 3600);
 		inst->file.ef = module_exfile_init(inst, conf, inst->file.max_entries, inst->file.max_idle, true, NULL, NULL);
 		if (!inst->file.ef) {

--- a/src/modules/rlm_linelog/rlm_linelog.c
+++ b/src/modules/rlm_linelog/rlm_linelog.c
@@ -126,13 +126,19 @@ typedef struct linelog_conn {
 } linelog_conn_t;
 
 
+static const CONF_PARSER limit_config[] = {
+	{ FR_CONF_OFFSET("max_files", PW_TYPE_INTEGER, linelog_instance_t, file.max_entries), .dflt = "64" },
+	{ FR_CONF_OFFSET("idle_timeout", PW_TYPE_INTEGER, linelog_instance_t, file.max_idle), .dflt = "30" },
+	CONF_PARSER_TERMINATOR
+};
+
 static const CONF_PARSER file_config[] = {
 	{ FR_CONF_OFFSET("filename", PW_TYPE_FILE_OUTPUT | PW_TYPE_XLAT, linelog_instance_t, file.name) },
 	{ FR_CONF_OFFSET("permissions", PW_TYPE_INTEGER, linelog_instance_t, file.permissions), .dflt = "0600" },
 	{ FR_CONF_OFFSET("group", PW_TYPE_STRING, linelog_instance_t, file.group_str) },
 	{ FR_CONF_OFFSET("escape_filenames", PW_TYPE_BOOLEAN, linelog_instance_t, file.escape), .dflt = "no" },
-	{ FR_CONF_OFFSET("max_open_logfiles", PW_TYPE_INTEGER, linelog_instance_t, file.max_entries), .dflt = "64" },
-	{ FR_CONF_OFFSET("log_idle_timeout", PW_TYPE_INTEGER, linelog_instance_t, file.max_idle), .dflt = "30" },
+
+	{ FR_CONF_POINTER("limit", PW_TYPE_SUBSECTION, NULL), .subcs = (void const *) limit_config },
 
 	CONF_PARSER_TERMINATOR
 };

--- a/src/modules/rlm_linelog/rlm_linelog.c
+++ b/src/modules/rlm_linelog/rlm_linelog.c
@@ -106,6 +106,8 @@ typedef struct linelog_instance_t {
 		exfile_t		*ef;			//!< Exclusive file access handle.
 		bool			escape;			//!< Do filename escaping, yes / no.
 		xlat_escape_t		escape_func;		//!< Escape function.
+		uint32_t		max_entries;		//!< Maximum number of log files opened for writing simultaneously
+		uint32_t		max_idle;		//!< Timeout before closing `unused' log file opened previously
 	} file;
 
 	struct {
@@ -129,6 +131,9 @@ static const CONF_PARSER file_config[] = {
 	{ FR_CONF_OFFSET("permissions", PW_TYPE_INTEGER, linelog_instance_t, file.permissions), .dflt = "0600" },
 	{ FR_CONF_OFFSET("group", PW_TYPE_STRING, linelog_instance_t, file.group_str) },
 	{ FR_CONF_OFFSET("escape_filenames", PW_TYPE_BOOLEAN, linelog_instance_t, file.escape), .dflt = "no" },
+	{ FR_CONF_OFFSET("max_open_logfiles", PW_TYPE_INTEGER, linelog_instance_t, file.max_entries), .dflt = "64" },
+	{ FR_CONF_OFFSET("log_idle_timeout", PW_TYPE_INTEGER, linelog_instance_t, file.max_idle), .dflt = "30" },
+
 	CONF_PARSER_TERMINATOR
 };
 
@@ -345,7 +350,11 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 			return -1;
 		}
 
-		inst->file.ef = module_exfile_init(inst, conf, 64, 30, true, NULL, NULL);
+		FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->file.max_entries, >=, 0);
+		FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->file.max_entries, <=, 2048);
+		FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->file.max_idle, >=, 0);
+		FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->file.max_idle, >=, 3600);
+		inst->file.ef = module_exfile_init(inst, conf, inst->file.max_entries, inst->file.max_idle, true, NULL, NULL);
 		if (!inst->file.ef) {
 			cf_log_err_cs(conf, "Failed creating log file context");
 			return -1;

--- a/src/modules/rlm_linelog/rlm_linelog.c
+++ b/src/modules/rlm_linelog/rlm_linelog.c
@@ -353,7 +353,7 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 		FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->file.max_entries, >=, 8);
 		FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->file.max_entries, <=, 2048);
 		FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->file.max_idle, >=, 1);
-		FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->file.max_idle, >=, 3600);
+		FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->file.max_idle, <=, 3600);
 		inst->file.ef = module_exfile_init(inst, conf, inst->file.max_entries, inst->file.max_idle, true, NULL, NULL);
 		if (!inst->file.ef) {
 			cf_log_err_cs(conf, "Failed creating log file context");

--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -79,6 +79,12 @@ static const CONF_PARSER postauth_config[] = {
 	CONF_PARSER_TERMINATOR
 };
 
+static const CONF_PARSER limit_config[] = {
+	{ FR_CONF_OFFSET("max_files", PW_TYPE_INTEGER, rlm_sql_config_t, max_entries), .dflt = "64" },
+	{ FR_CONF_OFFSET("idle_timeout", PW_TYPE_INTEGER, rlm_sql_config_t, max_idle), .dflt = "30" },
+	CONF_PARSER_TERMINATOR
+};
+
 static const CONF_PARSER module_config[] = {
 	{ FR_CONF_OFFSET("driver", PW_TYPE_STRING, rlm_sql_config_t, sql_driver_name), .dflt = "rlm_sql_null" },
 	{ FR_CONF_OFFSET("server", PW_TYPE_STRING, rlm_sql_config_t, sql_server), .dflt = "" },	/* Must be zero length so drivers can determine if it was set */
@@ -109,9 +115,7 @@ static const CONF_PARSER module_config[] = {
 #endif
 	{ FR_CONF_OFFSET("safe_characters", PW_TYPE_STRING, rlm_sql_config_t, allowed_chars), .dflt = "@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_: /" },
 
-	{ FR_CONF_OFFSET("max_open_logfiles", PW_TYPE_INTEGER, rlm_sql_config_t, max_entries), .dflt = "64" },
-	{ FR_CONF_OFFSET("log_idle_timeout", PW_TYPE_INTEGER, rlm_sql_config_t, max_idle), .dflt = "30" },
-
+	{ FR_CONF_POINTER("limit", PW_TYPE_SUBSECTION, NULL), .subcs = (void const *) limit_config },
 	/*
 	 *	This only works for a few drivers.
 	 */

--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -1191,9 +1191,9 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 				inst->module->sql_escape_func :
 				sql_escape_func;
 
-	FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->config->max_entries, >=, 0);
+	FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->config->max_entries, >=, 8);
 	FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->config->max_entries, <=, 2048);
-	FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->config->max_idle, >=, 0);
+	FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->config->max_idle, >=, 1);
 	FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->config->max_idle, >=, 3600);
 	inst->ef = module_exfile_init(inst, conf, inst->config->max_entries, inst->config->max_idle, true, NULL, NULL);
 	if (!inst->ef) {

--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -1194,7 +1194,7 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 	FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->config->max_entries, >=, 8);
 	FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->config->max_entries, <=, 2048);
 	FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->config->max_idle, >=, 1);
-	FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->config->max_idle, >=, 3600);
+	FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->config->max_idle, <=, 3600);
 	inst->ef = module_exfile_init(inst, conf, inst->config->max_entries, inst->config->max_idle, true, NULL, NULL);
 	if (!inst->ef) {
 		cf_log_err_cs(conf, "Failed creating log file context");

--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -109,6 +109,9 @@ static const CONF_PARSER module_config[] = {
 #endif
 	{ FR_CONF_OFFSET("safe_characters", PW_TYPE_STRING, rlm_sql_config_t, allowed_chars), .dflt = "@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_: /" },
 
+	{ FR_CONF_OFFSET("max_open_logfiles", PW_TYPE_INTEGER, rlm_sql_config_t, max_entries), .dflt = "64" },
+	{ FR_CONF_OFFSET("log_idle_timeout", PW_TYPE_INTEGER, rlm_sql_config_t, max_idle), .dflt = "30" },
+
 	/*
 	 *	This only works for a few drivers.
 	 */
@@ -1188,7 +1191,11 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 				inst->module->sql_escape_func :
 				sql_escape_func;
 
-	inst->ef = module_exfile_init(inst, conf, 64, 30, true, NULL, NULL);
+	FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->config->max_entries, >=, 0);
+	FR_INTEGER_BOUND_CHECK("max_open_logfiles", inst->config->max_entries, <=, 2048);
+	FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->config->max_idle, >=, 0);
+	FR_INTEGER_BOUND_CHECK("log_idle_timeout", inst->config->max_idle, >=, 3600);
+	inst->ef = module_exfile_init(inst, conf, inst->config->max_entries, inst->config->max_idle, true, NULL, NULL);
 	if (!inst->ef) {
 		cf_log_err_cs(conf, "Failed creating log file context");
 		return -1;

--- a/src/modules/rlm_sql/rlm_sql.h
+++ b/src/modules/rlm_sql/rlm_sql.h
@@ -138,6 +138,9 @@ typedef struct sql_config {
 	void			*driver;			//!< Where drivers should write a
 								//!< pointer to their configurations.
 
+	uint32_t		max_entries;			//!< Maximum number of log files opened for writing simultaneously
+	uint32_t		max_idle;			//!< Timeout before closing `unused' log file opened previously
+
 	/*
 	 *	@todo The rest of the queries should also be moved into
 	 *	their own sections.


### PR DESCRIPTION
Cope with "Too many different filenames" logging issue properly.
64 open log files are not enough for everybody :)
Especially, if you use NAS IP(v6) address as dir name and you have many NASes.