### PR TITLE
Add Attribute 3076/85 (CVPN3000-Tunnel-Group-Lock)

### DIFF
--- a/share/dictionary.cisco.vpn3000
+++ b/share/dictionary.cisco.vpn3000
@@ -1,5 +1,5 @@
 # -*- text -*-
-# Copyright (C) 2015 The FreeRADIUS Server project and contributors
+# Copyright (C) 2017 The FreeRADIUS Server project and contributors
 #
 #	 Cisco VPN 3000 Concentrator Dictionary
 #
@@ -84,6 +84,7 @@ ATTRIBUTE	CVPN3000-WebVPN-Exchange-Addr		74	string
 ATTRIBUTE	CVPN3000-LEAP-Bypass			75	integer
 ATTRIBUTE	CVPN3000-WebVPN-Exchange-NETBIOS-name	78	string
 ATTRIBUTE	CVPN3000-Port-Forwarding-Name		79	string
+ATTRIBUTE	CVPN3000-Tunnel-Group-Lock		85	string
 ATTRIBUTE	CVPN3000-Partition-Primary-DHCP		128	ipaddr
 ATTRIBUTE	CVPN3000-Partition-Secondary-DHCP	129	ipaddr
 ATTRIBUTE	CVPN3000-Partition-Premise-Router	131	ipaddr


### PR DESCRIPTION
Added Dictionary Attribute for Cisco Tunnel-Group-Lock, according to:
http://www.cisco.com/c/en/us/support/docs/security/ios-easy-vpn/117634-configure-asa-00.html