### PR TITLE
fix .deb patch script so that it applies to 4.0.x

### DIFF
--- a/debian/patches/disable-dhcp-bydefault.diff
+++ b/debian/patches/disable-dhcp-bydefault.diff
@@ -1,10 +1,12 @@
 diff a/raddb/all.mk b/raddb/all.mk
---- a/raddb/all.mk
-+++ b/raddb/all.mk
+Index: freeradius-server/raddb/all.mk
+===================================================================
+--- freeradius-server.orig/raddb/all.mk
++++ freeradius-server/raddb/all.mk
 @@ -8,7 +8,7 @@ DEFAULT_SITES :=	default inner-tunnel
  LOCAL_SITES :=		$(addprefix raddb/sites-enabled/,$(DEFAULT_SITES))
-
- DEFAULT_MODULES :=	always attr_filter cache_eap chap \
+ 
+ DEFAULT_MODULES :=	always attr_filter cache_eap chap client \
 -			detail detail.log digest dhcp dynamic_clients eap \
 +			detail detail.log digest dynamic_clients eap \
  			eap_inner echo exec expiration expr files linelog logintime \


### PR DESCRIPTION
Just fixes up debian package generation. 
`make deb` would fail with 
```
Applying patch disable-dhcp-bydefault.diff
patching file raddb/all.mk
Hunk #1 FAILED at 8.
1 out of 1 hunk FAILED -- rejects in file raddb/all.mk
Patch disable-dhcp-bydefault.diff does not apply (enforce with -f)
/usr/share/quilt/quilt.make:16: recipe for target 'debian/stamp-patched' failed
make[1]: *** [debian/stamp-patched] Error 1
make[1]: Leaving directory '/home/mattrose/github/freeradius-server'
dpkg-buildpackage: error: debian/rules build gave error exit status 2
Makefile:312: recipe for target 'deb' failed
make: *** [deb] Error 2
```