### PR TITLE
stopped rotation of the session database files

### DIFF
--- a/redhat/freeradius-logrotate
+++ b/redhat/freeradius-logrotate
@@ -25,13 +25,6 @@ delaycompress
 }
 
 #
-#  Session database modules
-#
-/var/log/radius/radutmp /var/log/radius/radwtmp {
-	nocreate
-}
-
-#
 #  SQL log files
 #
 /var/log/radius/sqllog.sql {


### PR DESCRIPTION
you really don't want to be rotating these under the server - they are not normal log files but are stateful session files (used by various utilities). these were removed from the logrotate some time ago but appear to have crept back in.