### PR TITLE
Arp bfd fix

### DIFF
--- a/raddb/sites-available/arp
+++ b/raddb/sites-available/arp
@@ -33,13 +33,14 @@ server arp {
 
 
 	#
-	#  For now, ARP is processed through the "post-auth"
-	#  section.  As we make the server more protocol agnostic,
-	#  this will change.
+	#  And the REAL contents.  This section is just like the
+	#  "post-auth" section of radiusd.conf.  In fact, it calls the
+	#  "post-auth" component of the modules that are listed here.
+	#  But it's called "arp" to highlight that it's for ARP.
 	#
 	#  If you need to know the interface, use %{listen:interface}
 	#
-	post-auth {
+	arp {
 		ok
 	}
 }

--- a/raddb/sites-available/bfd
+++ b/raddb/sites-available/bfd
@@ -88,11 +88,12 @@ listen {
 #  But you could run an external shell script, Perl, etc.
 #
 server bfd {
+	#  And the REAL contents.  This section is just like the
+	#  "authorize" section of radiusd.conf.  In fact, it calls the
+	#  "authorize" component of the modules that are listed here.
+	#  But it's called "bfd" to highlight that it's for BFD.
 	bfd {
 		# Say it's OK.
 		ok
-
-		#  Any other modules listed here will have their
-		#  "authorize" section run.
 	}
 }

--- a/src/main/modules.c
+++ b/src/main/modules.c
@@ -1147,6 +1147,19 @@ static int virtual_server_compile(CONF_SECTION *cs)
 			}
 #endif
 
+			subcs = cf_section_sub_find(cs, "arp");
+			if (subcs) {
+				cf_log_module(cs, "Loading arp {...}");
+				if (load_component_section(subcs, components,
+							   MOD_POST_AUTH) < 0) {
+					goto error;
+				}
+				c = lookup_by_index(components,
+						    MOD_POST_AUTH, 0);
+				if (c) server->mc[MOD_POST_AUTH] = c->modulelist;
+				break;
+			}
+
 #ifdef WITH_DHCP
 			/*
 			 *	It's OK to not have DHCP.

--- a/src/main/modules.c
+++ b/src/main/modules.c
@@ -1160,6 +1160,19 @@ static int virtual_server_compile(CONF_SECTION *cs)
 				break;
 			}
 
+			subcs = cf_section_sub_find(cs, "bfd");
+			if (subcs) {
+				cf_log_module(cs, "Loading bfd {...}");
+				if (load_component_section(subcs, components,
+							   MOD_AUTHORIZE) < 0) {
+					goto error;
+				}
+				c = lookup_by_index(components,
+						    MOD_AUTHORIZE, 0);
+				if (c) server->mc[MOD_AUTHORIZE] = c->modulelist;
+				break;
+			}
+
 #ifdef WITH_DHCP
 			/*
 			 *	It's OK to not have DHCP.

--- a/src/modules/proto_arp/proto_arp.c
+++ b/src/modules/proto_arp/proto_arp.c
@@ -147,6 +147,7 @@ static int arp_socket_recv(rad_listen_t *listener)
 	packet = talloc_zero(NULL, RADIUS_PACKET);
 	if (!packet) return 0;
 
+	packet->timestamp = header->ts;
 	packet->dst_port = 1;	/* so it's not a "fake" request */
 	packet->data_len = header->caplen - link_len;
 	packet->data = talloc_memdup(packet, arp, packet->data_len);

--- a/src/modules/proto_bfd/proto_bfd.c
+++ b/src/modules/proto_bfd/proto_bfd.c
@@ -225,6 +225,8 @@ typedef struct bfd_socket_t {
 	rbtree_t	*session_tree;
 } bfd_socket_t;
 
+extern fr_log_t debug_log;
+
 static int bfd_start_packets(bfd_state_t *session);
 static int bfd_start_control(bfd_state_t *session);
 static int bfd_stop_control(bfd_state_t *session);
@@ -1364,6 +1366,7 @@ static int bfd_process(bfd_state_t *session, bfd_packet_t *bfd)
 		if (rad_debug_lvl) {
 			request->log.lvl = RAD_REQUEST_LVL_DEBUG2;
 			request->log.func = vradlog_request;
+			request->log.output = &debug_log;
 		}
 		request->component = NULL;
 		request->module = NULL;


### PR DESCRIPTION
Bug fixes for ARP & BFD.
Allow section names in sample servers to be arp/bfd as is the case for vmps.