### PR TITLE
Normalised attribute type in juniper dictionary

### DIFF
--- a/share/dictionary.juniper
+++ b/share/dictionary.juniper
@@ -21,7 +21,7 @@ ATTRIBUTE	Juniper-Deny-Configuration		5	string
 ATTRIBUTE	Juniper-Interactive-Command		8	string
 ATTRIBUTE	Juniper-Configuration-Change		9	string
 ATTRIBUTE	Juniper-User-Permissions		10	string
-ATTRIBUTE	Juniper-Junosspace-Profile		11	String
+ATTRIBUTE	Juniper-Junosspace-Profile		11	string
 
 ATTRIBUTE	Juniper-CTP-Group			21	integer
 ATTRIBUTE	Juniper-CTPView-APP-Group		22	integer


### PR DESCRIPTION
This was the only occurence of capitalised String, instead of string
that is used everywhere else.