### PR TITLE
Fix typo in %files section to avoid error building RPM

### DIFF
--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -714,7 +714,7 @@ fi
 # man-pages
 %doc %{_mandir}/man1/dhcpclient.1.gz
 %doc %{_mandir}/man1/radclient.1.gz
-%doc %{_mandir}/man1/radcounter.1.gz
+%doc %{_mandir}/man1/rad_counter.1.gz
 %doc %{_mandir}/man1/radeapclient.1.gz
 %doc %{_mandir}/man1/radlast.1.gz
 %doc %{_mandir}/man1/radtest.1.gz


### PR DESCRIPTION
File not found: /home/jg4461/rpmbuild/BUILDROOT/freeradius-3.0.12-2.el7.centos.x86_64/usr/share/man/man1/radcounter.1.gz