### PR TITLE
small fix in dictionary.rfc4849 string should be octets

### DIFF
--- a/share/dictionary.rfc4849
+++ b/share/dictionary.rfc4849
@@ -6,4 +6,4 @@
 #
 #	$Id$
 #
-ATTRIBUTE	NAS-Filter-Rule				92	string
+ATTRIBUTE	NAS-Filter-Rule				92	octets


### PR DESCRIPTION
according to the rfc section2:

The String field is one or more octets. so this is an octets field instead of a string field