### PR TITLE
Use workaround for error logging in connection.c (2)

### DIFF
--- a/src/main/connection.c
+++ b/src/main/connection.c
@@ -970,7 +970,7 @@ fr_connection_pool_t *fr_connection_pool_init(TALLOC_CTX *ctx,
 	pool = talloc_zero(NULL, fr_connection_pool_t);
 	if (!pool) {
 		/* Simply using ERROR here results in a null pointer dereference */
-		_RADLOG(L_ERR, "%s: Out of memory", __FUNCTION__);
+		radlog(&default_log, L_ERR, "%s: Out of memory", __FUNCTION__);
 		return NULL;
 	}
 


### PR DESCRIPTION
The previous workaround was not enough.

Of course this one won't reproduce locally, but does occur on travis