### PR TITLE
Add all VP lists to rlm_rest JSON requests

### DIFF
--- a/src/modules/rlm_json/json.c
+++ b/src/modules/rlm_json/json.c
@@ -282,43 +282,11 @@ void fr_json_version_print(void)
 #endif
 }
 
-/** Returns a JSON string of a list of value pairs
- *
- *  The result is a talloc-ed string, freeing the string is the responsibility
- *  of the caller.
- *
- * Output format is:
-@verbatim
-{
-	"<attribute0>":{
-		"type":"<type0>",
-		"value":[<value0>,<value1>,<valueN>],
-		"mapping":[<enumv0>,<enumv1>,<enumvN>]
-	},
-	"<attribute1>":{
-		"type":"<type1>",
-		"value":[...]
-	},
-	"<attributeN>":{
-		"type":"<typeN>",
-		"value":[...]
-	},
-}
-@endverbatim
- *
- * @note Mapping element is only present for attributes with enumerated values.
- *
- * @param[in] ctx	Talloc context.
- * @param[in] vps	a list of value pairs.
- * @param[in] prefix	The prefix to use, can be NULL to skip the prefix.
- * @return JSON string representation of the value pairs
- */
-const char *fr_json_afrom_pair_list(TALLOC_CTX *ctx, VALUE_PAIR **vps, const char *prefix)
+static struct json_object *fr_json_obj_from_pair_list(TALLOC_CTX *ctx, VALUE_PAIR **vps, const char *prefix)
 {
 	vp_cursor_t		cursor;
 	VALUE_PAIR 		*vp;
 	struct json_object	*obj;
-	const char		*p;
 	char			buf[FR_DICT_ATTR_MAX_NAME_LEN + 32];
 
 	MEM(obj = json_object_new_object());
@@ -390,6 +358,47 @@ const char *fr_json_afrom_pair_list(TALLOC_CTX *ctx, VALUE_PAIR **vps, const cha
 			}
 		}
 	}
+
+	return obj;
+}
+
+/** Returns a JSON string of a list of value pairs
+ *
+ *  The result is a talloc-ed string, freeing the string is the responsibility
+ *  of the caller.
+ *
+ * Output format is:
+@verbatim
+{
+	"<attribute0>":{
+		"type":"<type0>",
+		"value":[<value0>,<value1>,<valueN>],
+		"mapping":[<enumv0>,<enumv1>,<enumvN>]
+	},
+	"<attribute1>":{
+		"type":"<type1>",
+		"value":[...]
+	},
+	"<attributeN>":{
+		"type":"<typeN>",
+		"value":[...]
+	},
+}
+@endverbatim
+ *
+ * @note Mapping element is only present for attributes with enumerated values.
+ *
+ * @param[in] ctx	Talloc context.
+ * @param[in] vps	a list of value pairs.
+ * @param[in] prefix	The prefix to use, can be NULL to skip the prefix.
+ * @return JSON string representation of the value pairs
+ */
+const char *fr_json_afrom_pair_list(TALLOC_CTX *ctx, VALUE_PAIR **vps, const char *prefix)
+{
+	struct json_object	*obj;
+	const char		*p;
+
+	obj = fr_json_obj_from_pair_list(ctx, vps, prefix);
 
 	MEM(p = json_object_to_json_string_ext(obj, JSON_C_TO_STRING_PLAIN));
 	MEM(p = talloc_strdup(ctx, p));

--- a/src/modules/rlm_json/json.h
+++ b/src/modules/rlm_json/json.h
@@ -70,5 +70,6 @@ size_t    	fr_json_from_pair(char *out, size_t outlen, VALUE_PAIR const *vp);
 void		fr_json_version_print(void);
 
 const char	*fr_json_afrom_pair_list(TALLOC_CTX *ctx, VALUE_PAIR **vps, const char *prefix);
+const char	*fr_json_afrom_request(TALLOC_CTX *ctx, REQUEST *request);
 #endif
 #endif /* _FR_JSON_H */

--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -528,17 +528,21 @@ no_space:
  * JSON request format is:
 @verbatim
 {
-	"<attribute0>":{
-		"type":"<type0>",
-		"value":[<value0>,<value1>,<valueN>]
+	"request":{
+		"<attribute0>":{
+			"type":"<type0>",
+			"value":[<value0>,<value1>,<valueN>]
+		},
+		"<attribute1>":{
+			"type":"<type1>",
+			"value":[...]
+		},
+		"<attributeN>":{
+			"type":"<typeN>",
+			"value":[...]
+		},
 	},
-	"<attribute1>":{
-		"type":"<type1>",
-		"value":[...]
-	},
-	"<attributeN>":{
-		"type":"<typeN>",
-		"value":[...]
+	"reply":{
 	},
 }
 @endverbatim
@@ -565,7 +569,7 @@ static size_t rest_encode_json(void *out, size_t size, size_t nmemb, void *userd
 	rad_assert(freespace > 0);
 
 	if (ctx->state == READ_STATE_INIT) {
-		encoded = fr_json_afrom_pair_list(data, &request->packet->vps, NULL);
+		encoded = fr_json_afrom_request(data, request);
 		if (!encoded) return -1;
 
 		data->start = data->p = encoded;


### PR DESCRIPTION
This provides a payload with the following format:

```json
{
  "request":{
    "User-Name":{"type":"string","value":["bob"]},
    "User-Password":{"type":"string","value":["hello"]},
    "NAS-IP-Address":{"type":"ipaddr","value":["127.0.1.1"]}
  },
  "reply":{},
  "control":{},
  "session-state":{
    "User-Name":{"type":"string","value":["bob"]}
  }
}
```

This is a new implementation of  #1625, using the new JSON library functions we've introduced earlier.

This means the rlm_json module is no longer backwards compatible with 3.x, and another imperfection is that the json body now includes much more information than the post body.