### PR TITLE
Initialise home server prefix len to /32

### DIFF
--- a/src/main/stats.c
+++ b/src/main/stats.c
@@ -738,6 +738,7 @@ void request_stats_reply(REQUEST *request)
 		memset(&ipaddr, 0, sizeof(ipaddr));
 #endif
 		ipaddr.af = AF_INET;
+		ipaddr.prefix = 32;
 		ipaddr.ipaddr.ip4addr.s_addr = server_ip->vp_ipaddr;
 		home = home_server_find(&ipaddr, server_port->vp_integer,
 					IPPROTO_UDP);


### PR DESCRIPTION
Required since 9e659f9 compares prefix, this allows home servers to be found by IP for stats lookup