### PR TITLE
Remove mentions of Auth-Type = System from docs

### DIFF
--- a/man/man5/rlm_unix.5
+++ b/man/man5/rlm_unix.5
@@ -19,8 +19,7 @@ password file, and allows the server to use them for authentication.
 The module also provides FreeRADIUS an interface into a radwtmp file
 (used by "radlast") when added to the accounting section.
 .PP
-The \fIrlm_unix\fP module does provides the functionality for
-"Auth-Type = System".  The module should be listed in the
+The \fIrlm_unix\fP module should be listed in the
 "authenticate" section.  Please see the default \fIradiusd.conf\fP
 shipped with the server for an example of the correct usage of this
 module.

--- a/man/man5/users.5
+++ b/man/man5/users.5
@@ -169,18 +169,6 @@ reply items, so the reply will be empty.
 .RE
 
 .DS
-DEFAULT	Auth-Type = System
-.br
-	Fall-Through = Yes
-
-.DE
-.RS
-For all users reaching this entry, perform authentication against the
-system, unless Auth-Type has already been set.  Also, process any
-following entries which may match.
-.RE
-
-.DS
 DEFAULT Service-Type == Framed-User, Framed-Protocol == PPP
 .br
 	Service-Type = Framed-User,


### PR DESCRIPTION
Remove mentions of "Auth-Type = System" support from the manpages,
as it is removed.