### PR TITLE
added CSI and CUI to the allowed outbound attributes list

### DIFF
--- a/raddb/mods-config/attr_filter/pre-proxy
+++ b/raddb/mods-config/attr_filter/pre-proxy
@@ -60,4 +60,6 @@ DEFAULT
 	NAS-IP-Address =* ANY,
 	NAS-Identifier =* ANY,
 	Operator-Name =* ANY,
+	Calling-Station-Id =* ANY,
+	Chargeable-User-Identity =* ANY,
 	Proxy-State =* ANY


### PR DESCRIPTION
ensures FR is more compliant with roaming consortia out of the box