### PR TITLE
bubble up RLM_MODULE_FAILED where appropriate for MSCHAP

### DIFF
--- a/src/modules/rlm_mschap/auth_wbclient.c
+++ b/src/modules/rlm_mschap/auth_wbclient.c
@@ -212,6 +212,7 @@ normalised_username_retry_failure:
 		memcpy(nthashhash, info->user_session_key, NT_DIGEST_LENGTH);
 		break;
 	case WBC_ERR_WINBIND_NOT_AVAILABLE:
+		rcode = -2;
 		RERROR("Unable to contact winbind!");
 		RDEBUG2("Check that winbind is running and that FreeRADIUS has");
 		RDEBUG2("permission to connect to the winbind privileged socket.");
@@ -249,6 +250,7 @@ normalised_username_retry_failure:
 		 *   WBC_ERR_NO_MEMORY
 		 * neither of which are particularly likely.
 		 */
+		rcode = -2;
 		if (error && error->display_string) {
 			REDEBUG2("libwbclient error: wbcErr %d (%s)", err, error->display_string);
 		} else {

--- a/src/modules/rlm_mschap/rlm_mschap.c
+++ b/src/modules/rlm_mschap/rlm_mschap.c
@@ -1176,6 +1176,18 @@ static int CC_HINT(nonnull (1, 2, 4, 5 ,6)) do_mschap(rlm_mschap_t *inst, REQUES
 				return -691;
 			}
 
+			if (strcasestr(buffer, "No logon servers") ||
+			    strcasestr(buffer, "0xC000005e")) {
+				REDEBUG2("%s", buffer);
+				return -2;
+			}
+
+			if (strcasestr(buffer, "could not obtain winbind separator") ||
+			    strcasestr(buffer, "Reading winbind reply failed")) {
+				REDEBUG2("%s", buffer);
+				return -2;
+			}
+
 			RDEBUG2("External script failed");
 			p = strchr(buffer, '\n');
 			if (p) *p = '\0';
@@ -1446,12 +1458,18 @@ static rlm_rcode_t mschap_error(rlm_mschap_t *inst, REQUEST *request, unsigned c
 		retry = 0;
 		message = "Account locked out";
 		rcode = RLM_MODULE_USERLOCK;
+	} else if (mschap_result == -2) {
+		RDEBUG("Authentication failed";
+		error = 691;
+		retry = inst->allow_retry;
+		message = "Authentication failed";
+		rcode = RLM_MODULE_FAIL;
 
 	} else if (mschap_result < 0) {
 		REDEBUG("MS-CHAP2-Response is incorrect");
 		error = 691;
 		retry = inst->allow_retry;
-		message = "Authentication failed";
+		message = "Authentication rejected";
 		rcode = RLM_MODULE_REJECT;
 	}
 


### PR DESCRIPTION
Not even compile tested...but...

When using ntlm_auth/winbind for mschap, failures to talk to the winbind daemon (or the AD infrastructure) returns with a 'reject' when really what we want is a 'failed'.

If winbind is not running, the response is:
````
$ ntlm_auth --username moocow --password=wibble
could not obtain winbind domain name!
could not obtain winbind separator!
Reading winbind reply failed! (0x01)
:  (0x0)
````

If winbind is running but unable to communicate with its domain controllers then you see:
````
$ ntlm_auth --username moocow --password=wibble
NT_STATUS_NO_LOGON_SERVERS: No logon servers (0xc000005e)
````

Conceptually, is the patch correct, or should I be doing something else here?