### PR TITLE
Fix rlm_sql_sqlite build under FreeBSD

### DIFF
--- a/src/modules/rlm_sql/drivers/rlm_sql_sqlite/configure
+++ b/src/modules/rlm_sql/drivers/rlm_sql_sqlite/configure
@@ -2933,7 +2933,7 @@ if test "x$smart_lib" != "x"; then
   SMART_LIBS="$smart_ldflags $smart_lib $SMART_LIBS"
 fi
 
-        LDFLAGS="$SMART_LIBS"
+        LDFLAGS="${LDFLAGS} ${SMART_LIBS}"
     if test "x$ac_cv_lib_sqlite3_sqlite3_open" != "xyes"
     then
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Sqlite libraries not found. Use --with-sqlite-lib-dir=<path>." >&5

--- a/src/modules/rlm_sql/drivers/rlm_sql_sqlite/configure.ac
+++ b/src/modules/rlm_sql/drivers/rlm_sql_sqlite/configure.ac
@@ -74,7 +74,7 @@ if test x$with_[]modname != xno; then
     smart_try_dir="$sqlite_lib_dir"
     FR_SMART_CHECK_LIB(sqlite3, sqlite3_open)
     dnl # Ensure we use the library we just found the rest of the checks
-    LDFLAGS="$SMART_LIBS"
+    LDFLAGS="${LDFLAGS} ${SMART_LIBS}"
     if test "x$ac_cv_lib_sqlite3_sqlite3_open" != "xyes"
     then
 	AC_MSG_WARN([Sqlite libraries not found. Use --with-sqlite-lib-dir=<path>.])


### PR DESCRIPTION
Under freebsd, detection of sqlite3 partially fails. You get various warnings and errors at runtime due to assumed lack of features making the module unusable.

There is an issue with autoconf. The following line works fine:

/src/modules/rlm_sql/drivers/rlm_sql_sqlite/configure.ac:131 - "FR_SMART_CHECK_LIB(sqlite3, sqlite3_open)"

so the library is found. But all subsequent function checks fail, making the freeradius module believe that we have a really outdated version of sqlite. 

There seems to be a fundamental flaw in library path detection. In FR_SMART_CHECK_LIB of  file /acinclude.m4, there is quite some magic to detect proper linker settings. Under FreeBSD, the default settings "just work", so line acinclude.m4:161 is successful:

```
dnl #
dnl #  Try using the default library path
dnl #
if test "x$smart_lib" = "x"; then
  AC_MSG_CHECKING([for $2 in -l$1])
  LIBS="-l$1 $old_LIBS"
  AC_TRY_LINK([extern char $2();],
	      [$2()],
	      [
	        smart_lib="-l$1"
	        AC_MSG_RESULT(yes)
	      ],
	      [AC_MSG_RESULT(no)])
  LIBS="$old_LIBS"
fi
```

Reason is that LD_CONFIG contains "-L /usr/local/lib" under FreeBSD by default and sqlite3 is located at this directory. If LD_CONFIG would be empty, the library couldn't be found.

So we get smart_lib="-lsqlite3" after this test.

Upon return we have
```
dnl #
dnl #  Found it, set the appropriate variable.
dnl #
if test "x$smart_lib" != "x"; then
  eval "ac_cv_lib_${sm_lib_safe}_${sm_func_safe}=yes"
  LIBS="$smart_ldflags $smart_lib $old_LIBS"
  SMART_LIBS="$smart_ldflags $smart_lib $SMART_LIBS"
fi
```

Thus, SMARTLIBS="-lsqlite3" (all other expanded variables are empty).

Upon return, configure.ac of rlm_sql_sqlite continues with

```
    dnl # Ensure we use the library we just found the rest of the checks
    LDFLAGS="${SMART_LIBS}"
```

So we get LDFLAGS="-lsqlite3".

This is wrong. The default search path is lost and thus libsqlite3 cannot be found subsequently and thus all further function existance checks will fail.

There are various ways to solve this:
  * don't overwrite "LDFLAGS" but "LIBS"
  * append SMART_LIBS to LDFLAGS (this is what I did; rlm_krb5 does it too)
  * replace return values of FR_SMART_CHECK_LIB (see below)

Basically, FR_SMART_CHECK_LIB fiddles with LIB and CPPFLAGS, so it should really return those two values.

I checked the source code and found that there is no consens how to interpret the result of FR_SMART_CHECK_LIB. I assume that most do it wrong.

The attached patch works for FreeBSD but a proper fix would probably to rewrite FR_SMART_CHECK_LIB and all its callees. Looking at the remarks inside the function and seeing all the magic, I'm really reluctant to do that.