### PR TITLE
Fixed rlm_rest

### DIFF
--- a/src/modules/rlm_rest/rlm_rest.c
+++ b/src/modules/rlm_rest/rlm_rest.c
@@ -115,6 +115,7 @@ static int rlm_rest_status_update(REQUEST *request, void *handle)
 	RDEBUG2("&REST-HTTP-Status-Code := %i", code);
 	REXDENT();
 
+	value.type = FR_TYPE_UINT32;
 	value.vb_uint32 = code;
 
 	/*


### PR DESCRIPTION
Add an explicit type to the value assigned to REST-HTTP-Status-Code.
Without this, the following error occurs:

CONSISTENCY CHECK FAILED src/lib/util/pair_cursor.c[478]: VALUE_PAIR
attribute 0xb6c639a8 "REST-HTTP-Status-Code" data type (int8) does not
match da type (uint32)