### PR TITLE
logrotate: don't accidentally define global options

### DIFF
--- a/debian/freeradius.logrotate
+++ b/debian/freeradius.logrotate
@@ -1,34 +1,30 @@
-# You can use this to rotate the /var/log/freeradius/* files, simply copy
-# it to /etc/logrotate.d/radiusd
-
-#
-#    Global options for all logfiles
-#
-daily
-rotate 52
-missingok
-compress
-delaycompress
-notifempty
-
-#
 #  The main server log
-#
 /var/log/freeradius/radius.log {
+	# common options
+	daily
+	rotate 52
+	missingok
+	compress
+	delaycompress
+	notifempty
+
 	copytruncate
 }
 
-#
+# (in order)
 #  Session monitoring utilities
-#
-/var/log/freeradius/checkrad.log /var/log/freeradius/radwatch.log {
-	nocreate
-}
-
-#
 #  SQL log files
-#
-/var/log/freeradius/sqllog.sql {
+/var/log/freeradius/checkrad.log /var/log/freeradius/radwatch.log
+/var/log/freeradius/sqllog.sql
+{
+	# common options
+	daily
+	rotate 52
+	missingok
+	compress
+	delaycompress
+	notifempty
+
 	nocreate
 }
 
@@ -40,5 +36,13 @@ notifempty
 # second technique, you will need another cron job that removes old
 # detail files.  You do not need to comment out the below for method #2.
 /var/log/freeradius/radacct/*/detail {
+	# common options
+	daily
+	rotate 52
+	missingok
+	compress
+	delaycompress
+	notifempty
+
 	nocreate
 }

--- a/scripts/logrotate/freeradius
+++ b/scripts/logrotate/freeradius
@@ -5,33 +5,34 @@
 #
 
 #
-#    Global options for all files
-#
-daily
-rotate 14
-missingok
-compress
-delaycompress
-notifempty
-
-#
 #  The main server log
 #
 /var/log/radius/radius.log {
+	# common options
+	daily
+	rotate 52
+	missingok
+	compress
+	delaycompress
+	notifempty
+
 	copytruncate
 }
 
-#
+# (in order)
 #  Session monitoring utilities
-#
-/var/log/radius/checkrad.log /var/log/radius/radwatch.log {
-	nocreate
-}
-
-#
 #  SQL log files
-#
-/var/log/radius/sqllog.sql {
+/var/log/freeradius/checkrad.log /var/log/freeradius/radwatch.log
+/var/log/freeradius/sqllog.sql
+{
+	# common options
+	daily
+	rotate 52
+	missingok
+	compress
+	delaycompress
+	notifempty
+
 	nocreate
 }
 
@@ -43,5 +44,13 @@ notifempty
 # second technique, you will need another cron job that removes old
 # detail files.  You do not need to comment out the below for method #2.
 /var/log/radius/radacct/*/detail {
+	# common options
+	daily
+	rotate 52
+	missingok
+	compress
+	delaycompress
+	notifempty
+
 	nocreate
 }


### PR DESCRIPTION
> The logrotate config file that ships with freeradius sets global options 
> in its file (/etc/logrotate.d/freeradius). These options do not just 
> apply to the freeradius log files, but to all log files that logrotate 
> encounters after processing /etc/logrotate.d/freeradius (e.g. other logs 
> defined in /etc/logrotate.d with a filename that come later 
> alphabetically). [...]

As reported to/fixed for Debian:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=872158
https://anonscm.debian.org/cgit/pkg-freeradius/freeradius.git/commit/?id=42fb7f66d29771f658c97d1812dc9594f76f7083
