### PR TITLE
If sid2gid mapping fails for a group winbind reports the gid as UINT32_MAX and doesn't log anything very useful - provide a hint of where to look

### DIFF
--- a/src/modules/rlm_winbind/rlm_winbind.c
+++ b/src/modules/rlm_winbind/rlm_winbind.c
@@ -202,6 +202,7 @@ static int winbind_group_cmp(void *instance, REQUEST *request, VALUE_PAIR *attr,
 		err = wbcCtxGetgrgid(wb_ctx, wb_groups[i], &group);
 		if (err != WBC_ERR_SUCCESS) {
 			REDEBUG("Failed resolving GID %i: %s", wb_groups[i], wbcErrorString(err));
+			if (wb_groups[i] == UINT32_MAX) REDEBUG("GID appears to be winbind placeholder value - idmap failed?");
 			continue;
 		}
 


### PR DESCRIPTION
Is checking against UINT32_MAX too much magic?  Perhaps this would be better simply as a documentation note?