### PR TITLE
added %{unhex} to rlm_expr

### DIFF
--- a/raddb/mods-available/expr
+++ b/raddb/mods-available/expr
@@ -77,6 +77,9 @@
 #  urlquote	quote special characters in URI
 #		"%{urlquote:http://example.org/}" == "http%3A%47%47example.org%47"
 #
+#  unhex	convert from hex to ASCII
+#		"%{unhex:0x4142434445}" == "ABCDE"
+#
 #  urlunquote	unquote URL special characters
 #		"%{urlunquote:http%%3A%%47%%47example.org%%47}" == "http://example.org/"
 #


### PR DESCRIPTION
I found that Cisco ASR sends ADSL-Agent-Circuit-ID and ADSL-Agent-Remote-ID as hex values so I needed to unhex them. See the following raddebug snippet:

```
(1) Sat Oct 28 23:12:54 2017: Debug:   ADSL-Agent-Circuit-Id = 0x43454e534f5245443a4c4a5f4272696874616c61625f39303030302d332d332d312d3930313a33393031
(1) Sat Oct 28 23:12:54 2017: Debug:   ADSL-Agent-Remote-Id = 0x574946492d43454e534f524544
```

At first I wanted to use `%{sql:SELECT UNHEX('0x....')}` stuff but we have two mysql servers running in master-master replication mode and I dont want to bother RADIUS with `redundant { }` if one mysql goes down so I figured maybe its better to offload `UNHEX()` from mysql to rlm_expr since there is already something similar with `%{urlunquote}`.