### PR TITLE
Call pthread_setspecific for every thread that calls fr_thread_local_…

### DIFF
--- a/src/include/threads.h
+++ b/src/include/threads.h
@@ -74,13 +74,13 @@ static void __fr_thread_local_destroy_##_n(UNUSED void *unused)\
 static void __fr_thread_local_key_init_##_n(void)\
 {\
 	(void) pthread_key_create(&__fr_thread_local_key_##_n, __fr_thread_local_destroy_##_n);\
-	(void) pthread_setspecific(__fr_thread_local_key_##_n, &(_n));\
 }\
 static _t __fr_thread_local_init_##_n(pthread_destructor_t func)\
 {\
 	__fr_thread_local_destructor_##_n = func;\
 	if (_n) return _n; \
 	(void) pthread_once(&__fr_thread_local_once_##_n, __fr_thread_local_key_init_##_n);\
+	(void) pthread_setspecific(__fr_thread_local_key_##_n, &(_n));\
 	return _n;\
 }
 #  define fr_thread_local_init(_n, _f)	__fr_thread_local_init_##_n(_f)


### PR DESCRIPTION
…init, not just the first one. Otherwise, the value associated with the key is NULL and the destructor isn't called.