### PR TITLE
NULL the configuration item if no trust router is configured

### DIFF
--- a/src/modules/rlm_realm/rlm_realm.c
+++ b/src/modules/rlm_realm/rlm_realm.c
@@ -171,8 +171,11 @@ static int check_for_realm(void *instance, REQUEST *request, REALM **returnrealm
 	/*
 	 *	Try querying for the dynamic realm.
 	 */
-	if (!realm && inst->trust_router)
+	if (!realm && inst->trust_router) {
 		realm = tr_query_realm(request, realmname, inst->default_community, inst->rp_realm, inst->trust_router, inst->tr_port);
+	} else {
+		RDEBUG2("No trust router configured, skipping dynamic realm lookup");
+	}
 #endif
 
 	if (!realm) {
@@ -384,6 +387,7 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 		if (!tr_init()) return -1;
 	} else {
 		rad_const_free(inst->trust_router);
+		inst->trust_router = NULL;
 	}
 #endif
 


### PR DESCRIPTION
The check guarding the trust router query does not run properly because the configuration entry is not nulled.

This change nulls the configuration entry, and adds a debug message so that a user is told why a dynamic realm lookup is not taking place.

Something similar to this should be applied to v4.0.x, do you need me to send a second pull request?