### PR TITLE
Add reload support to systemd unit files

### DIFF
--- a/debian/freeradius.service
+++ b/debian/freeradius.service
@@ -11,6 +11,8 @@ ExecStartPre=/usr/sbin/freeradius $FREERADIUS_OPTIONS -Cxm -lstdout
 ExecStart=/usr/sbin/freeradius $FREERADIUS_OPTIONS
 Restart=on-failure
 RestartSec=5
+ExecReload=/usr/sbin/freeradius $FREERADIUS_OPTIONS -Cxm -lstdout
+ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
 WantedBy=multi-user.target

--- a/redhat/radiusd.service
+++ b/redhat/radiusd.service
@@ -11,6 +11,8 @@ ExecStartPre=/usr/sbin/radiusd $FREERADIUS_OPTIONS -Cxm -lstdout
 ExecStart=/usr/sbin/radiusd $FREERADIUS_OPTIONS -m
 Restart=on-failure
 RestartSec=5
+ExecReload=/usr/sbin/radiusd $FREERADIUS_OPTIONS -Cxm -lstdout
+ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Currently the systemd unit files only support the restart action. This adds reload support so the daemon can be HUP'd when configs are changed. Addresses #1662. Let me know if I should target a different branch.