### PR TITLE
really replace Cache-Merge with Cache-Merge-New

### DIFF
--- a/share/dictionary.freeradius.internal
+++ b/share/dictionary.freeradius.internal
@@ -276,8 +276,8 @@ ATTRIBUTE	Cache-Allow-Insert			1177	integer	internal
 VALUE	Cache-Status-Only		no			0
 VALUE	Cache-Status-Only		yes			1
 
-VALUE	Cache-Merge			no			0
-VALUE	Cache-Merge			yes			1
+VALUE	Cache-Merge-New			no			0
+VALUE	Cache-Merge-New			yes			1
 
 VALUE	Cache-Allow-Merge		no			0
 VALUE	Cache-Allow-Merge		yes			1


### PR DESCRIPTION
just as in the 4.0.x tree..... otherwise trying to run FR blows up with

Errors reading dictionary: fr_dict_init: No ATTRIBUTE 'Cache-Merge' defined for VALUE 'yes'