### PR TITLE
fix segfault in src/main/tls_listen.c:353

### DIFF
--- a/src/main/tls_listen.c
+++ b/src/main/tls_listen.c
@@ -350,7 +350,6 @@ int dual_tls_recv(rad_listen_t *listener)
 
 	if (listener->status != RAD_LISTEN_STATUS_KNOWN) return 0;
 
-	rbio = SSL_get_rbio(sock->ssn->ssl);
 
 redo:
 	if (!tls_socket_recv(listener)) {
@@ -429,6 +428,7 @@ redo:
 	 *	SSL_peek() will set SSL_pending(), and
 	 *	tls_socket_recv() will read another packet.
 	 */
+	rbio = SSL_get_rbio(sock->ssn->ssl);
 	pending = BIO_ctrl_pending(rbio);
 	if (pending) {
 		char buf[1];

--- a/src/main/tls_listen.c
+++ b/src/main/tls_listen.c
@@ -186,8 +186,29 @@ static int tls_socket_recv(rad_listen_t *listener)
 
 	request = sock->request;
 
+	/*
+	 * PEAK: The previous invocation of tls_socket_recv might have
+	 * already received enough data and another RADIUS packet is ready
+	 * in the record-layer queue. (See dual_tls_recv.)
+	 */
+	if (SSL_pending(sock->ssn->ssl)) {
+		RDEBUG3("Reading pending buffered data");
+		sock->ssn->dirty_in.used = 0;
+		goto skip_socket_io;
+	}
+
 	RDEBUG3("Reading from socket %d", request->packet->sockfd);
 	PTHREAD_MUTEX_LOCK(&sock->mutex);
+#if 0
+	/*
+	 * PEAK: Nasty "bug-bait" hack to make the read syscall more likely
+	 * to receive multiple encrypted RADIUS packets.
+	 */
+	{
+		sleep(1);
+		DEBUG("Sleeping in tls_socket_recv");
+	}
+#endif
 	rcode = read(request->packet->sockfd,
 		     sock->ssn->dirty_in.data,
 		     sizeof(sock->ssn->dirty_in.data));
@@ -246,6 +267,7 @@ static int tls_socket_recv(rad_listen_t *listener)
 		 */
 	}
 
+	skip_socket_io:
 	/*
 	 *	Try to get application data.
 	 */
@@ -335,6 +357,7 @@ int dual_tls_recv(rad_listen_t *listener)
 
 	if (listener->status != RAD_LISTEN_STATUS_KNOWN) return 0;
 
+	again:
 	if (!tls_socket_recv(listener)) {
 		return 0;
 	}
@@ -400,6 +423,27 @@ int dual_tls_recv(rad_listen_t *listener)
 		FR_STATS_INC(auth, total_packets_dropped);
 		rad_free(&packet);
 		return 0;
+	}
+
+	/*
+	 * PEAK: tls_socket_recv might have received more than one RADIUS
+	 * packet. Check for extra unprocessed data in the input buffer and
+	 * restart dual_tls_recv if necessary.
+	 * SSL_peek extracts one TLS record from the input buffer, decrypt it,
+	 * puts it in the record-layer queue and sets SSL_pending for
+	 * tls_socket_recv.
+	 */
+	{
+		BIO *rbio = SSL_get_rbio(sock->ssn->ssl);
+		int pending = BIO_ctrl_pending(rbio);
+		if (pending) {
+			char buf[1];
+			int peek = SSL_peek(sock->ssn->ssl, buf, 1);
+			if (peek > 0) {
+				DEBUG("more TLS records after dual_tls_recv");
+				goto again;
+			}
+		}
 	}
 
 	return 1;


### PR DESCRIPTION
Reformated patch d7a30ad based on #2106 causes segfault at ``src/main/tls_listen.c:353`` The code segfaults imediately after receiving first packet throguht RadSec connection.
    
```
Fri Nov  3 19:00:54 2017 : Info: Ready to process requests
Fri Nov  3 19:00:55 2017 : Debug:  ... new connection request on TCP socket
Fri Nov  3 19:00:55 2017 : Debug: Listening on auth+acct from client (195.113.187.22, 46155) -> (*, 2083, virtual-$
Fri Nov  3 19:00:55 2017 : Debug: Waking up in 0.9 seconds.
    
Program received signal SIGSEGV, Segmentation fault.
0x00000000004407cb in dual_tls_recv (listener=0xb05a40) at src/main/tls_listen.c:353
353        rbio = SSL_get_rbio(sock->ssn->ssl);
```
  
I moved calling ``SSL_get_rbio()`` to originaly proposed place and it works as supposed.