### PR TITLE
fix typo: NEEDS_CONFIG

### DIFF
--- a/src/modules/all.mk
+++ b/src/modules/all.mk
@@ -18,6 +18,6 @@ EXT_MODULES := $(subst ${top_srcdir}/,,$(wildcard ${top_srcdir}/src/modules/*_ex
 #
 ifeq "$(CONFIGURE_ARGS)" ""
 NEEDS_CONFIG := $(patsubst %.in,%,$(foreach file,$(SUBMAKEFILES),$(wildcard $(file).in)))
-SUBMAKEFILES := $(sort $(SUBMAKEFILES) $(NEED_CONFIG))
+SUBMAKEFILES := $(sort $(SUBMAKEFILES) $(NEEDS_CONFIG))
 endif
 


### PR DESCRIPTION
This doesn’t seem to change anything obvious during compilation, but it seems good to fix the typo…?