### PR TITLE
Removed rlm_mruby from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ addons:
       - libldap2-dev
       - libluajit-5.1-dev
       - libmemcached-dev
+      - libmruby-dev
       - libmysqlclient-dev
       - libnl-genl-3-dev
       - libpam0g-dev

--- a/src/modules/rlm_mruby/rlm_mruby.c
+++ b/src/modules/rlm_mruby/rlm_mruby.c
@@ -434,7 +434,7 @@ static rlm_rcode_t CC_HINT(nonnull) do_mruby(REQUEST *request, rlm_mruby_t const
 	switch (mrb_type(mruby_result)) {
 		/* If it is a Fixnum: return that value */
 		case MRB_TT_FIXNUM:
-			return (rlm_rcode_t)mrb_int(mrb, mruby_result);
+			return (rlm_rcode_t)mrb_fixnum(mruby_result);
 			break;
 		case MRB_TT_ARRAY:
 			/* Must have exactly three items */
@@ -460,7 +460,7 @@ static rlm_rcode_t CC_HINT(nonnull) do_mruby(REQUEST *request, rlm_mruby_t const
 
 			add_vp_tuple(request->reply, request, &request->reply->vps, mrb, mrb_ary_entry(mruby_result, 1), function_name);
 			add_vp_tuple(request, request, &request->control, mrb, mrb_ary_entry(mruby_result, 2), function_name);
-			return (rlm_rcode_t)mrb_int(mrb, mrb_ary_entry(mruby_result, 0));
+			return (rlm_rcode_t)mrb_fixnum(mrb_ary_entry(mruby_result, 0));
 			break;
 		default:
 			/* Invalid return type */


### PR DESCRIPTION
The mruby version used on travis is very old (I can't say how old, the
ubuntu package used version 0.0.0, `mruby --version` doesn't show
anything other than a copyright notice.