### PR TITLE
add operator-name to allow list

### DIFF
--- a/raddb/mods-config/attr_filter/pre-proxy
+++ b/raddb/mods-config/attr_filter/pre-proxy
@@ -59,4 +59,5 @@ DEFAULT
 	State =* ANY,
 	NAS-IP-Address =* ANY,
 	NAS-Identifier =* ANY,
+	Operator-Name =* ANY,
 	Proxy-State =* ANY


### PR DESCRIPTION
if we've added operator-name locally via eg client.conf, we'd lose it when we enable,as we should!, this filter. this fixes that.