### PR TITLE
V4.0.x rhspec

### DIFF
--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -75,8 +75,8 @@ BuildRequires: libpcap-devel
 BuildRequires: libtalloc-devel
 BuildRequires: net-snmp-devel
 BuildRequires: net-snmp-utils
-BuildRequires: libwbclient-devel
-BuildRequires: samba-devel
+%{?el7:BuildRequires: samba-winbind-devel}
+%{?el6:BuildRequires: samba4-devel}
 %if %{?_unitdir:1}%{!?_unitdir:0}
 BuildRequires: systemd-devel
 %endif
@@ -99,8 +99,10 @@ Requires: readline
 Requires: libtalloc
 Requires: libkqueue
 Requires: net-snmp
-Requires: libwbclient
-Requires: samba-libs
+%{?el7:Requires: samba-libs}
+%{?el7:Requires: samba-winbind-clients}
+%{?el6:Requires: samba4-libs}
+%{?el6:Requires: samba4-winbind-clients}
 Requires: zlib
 Requires: pam
 
@@ -422,6 +424,7 @@ export LDFLAGS="-Wl,--build-id"
         --with-jsonc-lib-dir=%{_libdir} \
         --with-jsonc-include-dir=/usr/include/json \
         --with-winbind-include-dir=/usr/include/samba-4.0 \
+        --with-winbind-lib-dir=/usr/lib64/samba \
 %if %{?_with_freeradius_openssl:1}%{!?_with_freeradius_openssl:0}
         --with-openssl-lib-dir=/opt/openssl/lib \
         --with-openssl-include-dir=/opt/openssl/include \

--- a/scripts/docker/build-centos6/Dockerfile
+++ b/scripts/docker/build-centos6/Dockerfile
@@ -79,7 +79,7 @@ RUN yum localinstall -y $HOME/rpmbuild/RPMS/*/hiredis-*.rpm
 #
 WORKDIR /usr/local/src/repositories
 ARG source=https://github.com/FreeRADIUS/freeradius-server.git
-RUN git clone --depth 1 --no-single-branch ${source}
+RUN git clone --depth 1 ${source}
 
 WORKDIR freeradius-server
 


### PR DESCRIPTION
Pick the correct Samba4 winbind packages for RHEL 6 and 7, also includes fix for centos6 having an older version of git for our dockerfile.