### PR TITLE
UTF Scrub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ $(BUILD_DIR)/tests/radiusd-c: raddb/test.conf ${BUILD_DIR}/bin/radiusd $(GENERAT
 test: ${BUILD_DIR}/bin/radiusd ${BUILD_DIR}/bin/radclient tests.unit tests.xlat tests.keywords tests.auth tests.modules $(BUILD_DIR)/tests/radiusd-c tests.eap | build.raddb
 	@$(MAKE) -C src/tests tests
 
-#  Tests specifically for Travis.  We do a LOT more than just
-#  the above tests
+#  Tests specifically for Travis. We do a LOT more than just
+#  the above tests
 ifneq "$(findstring travis,${prefix})" ""
 travis-test: raddb/test.conf test
 	@FR_LIBRARY_PATH=./build/lib/local/.libs/ ./build/make/jlibtool --mode=execute ./build/bin/local/radiusd -xxxv -n test

--- a/doc/modules/RADIUS-LDAP-eDirectory
+++ b/doc/modules/RADIUS-LDAP-eDirectory
@@ -1,7 +1,7 @@
 "Integrating Novell eDirectory with FreeRADIUS"
 
 Overview
-You can integrate Novell® eDirectoryTM 8.7.1 or later with FreeRADIUS
+You can integrate Novell eDirectoryTM 8.7.1 or later with FreeRADIUS
 1.0.2 onwards to allow wireless authentication for eDirectory users.
 By integrating eDirectory with FreeRADIUS, you can do the following:
 * Use universal password for RADIUS authentication.
@@ -15,4 +15,4 @@ By integrating eDirectory with FreeRADIUS, you can do the following:
   failed logins into eDirectory.
 
 For configuration information please refer to the Novell documentation
-      http://www.novell.com/documentation/edir_radius/index.html
+	https://www.netiq.com/documentation/edir_radius/

--- a/src/modules/rlm_soh/README.md
+++ b/src/modules/rlm_soh/README.md
@@ -5,4 +5,4 @@
 </dl>
 
 ## Summary
-Implements support for Microsoft’s Statement of Health (SoH) protocol, which can run inside of PEAP or DHCP.
+Implements support for Microsoft's Statement of Health (SoH) protocol, which can run inside of PEAP or DHCP.

--- a/src/modules/rlm_sql/drivers/rlm_sql_db2/rlm_sql_db2.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_db2/rlm_sql_db2.c
@@ -100,7 +100,7 @@ static sql_rcode_t sql_socket_init(rlm_sql_handle_t *handle, rlm_sql_config_t *c
 		 *	And probably synthesis the retarded connection string ourselves,
 		 *	probably via config file expansions:
 		 *
-		 *	Driver={IBM DB2 ODBC Driver};Database=testDb;Hostname=remoteHostName.com;UID=username;PWD=mypasswd;PO‌​RT=50000
+		 *	Driver={IBM DB2 ODBC Driver};Database=testDb;Hostname=remoteHostName.com;UID=username;PWD=mypasswd;PORT=50000
 		 */
 		row = SQLConnect(conn->dbc_handle,
 				    server, SQL_NTS,

--- a/src/modules/rlm_unix/README.md
+++ b/src/modules/rlm_unix/README.md
@@ -5,7 +5,7 @@
 </dl>
 
 ## Summary
-Retrieves a user’s encrypted password from the local system and places it into the ``control:Crypt-Password`` attribute.
+Retrieves a user's encrypted password from the local system and places it into the ``control:Crypt-Password`` attribute.
 The password is retrieved via the ``getpwent()`` and ``getspwent()`` system calls.
 
 When used for accounting, works in conjunction with rlm_radutmp to update the utmp database.


### PR DESCRIPTION
After a recent encounter with UTF-8 in a dictionary I took a quick look to see what else was out there. 

The spirit of these changes was to get as many files to be ASCII-pure,  but not a cost of loss of information (e.g. names that have UTF-8 only characters). 

No code changes - docs and comments only.
