### PR TITLE
print newline after stats.failed in summary

### DIFF
--- a/src/main/radclient.c
+++ b/src/main/radclient.c
@@ -1630,7 +1630,7 @@ int main(int argc, char **argv)
 		       "\tRejected      : %" PRIu64 "\n"
 		       "\tLost          : %" PRIu64 "\n"
 		       "\tPassed filter : %" PRIu64 "\n"
-		       "\tFailed filter : %" PRIu64,
+		       "\tFailed filter : %" PRIu64 "\n",
 		       stats.accepted,
 		       stats.rejected,
 		       stats.lost,


### PR DESCRIPTION
As described in #1928 there's a newline missing now we have printf instead of DEBUG as of the last fix in #1926
