### PR TITLE
Remove debian patch to disable dhcp

### DIFF
--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,1 @@
 radiusd-to-freeradius.diff
-disable-dhcp-bydefault.diff


### PR DESCRIPTION
The way this patch interacts with quilt, and rules/all.mk seems to be very brittle, and I was thinking that it would be better to leave dhcp enabled for the development period.