### PR TITLE
Clarify ipaddr resolution preference

### DIFF
--- a/raddb/sites-available/default
+++ b/raddb/sites-available/default
@@ -92,8 +92,10 @@ listen {
 	#	IPv6 address (e.g. 2001:db8::1, for ipv6addr/ipaddr)
 	#	hostname     (radius.example.com,
 	#			A record for ipv4addr,
-	#       		AAAA record for ipv6addr,
-	#			A or AAAA record for ipaddr)
+	#			AAAA record for ipv6addr,
+	#			A or AAAA record for ipaddr;
+	#			A record is always preferred for ipaddr,
+	#			regardless of system configuration)
 	#       wildcard     (*)
 	#
 	# ipv4addr = *


### PR DESCRIPTION
Note in the raddb/sites-available/default that the "ipaddr" option
always prefers A records on hostname resolution, regardless of system
configuration (such as "/etc/gai.conf"), to clear up the possible
confusion.