### PR TITLE
Update abfab_tr policy

### DIFF
--- a/raddb/policy.d/abfab-tr
+++ b/raddb/policy.d/abfab-tr
@@ -60,7 +60,7 @@ abfab_client_check {
 	# set GSS-Acceptor-Service-Name attribute from the client configuration
 	if ("%{client:gss_acceptor_service_name}") {
 		update request {
-			GSS-Acceptor-Service-Name := "%{client:gss_acceptor_service_name}"
+			GSS-Acceptor-Service-Name = "%{client:gss_acceptor_service_name}"
 		}
 	}
 

--- a/raddb/policy.d/abfab-tr
+++ b/raddb/policy.d/abfab-tr
@@ -24,29 +24,46 @@ psk_authorize {
 }
 
 abfab_client_check {
-	# check that the acceptor host name is correct
-	if ("%{client:gss_acceptor_host_name}" && &gss-acceptor-host-name) {
-		if ("%{client:gss_acceptor_host_name}" != "%{gss-acceptor-host-name}") {
-			update reply {
-			        Reply-Message = "GSS-Acceptor-Host-Name incorrect"
-				}
-			reject
+	# check that GSS-Acceptor-Host-Name is correct
+	if ("%{client:gss_acceptor_host_name}") {
+		if (&request:GSS-Acceptor-Host-Name) {
+			if (&request:GSS-Acceptor-Host-Name != "%{client:gss_acceptor_host_name}") {
+				update reply {
+				        Reply-Message = "GSS-Acceptor-Host-Name incorrect"
+					}
+				reject
+			}
+		}
+		else {
+			# set GSS-Acceptor-Host-Name if it is not set by the mechanism 
+			# but it is defined in the client configuration
+			update request {
+				GSS-Acceptor-Host-Name = "%{client:gss_acceptor_host_name}"
+			}
 		}
 	}
 
-	# set trust-router-coi attribute from the client configuration
+	# set Trust-Router-COI attribute from the client configuration
 	if ("%{client:trust_router_coi}") {
 		update request {
 			Trust-Router-COI := "%{client:trust_router_coi}"
 		}
 	}
 
-	# set gss-acceptor-realm-name attribute from the client configuration
+	# set GSS-Acceptor-Realm-Name attribute from the client configuration
 	if ("%{client:gss_acceptor_realm_name}") {
 		update request {
 			GSS-Acceptor-Realm-Name := "%{client:gss_acceptor_realm_name}"
 		}
 	}
+	
+	# set GSS-Acceptor-Service-Name attribute from the client configuration
+	if ("%{client:gss_acceptor_service_name}") {
+		update request {
+			GSS-Acceptor-Service-Name := "%{client:gss_acceptor_service_name}"
+		}
+	}
+
 }
 
 #  A policy which is used to validate channel-bindings.


### PR DESCRIPTION
Include setting the GSS-Acceptor-Host-Name and GSS-Acceptor-Service-Name if they are not set (this does seem to happen occasionally). This does *not* set the inner tunnel attributes though.