### PR TITLE
Allow '_' in dictionary names

### DIFF
--- a/src/lib/dict.c
+++ b/src/lib/dict.c
@@ -174,7 +174,7 @@ const size_t dict_attr_sizes[PW_TYPE_MAX + 1][2] = {
  *
  */
 const bool fr_dict_attr_allowed_chars[UINT8_MAX] = {
-	['-'] = true, ['.'] = true, ['/'] = true,
+	['-'] = true, ['.'] = true, ['/'] = true, ['_'] = true,
 	['0'] = true, ['1'] = true, ['2'] = true, ['3'] = true, ['4'] = true,
 	['5'] = true, ['6'] = true, ['7'] = true, ['8'] = true, ['9'] = true,
 	['A'] = true, ['B'] = true, ['C'] = true, ['D'] = true, ['E'] = true,


### PR DESCRIPTION
This was forgotten in commit 46e53c09e53e5550f0de9824b0a2674f54a8e82a,
and caused the server to fail to start.

    share/freeradius/dictionary.3com[48]: Invalid character '_' in attribute name