### PR TITLE
src/lib/pair.c: fr_pair_fprint: avoid segfault

### DIFF
--- a/src/lib/pair.c
+++ b/src/lib/pair.c
@@ -2267,6 +2267,7 @@ size_t fr_pair_snprint(char *out, size_t outlen, VALUE_PAIR const *vp)
  */
 void fr_pair_fprint(FILE *fp, VALUE_PAIR const *vp)
 {
+	if (!fp) return;
 	char	buf[1024];
 	char	*p = buf;
 	size_t	len;

--- a/src/lib/pair.c
+++ b/src/lib/pair.c
@@ -2267,11 +2267,11 @@ size_t fr_pair_snprint(char *out, size_t outlen, VALUE_PAIR const *vp)
  */
 void fr_pair_fprint(FILE *fp, VALUE_PAIR const *vp)
 {
-	if (!fp) return;
 	char	buf[1024];
 	char	*p = buf;
 	size_t	len;
 
+	if (!fp) return;
 	VERIFY_VP(vp);
 
 	*p++ = '\t';


### PR DESCRIPTION
* prevent from calling fputs with null file pointer.
* radclient with -q option, then you can easily come across a segfault.