### PR TITLE
updated ldap default config

### DIFF
--- a/raddb/mods-available/ldap
+++ b/raddb/mods-available/ldap
@@ -451,7 +451,7 @@ ldap {
 		#  failures) default: 10
 		#
 		#  LDAP_OPT_NETWORK_TIMEOUT is set to this value.
-		net_timeout = 1
+		#net_timeout = 1
 
 		#  LDAP_OPT_X_KEEPALIVE_IDLE
 		idle = 60
@@ -469,7 +469,7 @@ ldap {
 		#
 		#	default: 0x0000 (no debugging messages)
 		#	Example:(LDAP_DEBUG_FILTER+LDAP_DEBUG_CONNS)
-		ldap_debug = 0x0028
+		#ldap_debug = 0x0028
 	}
 
 	#


### PR DESCRIPTION
net_timeout has a default setting of 10 in the code but the enabled value in the default config is 1 - therefore
the 'default' would be , for users, 1 - so commented out. users can enable it to change.
likewise, same for ldap_debug - 'default' is 0x0000 but it had a preconfigured value of 0x0028 - so commented
out so default is in play and admins can choose to change it.