### PR TITLE
allow operator-name out

### DIFF
--- a/raddb/mods-config/attr_filter/pre-proxy
+++ b/raddb/mods-config/attr_filter/pre-proxy
@@ -59,4 +59,5 @@ DEFAULT
 	State =* ANY,
 	NAS-IP-Address =* ANY,
 	NAS-Identifier =* ANY,
+	Operator-Name =* ANY,
 	Proxy-State =* ANY


### PR DESCRIPTION
if we've added operator-name locally via eg clients.conf we'll lose it if we've enabled this filter (which we should enable!)