### PR TITLE
Make.inc.in: use relative include paths

### DIFF
--- a/Make.inc.in
+++ b/Make.inc.in
@@ -47,11 +47,11 @@ MAKEFLAGS	= @FR_MAKEFLAGS@
 
 CC		= @CC@
 RANLIB		= @RANLIB@
-INCLUDE		= -I${top_srcdir} -I${top_srcdir}/src \
-		  -include ${top_srcdir}/src/freeradius-devel/autoconf.h \
-		  -include ${top_srcdir}/src/freeradius-devel/build.h \
-		  -include ${top_srcdir}/src/freeradius-devel/features.h \
-		  -include ${top_srcdir}/src/freeradius-devel/radpaths.h
+INCLUDE		= -I. -Isrc \
+		  -include src/freeradius-devel/autoconf.h \
+		  -include src/freeradius-devel/build.h \
+		  -include src/freeradius-devel/features.h \
+		  -include src/freeradius-devel/radpaths.h
 CFLAGS		= $(INCLUDE) -fno-strict-aliasing @CFLAGS@
 CPPFLAGS	= @CPPFLAGS@
 LIBPREFIX	= @LIBPREFIX@


### PR DESCRIPTION
This is necessary for the build to be reproducible (see
https://reproducible-builds.org/ for more details). Some binaries (e.g.
radeapclient or radiusd itself) include the CFLAGS with which they were
built, and hence the build path, which is different on different builds
of the package (at least on Debian).