### PR TITLE
Fix three cases of comparing pointer to zero char

### DIFF
--- a/src/main/evaluate.c
+++ b/src/main/evaluate.c
@@ -99,7 +99,7 @@ int radius_evaluate_tmpl(REQUEST *request, int modreturn, UNUSED int depth, vp_t
 		 *	The VPT *doesn't* have a "bare word" type,
 		 *	which arguably it should.
 		 */
-		rcode = (vpt->name != '\0');
+		rcode = (*vpt->name != '\0');
 		break;
 
 	case TMPL_TYPE_ATTR:

--- a/src/modules/rlm_mschap/rlm_mschap.c
+++ b/src/modules/rlm_mschap/rlm_mschap.c
@@ -436,7 +436,7 @@ static ssize_t mschap_xlat(void *instance, REQUEST *request,
 		char const *p;
 
 		p = fmt + 8;	/* 7 is the length of 'NT-Hash' */
-		if ((p == '\0')	 || (outlen <= 32))
+		if ((*p == '\0') || (outlen <= 32))
 			return 0;
 
 		while (isspace(*p)) p++;
@@ -459,7 +459,7 @@ static ssize_t mschap_xlat(void *instance, REQUEST *request,
 		char const *p;
 
 		p = fmt + 8;	/* 7 is the length of 'LM-Hash' */
-		if ((p == '\0') || (outlen <= 32))
+		if ((*p == '\0') || (outlen <= 32))
 			return 0;
 
 		while (isspace(*p)) p++;


### PR DESCRIPTION
Fix three cases of comparing pointer to a zero character, where pointers
were apparently intended to be dereferenced first and then compared.
Found with the help of GCC 7 warnings.