### PR TITLE
Use Framed-MTU value correctly

### DIFF
--- a/src/include/radiusd.h
+++ b/src/include/radiusd.h
@@ -432,6 +432,7 @@ void		rad_suid_set_down_uid(uid_t uid);
 void		rad_suid_down(void);
 void		rad_suid_up(void);
 void		rad_suid_down_permanent(void);
+size_t		rad_eap_calculate_mtu(size_t fragment_size, REQUEST *request);
 /* regex.c */
 
 #ifdef HAVE_REGEX

--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -566,7 +566,6 @@ tls_session_t *tls_new_session(TALLOC_CTX *ctx, fr_tls_server_conf_t *conf, REQU
 	tls_session_t	*state = NULL;
 	SSL		*new_tls = NULL;
 	int		verify_mode = 0;
-	VALUE_PAIR	*vp;
 
 	rad_assert(request != NULL);
 
@@ -668,11 +667,7 @@ tls_session_t *tls_new_session(TALLOC_CTX *ctx, fr_tls_server_conf_t *conf, REQU
 	 *	of EAP-TLS in order to calculate fragment sizes is
 	 *	just too much.
 	 */
-	state->mtu = conf->fragment_size;
-	vp = fr_pair_find_by_num(request->packet->vps, PW_FRAMED_MTU, 0, TAG_ANY);
-	if (vp && (vp->vp_integer > 100) && (vp->vp_integer < state->mtu)) {
-		state->mtu = vp->vp_integer;
-	}
+	state->mtu = rad_eap_calculate_mtu(conf->fragment_size, request);
 
 	if (conf->session_cache_enable) state->allow_session_resumption = true; /* otherwise it's false */
 

--- a/src/modules/rlm_eap/types/rlm_eap_pwd/rlm_eap_pwd.c
+++ b/src/modules/rlm_eap/types/rlm_eap_pwd/rlm_eap_pwd.c
@@ -172,7 +172,6 @@ static int mod_session_init (void *instance, eap_handler_t *handler)
 {
 	pwd_session_t *session;
 	eap_pwd_t *inst = (eap_pwd_t *)instance;
-	VALUE_PAIR *vp;
 	pwd_id_packet_t *packet;
 
 	if (!inst || !handler) {
@@ -220,21 +219,7 @@ static int mod_session_init (void *instance, eap_handler_t *handler)
 	/*
 	 *	The admin can dynamically change the MTU.
 	 */
-	session->mtu = inst->fragment_size;
-	vp = fr_pair_find_by_num(handler->request->packet->vps, PW_FRAMED_MTU, 0, TAG_ANY);
-
-	/*
-	 *	session->mtu is *our* MTU.  We need to subtract off the EAP
-	 *	overhead.
-	 *
-	 *	9 = 4 (EAPOL header) + 4 (EAP header) + 1 (EAP type)
-	 *
-	 *	The fragmentation code deals with the included length
-	 *	so we don't need to subtract that here.
-	 */
-	if (vp && (vp->vp_integer > 100) && (vp->vp_integer < session->mtu)) {
-		session->mtu = vp->vp_integer - 9;
-	}
+	session->mtu = rad_eap_calculate_mtu(inst->fragment_size, handler->request);
 
 	session->state = PWD_STATE_ID_REQ;
 	session->in = NULL;


### PR DESCRIPTION
Framed-MTU holds full packet length rather than EAP-Message payload size.
Calculate maximum EAP-Message payload based on Framed-MTU value correctly
to ensure IP fragment-free authentication.

This pull request is a proof of concept that is tested in my lab. Will do patches for 3.1 and 4.0 once this one is discussed and merged.