### PR TITLE
fix: correct receiving of multiple RADIUS packets through RadSec

### DIFF
--- a/src/main/tls_listen.c
+++ b/src/main/tls_listen.c
@@ -186,8 +186,29 @@ static int tls_socket_recv(rad_listen_t *listener)
 
 	request = sock->request;
 
+	/*
+	 * PEAK: The previous invocation of tls_socket_recv might have
+	 * already received enough data and another RADIUS packet is ready
+	 * in the record-layer queue. (See dual_tls_recv.)
+	 */
+	if (SSL_pending(sock->ssn->ssl)) {
+		RDEBUG3("Reading pending buffered data");
+		sock->ssn->dirty_in.used = 0;
+		goto skip_socket_io;
+	}
+
 	RDEBUG3("Reading from socket %d", request->packet->sockfd);
 	PTHREAD_MUTEX_LOCK(&sock->mutex);
+#if 0
+	/*
+	 * PEAK: Nasty "bug-bait" hack to make the read syscall more likely
+	 * to receive multiple encrypted RADIUS packets.
+	 */
+	{
+		sleep(1);
+		DEBUG("Sleeping in tls_socket_recv");
+	}
+#endif
 	rcode = read(request->packet->sockfd,
 		     sock->ssn->dirty_in.data,
 		     sizeof(sock->ssn->dirty_in.data));
@@ -246,6 +267,7 @@ static int tls_socket_recv(rad_listen_t *listener)
 		 */
 	}
 
+	skip_socket_io:
 	/*
 	 *	Try to get application data.
 	 */
@@ -335,6 +357,7 @@ int dual_tls_recv(rad_listen_t *listener)
 
 	if (listener->status != RAD_LISTEN_STATUS_KNOWN) return 0;
 
+	again:
 	if (!tls_socket_recv(listener)) {
 		return 0;
 	}
@@ -400,6 +423,27 @@ int dual_tls_recv(rad_listen_t *listener)
 		FR_STATS_INC(auth, total_packets_dropped);
 		rad_free(&packet);
 		return 0;
+	}
+
+	/*
+	 * PEAK: tls_socket_recv might have received more than one RADIUS
+	 * packet. Check for extra unprocessed data in the input buffer and
+	 * restart dual_tls_recv if necessary.
+	 * SSL_peek extracts one TLS record from the input buffer, decrypt it,
+	 * puts it in the record-layer queue and sets SSL_pending for
+	 * tls_socket_recv.
+	 */
+	{
+		BIO *rbio = SSL_get_rbio(sock->ssn->ssl);
+		int pending = BIO_ctrl_pending(rbio);
+		if (pending) {
+			char buf[1];
+			int peek = SSL_peek(sock->ssn->ssl, buf, 1);
+			if (peek > 0) {
+				DEBUG("more TLS records after dual_tls_recv");
+				goto again;
+			}
+		}
 	}
 
 	return 1;


### PR DESCRIPTION
On heavy loaded FR servers occurs a situation when multiple RADIUS packets are received at one time. Existing code inside function ``tls_socket_recv()`` isn't able to handle this situation.  Function ``tls_application_data()`` always reads only one RADIUS packet from OpenSSL buffer. Rest of received packets remains in OpenSSL buffer and waiting for more data coming through RadSec to trigger reading of next RADIUS packet.

On small deployments is ``idle_timeout = 30`` good enough to prevent any serious impact of this problem. On large deployments isn't this enough even with combination ``lifetime = 300`` which forces RadSec connection restart every 5minutes.

To easily reproduce the problem enable ``sleep(1)`` at ``src/main/tls_listen.c:208``. This will slow down PEAP-MSCHAPv2 authentication to more than 10s but the problem will show quickly. When running ``/usr/sbin/freeradius -fxxx -l stdout`` you can see following lines in output in the situation when the problem is fixed:
```
Thu Nov  2 22:55:56 2017 : Debug: more TLS records after dual_tls_recv
Thu Nov  2 22:55:56 2017 : Debug: (0) Reading pending buffered data
```

I work for CESNET as Czech eduroam operator. During summer 2017 we had campaigned for upgrading to freeRADIUS v3 and in the result, upgraded institutions stated to have troubles authenticating their traveling users. We believe that this patch correctly fixes receiving multiple RADIUS packets at once.