### PR TITLE
FreeRADIUS fails to build on systems with LibreSSL.

### DIFF
--- a/src/main/tls/session.c
+++ b/src/main/tls/session.c
@@ -1021,7 +1021,7 @@ do { \
 	 *	Only add extensions for the actual client certificate
 	 */
 	if (attr_index == 0) {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 		ext_list = X509_get0_extensions(cert);
 #else
 		ext_list = cert->cert_info->extensions;


### PR DESCRIPTION
FreeRADIUS tries to link against function X509_get0_extensions() that does
not exist on LibreSSL, so the following "if" clause does not work
correct for LibreSSL, since OpenSSL has a defined macro
OPENSSL_VERSION_NUMBER for LibreSSL bigger than
0x10100000, and does not have X509_get0_extensions():

 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
                ext_list = X509_get0_extensions(client_cert);

This patch guarantee that this check is not valid for LibreSSL, thus,
using the fall back.