### PR TITLE
Relax OpenSSL permissions for default key files

### DIFF
--- a/raddb/certs/Makefile
+++ b/raddb/certs/Makefile
@@ -62,6 +62,7 @@ ca.key ca.pem: ca.cnf
 	@[ -f serial ] || $(MAKE) serial
 	$(OPENSSL) req -new -x509 -keyout ca.key -out ca.pem \
 		-days $(CA_DEFAULT_DAYS) -config ./ca.cnf
+	chmod g+r ca.key
 
 ca.der: ca.pem
 	$(OPENSSL) x509 -inform PEM -outform DER -in ca.pem -out ca.der
@@ -73,15 +74,18 @@ ca.der: ca.pem
 ######################################################################
 server.csr server.key: server.cnf
 	$(OPENSSL) req -new  -out server.csr -keyout server.key -config ./server.cnf
+	chmod g+r server.key
 
 server.crt: server.csr ca.key ca.pem
 	$(OPENSSL) ca -batch -keyfile ca.key -cert ca.pem -in server.csr  -key $(PASSWORD_CA) -out server.crt -extensions xpserver_ext -extfile xpextensions -config ./server.cnf
 
 server.p12: server.crt
 	$(OPENSSL) pkcs12 -export -in server.crt -inkey server.key -out server.p12  -passin pass:$(PASSWORD_SERVER) -passout pass:$(PASSWORD_SERVER)
+	chmod g+r server.p12
 
 server.pem: server.p12
 	$(OPENSSL) pkcs12 -in server.p12 -out server.pem -passin pass:$(PASSWORD_SERVER) -passout pass:$(PASSWORD_SERVER)
+	chmod g+r server.pem
 
 .PHONY: server.vrfy
 server.vrfy: ca.pem
@@ -95,15 +99,18 @@ server.vrfy: ca.pem
 ######################################################################
 client.csr client.key: client.cnf
 	$(OPENSSL) req -new  -out client.csr -keyout client.key -config ./client.cnf
+	chmod g+r client.key
 
 client.crt: client.csr ca.pem ca.key
 	$(OPENSSL) ca -batch -keyfile ca.key -cert ca.pem -in client.csr  -key $(PASSWORD_CA) -out client.crt -extensions xpclient_ext -extfile xpextensions -config ./client.cnf
 
 client.p12: client.crt
 	$(OPENSSL) pkcs12 -export -in client.crt -inkey client.key -out client.p12  -passin pass:$(PASSWORD_CLIENT) -passout pass:$(PASSWORD_CLIENT)
+	chmod g+r client.p12
 
 client.pem: client.p12
 	$(OPENSSL) pkcs12 -in client.p12 -out client.pem -passin pass:$(PASSWORD_CLIENT) -passout pass:$(PASSWORD_CLIENT)
+	chmod g+r client.pem
 	cp client.pem $(USER_NAME).pem
 
 .PHONY: client.vrfy


### PR DESCRIPTION
Recent versions of OpenSSL appear to create keys with owner-only
permissions. Allow owning group to read the created default key files
in raddb/certs, so that they stay the same as with older OpenSSL, and
that the server can read its key.