### PR TITLE
OpenSSL v1.1 fixes for v3.0.x

### DIFF
--- a/configure
+++ b/configure
@@ -8665,6 +8665,7 @@ $as_echo "#define HAVE_OPENSSL_SSL_H 1" >>confdefs.h
 
 
     for ac_header in \
+      openssl/asn1.h \
       openssl/crypto.h \
       openssl/err.h \
       openssl/evp.h \

--- a/configure
+++ b/configure
@@ -8779,6 +8779,21 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
   conftest.$ac_objext conftest.beam conftest.$ac_ext
 fi
 
+                for ac_func in \
+      SSL_get_client_random \
+      SSL_get_server_random \
+
+do :
+  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+_ACEOF
+
+fi
+done
+
     CPPFLAGS="$old_CPPFLAGS"
   fi
 
@@ -8787,17 +8802,6 @@ fi
 
 
   export OPENSSL_LIBS OPENSSL_LDFLAGS OPENSSL_CPPFLAGS
-  for ac_func in SSL_get_client_random
-do :
-  ac_fn_c_check_func "$LINENO" "SSL_get_client_random" "ac_cv_func_SSL_get_client_random"
-if test "x$ac_cv_func_SSL_get_client_random" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_SSL_GET_CLIENT_RANDOM 1
-_ACEOF
- SSL_get_server_random
-fi
-done
-
 fi
 
 if test "x$PCAP_LIBS" = x; then

--- a/configure
+++ b/configure
@@ -8666,6 +8666,7 @@ $as_echo "#define HAVE_OPENSSL_SSL_H 1" >>confdefs.h
 
     for ac_header in \
       openssl/asn1.h \
+      openssl/conf.h \
       openssl/crypto.h \
       openssl/err.h \
       openssl/evp.h \

--- a/configure
+++ b/configure
@@ -8785,6 +8785,7 @@ fi
                 for ac_func in \
       SSL_get_client_random \
       SSL_get_server_random \
+      SSL_SESSION_get_master_key \
       HMAC_CTX_new \
       HMAC_CTX_free \
       ASN1_STRING_get0_data \

--- a/configure
+++ b/configure
@@ -8790,6 +8790,8 @@ fi
       HMAC_CTX_free \
       ASN1_STRING_get0_data \
       CONF_modules_load_file \
+      CRYPTO_set_id_callback \
+      CRYPTO_set_locking_callback
 
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`

--- a/configure
+++ b/configure
@@ -8785,6 +8785,10 @@ fi
                 for ac_func in \
       SSL_get_client_random \
       SSL_get_server_random \
+      HMAC_CTX_new \
+      HMAC_CTX_free \
+      ASN1_STRING_get0_data \
+      CONF_modules_load_file \
 
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`

--- a/configure
+++ b/configure
@@ -8668,6 +8668,7 @@ $as_echo "#define HAVE_OPENSSL_SSL_H 1" >>confdefs.h
       openssl/crypto.h \
       openssl/err.h \
       openssl/evp.h \
+      openssl/hmac.h \
       openssl/md5.h \
       openssl/md4.h \
       openssl/sha.h \

--- a/configure.ac
+++ b/configure.ac
@@ -1183,6 +1183,7 @@ if test "x$WITH_OPENSSL" = xyes; then
     AC_CHECK_FUNCS( \
       SSL_get_client_random \
       SSL_get_server_random \
+      SSL_SESSION_get_master_key \
       HMAC_CTX_new \
       HMAC_CTX_free \
       ASN1_STRING_get0_data \

--- a/configure.ac
+++ b/configure.ac
@@ -1107,6 +1107,7 @@ if test "x$WITH_OPENSSL" = xyes; then
       openssl/crypto.h \
       openssl/err.h \
       openssl/evp.h \
+      openssl/hmac.h \
       openssl/md5.h \
       openssl/md4.h \
       openssl/sha.h \

--- a/configure.ac
+++ b/configure.ac
@@ -1188,6 +1188,8 @@ if test "x$WITH_OPENSSL" = xyes; then
       HMAC_CTX_free \
       ASN1_STRING_get0_data \
       CONF_modules_load_file \
+      CRYPTO_set_id_callback \
+      CRYPTO_set_locking_callback
     )
     CPPFLAGS="$old_CPPFLAGS"
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -1105,6 +1105,7 @@ if test "x$WITH_OPENSSL" = xyes; then
 
     AC_CHECK_HEADERS( \
       openssl/asn1.h \
+      openssl/conf.h \
       openssl/crypto.h \
       openssl/err.h \
       openssl/evp.h \

--- a/configure.ac
+++ b/configure.ac
@@ -1174,6 +1174,13 @@ if test "x$WITH_OPENSSL" = xyes; then
         AC_MSG_RESULT([cross-compiling (assuming yes)])
       ]
     )
+    dnl #
+    dnl #  Check if the new HMAC_CTX interface is defined
+    dnl #
+    AC_CHECK_FUNCS( \
+      SSL_get_client_random \
+      SSL_get_server_random \
+    )
     CPPFLAGS="$old_CPPFLAGS"
   fi
 
@@ -1182,7 +1189,6 @@ if test "x$WITH_OPENSSL" = xyes; then
   AC_SUBST(OPENSSL_LDFLAGS)
   AC_SUBST(OPENSSL_CPPFLAGS)
   export OPENSSL_LIBS OPENSSL_LDFLAGS OPENSSL_CPPFLAGS
-  AC_CHECK_FUNCS(SSL_get_client_random,SSL_get_server_random)
 fi
 
 dnl #

--- a/configure.ac
+++ b/configure.ac
@@ -1183,6 +1183,10 @@ if test "x$WITH_OPENSSL" = xyes; then
     AC_CHECK_FUNCS( \
       SSL_get_client_random \
       SSL_get_server_random \
+      HMAC_CTX_new \
+      HMAC_CTX_free \
+      ASN1_STRING_get0_data \
+      CONF_modules_load_file \
     )
     CPPFLAGS="$old_CPPFLAGS"
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -1104,6 +1104,7 @@ if test "x$WITH_OPENSSL" = xyes; then
     AC_DEFINE(HAVE_OPENSSL_SSL_H, 1, [Define to 1 if you have the <openssl/ssl.h> header file.])
 
     AC_CHECK_HEADERS( \
+      openssl/asn1.h \
       openssl/crypto.h \
       openssl/err.h \
       openssl/evp.h \

--- a/src/include/autoconf.h.in
+++ b/src/include/autoconf.h.in
@@ -32,6 +32,9 @@
 /* Define to 1 if you have the <arpa/inet.h> header file. */
 #undef HAVE_ARPA_INET_H
 
+/* Define to 1 if you have the `ASN1_STRING_get0_data' function. */
+#undef HAVE_ASN1_STRING_GET0_DATA
+
 /* Define if your compiler supports the __bounded__ attribute (usually OpenBSD
    gcc). */
 #undef HAVE_ATTRIBUTE_BOUNDED
@@ -62,6 +65,9 @@
 
 /* Define to 1 if you have the `collectdclient' library (-lcollectdclient). */
 #undef HAVE_COLLECTDC_H
+
+/* Define to 1 if you have the `CONF_modules_load_file' function. */
+#undef HAVE_CONF_MODULES_LOAD_FILE
 
 /* Do we have the crypt function */
 #undef HAVE_CRYPT
@@ -151,6 +157,12 @@
 
 /* Define to 1 if you have the <history.h> header file. */
 #undef HAVE_HISTORY_H
+
+/* Define to 1 if you have the `HMAC_CTX_free' function. */
+#undef HAVE_HMAC_CTX_FREE
+
+/* Define to 1 if you have the `HMAC_CTX_new' function. */
+#undef HAVE_HMAC_CTX_NEW
 
 /* Define if the function (or macro) htonll exists. */
 #undef HAVE_HTONLL

--- a/src/include/autoconf.h.in
+++ b/src/include/autoconf.h.in
@@ -248,6 +248,9 @@
 /* Define to 1 if you have the `openat' function. */
 #undef HAVE_OPENAT
 
+/* Define to 1 if you have the <openssl/asn1.h> header file. */
+#undef HAVE_OPENSSL_ASN1_H
+
 /* Define to 1 if you have the <openssl/crypto.h> header file. */
 #undef HAVE_OPENSSL_CRYPTO_H
 

--- a/src/include/autoconf.h.in
+++ b/src/include/autoconf.h.in
@@ -398,6 +398,9 @@
 /* Define to 1 if you have the `SSL_get_server_random' function. */
 #undef HAVE_SSL_GET_SERVER_RANDOM
 
+/* Define to 1 if you have the `SSL_SESSION_get_master_key' function. */
+#undef HAVE_SSL_SESSION_GET_MASTER_KEY
+
 /* Define to 1 if you have the <stdbool.h> header file. */
 #undef HAVE_STDBOOL_H
 

--- a/src/include/autoconf.h.in
+++ b/src/include/autoconf.h.in
@@ -374,6 +374,9 @@
 /* Define to 1 if you have the `SSL_get_client_random' function. */
 #undef HAVE_SSL_GET_CLIENT_RANDOM
 
+/* Define to 1 if you have the `SSL_get_server_random' function. */
+#undef HAVE_SSL_GET_SERVER_RANDOM
+
 /* Define to 1 if you have the <stdbool.h> header file. */
 #undef HAVE_STDBOOL_H
 

--- a/src/include/autoconf.h.in
+++ b/src/include/autoconf.h.in
@@ -72,6 +72,12 @@
 /* Do we have the crypt function */
 #undef HAVE_CRYPT
 
+/* Define to 1 if you have the `CRYPTO_set_id_callback' function. */
+#undef HAVE_CRYPTO_SET_ID_CALLBACK
+
+/* Define to 1 if you have the `CRYPTO_set_locking_callback' function. */
+#undef HAVE_CRYPTO_SET_LOCKING_CALLBACK
+
 /* Define to 1 if you have the <crypt.h> header file. */
 #undef HAVE_CRYPT_H
 

--- a/src/include/autoconf.h.in
+++ b/src/include/autoconf.h.in
@@ -251,6 +251,9 @@
 /* Define to 1 if you have the <openssl/asn1.h> header file. */
 #undef HAVE_OPENSSL_ASN1_H
 
+/* Define to 1 if you have the <openssl/conf.h> header file. */
+#undef HAVE_OPENSSL_CONF_H
+
 /* Define to 1 if you have the <openssl/crypto.h> header file. */
 #undef HAVE_OPENSSL_CRYPTO_H
 

--- a/src/include/autoconf.h.in
+++ b/src/include/autoconf.h.in
@@ -260,6 +260,9 @@
 /* Define to 1 if you have the <openssl/evp.h> header file. */
 #undef HAVE_OPENSSL_EVP_H
 
+/* Define to 1 if you have the <openssl/hmac.h> header file. */
+#undef HAVE_OPENSSL_HMAC_H
+
 /* Define to 1 if you have the <openssl/md4.h> header file. */
 #undef HAVE_OPENSSL_MD4_H
 

--- a/src/include/missing-h
+++ b/src/include/missing-h
@@ -83,6 +83,18 @@ RCSIDH(missing_h, "$Id$")
 #  endif
 #endif
 
+#ifdef HAVE_OPENSSL_HMAC_H
+#  include <openssl/hmac.h>
+#endif
+
+#ifdef HAVE_OPENSSL_ASN1_H
+#  include <openssl/asn1.h>
+#endif
+
+#ifdef HAVE_OPENSSL_CONF_H
+#  include <openssl/conf.h>
+#endif
+
 /*
  *	Don't look for winsock.h if we're on cygwin.
  */
@@ -434,6 +446,46 @@ uint128_t ntohlll(uint128_t num);
 
 #ifndef HAVE_SIG_T
 typedef void(*sig_t)(int);
+#endif
+
+#ifdef HAVE_OPENSSL_HMAC_H
+#  ifndef HAVE_HMAC_CTX_NEW
+HMAC_CTX *HMAC_CTX_new(void);
+#  endif
+#  ifndef HAVE_HMAC_CTX_FREE
+void HMAC_CTX_free(HMAC_CTX *ctx);
+#  endif
+#endif
+
+#ifdef HAVE_OPENSSL_ASN1_H
+#  ifndef HAVE_ASN1_STRING_GET0_DATA
+static inline const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *x)
+{
+	/*
+	 * Trick the compiler into not issuing the warning on qualifier stripping.
+	 * We know that ASN1_STRING_data doesn't change x, and we're casting
+	 * the return value back to const immediately, so it's OK.
+	 */
+	union {
+		const ASN1_STRING	*c;
+		ASN1_STRING		*nc;
+	} const_strip = {.c = x};
+	return ASN1_STRING_data(const_strip.nc);
+}
+#  endif
+#endif
+
+#ifdef HAVE_OPENSSL_CONF_H
+#  ifndef HAVE_CONF_MODULES_LOAD_FILE
+static inline int CONF_modules_load_file(const char *filename,
+					 const char *appname,
+					 unsigned long flags)
+{
+	(void)filename;
+	(void)flags;
+	return OPENSSL_config(appname);
+}
+#  endif
 #endif
 
 #ifdef __cplusplus

--- a/src/include/missing-h
+++ b/src/include/missing-h
@@ -83,6 +83,10 @@ RCSIDH(missing_h, "$Id$")
 #  endif
 #endif
 
+#ifdef HAVE_OPENSSL_SSL_H
+#  include <openssl/ssl.h>
+#endif
+
 #ifdef HAVE_OPENSSL_HMAC_H
 #  include <openssl/hmac.h>
 #endif
@@ -490,6 +494,19 @@ static inline int CONF_modules_load_file(const char *filename,
 
 #ifdef __cplusplus
 }
+#endif
+
+#ifdef HAVE_OPENSSL_SSL_H
+#  ifndef HAVE_SSL_GET_CLIENT_RANDOM
+size_t SSL_get_client_random(const SSL *s, unsigned char *out, size_t outlen);
+#  endif
+#  ifndef HAVE_SSL_GET_SERVER_RANDOM
+size_t SSL_get_server_random(const SSL *s, unsigned char *out, size_t outlen);
+#  endif
+#  ifndef HAVE_SSL_SESSION_GET_MASTER_KEY
+size_t SSL_SESSION_get_master_key(const SSL_SESSION *s,
+				  unsigned char *out, size_t outlen);
+#  endif
 #endif
 
 /*

--- a/src/lib/missing.c
+++ b/src/lib/missing.c
@@ -341,6 +341,43 @@ void HMAC_CTX_free(HMAC_CTX *ctx)
 #  endif
 #endif
 
+#ifdef HAVE_OPENSSL_SSL_H
+#  ifndef HAVE_SSL_GET_CLIENT_RANDOM
+size_t SSL_get_client_random(const SSL *s, unsigned char *out, size_t outlen)
+{
+	if (!outlen) return sizeof(s->s3->client_random);
+
+	if (outlen > sizeof(s->s3->client_random)) outlen = sizeof(s->s3->client_random);
+
+	memcpy(out, s->s3->client_random, outlen);
+	return outlen;
+}
+#  endif
+#  ifndef HAVE_SSL_GET_SERVER_RANDOM
+size_t SSL_get_server_random(const SSL *s, unsigned char *out, size_t outlen)
+{
+	if (!outlen) return sizeof(s->s3->server_random);
+
+	if (outlen > sizeof(s->s3->server_random)) outlen = sizeof(s->s3->server_random);
+
+	memcpy(out, s->s3->server_random, outlen);
+	return outlen;
+}
+#  endif
+#  ifndef HAVE_SSL_SESSION_GET_MASTER_KEY
+size_t SSL_SESSION_get_master_key(const SSL_SESSION *s,
+				  unsigned char *out, size_t outlen)
+{
+	if (!outlen) return s->master_key_length;
+
+	if (outlen > (size_t)s->master_key_length) outlen = (size_t)s->master_key_length;
+
+	memcpy(out, s->master_key, outlen);
+	return outlen;
+}
+#  endif
+#endif
+
 /** Call talloc strdup, setting the type on the new chunk correctly
  *
  * For some bizarre reason the talloc string functions don't set the

--- a/src/lib/missing.c
+++ b/src/lib/missing.c
@@ -315,6 +315,32 @@ uint128_t ntohlll(uint128_t const num)
 }
 #endif
 
+#ifdef HAVE_OPENSSL_HMAC_H
+#  ifndef HAVE_HMAC_CTX_NEW
+HMAC_CTX *HMAC_CTX_new(void)
+{
+	HMAC_CTX *ctx;
+	ctx = OPENSSL_malloc(sizeof(*ctx));
+	memset(ctx, 0, sizeof(*ctx));
+	if (ctx == NULL) {
+                return NULL;
+        }
+        HMAC_CTX_init(ctx);
+	return ctx;
+}
+#  endif
+#  ifndef HAVE_HMAC_CTX_FREE
+void HMAC_CTX_free(HMAC_CTX *ctx)
+{
+        if (ctx == NULL) {
+                return;
+        }
+        HMAC_CTX_cleanup(ctx);
+        OPENSSL_free(ctx);
+}
+#  endif
+#endif
+
 /** Call talloc strdup, setting the type on the new chunk correctly
  *
  * For some bizarre reason the talloc string functions don't set the

--- a/src/main/threads.c
+++ b/src/main/threads.c
@@ -222,6 +222,7 @@ static const CONF_PARSER thread_config[] = {
 
 static pthread_mutex_t *ssl_mutexes = NULL;
 
+#ifdef HAVE_CRYPTO_SET_ID_CALLBACK
 static unsigned long ssl_id_function(void)
 {
 	unsigned long ret;
@@ -235,7 +236,9 @@ static unsigned long ssl_id_function(void)
 
 	return ret;
 }
+#endif
 
+#ifdef HAVE_CRYPTO_SET_LOCKING_CALLBACK
 static void ssl_locking_function(int mode, int n, UNUSED char const *file, UNUSED int line)
 {
 	if (mode & CRYPTO_LOCK) {
@@ -244,6 +247,7 @@ static void ssl_locking_function(int mode, int n, UNUSED char const *file, UNUSE
 		pthread_mutex_unlock(&(ssl_mutexes[n]));
 	}
 }
+#endif
 
 static int setup_ssl_mutexes(void)
 {
@@ -259,8 +263,12 @@ static int setup_ssl_mutexes(void)
 		pthread_mutex_init(&(ssl_mutexes[i]), NULL);
 	}
 
+#ifdef HAVE_CRYPTO_SET_ID_CALLBACK
 	CRYPTO_set_id_callback(ssl_id_function);
+#endif
+#ifdef HAVE_CRYPTO_SET_LOCKING_CALLBACK
 	CRYPTO_set_locking_callback(ssl_locking_function);
+#endif
 
 	return 1;
 }
@@ -1105,8 +1113,12 @@ void thread_pool_stop(void)
 	 *	We're no longer threaded.  Remove the mutexes and free
 	 *	the memory.
 	 */
+#ifdef HAVE_CRYPTO_SET_ID_CALLBACK
 	CRYPTO_set_id_callback(NULL);
+#endif
+#ifdef HAVE_CRYPTO_SET_LOCKING_CALLBACK
 	CRYPTO_set_locking_callback(NULL);
+#endif
 
 	free(ssl_mutexes);
 #endif

--- a/src/main/threads.c
+++ b/src/main/threads.c
@@ -718,7 +718,11 @@ static void *request_handler_thread(void *arg)
 	 *	must remove the thread's error queue before
 	 *	exiting to prevent memory leaks.
 	 */
+#if OPENSSL_VERSION_NUMBER < 0x10000000L
 	ERR_remove_state(0);
+#elif OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+	ERR_remove_thread_state(NULL);
+#endif
 #endif
 
 	pthread_mutex_lock(&thread_pool.queue_mutex);

--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -1412,7 +1412,11 @@ error:
 	return 0;
 }
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 static SSL_SESSION *cbtls_get_session(SSL *ssl, unsigned char *data, int len, int *copy)
+#else
+static SSL_SESSION *cbtls_get_session(SSL *ssl, const unsigned char *data, int len, int *copy)
+#endif
 {
 	size_t			size;
 	char			buffer[2 * MAX_SESSION_SIZE + 1];
@@ -1911,7 +1915,11 @@ int cbtls_verify(int ok, X509_STORE_CTX *ctx)
 	char		cn_str[1024];
 	char		buf[64];
 	X509		*client_cert;
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	const STACK_OF(X509_EXTENSION) *ext_list;
+#else
 	STACK_OF(X509_EXTENSION) *ext_list;
+#endif
 	SSL		*ssl;
 	int		err, depth, lookup, loc;
 	fr_tls_server_conf_t *conf;

--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -2053,14 +2053,14 @@ int cbtls_verify(int ok, X509_STORE_CTX *ctx)
 #ifdef GEN_EMAIL
 				case GEN_EMAIL:
 					vp = fr_pair_make(talloc_ctx, certs, cert_attr_names[FR_TLS_SAN_EMAIL][lookup],
-						      (char *) ASN1_STRING_data(name->d.rfc822Name), T_OP_SET);
+						      (char const *) ASN1_STRING_get0_data(name->d.rfc822Name), T_OP_SET);
 					rdebug_pair(L_DBG_LVL_2, request, vp, NULL);
 					break;
 #endif	/* GEN_EMAIL */
 #ifdef GEN_DNS
 				case GEN_DNS:
 					vp = fr_pair_make(talloc_ctx, certs, cert_attr_names[FR_TLS_SAN_DNS][lookup],
-						      (char *) ASN1_STRING_data(name->d.dNSName), T_OP_SET);
+						      (char const *) ASN1_STRING_get0_data(name->d.dNSName), T_OP_SET);
 					rdebug_pair(L_DBG_LVL_2, request, vp, NULL);
 					break;
 #endif	/* GEN_DNS */
@@ -2071,7 +2071,7 @@ int cbtls_verify(int ok, X509_STORE_CTX *ctx)
 					    /* we've got a UPN - Must be ASN1-encoded UTF8 string */
 					    if (name->d.otherName->value->type == V_ASN1_UTF8STRING) {
 						    vp = fr_pair_make(talloc_ctx, certs, cert_attr_names[FR_TLS_SAN_UPN][lookup],
-								  (char *) ASN1_STRING_data(name->d.otherName->value->value.utf8string), T_OP_SET);
+								  (char const *) ASN1_STRING_get0_data(name->d.otherName->value->value.utf8string), T_OP_SET);
 						    rdebug_pair(L_DBG_LVL_2, request, vp, NULL);
 						break;
 					    } else {

--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -2456,7 +2456,7 @@ void tls_global_init(void)
 	SSL_load_error_strings();	/* readable error messages (examples show call before library_init) */
 	SSL_library_init();		/* initialize library */
 	OpenSSL_add_all_algorithms();	/* required for SHA2 in OpenSSL < 0.9.8o and 1.0.0.a */
-	OPENSSL_config(NULL);
+	CONF_modules_load_file(NULL, NULL, 0);
 
 	/*
 	 *	Initialize the index for the certificates.

--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -2526,7 +2526,11 @@ int tls_global_version_check(char const *acknowledged)
  */
 void tls_global_cleanup(void)
 {
+#if OPENSSL_VERSION_NUMBER < 0x10000000L
 	ERR_remove_state(0);
+#elif OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+	ERR_remove_thread_state(NULL);
+#endif
 	ENGINE_cleanup();
 	CONF_modules_unload(1);
 	ERR_free_strings();

--- a/src/modules/rlm_eap/libeap/eap_tls.h
+++ b/src/modules/rlm_eap/libeap/eap_tls.h
@@ -62,12 +62,6 @@ int	eaptls_fail(eap_handler_t *handler, int peap_flag) CC_HINT(nonnull);
 int	eaptls_request(EAP_DS *eap_ds, tls_session_t *ssn) CC_HINT(nonnull);
 
 
-/* MPPE key generation */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-size_t SSL_get_client_random(const SSL *ssl, unsigned char *out, size_t outlen);
-size_t SSL_get_server_random(const SSL *ssl, unsigned char *out, size_t outlen);
-#endif
-
 void			T_PRF(unsigned char const *secret, unsigned int secret_len, char const *prf_label, unsigned char const *seed,  unsigned int seed_len, unsigned char *out, unsigned int out_len) CC_HINT(nonnull(1,3,6));
 void	eaptls_gen_mppe_keys(REQUEST *request, SSL *s, char const *prf_label);
 void	eapttls_gen_challenge(SSL *s, uint8_t *buffer, size_t size);

--- a/src/modules/rlm_eap/libeap/mppe_keys.c
+++ b/src/modules/rlm_eap/libeap/mppe_keys.c
@@ -37,51 +37,51 @@ static void P_hash(EVP_MD const *evp_md,
 		   unsigned char const *seed,   unsigned int seed_len,
 		   unsigned char *out, unsigned int out_len)
 {
-	HMAC_CTX ctx_a, ctx_out;
+	HMAC_CTX *ctx_a, *ctx_out;
 	unsigned char a[HMAC_MAX_MD_CBLOCK];
 	unsigned int size;
 
-	HMAC_CTX_init(&ctx_a);
-	HMAC_CTX_init(&ctx_out);
+	ctx_a = HMAC_CTX_new();
+	ctx_out = HMAC_CTX_new();
 #ifdef EVP_MD_CTX_FLAG_NON_FIPS_ALLOW
-	HMAC_CTX_set_flags(&ctx_a, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
-	HMAC_CTX_set_flags(&ctx_out, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+	HMAC_CTX_set_flags(ctx_a, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+	HMAC_CTX_set_flags(ctx_out, EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
 #endif
-	HMAC_Init_ex(&ctx_a, secret, secret_len, evp_md, NULL);
-	HMAC_Init_ex(&ctx_out, secret, secret_len, evp_md, NULL);
+	HMAC_Init_ex(ctx_a, secret, secret_len, evp_md, NULL);
+	HMAC_Init_ex(ctx_out, secret, secret_len, evp_md, NULL);
 
-	size = HMAC_size(&ctx_out);
+	size = HMAC_size(ctx_out);
 
 	/* Calculate A(1) */
-	HMAC_Update(&ctx_a, seed, seed_len);
-	HMAC_Final(&ctx_a, a, NULL);
+	HMAC_Update(ctx_a, seed, seed_len);
+	HMAC_Final(ctx_a, a, NULL);
 
 	while (1) {
 		/* Calculate next part of output */
-		HMAC_Update(&ctx_out, a, size);
-		HMAC_Update(&ctx_out, seed, seed_len);
+		HMAC_Update(ctx_out, a, size);
+		HMAC_Update(ctx_out, seed, seed_len);
 
 		/* Check if last part */
 		if (out_len < size) {
-			HMAC_Final(&ctx_out, a, NULL);
+			HMAC_Final(ctx_out, a, NULL);
 			memcpy(out, a, out_len);
 			break;
 		}
 
 		/* Place digest in output buffer */
-		HMAC_Final(&ctx_out, out, NULL);
-		HMAC_Init_ex(&ctx_out, NULL, 0, NULL, NULL);
+		HMAC_Final(ctx_out, out, NULL);
+		HMAC_Init_ex(ctx_out, NULL, 0, NULL, NULL);
 		out += size;
 		out_len -= size;
 
 		/* Calculate next A(i) */
-		HMAC_Init_ex(&ctx_a, NULL, 0, NULL, NULL);
-		HMAC_Update(&ctx_a, a, size);
-		HMAC_Final(&ctx_a, a, NULL);
+		HMAC_Init_ex(ctx_a, NULL, 0, NULL, NULL);
+		HMAC_Update(ctx_a, a, size);
+		HMAC_Final(ctx_a, a, NULL);
 	}
 
-	HMAC_CTX_cleanup(&ctx_a);
-	HMAC_CTX_cleanup(&ctx_out);
+	HMAC_CTX_free(ctx_a);
+	HMAC_CTX_free(ctx_out);
 	memset(a, 0, sizeof(a));
 }
 

--- a/src/modules/rlm_eap/libeap/mppe_keys.c
+++ b/src/modules/rlm_eap/libeap/mppe_keys.c
@@ -29,41 +29,6 @@ USES_APPLE_DEPRECATED_API	/* OpenSSL API has been deprecated by Apple */
 #include <openssl/hmac.h>
 
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
-/*
- *	OpenSSL compatibility, to avoid ifdef's through the rest of the code.
- */
-size_t SSL_get_client_random(const SSL *s, unsigned char *out, size_t outlen)
-{
-	if (!outlen) return sizeof(s->s3->client_random);
-
-	if (outlen > sizeof(s->s3->client_random)) outlen = sizeof(s->s3->client_random);
-
-	memcpy(out, s->s3->client_random, outlen);
-	return outlen;
-}
-
-size_t SSL_get_server_random(const SSL *s, unsigned char *out, size_t outlen)
-{
-	if (!outlen) return sizeof(s->s3->server_random);
-
-	if (outlen > sizeof(s->s3->server_random)) outlen = sizeof(s->s3->server_random);
-
-	memcpy(out, s->s3->server_random, outlen);
-	return outlen;
-}
-
-static size_t SSL_SESSION_get_master_key(const SSL_SESSION *s, unsigned char *out, size_t outlen)
-{
-	if (!outlen) return s->master_key_length;
-
-	if (outlen > (size_t)s->master_key_length) outlen = (size_t)s->master_key_length;
-
-	memcpy(out, s->master_key, outlen);
-	return outlen;
-}
-#endif
-
 /*
  * TLS PRF from RFC 2246
  */

--- a/src/modules/rlm_eap/libeap/mppe_keys.c
+++ b/src/modules/rlm_eap/libeap/mppe_keys.c
@@ -266,9 +266,9 @@ void eap_fast_tls_gen_challenge(SSL *s, uint8_t *buffer, uint8_t *scratch, size_
 	p = seed;
 	memcpy(p, prf_label, len);
 	p += len;
-	memcpy(p, s->s3->server_random, SSL3_RANDOM_SIZE);
+	SSL_get_server_random(s, p, SSL3_RANDOM_SIZE);
 	p += SSL3_RANDOM_SIZE;
-	memcpy(p, s->s3->client_random, SSL3_RANDOM_SIZE);
+	SSL_get_client_random(s, p, SSL3_RANDOM_SIZE);
 	p += SSL3_RANDOM_SIZE;
 
 	master_key_len = SSL_SESSION_get_master_key(SSL_get_session(s), master_key, sizeof(master_key));

--- a/src/modules/rlm_eap/types/rlm_eap_fast/configure
+++ b/src/modules/rlm_eap/types/rlm_eap_fast/configure
@@ -2893,7 +2893,7 @@ smart_prefix=
 
 
 sm_lib_safe=`echo "crypto" | sed 'y%./+-%__p_%'`
-sm_func_safe=`echo "EVP_cleanup" | sed 'y%./+-%__p_%'`
+sm_func_safe=`echo "EVP_CIPHER_CTX_new" | sed 'y%./+-%__p_%'`
 
 old_LIBS="$LIBS"
 old_CPPFLAGS="$CPPFLAGS"
@@ -2903,17 +2903,17 @@ smart_lib_dir=
 
 if test "x$smart_try_dir" != "x"; then
   for try in $smart_try_dir; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_cleanup in -lcrypto in $try" >&5
-$as_echo_n "checking for EVP_cleanup in -lcrypto in $try... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_CIPHER_CTX_new in -lcrypto in $try" >&5
+$as_echo_n "checking for EVP_CIPHER_CTX_new in -lcrypto in $try... " >&6; }
     LIBS="-lcrypto $old_LIBS"
     CPPFLAGS="-L$try -Wl,-rpath,$try $old_CPPFLAGS"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-extern char EVP_cleanup();
+extern char EVP_CIPHER_CTX_new();
 int
 main ()
 {
-EVP_cleanup()
+EVP_CIPHER_CTX_new()
   ;
   return 0;
 }
@@ -2938,16 +2938,16 @@ rm -f core conftest.err conftest.$ac_objext \
 fi
 
 if test "x$smart_lib" = "x"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_cleanup in -lcrypto" >&5
-$as_echo_n "checking for EVP_cleanup in -lcrypto... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_CIPHER_CTX_new in -lcrypto" >&5
+$as_echo_n "checking for EVP_CIPHER_CTX_new in -lcrypto... " >&6; }
   LIBS="-lcrypto $old_LIBS"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-extern char EVP_cleanup();
+extern char EVP_CIPHER_CTX_new();
 int
 main ()
 {
-EVP_cleanup()
+EVP_CIPHER_CTX_new()
   ;
   return 0;
 }
@@ -3024,17 +3024,17 @@ eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
 
 
   for try in $smart_lib_dir /usr/local/lib /opt/lib; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_cleanup in -lcrypto in $try" >&5
-$as_echo_n "checking for EVP_cleanup in -lcrypto in $try... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_CIPHER_CTX_new in -lcrypto in $try" >&5
+$as_echo_n "checking for EVP_CIPHER_CTX_new in -lcrypto in $try... " >&6; }
     LIBS="-lcrypto $old_LIBS"
     CPPFLAGS="-L$try -Wl,-rpath,$try $old_CPPFLAGS"
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-extern char EVP_cleanup();
+extern char EVP_CIPHER_CTX_new();
 int
 main ()
 {
-EVP_cleanup()
+EVP_CIPHER_CTX_new()
   ;
   return 0;
 }
@@ -3064,7 +3064,7 @@ if test "x$smart_lib" != "x"; then
   SMART_LIBS="$smart_ldflags $smart_lib $SMART_LIBS"
 fi
 
-        if test "x$ac_cv_lib_crypto_EVP_cleanup" != "xyes"; then
+        if test "x$ac_cv_lib_crypto_EVP_CIPHER_CTX_new" != "xyes"; then
 	  fail="libssl"
 	fi
 

--- a/src/modules/rlm_eap/types/rlm_eap_fast/configure.ac
+++ b/src/modules/rlm_eap/types/rlm_eap_fast/configure.ac
@@ -60,8 +60,8 @@ if test x$with_[]modname != xno; then
 	fi
 
 	smart_try_dir=$openssl_lib_dir
-        FR_SMART_CHECK_LIB(crypto, EVP_cleanup)
-        if test "x$ac_cv_lib_crypto_EVP_cleanup" != "xyes"; then
+        FR_SMART_CHECK_LIB(crypto, EVP_CIPHER_CTX_new)
+        if test "x$ac_cv_lib_crypto_EVP_CIPHER_CTX_new" != "xyes"; then
 	  fail="libssl"
 	fi
 

--- a/src/modules/rlm_eap/types/rlm_eap_fast/rlm_eap_fast.c
+++ b/src/modules/rlm_eap/types/rlm_eap_fast/rlm_eap_fast.c
@@ -185,9 +185,15 @@ static void eap_fast_session_ticket(tls_session_t *tls_session, uint8_t *client_
 }
 
 // hostap:src/crypto/tls_openssl.c:tls_sess_sec_cb()
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 static int _session_secret(SSL *s, void *secret, int *secret_len,
 			   UNUSED STACK_OF(SSL_CIPHER) *peer_ciphers,
 			   UNUSED SSL_CIPHER **cipher, void *arg)
+#else
+static int _session_secret(SSL *s, void *secret, int *secret_len,
+			   UNUSED STACK_OF(SSL_CIPHER) *peer_ciphers,
+			   UNUSED const SSL_CIPHER **cipher, void *arg)
+#endif
 {
 	// FIXME enforce non-anon cipher
 

--- a/src/modules/rlm_eap/types/rlm_eap_pwd/eap_pwd.c
+++ b/src/modules/rlm_eap/types/rlm_eap_pwd/eap_pwd.c
@@ -45,7 +45,7 @@ static void H_Init(HMAC_CTX *ctx)
 	uint8_t allzero[SHA256_DIGEST_LENGTH];
 
 	memset(allzero, 0, SHA256_DIGEST_LENGTH);
-	HMAC_Init(ctx, allzero, SHA256_DIGEST_LENGTH, EVP_sha256());
+	HMAC_Init_ex(ctx, allzero, SHA256_DIGEST_LENGTH, EVP_sha256(), NULL);
 }
 
 static void H_Update(HMAC_CTX *ctx, uint8_t const *data, int len)
@@ -76,7 +76,7 @@ static void eap_pwd_kdf(uint8_t *key, int keylen, char const *label, int labelle
 	L = htons(resultbitlen);
 	while (len < resultbytelen) {
 		ctr++; i = htons(ctr);
-		HMAC_Init(&hctx, key, keylen, EVP_sha256());
+		HMAC_Init_ex(&hctx, key, keylen, EVP_sha256(), NULL);
 		if (ctr > 1) {
 			HMAC_Update(&hctx, digest, mdlen);
 		}

--- a/src/modules/rlm_otp/otp_radstate.c
+++ b/src/modules/rlm_otp/otp_radstate.c
@@ -110,7 +110,7 @@ size_t otp_gen_state(char state[OTP_MAX_RADSTATE_LEN],
 		     size_t clen,
 		     int32_t flags, int32_t when, uint8_t const key[16])
 {
-	HMAC_CTX hmac_ctx;
+	HMAC_CTX *hmac_ctx;
 	uint8_t hmac[MD5_DIGEST_LENGTH];
 	char *p;
 
@@ -120,13 +120,13 @@ size_t otp_gen_state(char state[OTP_MAX_RADSTATE_LEN],
 	 *	having to collect the data to be signed into one
 	 *	contiguous piece.
 	 */
-	HMAC_CTX_init(&hmac_ctx);
-	HMAC_Init(&hmac_ctx, key, sizeof(key[0]) * 16, EVP_md5());
-	HMAC_Update(&hmac_ctx, (uint8_t const *) challenge, clen);
-	HMAC_Update(&hmac_ctx, (uint8_t *) &flags, 4);
-	HMAC_Update(&hmac_ctx, (uint8_t *) &when, 4);
-	HMAC_Final(&hmac_ctx, hmac, NULL);
-	HMAC_cleanup(&hmac_ctx);
+	hmac_ctx = HMAC_CTX_new();
+	HMAC_Init(hmac_ctx, key, sizeof(key[0]) * 16, EVP_md5());
+	HMAC_Update(hmac_ctx, (uint8_t const *) challenge, clen);
+	HMAC_Update(hmac_ctx, (uint8_t *) &flags, 4);
+	HMAC_Update(hmac_ctx, (uint8_t *) &when, 4);
+	HMAC_Final(hmac_ctx, hmac, NULL);
+	HMAC_CTX_free(hmac_ctx);
 
 	/*
 	 *	Generate the state.

--- a/src/modules/rlm_otp/otp_radstate.c
+++ b/src/modules/rlm_otp/otp_radstate.c
@@ -120,6 +120,7 @@ size_t otp_gen_state(char state[OTP_MAX_RADSTATE_LEN],
 	 *	having to collect the data to be signed into one
 	 *	contiguous piece.
 	 */
+	HMAC_CTX_init(&hmac_ctx);
 	HMAC_Init(&hmac_ctx, key, sizeof(key[0]) * 16, EVP_md5());
 	HMAC_Update(&hmac_ctx, (uint8_t const *) challenge, clen);
 	HMAC_Update(&hmac_ctx, (uint8_t *) &flags, 4);

--- a/src/modules/rlm_otp/otp_radstate.c
+++ b/src/modules/rlm_otp/otp_radstate.c
@@ -121,7 +121,7 @@ size_t otp_gen_state(char state[OTP_MAX_RADSTATE_LEN],
 	 *	contiguous piece.
 	 */
 	hmac_ctx = HMAC_CTX_new();
-	HMAC_Init(hmac_ctx, key, sizeof(key[0]) * 16, EVP_md5());
+	HMAC_Init_ex(hmac_ctx, key, sizeof(key[0]) * 16, EVP_md5(), NULL);
 	HMAC_Update(hmac_ctx, (uint8_t const *) challenge, clen);
 	HMAC_Update(hmac_ctx, (uint8_t *) &flags, 4);
 	HMAC_Update(hmac_ctx, (uint8_t *) &when, 4);

--- a/src/modules/rlm_wimax/rlm_wimax.c
+++ b/src/modules/rlm_wimax/rlm_wimax.c
@@ -27,10 +27,9 @@ USES_APPLE_DEPRECATED_API	/* OpenSSL API has been deprecated by Apple */
 #include <freeradius-devel/radiusd.h>
 #include <freeradius-devel/modules.h>
 
-/*
- *	FIXME: Add check for this header to configure.ac
- */
+#ifdef HAVE_OPENSSL_HMAC_H
 #include <openssl/hmac.h>
+#endif
 
 /*
  *	FIXME: Fix the build system to create definitions from names.

--- a/src/modules/rlm_wimax/rlm_wimax.c
+++ b/src/modules/rlm_wimax/rlm_wimax.c
@@ -121,7 +121,7 @@ static rlm_rcode_t CC_HINT(nonnull) mod_post_auth(void *instance, REQUEST *reque
 	rlm_wimax_t *inst = instance;
 	VALUE_PAIR *msk, *emsk, *vp;
 	VALUE_PAIR *mn_nai, *ip, *fa_rk;
-	HMAC_CTX hmac;
+	HMAC_CTX *hmac;
 	unsigned int rk1_len, rk2_len, rk_len;
 	uint32_t mip_spi;
 	uint8_t usage_data[24];
@@ -160,20 +160,20 @@ static rlm_rcode_t CC_HINT(nonnull) mod_post_auth(void *instance, REQUEST *reque
 	/*
 	 *	MIP-RK-1 = HMAC-SSHA256(EMSK, usage-data | 0x01)
 	 */
-	HMAC_CTX_init(&hmac);
-	HMAC_Init_ex(&hmac, emsk->vp_octets, emsk->vp_length, EVP_sha256(), NULL);
+	hmac = HMAC_CTX_new();
+	HMAC_Init_ex(hmac, emsk->vp_octets, emsk->vp_length, EVP_sha256(), NULL);
 
-	HMAC_Update(&hmac, &usage_data[0], sizeof(usage_data));
-	HMAC_Final(&hmac, &mip_rk_1[0], &rk1_len);
+	HMAC_Update(hmac, &usage_data[0], sizeof(usage_data));
+	HMAC_Final(hmac, &mip_rk_1[0], &rk1_len);
 
 	/*
 	 *	MIP-RK-2 = HMAC-SSHA256(EMSK, MIP-RK-1 | usage-data | 0x01)
 	 */
-	HMAC_Init_ex(&hmac, emsk->vp_octets, emsk->vp_length, EVP_sha256(), NULL);
+	HMAC_Init_ex(hmac, emsk->vp_octets, emsk->vp_length, EVP_sha256(), NULL);
 
-	HMAC_Update(&hmac, (uint8_t const *) &mip_rk_1, rk1_len);
-	HMAC_Update(&hmac, &usage_data[0], sizeof(usage_data));
-	HMAC_Final(&hmac, &mip_rk_2[0], &rk2_len);
+	HMAC_Update(hmac, (uint8_t const *) &mip_rk_1, rk1_len);
+	HMAC_Update(hmac, &usage_data[0], sizeof(usage_data));
+	HMAC_Final(hmac, &mip_rk_2[0], &rk2_len);
 
 	memcpy(mip_rk, mip_rk_1, rk1_len);
 	memcpy(mip_rk + rk1_len, mip_rk_2, rk2_len);
@@ -182,10 +182,10 @@ static rlm_rcode_t CC_HINT(nonnull) mod_post_auth(void *instance, REQUEST *reque
 	/*
 	 *	MIP-SPI = HMAC-SSHA256(MIP-RK, "SPI CMIP PMIP");
 	 */
-	HMAC_Init_ex(&hmac, mip_rk, rk_len, EVP_sha256(), NULL);
+	HMAC_Init_ex(hmac, mip_rk, rk_len, EVP_sha256(), NULL);
 
-	HMAC_Update(&hmac, (uint8_t const *) "SPI CMIP PMIP", 12);
-	HMAC_Final(&hmac, &mip_rk_1[0], &rk1_len);
+	HMAC_Update(hmac, (uint8_t const *) "SPI CMIP PMIP", 12);
+	HMAC_Final(hmac, &mip_rk_1[0], &rk1_len);
 
 	/*
 	 *	Take the 4 most significant octets.
@@ -245,12 +245,12 @@ static rlm_rcode_t CC_HINT(nonnull) mod_post_auth(void *instance, REQUEST *reque
 		 *	MN-HA-PMIP4 =
 		 *	   H(MIP-RK, "PMIP4 MN HA" | HA-IPv4 | MN-NAI);
 		 */
-		HMAC_Init_ex(&hmac, mip_rk, rk_len, EVP_sha1(), NULL);
+		HMAC_Init_ex(hmac, mip_rk, rk_len, EVP_sha1(), NULL);
 
-		HMAC_Update(&hmac, (uint8_t const *) "PMIP4 MN HA", 11);
-		HMAC_Update(&hmac, (uint8_t const *) &ip->vp_ipaddr, 4);
-		HMAC_Update(&hmac, (uint8_t const *) &mn_nai->vp_strvalue, mn_nai->vp_length);
-		HMAC_Final(&hmac, &mip_rk_1[0], &rk1_len);
+		HMAC_Update(hmac, (uint8_t const *) "PMIP4 MN HA", 11);
+		HMAC_Update(hmac, (uint8_t const *) &ip->vp_ipaddr, 4);
+		HMAC_Update(hmac, (uint8_t const *) &mn_nai->vp_strvalue, mn_nai->vp_length);
+		HMAC_Final(hmac, &mip_rk_1[0], &rk1_len);
 
 		/*
 		 *	Put MN-HA-PMIP4 into WiMAX-MN-hHA-MIP4-Key
@@ -295,12 +295,12 @@ static rlm_rcode_t CC_HINT(nonnull) mod_post_auth(void *instance, REQUEST *reque
 		 *	MN-HA-CMIP4 =
 		 *	   H(MIP-RK, "CMIP4 MN HA" | HA-IPv4 | MN-NAI);
 		 */
-		HMAC_Init_ex(&hmac, mip_rk, rk_len, EVP_sha1(), NULL);
+		HMAC_Init_ex(hmac, mip_rk, rk_len, EVP_sha1(), NULL);
 
-		HMAC_Update(&hmac, (uint8_t const *) "CMIP4 MN HA", 11);
-		HMAC_Update(&hmac, (uint8_t const *) &ip->vp_ipaddr, 4);
-		HMAC_Update(&hmac, (uint8_t const *) &mn_nai->vp_strvalue, mn_nai->vp_length);
-		HMAC_Final(&hmac, &mip_rk_1[0], &rk1_len);
+		HMAC_Update(hmac, (uint8_t const *) "CMIP4 MN HA", 11);
+		HMAC_Update(hmac, (uint8_t const *) &ip->vp_ipaddr, 4);
+		HMAC_Update(hmac, (uint8_t const *) &mn_nai->vp_strvalue, mn_nai->vp_length);
+		HMAC_Final(hmac, &mip_rk_1[0], &rk1_len);
 
 		/*
 		 *	Put MN-HA-CMIP4 into WiMAX-MN-hHA-MIP4-Key
@@ -345,12 +345,12 @@ static rlm_rcode_t CC_HINT(nonnull) mod_post_auth(void *instance, REQUEST *reque
 		 *	MN-HA-CMIP6 =
 		 *	   H(MIP-RK, "CMIP6 MN HA" | HA-IPv6 | MN-NAI);
 		 */
-		HMAC_Init_ex(&hmac, mip_rk, rk_len, EVP_sha1(), NULL);
+		HMAC_Init_ex(hmac, mip_rk, rk_len, EVP_sha1(), NULL);
 
-		HMAC_Update(&hmac, (uint8_t const *) "CMIP6 MN HA", 11);
-		HMAC_Update(&hmac, (uint8_t const *) &ip->vp_ipv6addr, 16);
-		HMAC_Update(&hmac, (uint8_t const *) &mn_nai->vp_strvalue, mn_nai->vp_length);
-		HMAC_Final(&hmac, &mip_rk_1[0], &rk1_len);
+		HMAC_Update(hmac, (uint8_t const *) "CMIP6 MN HA", 11);
+		HMAC_Update(hmac, (uint8_t const *) &ip->vp_ipv6addr, 16);
+		HMAC_Update(hmac, (uint8_t const *) &mn_nai->vp_strvalue, mn_nai->vp_length);
+		HMAC_Final(hmac, &mip_rk_1[0], &rk1_len);
 
 		/*
 		 *	Put MN-HA-CMIP6 into WiMAX-MN-hHA-MIP6-Key
@@ -392,11 +392,11 @@ static rlm_rcode_t CC_HINT(nonnull) mod_post_auth(void *instance, REQUEST *reque
 	 */
 	fa_rk = fr_pair_find_by_num(request->reply->vps, 14, VENDORPEC_WIMAX, TAG_ANY);
 	if (fa_rk && (fa_rk->vp_length <= 1)) {
-		HMAC_Init_ex(&hmac, mip_rk, rk_len, EVP_sha1(), NULL);
+		HMAC_Init_ex(hmac, mip_rk, rk_len, EVP_sha1(), NULL);
 
-		HMAC_Update(&hmac, (uint8_t const *) "FA-RK", 5);
+		HMAC_Update(hmac, (uint8_t const *) "FA-RK", 5);
 
-		HMAC_Final(&hmac, &mip_rk_1[0], &rk1_len);
+		HMAC_Final(hmac, &mip_rk_1[0], &rk1_len);
 
 		fr_pair_value_memcpy(fa_rk, &mip_rk_1[0], rk1_len);
 	}
@@ -450,7 +450,7 @@ static rlm_rcode_t CC_HINT(nonnull) mod_post_auth(void *instance, REQUEST *reque
 	/*
 	 *	Wipe the context of all sensitive information.
 	 */
-	HMAC_CTX_cleanup(&hmac);
+	HMAC_CTX_free(hmac);
 
 	return RLM_MODULE_UPDATED;
 }


### PR DESCRIPTION
This makes v3.0.x build on Fedora Rawhide and concerns #1817.

I tested the build on Fedora Rawhide, Debian Testing, and RHEL6.8.

I didn't run any tests.

There are still a couple OpenSSL-related warnings on Rawhide, which I'm not yet sure how to deal with:

	src/main/threads.c: In function ‘request_handler_thread’:
	src/main/threads.c:721:2: warning: ‘ERR_remove_state’ is deprecated [-Wdeprecated-declarations]
	  ERR_remove_state(0);
	  ^~~~~~~~~~~~~~~~
	In file included from /usr/include/openssl/opensslconf.h:42:0,
					 from /usr/include/openssl/md4.h:13,
					 from src/freeradius-devel/md4.h:30,
					 from src/freeradius-devel/libradius.h:96,
					 from src/freeradius-devel/radiusd.h:29,
					 from src/main/threads.c:27:
	/usr/include/openssl/err.h:247:1: note: declared here
	 DEPRECATEDIN_1_0_0(void ERR_remove_state(unsigned long pid))
	 ^
	At top level:
	src/main/threads.c:239:13: warning: ‘ssl_locking_function’ defined but not used [-Wunused-function]
	 static void ssl_locking_function(int mode, int n, UNUSED char const *file, UNUSED int line)
				 ^~~~~~~~~~~~~~~~~~~~
	src/main/threads.c:225:22: warning: ‘ssl_id_function’ defined but not used [-Wunused-function]
	 static unsigned long ssl_id_function(void)
						  ^~~~~~~~~~~~~~~

	src/main/tls.c: In function ‘tls_global_cleanup’:
	src/main/tls.c:2525:2: warning: ‘ERR_remove_state’ is deprecated [-Wdeprecated-declarations]
	  ERR_remove_state(0);
	  ^~~~~~~~~~~~~~~~
	In file included from /usr/include/openssl/opensslconf.h:42:0,
					 from /usr/include/openssl/md4.h:13,
					 from src/freeradius-devel/md4.h:30,
					 from src/freeradius-devel/libradius.h:96,
					 from src/freeradius-devel/radiusd.h:29,
					 from src/main/tls.c:28:
	/usr/include/openssl/err.h:247:1: note: declared here
	 DEPRECATEDIN_1_0_0(void ERR_remove_state(unsigned long pid))
	 ^

RHEL6.8 also complained a bit:

	src/main/tls.c: In function ‘cbtls_verify’:
	src/main/tls.c:2131: warning: cast discards qualifiers from pointer target type
	src/main/tls.c:2139: warning: cast discards qualifiers from pointer target type
	src/main/tls.c:2143: warning: cast discards qualifiers from pointer target type

The above can be fixed by checking that we're below OpenSSL_0_9_8y, and
removing const from `ext_list` in `cbtls_verify` in `src/main/tls.c`, but I'm not
sure if it's worth it, or maybe I just had enough for today.

Some of the fallback functions I defined in `missing-h` might not be necessary.

Please tell me what you think and if anything needs changing.

Thank you.
