### PR TITLE
Fixed pair comparison.

### DIFF
--- a/src/lib/pair.c
+++ b/src/lib/pair.c
@@ -993,7 +993,7 @@ int8_t fr_pair_cmp_by_parent_num_tag(void const *a, void const *b)
 
 	for (da_a = tlv_stack_a[0], da_b = tlv_stack_b[0]; da_a && da_b; da_a++, da_b++) {
 		if (da_a->attr > da_b->attr) return +1;
-		if (da_b->attr < da_b->attr) return -1;
+		if (da_b->attr < da_a->attr) return -1;
 	}
 
 	/*
@@ -1005,7 +1005,7 @@ int8_t fr_pair_cmp_by_parent_num_tag(void const *a, void const *b)
 	if (!da_a && da_b) return -1;
 
 	if (vp_a->tag > vp_b->tag) return +1;
-	if (vp_b->tag < vp_b->tag) return -1;
+	if (vp_b->tag < vp_a->tag) return -1;
 
 	return 0;
 }


### PR DESCRIPTION
Fixed pair comparison, possibly meant to compare both sides. Cookie goes to -Wtautological-compare .