### PR TITLE
Use -h to check for symlink existance

### DIFF
--- a/debian/freeradius-config.postinst
+++ b/debian/freeradius-config.postinst
@@ -28,7 +28,8 @@ case "$1" in
               eap_inner echo exec expiration expr files linelog logintime \
               mschap ntlm_auth pap passwd preprocess radutmp realm \
               replicate soh sradutmp unix unpack utf8 ; do
-            if [ ! -e /etc/freeradius/mods-enabled/$mod ]; then
+            if test ! -h /etc/freeradius/mods-enabled/$mod && \
+               test ! -e /etc/freeradius/mods-enabled/$mod; then
               ln -s ../mods-available/$mod /etc/freeradius/mods-enabled/$mod
             fi
           done
@@ -39,7 +40,8 @@ case "$1" in
         # want to remove them...
         if [ -z "$2" ] || dpkg --compare-versions "$2" lt 2.0.4+dfsg-4; then
           for site in default inner-tunnel; do
-            if [ ! -e /etc/freeradius/sites-enabled/$site ]; then
+            if test ! -h /etc/freeradius/sites-enabled/$site && \
+               test ! -e /etc/freeradius/sites-enabled/$site; then
               ln -s ../sites-available/$site /etc/freeradius/sites-enabled/$site
             fi
           done


### PR DESCRIPTION
-e dereferences symlinks, making the package installation fail when the target does not exist.