### PR TITLE
Make Freeradius 3.1.x compile with OpenSSL 1.1

### DIFF
--- a/raddb/certs/Makefile
+++ b/raddb/certs/Makefile
@@ -53,7 +53,7 @@ passwords.mk: server.cnf ca.cnf client.cnf ocsp.cnf
 #
 ######################################################################
 dh:
-	openssl gendh -out dh -2 $(DH_KEY_SIZE)
+	openssl dhparam -outform PEM -out dh -2 $(DH_KEY_SIZE)
 
 ######################################################################
 #

--- a/src/include/tls-h
+++ b/src/include/tls-h
@@ -107,7 +107,7 @@ do {\
  *	exiting to prevent memory leaks.
  */
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
-#  define FR_TLS_REMOVE_THREAD_STATE() ERR_remove_thread_state();
+#  define FR_TLS_REMOVE_THREAD_STATE()
 #elif OPENSSL_VERSION_NUMBER >= 0x10000000L
 #  define FR_TLS_REMOVE_THREAD_STATE() ERR_remove_thread_state(NULL);
 #else

--- a/src/main/tls/global.c
+++ b/src/main/tls/global.c
@@ -355,6 +355,8 @@ int tls_global_init(void)
 		ERROR("FATAL: Failed to set up SSL mutexes");
 		return -1;
 	}
+
+	OPENSSL_config(NULL);
 #else
 	OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG | OPENSSL_INIT_ENGINE_ALL_BUILTIN, NULL);
 #endif
@@ -369,7 +371,6 @@ int tls_global_init(void)
 	ENGINE_register_all_complete();
 
 	tls_done_init = true;
-	OPENSSL_config(NULL);
 
 	return 0;
 }

--- a/src/main/tls/validate.c
+++ b/src/main/tls/validate.c
@@ -165,7 +165,7 @@ int tls_validate_cert_cb(int ok, X509_STORE_CTX *x509_ctx)
 	X509_NAME_oneline(X509_get_subject_name(cert), subject, sizeof(subject));
 	subject[sizeof(subject) - 1] = '\0';
 
-	X509_NAME_oneline(X509_get_issuer_name(x509_ctx->current_cert), issuer, sizeof(issuer));
+	X509_NAME_oneline(X509_get_issuer_name(cert), issuer, sizeof(issuer));
 	issuer[sizeof(issuer) - 1] = '\0';
 
 	/*
@@ -189,7 +189,7 @@ int tls_validate_cert_cb(int ok, X509_STORE_CTX *x509_ctx)
 		return my_ok;
 	}
 
-	switch (x509_ctx->error) {
+	switch (X509_STORE_CTX_get_error(x509_ctx)) {
 	case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT:
 		RERROR("issuer=%s", issuer);
 		break;

--- a/src/modules/rlm_eap/types/rlm_eap_pwd/configure
+++ b/src/modules/rlm_eap/types/rlm_eap_pwd/configure
@@ -2917,7 +2917,7 @@ smart_prefix=
 
 
 sm_lib_safe=`echo "crypto" | sed 'y%./+-%__p_%'`
-sm_func_safe=`echo "EVP_cleanup" | sed 'y%./+-%__p_%'`
+sm_func_safe=`echo "EVP_CIPHER_CTX_new" | sed 'y%./+-%__p_%'`
 
 old_LIBS="$LIBS"
 old_CPPFLAGS="$CPPFLAGS"
@@ -2927,17 +2927,17 @@ smart_lib_dir=
 
 if test "x$smart_try_dir" != "x"; then
   for try in $smart_try_dir; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_cleanup in -lcrypto in $try" >&5
-$as_echo_n "checking for EVP_cleanup in -lcrypto in $try... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_CIPHER_CTX_new in -lcrypto in $try" >&5
+$as_echo_n "checking for EVP_CIPHER_CTX_new in -lcrypto in $try... " >&6; }
     LIBS="-lcrypto $old_LIBS"
     CPPFLAGS="-L$try -Wl,-rpath,$try $old_CPPFLAGS"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-extern char EVP_cleanup();
+extern char EVP_CIPHER_CTX_new();
 int
 main ()
 {
-EVP_cleanup()
+EVP_CIPHER_CTX_new()
   ;
   return 0;
 }
@@ -2962,16 +2962,16 @@ rm -f core conftest.err conftest.$ac_objext \
 fi
 
 if test "x$smart_lib" = "x"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_cleanup in -lcrypto" >&5
-$as_echo_n "checking for EVP_cleanup in -lcrypto... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_CIPHER_CTX_new in -lcrypto" >&5
+$as_echo_n "checking for EVP_CIPHER_CTX_new in -lcrypto... " >&6; }
   LIBS="-lcrypto $old_LIBS"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-extern char EVP_cleanup();
+extern char EVP_CIPHER_CTX_new();
 int
 main ()
 {
-EVP_cleanup()
+EVP_CIPHER_CTX_new()
   ;
   return 0;
 }
@@ -3048,17 +3048,17 @@ eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
 
 
   for try in $smart_lib_dir /usr/local/lib /opt/lib; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_cleanup in -lcrypto in $try" >&5
-$as_echo_n "checking for EVP_cleanup in -lcrypto in $try... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_CIPHER_CTX_new in -lcrypto in $try" >&5
+$as_echo_n "checking for EVP_CIPHER_CTX_new in -lcrypto in $try... " >&6; }
     LIBS="-lcrypto $old_LIBS"
     CPPFLAGS="-L$try -Wl,-rpath,$try $old_CPPFLAGS"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-extern char EVP_cleanup();
+extern char EVP_CIPHER_CTX_new();
 int
 main ()
 {
-EVP_cleanup()
+EVP_CIPHER_CTX_new()
   ;
   return 0;
 }
@@ -3088,7 +3088,7 @@ if test "x$smart_lib" != "x"; then
   SMART_LIBS="$smart_ldflags $smart_lib $SMART_LIBS"
 fi
 
-        if test "x$ac_cv_lib_crypto_EVP_cleanup" != "xyes"; then
+        if test "x$ac_cv_lib_crypto_EVP_CIPHER_CTX_new" != "xyes"; then
 	  fail="libssl"
         else
           for ac_func in EVP_sha256

--- a/src/modules/rlm_eap/types/rlm_eap_pwd/configure.ac
+++ b/src/modules/rlm_eap/types/rlm_eap_pwd/configure.ac
@@ -60,8 +60,8 @@ if test x$with_[]modname != xno; then
 	fi
 
 	smart_try_dir=$openssl_lib_dir
-        FR_SMART_CHECK_LIB(crypto, EVP_cleanup)
-        if test "x$ac_cv_lib_crypto_EVP_cleanup" != "xyes"; then
+        FR_SMART_CHECK_LIB(crypto, EVP_CIPHER_CTX_new)
+        if test "x$ac_cv_lib_crypto_EVP_CIPHER_CTX_new" != "xyes"; then
 	  fail="libssl"
         else
           AC_CHECK_FUNCS(EVP_sha256)


### PR DESCRIPTION
This only fixes the compile errors, there are still a lot of warnings
(deprecated functions, missing const quantifiers)

And once again: I'm abusing Travis to see if it still compiles with older versions of OpenSSL