### PR TITLE
conffile: cleanup section children and tail on data remove

### DIFF
--- a/src/main/conffile.c
+++ b/src/main/conffile.c
@@ -3624,6 +3624,7 @@ void *cf_data_remove(CONF_SECTION *cs, char const *name)
 {
 	CONF_DATA mycd;
 	CONF_DATA *cd;
+	CONF_ITEM *ci, *it;
 	void *data;
 
 	if (!cs || !name) return NULL;
@@ -3636,6 +3637,20 @@ void *cf_data_remove(CONF_SECTION *cs, char const *name)
 	mycd.flag = 0;
 	cd = rbtree_finddata(cs->data_tree, &mycd);
 	if (!cd) return NULL;
+
+	ci = cf_data_to_item(cd);
+	if (cs->children == ci) {
+		cs->children = ci->next;
+		if (cs->tail == ci) cs->tail = NULL;
+	} else {
+		for (it = cs->children; it; it = it->next) {
+			if (it->next == ci) {
+				it->next = ci->next;
+				if (cs->tail == ci) cs->tail = it;
+				break;
+			}
+		}
+	}
 
 	talloc_set_destructor(cd, NULL);	/* Disarm the destructor */
 	rbtree_deletebydata(cs->data_tree, &mycd);


### PR DESCRIPTION
cleanup conf section `children` and `tail` on data remove

Signed-off-by: Aleksey Katargin <gureedo@intersvyaz.net>