### PR TITLE
Virtual server fixup

### DIFF
--- a/raddb/sites-available/virtual.example.com
+++ b/raddb/sites-available/virtual.example.com
@@ -3,8 +3,6 @@
 #
 #	Sample virtual server for internally proxied requests.
 #
-#	See the "realm virtual.example.com" example in "proxy.conf".
-#
 #	$Id$
 #
 ######################################################################
@@ -19,14 +17,107 @@
 #  attributes can be accessed as "outer.request", "outer.control", etc.
 #  See "man unlang" for more details.
 #
-server virtual.example.com {
-recv Access-Request {
-	# insert policies here
-}
 
-send Access-Accept {
-	# insert policies here
-}
+#
+#  This example virtual server will listen on alternate ports
+#  and perform basic authentication and accounting.
+#  Consult the default file for information on the syntax and available options.
+#
+
+server virtual.example.com {
+
+	#  In v4, all "server" sections MUST start with a "namespace"
+	#  parameter.  This tells the server which protocol is being used.
+	#  Consult the sites-available/default for more information and documentation.
+
+	namespace = radius
+
+	#
+	# Define our listeners and the types of application packets we expect.
+	#
+	listen {
+		type = Access-Request
+
+		transport = udp
+
+		udp {
+			ipaddr = *
+			port = 11812
+		}
+	}
+
+	#
+	# Our listener for Accounting
+	#
+	listen {
+		type = Accounting-Request
+
+		transport = udp
+
+		udp {
+			ipaddr = *
+			port = 11813
+		}
+	}
+
+	#
+	# Now we define our policy framework for how this virtual server will handle various application packets.
+	# Consult the default file for information on the syntax and available options.
+	recv Access-Request {
+		# insert policies here
+
+		# In this example we simply validate locally
+
+		filter_username
+
+		auth_log
+
+		files
+
+		pap
+	}
+
+	send Access-Accept {
+		# insert policies here
+	}
+
+	recv Accounting-Request {
+		# insert policies here
+
+		#
+		#  Ensure that we have a semi-unique identifier for every
+		#  request, and many NAS boxes are broken.
+		#
+		acct_unique
+
+		#
+		# Read the 'acct_users' file
+		#
+		files
+	}
+
+	send Accounting-Response {
+
+		#
+		#  Create a 'detail'ed log of the packets.
+		#  Note that accounting requests which are proxied
+		#  are also logged in the detail file.
+		#
+		detail
+
+		#
+		#  Filter attributes from the accounting response.
+		#
+		attr_filter.accounting_response
+
+	}
+
+	#
+	# Allow for PAP in our example
+	#
+	authenticate pap {
+		pap
+	}
 
 # etc.
 }

--- a/src/main/virtual_servers.c
+++ b/src/main/virtual_servers.c
@@ -501,7 +501,7 @@ int virtual_servers_bootstrap(CONF_SECTION *config)
 		 *	Forbid old-style virtual servers.
 		 */
 		if (!cf_pair_find(cs, "namespace")) {
-			cf_log_err(cs, "server %s { ...} section must set 'namesspace = ...'", server_name);
+			cf_log_err(cs, "server %s { ...} section must set 'namespace = ...' to define the server protocol", server_name);
 			return -1;
 		}
 	}


### PR DESCRIPTION
Update virtual-server example to be a mostly working example with the new requirements for namespace to be set on a server {} block.

There are other example config files that need this same sort of update - just making sure this is useful before updating the remaining ones.

While here - also fix a small typo and expand the error message when a virtual server lacks the namespace directive.


