### PR TITLE
Simplified a macro in rlm_perl

### DIFF
--- a/src/modules/rlm_perl/rlm_perl.c
+++ b/src/modules/rlm_perl/rlm_perl.c
@@ -89,9 +89,8 @@ typedef struct rlm_perl_t {
 /*
  *	A mapping of configuration file names to internal variables.
  */
-#define RLM_PERL_CONF(_x) { .name = "func_" STRINGIFY(_x), .type = PW_TYPE_STRING, \
-			   .offset = offsetof(rlm_perl_t,func_##_x), .data = NULL, \
-			   .dflt = STRINGIFY(_x), .quote = T_INVALID }
+#define RLM_PERL_CONF(_x) { FR_CONF_OFFSET("func_" STRINGIFY(_x), PW_TYPE_STRING, rlm_perl_t, func_##_x), \
+			   .data = NULL, .dflt = STRINGIFY(_x), .quote = T_INVALID }
 
 static const CONF_PARSER module_config[] = {
 	{ FR_CONF_OFFSET("filename", PW_TYPE_FILE_INPUT | PW_TYPE_REQUIRED, rlm_perl_t, module) },


### PR DESCRIPTION
By using another macro. This way it looks more like everywhere else
where we define CONF_PARSER entries.