### PR TITLE
stop rotation of the session database files

### DIFF
--- a/debian/freeradius.logrotate
+++ b/debian/freeradius.logrotate
@@ -26,13 +26,6 @@ notifempty
 }
 
 #
-#  Session database modules
-#
-/var/log/freeradius/radutmp /var/log/freeradius/radwtmp {
-	nocreate
-}
-
-#
 #  SQL log files
 #
 /var/log/freeradius/sqllog.sql {

--- a/redhat/freeradius-logrotate
+++ b/redhat/freeradius-logrotate
@@ -25,13 +25,6 @@ delaycompress
 }
 
 #
-#  Session database modules
-#
-/var/log/radius/radutmp /var/log/radius/radwtmp {
-	nocreate
-}
-
-#
 #  SQL log files
 #
 /var/log/radius/sqllog.sql {

--- a/scripts/logrotate/freeradius
+++ b/scripts/logrotate/freeradius
@@ -29,13 +29,6 @@ notifempty
 }
 
 #
-#  Session database modules
-#
-/var/log/radius/radutmp /var/log/radius/radwtmp {
-	nocreate
-}
-
-#
 #  SQL log files
 #
 /var/log/radius/sqllog.sql {

--- a/suse/radiusd-logrotate
+++ b/suse/radiusd-logrotate
@@ -28,14 +28,6 @@ notifempty
 }
 
 #
-#  Session database modules
-#
-/var/log/radius/radutmp /var/log/radius/radwtmp {
-	nocreate
-	size=+2048k
-}
-
-#
 #  SQL log files
 #
 /var/log/radius/sqllog.sql {


### PR DESCRIPTION
you really don't want to be rotating these under the server - they are
not normal log files but are stateful session files (used by various
utilities). these were removed from the logrotate some time ago but
appear to have crept back in.