### PR TITLE
Review wanted: add all lists (like reply and control) to rlm_rest

### DIFF
--- a/raddb/mods-available/rest
+++ b/raddb/mods-available/rest
@@ -58,28 +58,31 @@ rest {
 	#  the settings from the authorize section here will be used.
 	#
 	#  The following config items may be listed in any of the sections:
-	#    uri          - to send the request to.
-	#    proxy        - the request via this server, supports socks/http/https uri
-	#                   and :port.
-	#    method       - HTTP method to use, one of 'get', 'post', 'put', 'patch',
-	#                   'delete' or any custom HTTP method.
-	#    body         - The format of the HTTP body sent to the remote server.
-	#                   May be 'none', 'post' or 'json', defaults to 'none'.
-	#    data         - Send custom freeform data in the HTTP body. Content-type
-	#                   may be specified with 'body'. Will be expanded.
-	#                   Values from expansion will not be escaped, this should be
-	#                   done using the appropriate xlat method e.g. %{urlencode:<attr>}.
-	#    force_to     - Force the response to be decoded with this decoder.
-	#                   May be 'plain' (creates reply:REST-HTTP-Body), 'post'
-	#                   or 'json'.
-	#    tls          - TLS settings for HTTPS.
-	#    auth         - HTTP auth method to use, one of 'none', 'srp', 'basic',
-	#                   'digest', 'digest-ie', 'gss-negotiate', 'ntlm',
-	#                   'ntlm-winbind', 'any', 'safe'. defaults to 'none'.
-	#    username     - User to authenticate as, will be expanded.
-	#    password     - Password to use for authentication, will be expanded.
-	#    require_auth - Require HTTP authentication.
-	#    timeout      - HTTP request timeout in seconds, defaults to 4.0.
+	#    uri            - to send the request to.
+	#    proxy          - the request via this server, supports socks/http/https uri
+	#                     and :port.
+	#    method         - HTTP method to use, one of 'get', 'post', 'put', 'patch',
+	#                     'delete' or any custom HTTP method.
+	#    body           - The format of the HTTP body sent to the remote server.
+	#                     May be 'none', 'post' or 'json', defaults to 'none'.
+	#    all_lists_body - Include all lists in the body, not just the request.
+	#                     Attributes are encoded as '%{listname}:%{attribute}. Defaults
+	#                     to "no"
+	#    data           - Send custom freeform data in the HTTP body. Content-type
+	#                     may be specified with 'body'. Will be expanded.
+	#                     Values from expansion will not be escaped, this should be
+	#                     done using the appropriate xlat method e.g. %{urlencode:<attr>}.
+	#    force_to       - Force the response to be decoded with this decoder.
+	#                     May be 'plain' (creates reply:REST-HTTP-Body), 'post'
+	#                     or 'json'.
+	#    tls            - TLS settings for HTTPS.
+	#    auth           - HTTP auth method to use, one of 'none', 'srp', 'basic',
+	#                     'digest', 'digest-ie', 'gss-negotiate', 'ntlm',
+	#                     'ntlm-winbind', 'any', 'safe'. defaults to 'none'.
+	#    username       - User to authenticate as, will be expanded.
+	#    password       - Password to use for authentication, will be expanded.
+	#    require_auth   - Require HTTP authentication.
+	#    timeout        - HTTP request timeout in seconds, defaults to 4.0.
 	#
 	#  Additional HTTP headers may be specified with control:REST-HTTP-Header.
 	#  The values of those attributes should be in the format:

--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -662,11 +662,10 @@ no_space:
  * @param[in] request Current request.
  * @param[in] vps The list of value pairs to initialize
  * @param[in] ctx to initialise.
- * @param[in] list_name The name of the list
  * @param[in] sort If true VALUE_PAIRs will be sorted within the VALUE_PAIR
  *	pointer array.
  */
-static void rest_request_init(REQUEST *request, VALUE_PAIR **vps, rlm_rest_request_t *ctx, char const *list_name, bool sort)
+static void rest_request_init(REQUEST *request, VALUE_PAIR **vps, rlm_rest_request_t *ctx, bool sort)
 {
 	/*
 	 * 	Setup stream read data
@@ -681,7 +680,6 @@ static void rest_request_init(REQUEST *request, VALUE_PAIR **vps, rlm_rest_reque
 		fr_pair_list_sort(vps, fr_pair_cmp_by_da_tag);
 	}
 	fr_cursor_init(&ctx->cursor, vps);
-	ctx->list_name = list_name;
 }
 
 #ifdef HAVE_JSON
@@ -802,7 +800,8 @@ static size_t rest_encode_json(void *out, size_t size, size_t nmemb, void *userd
 		 */
 		if (!vp && (ctx->state == READ_STATE_ATTR_BEGIN)) {
 			if (ctx->next_vps->list_name != NULL) {
-				rest_request_init(request, ctx->next_vps->vps, ctx, ctx->next_vps->list_name, true);
+				rest_request_init(request, ctx->next_vps->vps, ctx, true);
+				ctx->list_name = ctx->next_vps->list_name;
 				vp = fr_cursor_current(&ctx->cursor);
 				ctx->next_vps++;
 				ctx->state = READ_STATE_ATTR_BEGIN;
@@ -2359,7 +2358,7 @@ int rest_request_config(rlm_rest_t const *instance, rlm_rest_section_t *section,
 #endif
 
 	case HTTP_BODY_POST:
-		rest_request_init(request, &request->packet->vps, &ctx->request, "request", false);
+		rest_request_init(request, &request->packet->vps, &ctx->request, false);
 
 		if (rest_request_config_body(instance, section, request, handle,
 					     rest_encode_post) < 0) {

--- a/src/modules/rlm_rest/rest.h
+++ b/src/modules/rlm_rest/rest.h
@@ -199,6 +199,8 @@ typedef struct rlm_rest_request_t {
 	size_t			chunk;		//!< Chunk size
 
 	void			*encoder;	//!< Encoder specific data.
+
+	VALUE_PAIR		**next_vps;	//!< Dirty hack to make things work
 } rlm_rest_request_t;
 
 /*

--- a/src/modules/rlm_rest/rest.h
+++ b/src/modules/rlm_rest/rest.h
@@ -120,6 +120,8 @@ typedef struct rlm_rest_section_t {
 
 	char const		*data;		//!< Custom body data (optional).
 
+	bool			all_lists_body;	//!< Include all lists in the HTTP request
+
 	char const		*auth_str;	//!< The string version of the Auth-Type.
 	http_auth_type_t	auth;		//!< HTTP auth type.
 	bool			require_auth;	//!< Whether HTTP-Auth is required or not.

--- a/src/modules/rlm_rest/rest.h
+++ b/src/modules/rlm_rest/rest.h
@@ -185,6 +185,11 @@ typedef enum {
 	WRITE_STATE_DISCARD,
 } write_state_t;
 
+typedef struct rlm_rest_next_vps_t {
+	VALUE_PAIR	**vps;		//!< The actual value pairs
+	char const	*list_name;	//!< The name of the list, used a prefix
+} rlm_rest_next_vps_t;
+
 /*
  *	Outbound data context (passed to CURLOPT_READFUNCTION as CURLOPT_READDATA)
  */
@@ -200,7 +205,7 @@ typedef struct rlm_rest_request_t {
 
 	void			*encoder;	//!< Encoder specific data.
 
-	VALUE_PAIR		**next_vps;	//!< Dirty hack to make things work
+	rlm_rest_next_vps_t	*next_vps;	//!< The list of value pairs to come
 } rlm_rest_request_t;
 
 /*

--- a/src/modules/rlm_rest/rest.h
+++ b/src/modules/rlm_rest/rest.h
@@ -194,6 +194,7 @@ typedef struct rlm_rest_request_t {
 	read_state_t		state;		//!< Encoder state
 
 	vp_cursor_t		cursor;		//!< Cursor pointing to the start of the list to encode.
+	char const		*list_name;	//!< Name of the current list
 
 	size_t			chunk;		//!< Chunk size
 

--- a/src/modules/rlm_rest/rlm_rest.c
+++ b/src/modules/rlm_rest/rlm_rest.c
@@ -52,6 +52,7 @@ static const CONF_PARSER section_config[] = {
 	{ FR_CONF_OFFSET("proxy", PW_TYPE_STRING, rlm_rest_section_t, proxy) },
 	{ FR_CONF_OFFSET("method", PW_TYPE_STRING, rlm_rest_section_t, method_str), .dflt = "GET" },
 	{ FR_CONF_OFFSET("body", PW_TYPE_STRING, rlm_rest_section_t, body_str), .dflt = "none" },
+	{ FR_CONF_OFFSET("all_lists_body", PW_TYPE_BOOLEAN, rlm_rest_section_t, all_lists_body), .dflt = "no" },
 	{ FR_CONF_OFFSET("data", PW_TYPE_STRING | PW_TYPE_XLAT, rlm_rest_section_t, data) },
 	{ FR_CONF_OFFSET("force_to", PW_TYPE_STRING, rlm_rest_section_t, force_to_str) },
 


### PR DESCRIPTION
First of all: this is very much work in progress, I mainly want an opinion to see if things in this patch are done in a sane way and if this would be accepted in the release (once finished)

At the moment, `rlm_rest` only sends the `request` list. It can be really useful to have the other lists too (compare  #1464 where this functionality is requested for `rlm_python`). This branch fixes this, but only if the body is of the json-type (as I said before: this is work in progress).
Even though json would support a structure like `{"request:{...attributes...},"reply":{...attributes...}}`, I choose to use the old hash format and prepend every attribute with the list name. This way it would also be possible to use this functionality using post-vars (or any other body type that does not support a more complex structure)