### PR TITLE
implement radiusd::radius_xlat in rlm_perl

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -22,6 +22,8 @@ FreeRADIUS 3.1.0 Thu 26 Nov 2015 15:48:14 EDT urgency=medium
 	* TLV Attributes can now be nested to nearly any depth.
 	* radsnmp client which can listen on Net-SNMP "pass persist"
 	  and translate that into queries to the server.
+	* rlm_perl: radiusd::xlat to evaluate xlat string within
+	  perl script
 
 	Bug fixes
 	* Attribute names in unlang MUST be prefixed with &

--- a/raddb/mods-config/perl/example.pl
+++ b/raddb/mods-config/perl/example.pl
@@ -126,7 +126,12 @@ sub authenticate {
 		return RLM_MODULE_REJECT;
 	} else {
 		# Accept user and set some attribute
-		$RAD_REPLY{'h323-credit-amount'} = "100";
+		if (&radiusd::xlat("%{client:group}") eq 'UltraAllInclusive') {
+			# User called from NAS with unlim plan set, set higher limits
+			$RAD_REPLY{'h323-credit-amount'} = "1000000";
+		} else {
+			$RAD_REPLY{'h323-credit-amount'} = "100";
+		}
 		return RLM_MODULE_OK;
 	}
 }

--- a/src/modules/rlm_perl/rlm_perl.c
+++ b/src/modules/rlm_perl/rlm_perl.c
@@ -126,7 +126,7 @@ static const CONF_PARSER module_config[] = {
  */
 EXTERN_C void boot_DynaLoader(pTHX_ CV* cv);
 
-_Thread_local REQUEST *rlm_perl_request;
+static _Thread_local REQUEST *rlm_perl_request;
 
 #ifdef USE_ITHREADS
 #  define dl_librefs "DynaLoader::dl_librefs"

--- a/src/modules/rlm_perl/rlm_perl.c
+++ b/src/modules/rlm_perl/rlm_perl.c
@@ -126,6 +126,8 @@ static const CONF_PARSER module_config[] = {
  */
 EXTERN_C void boot_DynaLoader(pTHX_ CV* cv);
 
+_Thread_local REQUEST *rlm_perl_request;
+
 #ifdef USE_ITHREADS
 #  define dl_librefs "DynaLoader::dl_librefs"
 #  define dl_modules "DynaLoader::dl_modules"
@@ -296,6 +298,39 @@ static XS(XS_radiusd_radlog)
 	XSRETURN_NO;
 }
 
+/*
+ *	This is a wraper for radius_axlat
+ *	Now users are able to get data that is accessible only via xlat
+ *	e.g. %{client:...}
+ *	Call syntax is radiusd::xlat(string), string will be handled the
+ *	same way it is described in EXPANSIONS section of man unlang
+ */
+static XS(XS_radiusd_xlat)
+{
+	dXSARGS;
+	char *in_str;
+	char *expanded;
+	ssize_t slen;
+	REQUEST *request;
+
+	if (items != 1) croak("Usage: radiusd::xlat(string)");
+
+	request = rlm_perl_request;
+
+	in_str = (char *) SvPV(ST(0), PL_na);
+	expanded = NULL;
+	slen = radius_axlat(&expanded, request, in_str, NULL, NULL);
+
+	if (slen < 0) {
+		REDEBUG("Error parsing xlat '%s'", in_str);
+		XSRETURN_UNDEF;
+	}
+
+	XST_mPV(0, expanded);
+	talloc_free(expanded);
+	XSRETURN(1);
+}
+
 static void xs_init(pTHX)
 {
 	char const *file = __FILE__;
@@ -304,6 +339,7 @@ static void xs_init(pTHX)
 	newXS("DynaLoader::boot_DynaLoader", boot_DynaLoader, file);
 
 	newXS("radiusd::radlog",XS_radiusd_radlog, "rlm_perl");
+	newXS("radiusd::xlat",XS_radiusd_xlat, "rlm_perl");
 }
 
 /*
@@ -858,6 +894,11 @@ static int do_perl(void *instance, REQUEST *request, char const *function_name)
 			hv_undef(rad_request_proxy_reply_hv);
 		}
 #endif
+
+		/*
+		 * Store pointer to request structure globally so radiusd::xlat works
+		 */
+		rlm_perl_request = request;
 
 		PUSHMARK(SP);
 		/*


### PR DESCRIPTION
Main goal is to get access to things like `%{client:group}` inside perl scripts