### PR TITLE
bugfix stats request

### DIFF
--- a/src/main/stats.c
+++ b/src/main/stats.c
@@ -589,7 +589,7 @@ void request_stats_reply(REQUEST *request)
 						    &client->auth);
 			}
 #ifdef WITH_ACCOUNTING
-			if ((flag->vp_integer & 0x01) != 0) {
+			if ((flag->vp_integer & 0x02) != 0) {
 				request_stats_addvp(request, client_acctvp,
 						    &client->acct);
 			}


### PR DESCRIPTION
bugfix for stats request to server for specific client (accounting).
bit matrix was evaluated at wrong position.
this affects all versions of freeradius server (4.0, 3.1, 3.0)