### PR TITLE
Ignore non http version headers in init state

### DIFF
--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -1556,6 +1556,12 @@ static size_t rest_response_header(void *in, size_t size, size_t nmemb, void *us
 	case WRITE_STATE_INIT:
 		RDEBUG2("Processing response header");
 
+		/**
+		* Ignore other headers since we are looking for only http version header
+		* in this state.
+		*/
+		if (strncasecmp("HTTP", p, 4) != 0) return t;
+
 		/*
 		 *  HTTP/<version> <reason_code>[ <reason_phrase>]\r\n
 		 *


### PR DESCRIPTION
Version: FreeRadius 3.0.x
Issue: Some servers return server name and date headers along with http version header. It is throwing out freeradius rest server. While in init state, ignore other headers.