### PR TITLE
remove asserts on vars declared as nonnull

### DIFF
--- a/src/main/client.c
+++ b/src/main/client.c
@@ -1170,9 +1170,6 @@ RADCLIENT *client_afrom_query(TALLOC_CTX *ctx, char const *identifier, char cons
 	RADCLIENT *c;
 	char buffer[128];
 
-	rad_assert(identifier);
-	rad_assert(secret);
-
 	c = talloc_zero(ctx, RADCLIENT);
 
 	if (fr_pton(&c->ipaddr, identifier, -1, AF_UNSPEC, true) < 0) {

--- a/src/main/log.c
+++ b/src/main/log.c
@@ -630,8 +630,6 @@ void vradlog_request(log_type_t type, log_lvl_t lvl, REQUEST *request, char cons
 	uint8_t indent;
 	va_list aq;
 
-	rad_assert(request);
-
 	/*
 	 *	Debug messages get treated specially.
 	 */
@@ -782,8 +780,6 @@ void radlog_request(log_type_t type, log_lvl_t lvl, REQUEST *request, char const
 {
 	va_list ap;
 
-	rad_assert(request);
-
 	if (!request->log.func && !(type & L_DBG)) return;
 
 	va_start(ap, msg);
@@ -812,8 +808,6 @@ void radlog_request_error(log_type_t type, log_lvl_t lvl, REQUEST *request, char
 {
 	va_list ap;
 
-	rad_assert(request);
-
 	va_start(ap, msg);
 	if (request->log.func) request->log.func(type, lvl, request, msg, ap);
 	else if (!(type & L_DBG)) vradlog_request(type, lvl, request, msg, ap);
@@ -835,8 +829,6 @@ void radlog_request_marker(log_type_t type, log_lvl_t lvl, REQUEST *request,
 {
 	char const *prefix = "";
 	uint8_t indent;
-
-	rad_assert(request);
 
 	if (idx >= sizeof(spaces)) {
 		size_t offset = (idx - (sizeof(spaces) - 1)) + (sizeof(spaces) * 0.75);

--- a/src/modules/rlm_ldap/ldap.c
+++ b/src/modules/rlm_ldap/ldap.c
@@ -1331,8 +1331,6 @@ int rlm_ldap_global_init(rlm_ldap_t *inst)
 {
 	int ldap_errno;
 
-	rad_assert(inst); /* clang scan */
-
 #define do_ldap_global_option(_option, _name, _value) \
 	if (ldap_set_option(NULL, _option, _value) != LDAP_OPT_SUCCESS) { \
 		ldap_get_option(NULL, LDAP_OPT_ERROR_NUMBER, &ldap_errno); \


### PR DESCRIPTION
stops gcc6 complaints with -Wnonnull-compare