### PR TITLE
remove Reply-Message from Access-Challenge if EAP-Message

### DIFF
--- a/raddb/sites-available/default
+++ b/raddb/sites-available/default
@@ -817,6 +817,15 @@ post-auth {
 		#  Remove reply message if the response contains an EAP-Message
 		remove_reply_message_if_eap
 	}
+
+        #
+        #  Filter access challenges.
+        #
+        Post-Auth-Type Challenge {
+#               remove_reply_message_if_eap
+#               attr_filter.access_challenge.post-auth
+        }
+
 }
 
 #


### PR DESCRIPTION
RFC 3579 doesn't allow Reply-Message if EAP-Message exists..which it
may in Access-Challenge.
We already do a basic filter in the Auth-Type EAP but thats to match
2865 and gets a little tricky/messy if its not an
EAP challenge-response..so best cleared up here.