### PR TITLE
More eap-fast tls related stuff

### DIFF
--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -879,6 +879,8 @@ eap {
 		# This is not as straight forward as appending "ADH" alongside
 		# "DEFAULT" as "DEFAULT" contains "!aNULL" so instead it is
 		# recommended "ALL:!EXPORT:!eNULL:!SSLv2" is used
+		# Note - for OpenSSL 1.1.0 and above you may need
+		# to add ":@SECLEVEL=0"
 		#
 #		tls = tls-common
 

--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -2680,16 +2680,16 @@ void tls_global_cleanup(void)
  */
 static const FR_NAME_NUMBER version2int[] = {
 	{ "1.0",    TLS1_VERSION },
-#ifdef TLS_1_1_VERSION
+#ifdef TLS1_1_VERSION
 	{ "1.1",    TLS1_1_VERSION },
 #endif
-#ifdef TLS_1_2_VERSION
+#ifdef TLS1_2_VERSION
 	{ "1.2",    TLS1_2_VERSION },
 #endif
-#ifdef TLS_1_3_VERSION
+#ifdef TLS1_3_VERSION
 	{ "1.3",    TLS1_3_VERSION },
 #endif
-#ifdef TLS_1_4_VERSION
+#ifdef TLS1_4_VERSION
 	{ "1.4",    TLS1_4_VERSION },
 #endif
 	{ NULL, 0 }


### PR DESCRIPTION
Regarding ":@SECLEVEL=0", I had to add it in order to get ADH to work with OpenSSL 1.1.0f-fips, otherwise I was getting the below error (although the cipher was supported):
(2) eap_fast: <<< recv TLS 1.2  [length 005d]
(2) eap_fast: >>> send TLS 1.0 Alert [length 0002], fatal handshake_failure
(2) eap_fast: ERROR: TLS Alert write:fatal:handshake failure
tls: TLS_accept: Error in error
(2) eap_fast: ERROR: Failed in __FUNCTION__ (SSL_read): error:1417A0C1:SSL routines:tls_post_process_client_hello:no shared cipher

That comment should be added to v4 as well.
Thanks.