### PR TITLE
Fix typo in previous commit

### DIFF
--- a/src/modules/rlm_realm/trustrouter.c
+++ b/src/modules/rlm_realm/trustrouter.c
@@ -70,7 +70,7 @@ static fr_tls_server_conf_t *construct_tls(TIDC_INSTANCE *inst,
 	char *hexbuf = NULL;
 	DH *aaa_server_dh;
 
-	tls = fr_tls_server_conf_alloc(hs);
+	tls = tls_server_conf_alloc(hs);
 	if (!tls) return NULL;
 
 	aaa_server_dh = tid_srvr_get_dh(server);


### PR DESCRIPTION
I made a mistake in the call, that should be "tls_server_conf_alloc" and not "fr_tls_server_conf_alloc".
