### PR TITLE
Removed references to version 2.1.10 in the config docs

### DIFF
--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -298,9 +298,9 @@ eap {
 		#  the values do not match, the certificate verification will
 		#  fail, rejecting the user.
 		#
-		#  In 2.1.10 and later, this check can be done more generally by
-		#  checking the value of the TLS-Client-Cert-Issuer attribute.
-		#  This check can be done via any mechanism you choose.
+		#  This check can be done more generally by checking the value
+		#  of the TLS-Client-Cert-Issuer attribute.  This check can be
+		#  done via any mechanism you choose.
 		#
 #		check_cert_issuer = "/C=GB/ST=Berkshire/L=Newbury/O=My Company Ltd"
 
@@ -313,9 +313,9 @@ eap {
 		#  This check is done only if the previous "check_cert_issuer"
 		#  is not set, or if the check succeeds.
 		#
-		#  In 2.1.10 and later, this check can be done more generally by
-		#  checking the value of the TLS-Client-Cert-CN attribute.
-		#  This check can be done via any mechanism you choose.
+		#  This check can be done more generally by checking the value
+		#  of the TLS-Client-Cert-CN attribute.  This check can be done
+		#  via any mechanism you choose.
 		#
 #		check_cert_cn = %{User-Name}
 

--- a/raddb/sites-available/tls
+++ b/raddb/sites-available/tls
@@ -136,10 +136,9 @@ server radsec {
 			#  match, the certificate verification will fail,
 			#  rejecting the user.
 			#
-			#  In 2.1.10 and later, this check can be done
-			#  more generally by checking the value of the
-			#  TLS-Client-Cert-Issuer attribute.  This check
-			#  can be done via any mechanism you choose.
+			#  This check can be done more generally by checking
+			#  the value of the TLS-Client-Cert-Issuer attribute.
+			#  This check can be done via any mechanism you choose.
 			#
 		#	check_cert_issuer = "/C=GB/ST=Berkshire/L=Newbury/O=My Company Ltd"
 
@@ -154,10 +153,9 @@ server radsec {
 			#  "check_cert_issuer" is not set, or if
 			#  the check succeeds.
 			#
-			#  In 2.1.10 and later, this check can be done
-			#  more generally by checking the value of the
-			#  TLS-Client-Cert-CN attribute.  This check
-			#  can be done via any mechanism you choose.
+			#  This check can be done more generally by checking
+			#  the value of the TLS-Client-Cert-CN attribute.
+			#  This check can be done via any mechanism you choose.
 			#
 		#	check_cert_cn = %{User-Name}
 		#


### PR DESCRIPTION
That version is years out of date, there's no added value in keeping
references to that version in the docs.