### PR TITLE
remove unnecessary "Need 0 more connections to reach..." INFO output

### DIFF
--- a/src/main/connection.c
+++ b/src/main/connection.c
@@ -643,7 +643,7 @@ static int fr_connection_pool_check(fr_connection_pool_t *pool)
 	 *	have fewer than "min".  When that happens, open more
 	 *	connections to enforce "min".
 	 */
-	if ((pool->num + pool->pending) <= pool->min) {
+	if ((pool->num + pool->pending) < pool->min) {
 		spawn = pool->min - (pool->num + pool->pending);
 		extra = 0;
 
@@ -668,7 +668,7 @@ static int fr_connection_pool_check(fr_connection_pool_t *pool)
 	 *	AND we don't have enough idle connections.
 	 *	Open some more.
 	 */
-	} else if (idle <= pool->spare) {
+	} else if (idle < pool->spare) {
 		/*
 		 *	Not enough spare connections.  Spawn a few.
 		 *	But cap the pool size at "max"


### PR DESCRIPTION
the <= means that when the value is 0 the server keeps spewing out "Need 0 more connections to reach..." messages into the log output.  this ensures messages come out only when there is a need.