### PR TITLE
Enable redis builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,7 @@ addons:
 services:
   - mysql
   - postgresql
+  - redis
 before_install:
   - if [ "${CC}" == 'gcc' ]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60; fi
   - if [ "${CC}" == 'gcc' ]; then sudo update-alternatives --config gcc; fi

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -51,5 +51,4 @@ echo "Setting up fixtures"
 ./scripts/travis/postgresql-setup.sh
 ./scripts/travis/mysql-setup.sh
 ./scripts/travis/ldap-setup.sh
-# Travis doesn't have Redis 3.0 available yet
-# ./scripts/travis/redis-setup.sh
+./scripts/travis/redis-setup.sh


### PR DESCRIPTION
The comment said Redis 3.0 wasn't available, but that is outdated.