### PR TITLE
Cast byte as an unsigned char instead

### DIFF
--- a/src/lib/print.c
+++ b/src/lib/print.c
@@ -583,7 +583,7 @@ size_t vp_prints_value_json(char *out, size_t outlen, VALUE_PAIR const *vp)
 					freespace--;
 					break;
 				default:
-					len = snprintf(out, freespace, "u%04X", (uint32_t) *q);
+					len = snprintf(out, freespace, "u%04X", (uint8_t) *q);
 					if (is_truncated(len, freespace)) return (outlen - freespace) + len;
 					out += len;
 					freespace -= len;

--- a/src/modules/rlm_rest/rlm_rest.c
+++ b/src/modules/rlm_rest/rlm_rest.c
@@ -189,7 +189,7 @@ static ssize_t jsonquote_xlat(UNUSED void *instance, UNUSED REQUEST *request,
 				break;
 
 			default:
-				len = snprintf(out, freespace, "u%04X", (uint32_t) *p);
+				len = snprintf(out, freespace, "u%04X", (uint8_t) *p);
 				if (is_truncated(len, freespace)) return (outlen - freespace) + len;
 				out += len;
 				freespace -= len;


### PR DESCRIPTION
When casting a signed char that is negative to a unsigned 32 bit integer the signed bit is extended.

To avoid the signed bit being extended it is safer to cast a signed char to an unsigned char.