### PR TITLE
Allow to drop DHCP response from relay

### DIFF
--- a/src/modules/proto_dhcp/dhcpd.c
+++ b/src/modules/proto_dhcp/dhcpd.c
@@ -423,6 +423,9 @@ static int dhcp_process(REQUEST *request)
 
 	/* BOOTREPLY received on port 67 (i.e. from a server) */
 	if (vp->vp_byte == 2) {
+		if (request->reply->code == 0) {
+			return 1;
+		}
 		return dhcprelay_process_server_reply(request);
 	}
 


### PR DESCRIPTION
This small fix allows to honor the following unlang in order to drop a
DHCP response from a relay (which we may want to do).

update reply {
&DHCP-Message-Type = DHCP-Do-Not-Respond
}
handled