### PR TITLE
Rlm json fixes v4.0.x

### DIFF
--- a/src/modules/rlm_json/json.c
+++ b/src/modules/rlm_json/json.c
@@ -285,6 +285,16 @@ static void json_array_add_vp(TALLOC_CTX *ctx, json_object *arr, VALUE_PAIR *vp)
 	json_object_array_add(arr, to_add);
 }
 
+/** Returns a JSON string of a list of value pairs
+ *
+ *  The result is a talloc-ed string, freeing the string is the responsibility
+ *  of the caller.
+ *
+ * @param ctx Talloc context
+ * @param vps The list of value pairs
+ * @param prefix The prefix to use, can be NULL to skip the prefix
+ * @return JSON string representation of the value pairs
+ */
 const char *fr_json_from_pair_list(TALLOC_CTX *ctx, VALUE_PAIR **vps, const char *prefix) {
 	TALLOC_CTX *local_ctx;
 	vp_cursor_t cursor;

--- a/src/modules/rlm_json/json.h
+++ b/src/modules/rlm_json/json.h
@@ -67,6 +67,6 @@ size_t    	fr_json_from_pair(char *out, size_t outlen, VALUE_PAIR const *vp);
 
 void		fr_json_version_print(void);
 
-const char *fr_json_from_pair_list(VALUE_PAIR **vps, const char *prefix);
+const char *fr_json_from_pair_list(TALLOC_CTX *ctx, VALUE_PAIR **vps, const char *prefix);
 #endif
 #endif /* _FR_JSON_H */


### PR DESCRIPTION
The return of `fr_json_from_pair_list` was a string that was memory managed by the root JSON object. We freed that object, thus returned an invalid pointer. Change the signature to include a talloc context, duplicate the string with that talloc context as parent, and return that.

Added some doxygen comments to the function as well.