### PR TITLE
Fix SIGSEGV on exit when an EAP method is referenced (v3.1.x)

### DIFF
--- a/src/modules/rlm_eap/eap.c
+++ b/src/modules/rlm_eap/eap.c
@@ -72,6 +72,13 @@ static char const *eap_codes[] = {
 static int _eap_module_free(eap_module_t *inst)
 {
 	/*
+	 * Check if handle is still valid. If not, type is referencing freed memory
+	 */
+
+	if (!inst->handle)
+		return 0;
+
+	/*
 	 *	We have to check inst->type as it's only allocated
 	 *	if we loaded the eap method.
 	 */
@@ -83,7 +90,7 @@ static int _eap_module_free(eap_module_t *inst)
 	 *	ad it removes the symbols needed by valgrind.
 	 */
 #else
-	if (inst->handle) dlclose(inst->handle);
+	dlclose(inst->handle);
 #endif
 
 	return 0;

--- a/src/modules/rlm_eap/eap.c
+++ b/src/modules/rlm_eap/eap.c
@@ -75,8 +75,7 @@ static int _eap_module_free(eap_module_t *inst)
 	 * Check if handle is still valid. If not, type is referencing freed memory
 	 */
 
-	if (!inst->handle)
-		return 0;
+	if (!inst->handle) return 0;
 
 	/*
 	 *	We have to check inst->type as it's only allocated


### PR DESCRIPTION
in multiple eap stansas, e.g.
===========================
eap instance1 {
	...
	md5 {
	}
	...
}
eap instance2 {
	...
	md5 {
	}
	...
}
===========================

Sponsored by: Yandex LLC