### PR TITLE
Fixed compile error in v3.0.x

### DIFF
--- a/src/modules/rlm_rest/rlm_rest.c
+++ b/src/modules/rlm_rest/rlm_rest.c
@@ -280,7 +280,7 @@ static ssize_t rest_xlat(void *instance, REQUEST *request,
 				  uri, NULL, NULL);
 	talloc_free(uri);
 	if (ret < 0) {
-		slen = -1;
+		outlen = -1;
 		goto finish;
 	}
 
@@ -290,7 +290,7 @@ static ssize_t rest_xlat(void *instance, REQUEST *request,
 	 */
 	ret = rest_request_perform(instance, &section, request, handle);
 	if (ret < 0) {
-		slen = -1;
+		outlen = -1;
 		goto finish;
 	}
 


### PR DESCRIPTION
Commit 7412786d95ac2b39a19ee2f77a29981c9adb86b3 was probably
cherry-picked from v3.1.x, but the variable has a different name in
v3.0.x.