### PR TITLE
Fixes for docker build for debian9

### DIFF
--- a/scripts/docker/build-debian9/Dockerfile
+++ b/scripts/docker/build-debian9/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y devscripts equivs git quilt
 #
 #  Install eapol_test dependencies
 #
-RUN apt-get install libnl-3-dev libnl-genl-3-dev
+RUN apt-get install -y libnl-3-dev libnl-genl-3-dev
 
 #
 #  Setup a src dir in /usr/local


### PR DESCRIPTION
It still doesn't work, but fails further down the line.