### PR TITLE
For CentOS, use LTB's openldap packages intead of the distribution ve…

### DIFF
--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -185,8 +185,8 @@ This plugin provides Kerberos 5 support for the FreeRADIUS server project.
 Summary: LDAP support for FreeRADIUS
 Group: System Environment/Daemons
 Requires: %{name} = %{version}-%{release}
-Requires: openldap
-BuildRequires: openldap-devel
+Requires: openldap-ltb
+BuildRequires: openldap-ltb
 
 %description ldap
 This plugin provides LDAP support for the FreeRADIUS server project.
@@ -403,6 +403,8 @@ export LDFLAGS="-Wl,--build-id"
         --with-threads \
         --with-thread-pool \
         --with-docdir=%{docdir} \
+	--with-rlm-ldap-include-dir=/usr/local/openldap/include \
+	--with-rlm-ldap-lib-dir=/usr/local/openldap/lib64 \
         --with-rlm-sql_postgresql-include-dir=/usr/include/pgsql \
         --with-rlm-sql-postgresql-lib-dir=%{_libdir} \
         --with-rlm-sql_mysql-include-dir=/usr/include/mysql \

--- a/scripts/docker/build-centos6/Dockerfile
+++ b/scripts/docker/build-centos6/Dockerfile
@@ -51,6 +51,18 @@ RUN cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR
     cpack -G RPM
 RUN yum localinstall -y ./*.rpm
 
+#
+#  Use LTB's openldap packages intead of the distribution version to avoid linking against NSS
+#
+RUN echo $'[ltb-project]\n\
+name=LTB project packages\n\
+baseurl=https://ltb-project.org/rpm/$releasever/$basearch\n\
+enabled=1\n\
+gpgcheck=1\n\
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-LTB-project'\
+> /etc/yum.repos.d/ltb-project.repo
+RUN rpm --import https://ltb-project.org/lib/RPM-GPG-KEY-LTB-project
+
 
 WORKDIR /usr/local/src/repositories
 RUN git clone --depth=1 https://github.com/mattrose/hiredis.git

--- a/scripts/docker/build-centos7/Dockerfile
+++ b/scripts/docker/build-centos7/Dockerfile
@@ -51,6 +51,18 @@ RUN cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR
 RUN yum localinstall -y ./*.rpm
 
 #
+#  Use LTB's openldap packages intead of the distribution version to avoid linking against NSS
+#
+RUN echo $'[ltb-project]\n\
+name=LTB project packages\n\
+baseurl=https://ltb-project.org/rpm/$releasever/$basearch\n\
+enabled=1\n\
+gpgcheck=1\n\
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-LTB-project'\
+> /etc/yum.repos.d/ltb-project.repo
+RUN rpm --import https://ltb-project.org/lib/RPM-GPG-KEY-LTB-project
+
+#
 #  Shallow clone the FreeRADIUS source
 #
 WORKDIR /usr/local/src/repositories

--- a/scripts/docker/centos7/Dockerfile
+++ b/scripts/docker/centos7/Dockerfile
@@ -43,6 +43,19 @@ WORKDIR /usr/local/src/repositories
 RUN git clone --depth=1 --no-single-branch https://github.com/arr2036/libkqueue.git
 WORKDIR libkqueue
 
+#
+#  Use LTB's openldap packages intead of the distribution version to avoid linking against NSS
+#
+RUN echo $'[ltb-project]\n\
+name=LTB project packages\n\
+baseurl=https://ltb-project.org/rpm/$releasever/$basearch\n\
+enabled=1\n\
+gpgcheck=1\n\
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-LTB-project'\
+> /etc/yum.repos.d/ltb-project.repo
+RUN rpm --import https://ltb-project.org/lib/RPM-GPG-KEY-LTB-project
+
+
 # Fixme: Change to the main repo when they merge this branch
 RUN git checkout patch-3
 RUN cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=lib ./ && \


### PR DESCRIPTION
…rsion to avoid linking against NSS. Linking against NSS & OpenLDAP causes issues that manifest themselves through unexplained connection errors.