### PR TITLE
replace EVP_cleanup check with EVP_PKEY_new

### DIFF
--- a/src/modules/rlm_eap/types/rlm_eap_pwd/configure
+++ b/src/modules/rlm_eap/types/rlm_eap_pwd/configure
@@ -2917,7 +2917,7 @@ smart_prefix=
 
 
 sm_lib_safe=`echo "crypto" | sed 'y%./+-%__p_%'`
-sm_func_safe=`echo "EVP_cleanup" | sed 'y%./+-%__p_%'`
+sm_func_safe=`echo "EVP_PKEY_new" | sed 'y%./+-%__p_%'`
 
 old_LIBS="$LIBS"
 old_CPPFLAGS="$CPPFLAGS"
@@ -2927,17 +2927,17 @@ smart_lib_dir=
 
 if test "x$smart_try_dir" != "x"; then
   for try in $smart_try_dir; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_cleanup in -lcrypto in $try" >&5
-$as_echo_n "checking for EVP_cleanup in -lcrypto in $try... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_PKEY_new in -lcrypto in $try" >&5
+$as_echo_n "checking for EVP_PKEY_new in -lcrypto in $try... " >&6; }
     LIBS="-lcrypto $old_LIBS"
     CPPFLAGS="-L$try -Wl,-rpath,$try $old_CPPFLAGS"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-extern char EVP_cleanup();
+extern char EVP_PKEY_new();
 int
 main ()
 {
-EVP_cleanup()
+EVP_PKEY_new()
   ;
   return 0;
 }
@@ -2962,16 +2962,16 @@ rm -f core conftest.err conftest.$ac_objext \
 fi
 
 if test "x$smart_lib" = "x"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_cleanup in -lcrypto" >&5
-$as_echo_n "checking for EVP_cleanup in -lcrypto... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_PKEY_new in -lcrypto" >&5
+$as_echo_n "checking for EVP_PKEY_new in -lcrypto... " >&6; }
   LIBS="-lcrypto $old_LIBS"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-extern char EVP_cleanup();
+extern char EVP_PKEY_new();
 int
 main ()
 {
-EVP_cleanup()
+EVP_PKEY_new()
   ;
   return 0;
 }
@@ -3048,17 +3048,17 @@ eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
 
 
   for try in $smart_lib_dir /usr/local/lib /opt/lib; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_cleanup in -lcrypto in $try" >&5
-$as_echo_n "checking for EVP_cleanup in -lcrypto in $try... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_PKEY_new in -lcrypto in $try" >&5
+$as_echo_n "checking for EVP_PKEY_new in -lcrypto in $try... " >&6; }
     LIBS="-lcrypto $old_LIBS"
     CPPFLAGS="-L$try -Wl,-rpath,$try $old_CPPFLAGS"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-extern char EVP_cleanup();
+extern char EVP_PKEY_new();
 int
 main ()
 {
-EVP_cleanup()
+EVP_PKEY_new()
   ;
   return 0;
 }
@@ -3088,7 +3088,7 @@ if test "x$smart_lib" != "x"; then
   SMART_LIBS="$smart_ldflags $smart_lib $SMART_LIBS"
 fi
 
-        if test "x$ac_cv_lib_crypto_EVP_cleanup" != "xyes"; then
+        if test "x$ac_cv_lib_crypto_EVP_PKEY_new" != "xyes"; then
 	  fail="libssl"
         else
           for ac_func in EVP_sha256

--- a/src/modules/rlm_eap/types/rlm_eap_pwd/configure.ac
+++ b/src/modules/rlm_eap/types/rlm_eap_pwd/configure.ac
@@ -60,8 +60,8 @@ if test x$with_[]modname != xno; then
 	fi
 
 	smart_try_dir=$openssl_lib_dir
-        FR_SMART_CHECK_LIB(crypto, EVP_cleanup)
-        if test "x$ac_cv_lib_crypto_EVP_cleanup" != "xyes"; then
+        FR_SMART_CHECK_LIB(crypto, EVP_PKEY_new)
+        if test "x$ac_cv_lib_crypto_EVP_PKEY_new" != "xyes"; then
 	  fail="libssl"
         else
           AC_CHECK_FUNCS(EVP_sha256)


### PR DESCRIPTION
EVP_cleanup is no longer shipped in libcrypto starting with OpenSSL
1.1. Instead, EVP_cleanup is a no-op define:

  /usr/include/openssl/evp.h:#  define EVP_cleanup() while(0) continue

This resulted in rlm_eap_pwd not being compiled when OpenSSL 1.1 is
installed.