### PR TITLE
Added mapping for char const * in PW_TYPE_FROM_PTR

### DIFF
--- a/src/include/tmpl.h
+++ b/src/include/tmpl.h
@@ -346,6 +346,7 @@ do {\
 #define	PW_TYPE_FROM_PTR(_ptr) \
 	_Generic((_ptr), \
 		 char **: PW_TYPE_STRING, \
+		 char const **: PW_TYPE_STRING, \
 		 uint8_t **: PW_TYPE_OCTETS, \
 		 uint8_t *: PW_TYPE_BYTE, \
 		 uint16_t *: PW_TYPE_SHORT, \


### PR DESCRIPTION
Without this, my build failed with the following message:

```
src/freeradius-devel/tmpl.h:347:11: error: ‘_Generic’ selector of type ‘const char **’ is not compatible with any association
  _Generic((_ptr), \
src/freeradius-devel/tmpl.h:362:77: note: in expansion of macro ‘PW_TYPE_FROM_PTR’
  _tmpl_to_atype(_ctx, (void *)(_out), _request, _vpt, _escape, _escape_ctx, PW_TYPE_FROM_PTR(_out))
src/modules/rlm_winbind/rlm_winbind.c:101:10: note: in expansion of macro ‘tmpl_aexpand’
  slen = tmpl_aexpand(request, &domain, request, inst->wb_domain, NULL, NULL);
```

Might be something that only shows up with certain compilers, I was using gcc-5.4.0