### PR TITLE
Adding ABFAB-specific things to last 3.0.x release. 

### DIFF
--- a/raddb/policy.d/moonshot-targeted-ids
+++ b/raddb/policy.d/moonshot-targeted-ids
@@ -1,0 +1,73 @@
+#
+#  The following policies generate targeted IDs for ABFAB (Moonshot)
+#
+#  This policy requires that the UUID package is installed on your platform
+#  and that this is called from the inner-tunnel
+#
+#  The following string attributes need to exist in the UKERNA dictionary
+#  Moonshot-Host-TargetedId (138)
+#  Moonshot-Realm-TargetedId (139)
+#  Moonshot-TR-COI-TargetedId (140)
+#
+#  These attributes should also be listed in the attr_filter policies
+#  post-proxy and pre-proxy when you use attribute filtering:
+#       Moonshot-Host-TargetedId =* ANY,
+#       Moonshot-Realm-TargetedId =* ANY,
+#       Moonshot-TR-COI-TargetedId =* ANY,
+#
+ 
+#
+#  targeted_id_salt definition
+#  This salt serves the purpose of protecting targeted IDs against
+#  dictionary attacks, therefore should be chosen as a "random"
+#  string and kept secret.
+#
+targeted_id_salt = "changeme"
+#
+#  Moonshot namespaces
+#  These namespaces are used for UUID generation.
+#  They should not be changed by implementors
+#
+moonshot_host_namespace = "a574a04e-b7ff-4850-aa24-a8599c7de1c6"
+moonshot_realm_namespace = "dea5f26d-a013-4444-977d-d09fc990d2e6"
+moonshot_coi_namespace = "145d7e7e-7d54-43ee-bbcb-3c6ad9428247"
+ 
+#  This policy generates a host-specific targeted ID
+#
+moonshot_host_tid.post-auth {
+	#  generate a UUID for Moonshot-Host-TargetedId
+	#  targeted id = (uuid -v 5 [namespace] [username][salt][RP host name])@[IdP realm name]
+	if (&outer.request:GSS-Acceptor-Host-Name) {
+		if ("%{echo:/usr/bin/uuid -v 5 ${policy.moonshot_host_namespace} %{tolower:%{User-Name}}${policy.targeted_id_salt}%{tolower:%{outer.request:GSS-Acceptor-Host-Name}}}" =~ /^([^ ]+)([ ]*)$/) {
+			update outer.session-state {
+				Moonshot-Host-TargetedId := "%{1}@%{tolower:%{request:Realm}}"
+			}
+		}
+	}
+}
+#  This policy generates a realm-specific targeted ID
+#
+moonshot_realm_tid.post-auth {
+	#  generate a UUID for Moonshot-Realm-TargetedId
+	#  targeted id = (uuid -v 5 [namespace] [username][salt][RP realm name])@[IdP realm name]
+	if (&outer.request:GSS-Acceptor-Realm-Name) {
+		if ("%{echo:/usr/bin/uuid -v 5 ${policy.moonshot_realm_namespace} %{tolower:%{User-Name}}${policy.targeted_id_salt}%{tolower:%{outer.request:GSS-Acceptor-Realm-Name}}}" =~ /^([^ ]+)([ ]*)$/) {
+			update outer.session-state {
+				Moonshot-Realm-TargetedId := "%{1}@%{tolower:%{request:Realm}}"
+			}
+		}
+	}
+}
+#  This policy generates a COI-specific targeted ID
+#
+moonshot_coi_tid.post-auth {
+	#  generate a UUID for Moonshot-TR-COI-TargetedId
+	#  targeted id = (uuid -v 5 [namespace] [username][salt][RP COI name])@[IdP realm name]
+	if (&outer.request:Trust-Router-COI) {
+		if ("%{echo:/usr/bin/uuid -v 5 ${policy.moonshot_coi_namespace} %{tolower:%{User-Name}}${policy.targeted_id_salt}%{tolower:%{outer.request:Trust-Router-COI}}}" =~ /^([^ ]+)([ ]*)$/) {
+			update outer.session-state {
+				Moonshot-TR-COI-TargetedId := "%{1}@%{tolower:%{request:Realm}}"
+			}
+		}
+	}
+}

--- a/raddb/sites-available/inner-tunnel
+++ b/raddb/sites-available/inner-tunnel
@@ -311,6 +311,14 @@ post-auth {
 
 
 	#
+	#  Un-comment the following if you want to generate Moonshot (ABFAB) TargetedIds
+	#  IMPORTANT: This requires the UUID package to be installed!
+	#
+#	moonshot_host_tid
+#	moonshot_realm_tid
+#	moonshot_coi_tid
+
+	#
 	#  Instead of "use_tunneled_reply", uncomment the
 	#  next two "update" blocks.
 	#


### PR DESCRIPTION
- Add moonshot-targeted-ids policy (requires UUID)
- Add entries for above moonshot-targeted-ids into inner-tunnel, disabled by default.