### PR TITLE
remove Reply-Message from Access-Challenge if EAP-Message

### DIFF
--- a/raddb/sites-available/default
+++ b/raddb/sites-available/default
@@ -832,6 +832,12 @@ post-auth {
 		#  Remove reply message if the response contains an EAP-Message
 		remove_reply_message_if_eap
 	}
+	
+	Post-Auth-Type CHALLENGE {
+		#  Remove reply message if the response contains an EAP-Message
+		remove_reply_message_if_eap
+	}
+	
 }
 
 #


### PR DESCRIPTION
RFC 3579 doesn't allow Reply-Message if EAP-Message exists..which it may in Access-Challenge.
We already do a basic filter in the Auth-Type EAP but thats to match 2865 and gets a little tricky/messy if its not an EAP challenge-response..so best cleared up here.