### PR TITLE
fix segfault when setting pythonpath in rlm_python extension.

### DIFF
--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -926,14 +926,11 @@ static int python_interpreter_init(rlm_python_t *inst, CONF_SECTION *conf)
 #if PY_VERSION_HEX > 0x03050000
 			{
 				inst->wide_path = Py_DecodeLocale(inst->python_path, strlen(inst->python_path));
-				PySys_SetPath(path);
+				PySys_SetPath(inst->wide_path);
 			}
 #else
 			{
-				char *path;
-
-				memcpy(&path, inst->python_path, sizeof(path));
-				PySys_SetPath(path);
+				PySys_SetPath(inst->python_path);
 			}
 #endif
 		}


### PR DESCRIPTION
The bug might only be triggered when specifying "python_path" in the config file for the module and results in trying to memcpy to an uninitialized pointer (char *path). Copying the string is not really necessary, so the code is just removed.

The bug appears to be present in 3.0.x and also 4.0.x