### PR TITLE
Don't include sites-enabled & mods-enabled symlinks in debian package

### DIFF
--- a/debian/freeradius-config.postinst
+++ b/debian/freeradius-config.postinst
@@ -22,6 +22,17 @@ case "$1" in
           # Create snakoil certificates on initial install
           make -C /etc/freeradius/certs/
         fi
+
+        # Create links for default sites, but only if this is an initial
+        # install or an upgrade from before there were links; users may
+        # want to remove them...
+        if [ -z "$2" ] || dpkg --compare-versions "$2" lt 2.0.4+dfsg-4; then
+          for site in default inner-tunnel; do
+            if [ ! -e /etc/freeradius/sites-enabled/$site ]; then
+              ln -s ../sites-available/$site /etc/freeradius/sites-enabled/$site
+            fi
+          done
+        fi
         ;;
 esac
 

--- a/debian/freeradius-config.postinst
+++ b/debian/freeradius-config.postinst
@@ -24,7 +24,7 @@ case "$1" in
 
           # Create links for default modules
           for mod in always attr_filter cache_eap chap \
-              detail detail.log digest dhcp dynamic_clients eap \
+              detail detail.log digest dynamic_clients eap \
               eap_inner echo exec expiration expr files linelog logintime \
               mschap ntlm_auth pap passwd preprocess radutmp realm \
               replicate soh sradutmp unix unpack utf8 ; do

--- a/debian/freeradius-config.postinst
+++ b/debian/freeradius-config.postinst
@@ -21,6 +21,17 @@ case "$1" in
 
           # Create snakoil certificates on initial install
           make -C /etc/freeradius/certs/
+
+          # Create links for default modules
+          for mod in always attr_filter cache_eap chap \
+              detail detail.log digest dhcp dynamic_clients eap \
+              eap_inner echo exec expiration expr files linelog logintime \
+              mschap ntlm_auth pap passwd preprocess radutmp realm \
+              replicate soh sradutmp unix unpack utf8 ; do
+            if [ ! -e /etc/freeradius/mods-enabled/$mod ]; then
+              ln -s ../mods-available/$mod /etc/freeradius/mods-enabled/$mod
+            fi
+          done
         fi
 
         # Create links for default sites, but only if this is an initial

--- a/debian/freeradius-config.postrm
+++ b/debian/freeradius-config.postrm
@@ -6,6 +6,13 @@ case "$1" in
 	remove)
 		;;
 	purge)
+		# Remove dangling links from sites-enabled.
+		for link in /etc/freeradius/sites-enabled/*; do
+			if [ -L "$link" ] && [ ! -e "$link" ]; then
+				rm -f "$link"
+			fi
+		done
+
 		if dpkg-statoverride --list | grep -qw /etc/freeradius/dictionary$; then
 			dpkg-statoverride --remove /etc/freeradius/dictionary
 		fi

--- a/debian/freeradius-config.postrm
+++ b/debian/freeradius-config.postrm
@@ -13,6 +13,13 @@ case "$1" in
 			fi
 		done
 
+		# Remove dangling links from mods-enabled.
+		for link in /etc/freeradius/mods-enabled/*; do
+			if [ -L "$link" ] && [ ! -e "$link" ]; then
+				rm -f "$link"
+			fi
+		done
+
 		if dpkg-statoverride --list | grep -qw /etc/freeradius/dictionary$; then
 			dpkg-statoverride --remove /etc/freeradius/dictionary
 		fi

--- a/debian/freeradius.postinst
+++ b/debian/freeradius.postinst
@@ -55,17 +55,6 @@ case "$1" in
           action="restart"
         fi
 
-        # Create links for default sites, but only if this is an initial
-        # install or an upgrade from before there were links; users may
-        # want to remove them...
-        if [ -z "$2" ] || dpkg --compare-versions "$2" lt 2.0.4+dfsg-4; then
-          for site in default inner-tunnel; do
-            if [ ! -e /etc/freeradius/sites-enabled/$site ]; then
-              ln -s ../sites-available/$site /etc/freeradius/sites-enabled/$site
-            fi
-          done
-        fi
-
         if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
           invoke-rc.d freeradius $action || true
         else

--- a/debian/freeradius.postrm
+++ b/debian/freeradius.postrm
@@ -8,13 +8,6 @@ case "$1" in
         purge)
                update-rc.d -f freeradius remove >/dev/null
 
-               # Remove dangling links from sites-enabled.
-               for link in /etc/freeradius/sites-enabled/*; do
-                 if [ -L "$link" ] && [ ! -e "$link" ]; then
-                   rm -f "$link"
-                 fi
-               done
-
 	       if [ -L /etc/freeradius/certs/server.pem ]; then
 	         rm -f /etc/freeradius/certs/server.pem
 	       fi

--- a/debian/rules
+++ b/debian/rules
@@ -156,6 +156,11 @@ install-arch: build-arch-stamp
 	mv $(freeradius_dir)/usr/sbin/radiusd $(freeradius_dir)/usr/sbin/$(package)
 	mv $(freeradius_dir)/$(mandir)/man8/radiusd.8 $(freeradius_dir)/$(mandir)/man8/$(package).8
 
+	# don't package symlinks in sites-enabled and mods-enabled - they're
+	# created on install by freeradius-config.postinst
+	rm $(freeradius_dir)/etc/freeradius/sites-enabled/*
+	rm $(freeradius_dir)/etc/freeradius/mods-enabled/*
+
 	dh_install -i --sourcedir=$(freeradius_dir)
 	dh_install --sourcedir=$(freeradius_dir) -p libfreeradius3
 	dh_install --sourcedir=$(freeradius_dir) -p libfreeradius-dev


### PR DESCRIPTION
The freeradius-config package previously included the default symlinks in sites-enabled and mods-enabled (they were matched in freeradius-config.install).

If these symlinks were removed or replaced by 'real' files by the administrator they would be forcibly replaced on package upgrade.

This pull request:
 * Creates default symlinks in mods-enabled and sites-enabled at install time (and not during an upgrade) (freeradius-config.postinst)
 * Removes dangling links at purge time (freeradius-config.postrm)
 * Cleans up freeradius.postinst which previously did the sites-enabled part of the above.
and,
 * Ensures that no files are packaged inside sites-enabled or mods-enabled (debian/rules)

There is one niggle - on upgrading from a previous package the default files are removed (as they were listed in freeradius-config.install and are not any more).  Ideally postinst would create the symlinks if we were upgrading from a release earlier than the one that contains these changes, however 3.1.x has never had such a release so I'm not clear on the best way to handle this.