### PR TITLE
Check the CVE ID, not the name

### DIFF
--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -2483,7 +2483,7 @@ int tls_global_version_check(char const *acknowledged)
 			/*
 			 *	If the CVE is acknowledged, allow it.
 			 */
-			if (strcmp(acknowledged, defect->name) == 0) return 0;
+			if (strcmp(acknowledged, defect->id) == 0) return 0;
 
 			ERROR("Refusing to start with libssl version %s (in range %s)",
 			      ssl_version(), ssl_version_range(defect->low, defect->high));


### PR DESCRIPTION
I think the ID is intended to be checked, not the name.