### PR TITLE
Fix memory leak in trustrouter.c

### DIFF
--- a/src/include/tls-h
+++ b/src/include/tls-h
@@ -308,6 +308,7 @@ tls_session_t	*tls_new_session(TALLOC_CTX *ctx, fr_tls_server_conf_t *conf, REQU
 tls_session_t	*tls_new_client_session(TALLOC_CTX *ctx, fr_tls_server_conf_t *conf, int fd);
 fr_tls_server_conf_t *tls_server_conf_parse(CONF_SECTION *cs);
 fr_tls_server_conf_t *tls_client_conf_parse(CONF_SECTION *cs);
+fr_tls_server_conf_t *tls_server_conf_alloc(TALLOC_CTX *ctx);
 SSL_CTX		*tls_init_ctx(fr_tls_server_conf_t *conf, int client);
 int 		tls_handshake_recv(REQUEST *, tls_session_t *ssn);
 int 		tls_handshake_send(REQUEST *, tls_session_t *ssn);

--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -3104,7 +3104,7 @@ static int _tls_server_conf_free(fr_tls_server_conf_t *conf)
 	return 0;
 }
 
-static fr_tls_server_conf_t *tls_server_conf_alloc(TALLOC_CTX *ctx)
+fr_tls_server_conf_t *tls_server_conf_alloc(TALLOC_CTX *ctx)
 {
 	fr_tls_server_conf_t *conf;
 

--- a/src/modules/rlm_realm/trustrouter.c
+++ b/src/modules/rlm_realm/trustrouter.c
@@ -70,7 +70,7 @@ static fr_tls_server_conf_t *construct_tls(TIDC_INSTANCE *inst,
 	char *hexbuf = NULL;
 	DH *aaa_server_dh;
 
-	tls = talloc_zero( hs, fr_tls_server_conf_t);
+	tls = fr_tls_server_conf_alloc(hs);
 	if (!tls) return NULL;
 
 	aaa_server_dh = tid_srvr_get_dh(server);


### PR DESCRIPTION
In the trustrouter.c file, servers were being created using
talloc_zero() instead of tls_server_conf_alloc(). Thus, the
destructor _tls_server_conf_free() which frees the SSL_CTX
object was not being called.