### PR TITLE
Fix for bug where originating CoA requests causes segfault if proxying is disabled.

### DIFF
--- a/src/include/radiusd.h
+++ b/src/include/radiusd.h
@@ -129,6 +129,9 @@ typedef struct main_config {
 #ifdef WITH_PROXY
 	bool		proxy_requests;			//!< Toggle to enable/disable proxying globally.
 #endif
+#ifdef WITH_COA
+	bool            originate_coa_requests;         //!< Toggle to enable/disable originating COA requests globally.
+#endif
 	struct timeval	reject_delay;			//!< How long to wait before sending an Access-Reject.
 	bool		status_server;			//!< Whether to respond to status-server messages.
 

--- a/src/main/mainconfig.c
+++ b/src/main/mainconfig.c
@@ -198,6 +198,9 @@ static const CONF_PARSER server_config[] = {
 #ifdef WITH_PROXY
 	{ "proxy_requests", FR_CONF_POINTER(PW_TYPE_BOOLEAN, &main_config.proxy_requests), "yes" },
 #endif
+#ifdef WITH_COA
+	{ "originate_coa_requests", FR_CONF_POINTER(PW_TYPE_BOOLEAN, &main_config.originate_coa_requests), "yes" },
+#endif
 	{ "log", FR_CONF_POINTER(PW_TYPE_SUBSECTION, NULL), (void const *) log_config },
 
 	{ "resources", FR_CONF_POINTER(PW_TYPE_SUBSECTION, NULL), (void const *) resources },

--- a/src/main/process.c
+++ b/src/main/process.c
@@ -633,10 +633,12 @@ static void request_done(REQUEST *request, int action)
 	/*
 	 *	Move the CoA request to its own handler.
 	 */
-	if (request->coa) {
-		coa_separate(request->coa);
-	} else if (request->parent && (request->parent->coa == request)) {
-		coa_separate(request);
+	if (request->root->originate_coa_requests) {
+		if (request->coa) {
+			coa_separate(request->coa);
+		} else if (request->parent && (request->parent->coa == request)) {
+			coa_separate(request);
+		}
 	}
 #endif
 
@@ -1328,7 +1330,7 @@ static void request_finish(REQUEST *request, int action)
 	/*
 	 *	Maybe originate a CoA request.
 	 */
-	if ((action == FR_ACTION_RUN) && !request->proxy && request->coa) {
+	if ((action == FR_ACTION_RUN) && request->root->originate_coa_requests && !request->proxy && request->coa) {
 		request_coa_originate(request);
 	}
 #endif
@@ -5390,6 +5392,13 @@ int radius_event_start(CONF_SECTION *cs, bool have_children)
 		main_config.init_delay.tv_sec >>= 1;
 
 		proxy_ctx = talloc_init("proxy");
+	}
+#endif
+
+#ifdef WITH_COA
+	if (main_config.originate_coa_requests && !proxy_list && !check_config) {
+		proxy_list = fr_packet_list_create(1);
+		if (!proxy_list) return 0;
 	}
 #endif
 


### PR DESCRIPTION
If FreeRADIUS 3.0.11 is configured to originate CoA requests in response to certain packets using the following files:

  etc/raddb/sites-enabled/default
  etc/raddb/sites-enabled/originate-coa
  etc/raddb/clients.conf

it will segfault if the following line is present in etc/raddb/radiusd.conf:

  proxy_requests = no

In src/main/process.c request_coa_originate() calls insert_into_proxy_hash(), which expects the global variable proxy_list to be initialised. It is initialised in radius_event_start(), but only if main_config.proxy_requests is true.

The patch adds the following configuration parameter:

  originate_coa_requests = yes / no

If it is set to 'yes' the proxy_list global will be initialised if the proxy code hasn't already done so. Otherwise CoA requests will not be originated. It defaults to 'yes'.