### PR TITLE
Fix for mikrotik_snmp not working

### DIFF
--- a/src/main/checkrad.in
+++ b/src/main/checkrad.in
@@ -1251,8 +1251,8 @@ sub mikrotik_snmp {
     }
   }
 
-  # We want interface descriptions
-  $oid = "ifDescr";
+  # We want  mtxrInterfaceStatsName from MIKROTIK-MIB
+  $oid = "1.3.6.1.4.1.14988.1.1.14.1.1.2";
 
   # Mikrotik doesnt give port IDs correctly to RADIUS :(
   # practically this would limit us to a simple only-one user limit for


### PR DESCRIPTION
If the interface table is above a certain size, MikroTik does not show the ppp interfaces in the interfae table, but they are always in the mtxrInterfaceStatsName in MIKROTIK-MIB. Simply switching to that fixes the problem and should not break compatibility for current users.