### PR TITLE
Add openssl to BuildRequires

### DIFF
--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -55,7 +55,7 @@ BuildRequires: autoconf
 BuildRequires: gdbm-devel
 BuildRequires: libtool
 BuildRequires: libtool-ltdl-devel
-BuildRequires: openssl-devel
+BuildRequires: openssl, openssl-devel
 BuildRequires: pam-devel
 BuildRequires: zlib-devel
 BuildRequires: net-snmp-devel


### PR DESCRIPTION
The build step:

BOOTSTRAP raddb/certs/

...run `openssl dhparam -out dh -2 2048` which means you need to BuildRequires: openssl - openssl-devel does not pull in the binaries