### PR TITLE
Use 'openssl dhparam' to create DH-params

### DIFF
--- a/raddb/certs/Makefile
+++ b/raddb/certs/Makefile
@@ -53,7 +53,7 @@ passwords.mk: server.cnf ca.cnf client.cnf ocsp.cnf
 #
 ######################################################################
 dh:
-	openssl gendh -out dh -2 $(DH_KEY_SIZE)
+	openssl dhparam -outform PEM -out dh -2 $(DH_KEY_SIZE)
 
 ######################################################################
 #


### PR DESCRIPTION
'openssl gendh' is removed in newer version of OpenSSL, and using
dhparam appears to work since at least release 0.9.8