### PR TITLE
Fixed docker build for debian8

### DIFF
--- a/scripts/docker/build-debian8/Dockerfile
+++ b/scripts/docker/build-debian8/Dockerfile
@@ -10,7 +10,7 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 50 --slave /
 #
 #  Install eapol_test dependencies
 #
-RUN apt-get install libnl-3-dev libnl-genl-3-dev
+RUN apt-get install -y libnl-3-dev libnl-genl-3-dev
 
 #
 #  Setup a src dir in /usr/local


### PR DESCRIPTION
A '-y' switch was required for the installation of libnl-dev