### PR TITLE
Fixed redis service definition in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ addons:
 services:
   - mysql
   - postgresql
-  - redis
+  - redis-server
 before_install:
   - if [ "${CC}" == 'gcc' ]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60; fi
   - if [ "${CC}" == 'gcc' ]; then sudo update-alternatives --config gcc; fi


### PR DESCRIPTION
According to https://docs.travis-ci.com/user/database-setup/#Redis we
needed `redis-server` instead of `redis`. Surprisingly, the Travis tests
did not break with an invalid value.

My bad