### PR TITLE
Fix command for linking modules in mods-enabled.

### DIFF
--- a/raddb/README.rst
+++ b/raddb/README.rst
@@ -76,8 +76,8 @@ ordering when the modules are loaded.
 
 Modules can be enabled by creating a soft link.  For module ``foo``, do::
 
-  $ cd raddb
-  $ ln -s mods-available/foo mods-enabled/foo
+  $ cd raddb/mods-enabled
+  $ ln -s ../mods-available/foo
 
 To create "local" versions of the modules, we suggest copying the file
 instead.  This leaves the original file (with documentation) in the


### PR DESCRIPTION
Running `ln -s mods-available/foo mods-enabled/foo` will result in a dead link: `mods-enabled/foo` will point to `mods-enabled/mods-available/foo`, which doesn't exist. That is because the link is relative from its own location, not from the current directory at the time of its creation.

The easiest method that also allows using tab completion is to link from within `mods-enabled`. The second parameter to `ln` can be left off in that case, as well. This is the change I have proposed. Another alternative would be to run `ln -s ../mods-available/foo mods-enabled/foo` from the `raddb` directory.