### PR TITLE
fixed silly typo (copied initially from 4.0.x) and layout

### DIFF
--- a/src/main/tls/ocsp.c
+++ b/src/main/tls/ocsp.c
@@ -274,9 +274,8 @@ int tls_ocsp_staple_cb(SSL *ssl, void *data)
 		goto error;
 	}
 
-	if ((X509_STORE_CTX_get1_issuer(&issuer_cert, server_store_ctx, cert) != 1) ||
-	    !issuer_cert) {
-		tls_log_error(request, "Can't get server certificate's issue");
+	if ((X509_STORE_CTX_get1_issuer(&issuer_cert, server_store_ctx, cert) != 1) || !issuer_cert) {
+		tls_log_error(request, "Can't get server certificate's issuer");
 		goto error;
 	}
 


### PR DESCRIPTION
backport from recent 4.0.x change