### PR TITLE
Update abfab-tr

### DIFF
--- a/raddb/policy.d/abfab-tr
+++ b/raddb/policy.d/abfab-tr
@@ -24,29 +24,46 @@ psk_authorize {
 }
 
 abfab_client_check {
-	# check that the acceptor host name is correct
-	if ("%{client:gss_acceptor_host_name}" && &gss-acceptor-host-name) {
-		if ("%{client:gss_acceptor_host_name}" != "%{gss-acceptor-host-name}") {
-			update reply {
-			        Reply-Message = "GSS-Acceptor-Host-Name incorrect"
-				}
-			reject
+	# check that GSS-Acceptor-Host-Name is correct
+	if ("%{client:gss_acceptor_host_name}") {
+		if (&request:GSS-Acceptor-Host-Name) {
+			if ("%{client:gss_acceptor_host_name}" != "%{gss-acceptor-host-name}") {
+				update reply {
+				        Reply-Message = "GSS-Acceptor-Host-Name incorrect"
+					}
+				reject
+			}
+		}
+		else {
+			# set GSS-Acceptor-Host-Name if it is not set by the mechanism 
+			# but it is defined in the client configuration
+			update request {
+				GSS-Acceptor-Host-Name = "%{client:gss_acceptor_host_name}"
+			}
 		}
 	}
 
-	# set trust-router-coi attribute from the client configuration
+	# set Trust-Router-COI attribute from the client configuration
 	if ("%{client:trust_router_coi}") {
 		update request {
 			Trust-Router-COI := "%{client:trust_router_coi}"
 		}
 	}
 
-	# set gss-acceptor-realm-name attribute from the client configuration
+	# set GSS-Acceptor-Realm-Name attribute from the client configuration
 	if ("%{client:gss_acceptor_realm_name}") {
 		update request {
 			GSS-Acceptor-Realm-Name := "%{client:gss_acceptor_realm_name}"
 		}
 	}
+	
+	# set GSS-Acceptor-Service-Name attribute from the client configuration
+	if ("%{client:gss_acceptor_service_name}") {
+		update request {
+			GSS-Acceptor-Service-Name := "%{client:gss_acceptor_service_name}"
+		}
+	}
+
 }
 
 #  A policy which is used to validate channel-bindings.


### PR DESCRIPTION
Since there seem to be problems with the GSS-Acceptor-Host-Name occasionally, set it if it hasn't been set yet (and it's defined in the client definition). Also add the GSS-Acceptor-Service-Name if it hasn't been set, or override the one set.