### PR TITLE
Add SQL backing to Moonshot-*-TargetedId generation

### DIFF
--- a/raddb/mods-available/moonshot-targeted-ids
+++ b/raddb/mods-available/moonshot-targeted-ids
@@ -1,0 +1,53 @@
+# -*- text -*-
+#
+#  $Id$
+
+#
+#  Write Moonshot-*-TargetedId to the database.
+#
+#  Schema	raddb/sql/moonshot-targeted-ids/<DB>/schema.sql
+#  Queries	raddb/sql/moonshot-targeted-ids/<DB>/queries.conf
+#
+sql moonshot_tid_sql {
+
+	# The dialect of SQL you want to use, this should usually match
+	# the driver below.
+	#
+	# If you're using rlm_sql_null, then it should be the type of
+	# database the logged queries are going to be executed against.
+	dialect = "sqlite"
+
+	# The sub-module to use to execute queries. This should match
+	# the database you're attempting to connect to.
+	#
+	# There are CUI queries available for:
+	#    * rlm_sql_mysql
+	#    * rlm_sql_postgresql
+	#    * rlm_sql_sqlite
+	#    * rlm_sql_null (log queries to disk)
+	#
+	driver = "rlm_sql_${dialect}"
+
+	sqlite {
+		filename = ${radacctdir}/moonshot-targeted-ids.sqlite
+		bootstrap = ${modconfdir}/${..:name}/moonshot-targeted-ids/sqlite/schema.sql
+	}
+
+	# Write CUI queries to a logfile. Useful for debugging.
+#	logfile = ${logdir}/cuilog.sql
+
+	pool {
+		start = 5
+		min = 4
+		max = 10
+		spare = 3
+		uses = 0
+		lifetime = 0
+		idle_timeout = 60
+	}
+
+	moonshot_tid_table = "moonshot-targeted-ids"
+	sql_user_name = "%{User-Name}"
+
+	$INCLUDE ${modconfdir}/${.:name}/moonshot-targeted-ids/${dialect}/queries.conf
+}

--- a/raddb/mods-available/moonshot-targeted-ids
+++ b/raddb/mods-available/moonshot-targeted-ids
@@ -3,7 +3,7 @@
 #  $Id$
 
 #
-#  Write Moonshot-*-TargetedId to the database.
+#  Write Moonshot-*-TargetedId (MSTID) to the database.
 #
 #  Schema	raddb/sql/moonshot-targeted-ids/<DB>/schema.sql
 #  Queries	raddb/sql/moonshot-targeted-ids/<DB>/queries.conf
@@ -20,7 +20,7 @@ sql moonshot_tid_sql {
 	# The sub-module to use to execute queries. This should match
 	# the database you're attempting to connect to.
 	#
-	# There are CUI queries available for:
+	# There are MSTID queries available for:
 	#    * rlm_sql_mysql
 	#    * rlm_sql_postgresql
 	#    * rlm_sql_sqlite
@@ -33,8 +33,8 @@ sql moonshot_tid_sql {
 		bootstrap = ${modconfdir}/${..:name}/moonshot-targeted-ids/sqlite/schema.sql
 	}
 
-	# Write CUI queries to a logfile. Useful for debugging.
-#	logfile = ${logdir}/cuilog.sql
+	# Write MSTID queries to a logfile. Useful for debugging.
+#	logfile = ${logdir}/moonshot-targeted-id-log.sql
 
 	pool {
 		start = 5
@@ -46,7 +46,11 @@ sql moonshot_tid_sql {
 		idle_timeout = 60
 	}
 
-	moonshot_tid_table = "moonshot-targeted-ids"
+	#  If you adjust the table name here, you must also modify the table name in
+	#  the moonshot_get_targeted_id.post-auth policy in policy.d/moonshot-targeted-ids
+	#  and the schema.sql files in the mods-config/sql/moonshot-targeted-ids tree.
+	#
+	moonshot_tid_table = "moonshot_targeted_ids"
 	sql_user_name = "%{User-Name}"
 
 	$INCLUDE ${modconfdir}/${.:name}/moonshot-targeted-ids/${dialect}/queries.conf

--- a/raddb/mods-config/sql/moonshot-targeted-ids/mysql/queries.conf
+++ b/raddb/mods-config/sql/moonshot-targeted-ids/mysql/queries.conf
@@ -1,13 +1,13 @@
 # -*- text -*-
 #
-#  moonshot-targeted-ids/sqlite/queries.conf -- Queries to update a sqlite Moonshot-*-Targeted-Ids table.
+#  moonshot-targeted-ids/mysql/queries.conf -- Queries to update a MySQL Moonshot-Targeted-Ids table.
 #
 #  $Id$
 
 post-auth {
 	#  Query to store the Moonshot-*-TargetedId
 	query = "\
-		INSERT INTO ${..moonshot_tid_table} \
+		INSERT IGNORE INTO ${..moonshot_tid_table} \
 			(gss_acceptor, namespace, username, targeted_id) \
 		VALUES \
 			('%{control:Moonshot-MSTID-GSS-Acceptor}', '%{control:Moonshot-MSTID-Namespace}', \

--- a/raddb/mods-config/sql/moonshot-targeted-ids/mysql/schema.sql
+++ b/raddb/mods-config/sql/moonshot-targeted-ids/mysql/schema.sql
@@ -5,4 +5,4 @@ CREATE TABLE `moonshot_targeted_ids` (
   `targeted_id` varchar(128) NOT NULL default '',
   `creationdate` timestamp NOT NULL default CURRENT_TIMESTAMP,
   PRIMARY KEY  (`username`,`gss_acceptor`,`namespace`)
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/raddb/mods-config/sql/moonshot-targeted-ids/postgresql/queries.conf
+++ b/raddb/mods-config/sql/moonshot-targeted-ids/postgresql/queries.conf
@@ -1,6 +1,6 @@
 # -*- text -*-
 #
-#  moonshot-targeted-ids/sqlite/queries.conf -- Queries to update a sqlite Moonshot-*-Targeted-Ids table.
+#  moonshot-targeted-ids/postgresql/queries.conf -- Queries to update a PostgreSQL Moonshot-*-Targeted-Ids table.
 #
 #  $Id$
 

--- a/raddb/mods-config/sql/moonshot-targeted-ids/postgresql/schema.sql
+++ b/raddb/mods-config/sql/moonshot-targeted-ids/postgresql/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE moonshot_targeted_ids (
+  gss_acceptor varchar(254) NOT NULL DEFAULT '',
+  namespace varchar(36) NOT NULL DEFAULT '',
+  username varchar(64) NOT NULL DEFAULT '',
+  targeted_id varchar(128) NOT NULL DEFAULT '',
+  creationdate TIMESTAMP with time zone NOT NULL default 'now()',
+  PRIMARY KEY  (username, gss_acceptor, namespace)
+);

--- a/raddb/mods-config/sql/moonshot-targeted-ids/sqlite/queries.conf
+++ b/raddb/mods-config/sql/moonshot-targeted-ids/sqlite/queries.conf
@@ -1,0 +1,15 @@
+# -*- text -*-
+#
+#  moonshot-targeted-ids/sqlite/queries.conf -- Queries to update a sqlite Moonshot-*-Targeted-Ids table.
+#
+#  $Id$
+
+post-auth {
+	#  Query to store the Moonshot-*-TargetedId
+	query = "\
+		INSERT INTO `${..moonshot_tid_table}` \
+			(gss_acceptor, namespace, username, targeted_id) \
+		VALUES \
+			('%{control:Moonshot-MSTID-GSS-Acceptor}', '%{control:Moonshot-MSTID-Namespace}', \
+			'%{tolower:%{User-Name}}', '%{control:Moonshot-MSTID-TargetedId}')"
+}

--- a/raddb/mods-config/sql/moonshot-targeted-ids/sqlite/schema.sql
+++ b/raddb/mods-config/sql/moonshot-targeted-ids/sqlite/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `moonshot-targeted-ids` (
+  `gss_acceptor` varchar(254) NOT NULL default '',
+  `namespace` varchar(36) NOT NULL default '',
+  `username` varchar(64) NOT NULL default '',
+  `targeted_id` varchar(128) NOT NULL default '',
+  `creationdate` timestamp NOT NULL default CURRENT_TIMESTAMP,
+  PRIMARY KEY  (`username`,`gss_acceptor`,`namespace`)
+);

--- a/raddb/policy.d/moonshot-targeted-ids
+++ b/raddb/policy.d/moonshot-targeted-ids
@@ -8,6 +8,9 @@
 #  Moonshot-Host-TargetedId (138)
 #  Moonshot-Realm-TargetedId (139)
 #  Moonshot-TR-COI-TargetedId (140)
+#  Moonshot-MSTID-GSS-Acceptor (141)
+#  Moonshot-MSTID-Namespace (142)
+#  Moonshot-MSTID-TargetedId (143)
 #
 #  These attributes should also be listed in the attr_filter policies
 #  post-proxy and pre-proxy when you use attribute filtering:
@@ -35,63 +38,194 @@ moonshot_host_namespace = 'a574a04e-b7ff-4850-aa24-a8599c7de1c6'
 moonshot_realm_namespace = 'dea5f26d-a013-4444-977d-d09fc990d2e6'
 moonshot_coi_namespace = '145d7e7e-7d54-43ee-bbcb-3c6ad9428247'
 
-#  This policy generates a host-specific targeted ID
+
+#  This policy generates a host-specific TargetedId
 #
 moonshot_host_tid.post-auth {
-	#  generate a UUID for Moonshot-Host-TargetedId
-	#  targeted id = (uuid -v 5 [namespace] [username][salt][RP host name])@[IdP realm name]
+	#  retrieve or generate a UUID for Moonshot-Host-TargetedId
 	if (&outer.request:GSS-Acceptor-Host-Name) {
-		if ("%{echo:/usr/bin/uuid -v 5 ${policy.moonshot_host_namespace} %{tolower:%{User-Name}}${policy.targeted_id_salt}%{tolower:%{outer.request:GSS-Acceptor-Host-Name}}}" =~ /^([^ ]+)([ ]*)$/) {
+		# prep some variables (used regardless of SQL backing or not!)
+		update control {
+			Moonshot-MSTID-GSS-Acceptor := "%{tolower:%{outer.request:GSS-Acceptor-Host-Name}}"
+			Moonshot-MSTID-Namespace := "${policy.moonshot_host_namespace}"
+		}
+
+		#  if you want to use SQL-based backing, remove the comment from
+		#  this line. You also have to configure and enable the 
+		#  moonshot-targeted-ids sql module in mods-enabled. 
+		#
+#		moonshot_get_targeted_id
+
+		#  generate a UUID for Moonshot-Host-TargetedId
+		if (!&control:Moonshot-MSTID-TargetedId) {
+			#  generate the TID
+			moonshot_make_targeted_id
+
+			#  if you want to store your TargetedId in SQL-based backing, 
+			#  remove the comment from this line. You also have to configure 
+			#  and enable the moonshot-targeted-ids sql module in mods-enabled.
+			#
+#			moonshot_tid_sql
+		}
+
+		#  set the actual TargetedId in the session-state list
+		if (&control:Moonshot-MSTID-TargetedId) {
 			update outer.session-state {
-				Moonshot-Host-TargetedId := "%{1}@%{tolower:%{request:Realm}}"
+				Moonshot-Host-TargetedId := &control:Moonshot-MSTID-TargetedId
 			}
-			if (&outer.session-state:Moonshot-Host-TargetedId =~ /([\%\{\}]+)/) {
-				update outer.session-state {
-					Moonshot-Host-TargetedId !* ANY
-					Module-Failure-Message = 'Invalid Moonshot-Host-TargetedId, check your targeted_id_salt!'
-				}
-				reject
+			update control {
+				Moonshot-MSTID-TargetedId !* ANY
 			}
 		}
 	}
 }
-#  This policy generates a realm-specific targeted ID
+
+#  This policy generates a realm-specific TargetedId
 #
 moonshot_realm_tid.post-auth {
-	#  generate a UUID for Moonshot-Realm-TargetedId
-	#  targeted id = (uuid -v 5 [namespace] [username][salt][RP realm name])@[IdP realm name]
+	#  retrieve or generate a UUID for Moonshot-Realm-TargetedId
 	if (&outer.request:GSS-Acceptor-Realm-Name) {
-		if ("%{echo:/usr/bin/uuid -v 5 ${policy.moonshot_realm_namespace} %{tolower:%{User-Name}}${policy.targeted_id_salt}%{tolower:%{outer.request:GSS-Acceptor-Realm-Name}}}" =~ /^([^ ]+)([ ]*)$/) {
+		# prep some variables (used regardless of SQL backing or not!)
+		update control {
+			Moonshot-MSTID-GSS-Acceptor := "%{tolower:%{outer.request:GSS-Acceptor-Realm-Name}}"
+			Moonshot-MSTID-Namespace := "${policy.moonshot_realm_namespace}"
+		}
+
+		#  if you want to use SQL-based backing, remove the comment from
+		#  this line. You also have to configure and enable the 
+		#  moonshot-targeted-ids sql module in mods-enabled. 
+		#
+#		moonshot_get_targeted_id
+
+		#  generate a UUID for Moonshot-Realm-TargetedId
+		if (!&control:Moonshot-MSTID-TargetedId) {
+			#  generate the TID
+			moonshot_make_targeted_id
+
+			#  if you want to store your TargetedId in SQL-based backing, 
+			#  remove the comment from this line. You also have to configure 
+			#  and enable the moonshot-targeted-ids sql module in mods-enabled.
+			#
+#			moonshot_tid_sql
+		}
+
+		#  set the actual TargetedId in the session-state list
+		if (&control:Moonshot-MSTID-TargetedId) {
 			update outer.session-state {
-				Moonshot-Realm-TargetedId := "%{1}@%{tolower:%{request:Realm}}"
+				Moonshot-Realm-TargetedId := &control:Moonshot-MSTID-TargetedId
 			}
-			if (&outer.session-state:Moonshot-Realm-TargetedId =~ /([\%\{\}]+)/) {
-				update outer.session-state {
-					Moonshot-Realm-TargetedId !* ANY
-					Module-Failure-Message = 'Invalid Moonshot-Realm-TargetedId, check your targeted_id_salt!'
-				}
-				reject
+			update control {
+				Moonshot-MSTID-TargetedId !* ANY
 			}
 		}
 	}
 }
+
 #  This policy generates a COI-specific targeted ID
 #
 moonshot_coi_tid.post-auth {
-	#  generate a UUID for Moonshot-TR-COI-TargetedId
-	#  targeted id = (uuid -v 5 [namespace] [username][salt][RP COI name])@[IdP realm name]
+	#  retrieve or generate a UUID for Moonshot-TR-COI-TargetedId
 	if (&outer.request:Trust-Router-COI) {
-		if ("%{echo:/usr/bin/uuid -v 5 ${policy.moonshot_coi_namespace} %{tolower:%{User-Name}}${policy.targeted_id_salt}%{tolower:%{outer.request:Trust-Router-COI}}}" =~ /^([^ ]+)([ ]*)$/) {
+		# prep some variables (used regardless of SQL backing or not!)
+		update control {
+			Moonshot-MSTID-GSS-Acceptor := "%{tolower:%{outer.request:Trust-Router-COI}}"
+			Moonshot-MSTID-Namespace := "${policy.moonshot_coi_namespace}"
+		}
+
+		#  if you want to use SQL-based backing, remove the comment from
+		#  this line. You also have to configure and enable the 
+		#  moonshot-targeted-ids sql module in mods-enabled. 
+		#
+#		moonshot_get_targeted_id
+
+		#  generate a UUID for Moonshot-TR-COI-TargetedId
+		if (!&control:Moonshot-MSTID-TargetedId) {
+			#  generate the TID
+			moonshot_make_targeted_id
+
+			#  if you want to store your TargetedId in SQL-based backing, 
+			#  remove the comment from this line. You also have to configure 
+			#  and enable the moonshot-targeted-ids sql module in mods-enabled.
+			#
+#			moonshot_tid_sql
+		}
+
+		#  set the actual TargetedId in the session-state list
+		if (&control:Moonshot-MSTID-TargetedId) {
 			update outer.session-state {
-				Moonshot-TR-COI-TargetedId := "%{1}@%{tolower:%{request:Realm}}"
+				Moonshot-TR-COI-TargetedId := &control:Moonshot-MSTID-TargetedId
 			}
-			if (&outer.session-state:Moonshot-TR-COI-TargetedId =~ /([\%\{\}]+)/) {
+			update control {
+				Moonshot-MSTID-TargetedId !* ANY
+			}
+		}
+	}
+}
+
+#  This is the generic generation policy. It requires moonshot_host_tid, moonshot_realm_tid, or moonshot_coi_tid to set variables
+#
+moonshot_make_targeted_id.post-auth {
+	#  uses variables set in the control list
+	#
+	if (&control:Moonshot-MSTID-Namespace && &control:Moonshot-MSTID-GSS-Acceptor) {
+		#  targeted id = (uuid -v 5 [namespace] [username][salt][GSS acceptor value])@[IdP realm name]
+		#
+		if ("%{echo:/usr/bin/uuid -v 5 %{control:Moonshot-MSTID-Namespace} %{tolower:%{User-Name}}${policy.targeted_id_salt}%{control:Moonshot-MSTID-GSS-Acceptor}}" =~ /^([^ ]+)([ ]*)$/) {
+			update control {
+				Moonshot-MSTID-TargetedId := "%{1}@%{tolower:%{request:Realm}}"
+			}
+			if (&control:Moonshot-MSTID-TargetedId =~ /([\%\{\}]+)/) {
+				update control {
+					Moonshot-MSTID-TargetedId !* ANY
+				}
 				update outer.session-state {
-					Moonshot-TR-COI-TargetedId !* ANY
-					Module-Failure-Message = 'Invalid Moonshot-TR-COI-TargetedId, check your targeted_id_salt!'
+					Module-Failure-Message = 'Invalid TargetedId generated, check your targeted_id_salt!'
 				}
 				reject
 			}
 		}
+		else {
+			#  we simply return the 'echo' error message as the Module-Failure-Message, usually a lack of 'uuid'
+			reject
+		}
+	}
+	else {
+		#  Our variables were not set, so we'll throw an error because there's no point in continuing!
+		update outer.session-state {
+			Module-Failure-Message = 'Required variables for moonshot_make_targeted_id not set!'
+		}
+		reject
+	}
+}
+
+#  This is the generic generation policy. It requires moonshot_host_tid, moonshot_realm_tid, or moonshot_coi_tid to set variables
+#
+moonshot_get_targeted_id.post-auth {
+	#  uses variables set in the control list
+	#
+	if (&control:Moonshot-MSTID-Namespace && &control:Moonshot-MSTID-GSS-Acceptor) {
+		#  retrieve the TargetedId
+		#
+		update control {
+			Moonshot-MSTID-TargetedId := "%{moonshot_tid_sql:\
+				SELECT targeted_id FROM `moonshot-targeted-ids` \
+				WHERE gss_acceptor = '%{control:Moonshot-MSTID-GSS-Acceptor}' \
+				AND namespace = '%{control:Moonshot-MSTID-Namespace}' \
+				AND username = '%{tolower:%{User-Name}}'}"
+		}
+
+		#  if the value is empty, there's no point in setting it and delete it from the control list!
+		if (&control:Moonshot-MSTID-TargetedId == '') {
+			update control {
+				Moonshot-MSTID-TargetedId !* ANY
+			}
+		}
+	}
+	else {
+		#  Our variables were not set, so we'll throw an error because there's no point in continuing!
+		update outer.session-state {
+			Module-Failure-Message = 'Required variables for moonshot_get_targeted_id not set!'
+		}
+		reject
 	}
 }

--- a/raddb/policy.d/moonshot-targeted-ids
+++ b/raddb/policy.d/moonshot-targeted-ids
@@ -198,7 +198,7 @@ moonshot_make_targeted_id.post-auth {
 	}
 }
 
-#  This is the generic generation policy. It requires moonshot_host_tid, moonshot_realm_tid, or moonshot_coi_tid to set variables
+#  This is the generic retrieval policy. It requires moonshot_host_tid, moonshot_realm_tid, or moonshot_coi_tid to set variables
 #
 moonshot_get_targeted_id.post-auth {
 	#  uses variables set in the control list

--- a/raddb/policy.d/moonshot-targeted-ids
+++ b/raddb/policy.d/moonshot-targeted-ids
@@ -208,7 +208,7 @@ moonshot_get_targeted_id.post-auth {
 		#
 		update control {
 			Moonshot-MSTID-TargetedId := "%{moonshot_tid_sql:\
-				SELECT targeted_id FROM `moonshot-targeted-ids` \
+				SELECT targeted_id FROM moonshot_targeted_ids \
 				WHERE gss_acceptor = '%{control:Moonshot-MSTID-GSS-Acceptor}' \
 				AND namespace = '%{control:Moonshot-MSTID-Namespace}' \
 				AND username = '%{tolower:%{User-Name}}'}"

--- a/raddb/sites-available/inner-tunnel
+++ b/raddb/sites-available/inner-tunnel
@@ -317,7 +317,14 @@ post-auth {
 
 	#
 	#  Un-comment the following if you want to generate Moonshot (ABFAB) TargetedIds
-	#  IMPORTANT: This requires the UUID package to be installed!
+	#
+	#  IMPORTANT: This requires the UUID package to be installed, and a targeted_id_salt
+	#             to be configured.
+	#
+	#  This functionality also supports SQL backing. To use this functionality, enable
+	#  and configure the moonshot-targeted-ids SQL module in the mods-enabled directory.
+	#  Then remove the comments from the appropriate lines in each of the below
+	#  policies in the policy.d/moonshot-targeted-ids file.
 	#
 #	moonshot_host_tid
 #	moonshot_realm_tid

--- a/share/dictionary.ukerna
+++ b/share/dictionary.ukerna
@@ -21,5 +21,8 @@ ATTRIBUTE	Trust-Router-APC			137	string
 ATTRIBUTE	Moonshot-Host-TargetedId		138	string
 ATTRIBUTE	Moonshot-Realm-TargetedId		139	string
 ATTRIBUTE	Moonshot-TR-COI-TargetedId		140	string
+ATTRIBUTE	Moonshot-MSTID-GSS-Acceptor		141	string
+ATTRIBUTE	Moonshot-MSTID-Namespace		142	string
+ATTRIBUTE	Moonshot-MSTID-TargetedId		143	string
 
 END-VENDOR UKERNA


### PR DESCRIPTION
This gives some SQL backing to the Moonshot TargetedId generation policies.