### PR TITLE
Create JSON representation of lists via json-c

### DIFF
--- a/src/modules/rlm_json/json.h
+++ b/src/modules/rlm_json/json.h
@@ -66,5 +66,7 @@ char		*fr_json_from_string(TALLOC_CTX *ctx, char const *s, bool include_quotes);
 size_t    	fr_json_from_pair(char *out, size_t outlen, VALUE_PAIR const *vp);
 
 void		fr_json_version_print(void);
+
+const char *fr_json_from_pair_list(VALUE_PAIR **vps, const char *prefix);
 #endif
 #endif /* _FR_JSON_H */


### PR DESCRIPTION
This might be a first step to implement https://github.com/FreeRADIUS/freeradius-server/pull/1618#issuecomment-231619422 It contains a method to create a JSON-string from a list. It is nowhere used yet, but it's a nice start to use this in rlm_rest. 