### PR TITLE
*vps being set to NULL is valid

### DIFF
--- a/src/modules/rlm_perl/rlm_perl.c
+++ b/src/modules/rlm_perl/rlm_perl.c
@@ -700,8 +700,6 @@ static void pairadd_sv(TALLOC_CTX *ctx, REQUEST *request, VALUE_PAIR **vps, char
 	VALUE_PAIR      *vp;
 	STRLEN len;
 
-	VERIFY_LIST(*vps);
-
 	if (!SvOK(sv)) {
 	fail:
 		REDEBUG("Failed to create pair &%s:%s %s $%s{'%s'} -> '%s'", list_name, key,


### PR DESCRIPTION
Receiving lots of 
'SOFT ASSERT FAILED src/modules/rlm_perl/rlm_perl.c[703]: *vps' in the radius log.

However get_hv_content and do_perl set the value pair to NULL before pairadd_sv is called.

https://github.com/FreeRADIUS/freeradius-server/blob/v3.0.x/src/modules/rlm_perl/rlm_perl.c#L741

https://github.com/FreeRADIUS/freeradius-server/blob/v3.0.x/src/modules/rlm_perl/rlm_perl.c#L870

