### PR TITLE
updated variables to use correct "&" prefix

### DIFF
--- a/raddb/policy.d/filter
+++ b/raddb/policy.d/filter
@@ -132,7 +132,7 @@ filter_inner_identity {
 		#
 		if (&outer.request:User-Name =~ /@([^@]+)$/) {
 			update request {
-				Outer-Realm-Name = "%{1}"
+				&Outer-Realm-Name = "%{1}"
 			}
 
 			#
@@ -169,7 +169,7 @@ filter_inner_identity {
 		#
 		if (&User-Name =~ /@([^@]+)$/) {
 			update request {
-				Inner-Realm-Name = "%{1}"
+				&Inner-Realm-Name = "%{1}"
 			}
 
 			#


### PR DESCRIPTION
fixed variables in filter policy to use correct "&" prefix - no more warnings with default configuration
