### PR TITLE
Add --disable-openssl-compat-check configure option

### DIFF
--- a/configure
+++ b/configure
@@ -757,6 +757,7 @@ with_openssl
 with_openssl_lib_dir
 with_openssl_include_dir
 enable_openssl_version_check
+enable_openssl_compat_check
 with_talloc_lib_dir
 with_talloc_include_dir
 with_pcap_lib_dir
@@ -1404,6 +1405,9 @@ Optional Features:
   --enable-werror         causes the build to fail if any warnings are generated.
   --disable-openssl-version-check
                           disable vulnerable OpenSSL version check
+
+  --disable-openssl-compat-check
+                          disable built/linked OpenSSL compatibility check
 
 
 Optional Packages:
@@ -5466,6 +5470,17 @@ else
   openssl_version_check_config=
 fi
 
+
+# Check whether --enable-openssl-compat-check was given.
+if test "${enable_openssl_compat_check+set}" = set; then :
+  enableval=$enable_openssl_compat_check;
+fi
+
+if test "x$enable_openssl_compat_check" != "xno"; then
+
+$as_echo "#define ENABLE_OPENSSL_COMPAT_CHECK 1" >>confdefs.h
+
+fi
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -597,6 +597,18 @@ else
 fi
 AC_SUBST([openssl_version_check_config])
 
+dnl #
+dnl #  extra argument: --disable-openssl-compat-check
+dnl #
+AC_ARG_ENABLE(openssl-compat-check,
+[AS_HELP_STRING([--disable-openssl-compat-check],
+                [disable built/linked OpenSSL compatibility check])]
+)
+if test "x$enable_openssl_compat_check" != "xno"; then
+  AC_DEFINE(ENABLE_OPENSSL_COMPAT_CHECK, [1],
+            [Define to 1 to have built/linked OpenSSL compatibility check enabled])
+fi
+
 
 dnl #############################################################
 dnl #

--- a/src/include/autoconf.h.in
+++ b/src/include/autoconf.h.in
@@ -9,6 +9,9 @@
 /* style of ctime_r function */
 #undef CTIMERSTYLE
 
+/* Define to 1 to have built/linked OpenSSL compatibility check enabled */
+#undef ENABLE_OPENSSL_COMPAT_CHECK
+
 /* Define to 1 to have OpenSSL version check enabled */
 #undef ENABLE_OPENSSL_VERSION_CHECK
 

--- a/src/include/radiusd.h
+++ b/src/include/radiusd.h
@@ -460,7 +460,9 @@ void		pairlist_free(PAIR_LIST **);
 
 /* version.c */
 int		rad_check_lib_magic(uint64_t magic);
+#ifdef ENABLE_OPENSSL_COMPAT_CHECK
 int 		ssl_check_consistency(void);
+#endif
 char const	*ssl_version_by_num(uint32_t version);
 char const	*ssl_version_num(void);
 char const	*ssl_version_range(uint32_t low, uint32_t high);

--- a/src/main/radiusd.c
+++ b/src/main/radiusd.c
@@ -280,7 +280,9 @@ int main(int argc, char *argv[])
 	 *  here than segfault later.
 	 */
 #ifdef HAVE_OPENSSL_CRYPTO_H
+#ifdef ENABLE_OPENSSL_COMPAT_CHECK
 	if (ssl_check_consistency() < 0) exit(EXIT_FAILURE);
+#endif
 #endif
 
 	if (flag && (flag != 0x03)) {

--- a/src/main/version.c
+++ b/src/main/version.c
@@ -36,6 +36,7 @@ char const	*radiusd_version_short = RADIUSD_VERSION_STRING;
 
 static long ssl_built = OPENSSL_VERSION_NUMBER;
 
+#ifdef ENABLE_OPENSSL_COMPAT_CHECK
 /** Check built and linked versions of OpenSSL match
  *
  * OpenSSL version number consists of:
@@ -82,6 +83,7 @@ int ssl_check_consistency(void)
 
 	return 0;
 }
+#endif /* ifdef ENABLE_OPENSSL_COMPAT_CHECK */
 
 /** Convert a version number to a text string
  *
@@ -178,9 +180,11 @@ char const *ssl_version(void)
 	return buffer;
 }
 #  else
+#ifdef ENABLE_OPENSSL_COMPAT_CHECK
 int ssl_check_consistency(void) {
 	return 0;
 }
+#endif
 
 char const *ssl_version_num(void)
 {


### PR DESCRIPTION
Add support for --disable-openssl-compat-check configure option, which
disables checking whether the linked OpenSSL (or related) libraries are
compatible with the ones FreeRADIUS was built with.

This is needed for distribution, which are tracking OpenSSL ABI changes
themselves and make sure shared library major and minor numbers change
if there is any breakage, thus ensuring incompatible applications and
libraries are not linked. That is also supported by the new OpenSSL
upstream policy to keep ABI compatible between "fix" and "patch"
version numbers.

See also https://bugzilla.redhat.com/show_bug.cgi?id=1299388