### PR TITLE
Fix SIGSEGV on exit when an EAP method is referenced (v3.0.x)

### DIFF
--- a/src/modules/rlm_eap/eap.c
+++ b/src/modules/rlm_eap/eap.c
@@ -74,8 +74,7 @@ static int _eap_module_free(eap_module_t *inst)
 	/*
 	 * Check if handle is still valid. If not, type is referencing freed memory
 	 */
-        if (!inst->handle)
-		return 0;
+        if (!inst->handle) return 0;
 
 	/*
 	 *	We have to check inst->type as it's only allocated

--- a/src/modules/rlm_eap/eap.c
+++ b/src/modules/rlm_eap/eap.c
@@ -72,6 +72,12 @@ static char const *eap_codes[] = {
 static int _eap_module_free(eap_module_t *inst)
 {
 	/*
+	 * Check if handle is still valid. If not, type is referencing freed memory
+	 */
+        if (!inst->handle)
+		return 0;
+
+	/*
 	 *	We have to check inst->type as it's only allocated
 	 *	if we loaded the eap method.
 	 */
@@ -85,7 +91,7 @@ static int _eap_module_free(eap_module_t *inst)
 	 */
 	if (!main_config.debug_memory)
 #endif
-	if (inst->handle) dlclose(inst->handle);
+	dlclose(inst->handle);
 
 	return 0;
 }

--- a/src/modules/rlm_eap/eap.c
+++ b/src/modules/rlm_eap/eap.c
@@ -72,7 +72,8 @@ static char const *eap_codes[] = {
 static int _eap_module_free(eap_module_t *inst)
 {
 	/*
-	 * Check if handle is still valid. If not, type is referencing freed memory
+	 * Check if handle is still valid. If not, inst was loaded using dlsym(RTLD_SELF, ...)
+	 * No need to call detach or dlclose()
 	 */
         if (!inst->handle) return 0;
 


### PR DESCRIPTION
in multiple eap stansas, e.g.
===========================
eap instance1 {
	...
	md5 {
	}
	...
}
eap instance2 {
	...
	md5 {
	}
	...
}
===========================

Sponsored by: Yandex LLC