### PR TITLE
feature: force server-side cipher preference instead of list from client

### DIFF
--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -316,6 +316,14 @@ eap {
 		#
 		cipher_list = "ALL:!EXPORT:!eNULL:!SSLv2"
 
+		# If enabled, OpenSSL will use server cipher list
+		# (possibly defined by cipher_list option above)
+		# for choosing right cipher suite rather than
+		# using client-specified list which is OpenSSl default
+		# behavior. Having it set to yes is a current best practice
+		# for TLS
+		cipher_server_preference = no
+
 		#
 		#  Work-arounds for OpenSSL nonsense OpenSSL 1.0.1f and 1.0.1g do
 		#  not calculate the EAP keys correctly.  The fix is to upgrade

--- a/raddb/sites-available/tls
+++ b/raddb/sites-available/tls
@@ -199,6 +199,14 @@ listen {
 		# in "man 1 ciphers".
 		cipher_list = "DEFAULT"
 
+		# If enabled, OpenSSL will use server cipher list
+		# (possibly defined by cipher_list option above)
+		# for choosing right cipher suite rather than
+		# using client-specified list which is OpenSSl default
+		# behavior. Having it set to yes is a current best practice
+		# for TLS
+		cipher_server_preference = no
+
 		#
 		#  Session resumption / fast reauthentication
 		#  cache.

--- a/src/include/tls-h
+++ b/src/include/tls-h
@@ -237,6 +237,7 @@ struct fr_tls_conf_t {
 	char const	*check_cert_cn;			//!< Verify cert CN matches the expansion of this string.
 
 	char const	*cipher_list;			//!< Acceptable ciphers.
+	bool		cipher_server_preference;	//!< use server preferences for cipher selection
 #ifdef SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS
 	bool		allow_renegotiation;		//!< Whether or not to allow cipher renegotiation.
 #endif

--- a/src/main/tls/conf.c
+++ b/src/main/tls/conf.c
@@ -104,6 +104,7 @@ static CONF_PARSER tls_server_config[] = {
 	{ FR_CONF_OFFSET("allow_expired_crl", PW_TYPE_BOOLEAN, fr_tls_conf_t, allow_expired_crl) },
 	{ FR_CONF_OFFSET("check_cert_cn", PW_TYPE_STRING, fr_tls_conf_t, check_cert_cn) },
 	{ FR_CONF_OFFSET("cipher_list", PW_TYPE_STRING, fr_tls_conf_t, cipher_list) },
+	{ FR_CONF_OFFSET("cipher_server_preference", PW_TYPE_BOOLEAN, fr_tls_conf_t, cipher_server_preference), .dflt = "no" /* FIXME in next major release */ },
 #ifdef SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS
 	{ FR_CONF_OFFSET("allow_renegotiation", PW_TYPE_BOOLEAN, fr_tls_conf_t, allow_renegotiation), .dflt = "no" },
 #endif

--- a/src/main/tls/ctx.c
+++ b/src/main/tls/ctx.c
@@ -350,6 +350,15 @@ post_ca:
 	 */
 	ctx_options |= SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS;
 
+	if (conf->cipher_server_preference) {
+	/*
+	 *	SSL_OP_CIPHER_SERVER_PREFERENCE to follow best practice
+	 *	of nowday's TLS: do not allow poorly-selected ciphers from
+	 *	client to take preference
+	 */
+		ctx_options |= SSL_OP_CIPHER_SERVER_PREFERENCE;
+	}
+
 	SSL_CTX_set_options(ctx, ctx_options);
 
 	/*


### PR DESCRIPTION
It is current best practices to force secure cipher for TLS from server side. By default OpenSSL will choose cipher based on client cipher list which may be
  * poor
  * buggy

Forcing this from server side makes some order in this mess.
Please consider to enable this option by default in 4.0. It is a common best practice in TLS world now.