### PR TITLE
remove __DATE__ and __TIME__

### DIFF
--- a/src/main/radclient.c
+++ b/src/main/radclient.c
@@ -77,7 +77,7 @@ static char const *radclient_version = "radclient version " RADIUSD_VERSION_STRI
 #ifdef RADIUSD_VERSION_COMMIT
 " (git #" STRINGIFY(RADIUSD_VERSION_COMMIT) ")"
 #endif
-", built on " __DATE__ " at " __TIME__;
+;
 
 static void NEVER_RETURNS usage(void)
 {

--- a/src/main/radiusd.c
+++ b/src/main/radiusd.c
@@ -63,7 +63,7 @@ char const *radiusd_version = "FreeRADIUS Version " RADIUSD_VERSION_STRING
 #ifdef RADIUSD_VERSION_COMMIT
 " (git #" STRINGIFY(RADIUSD_VERSION_COMMIT) ")"
 #endif
-", for host " HOSTINFO ", built on " __DATE__ " at " __TIME__;
+", for host " HOSTINFO "";
 
 static pid_t radius_pid;
 

--- a/src/main/radmin.c
+++ b/src/main/radmin.c
@@ -70,7 +70,7 @@ static char const *radmin_version = "radmin version " RADIUSD_VERSION_STRING
 #ifdef RADIUSD_VERSION_COMMIT
 " (git #" STRINGIFY(RADIUSD_VERSION_COMMIT) ")"
 #endif
-", built on " __DATE__ " at " __TIME__;
+;
 
 
 /*

--- a/src/main/radsniff.c
+++ b/src/main/radsniff.c
@@ -60,7 +60,7 @@ static char const *radsniff_version = "radsniff version " RADIUSD_VERSION_STRING
 #ifdef RADIUSD_VERSION_COMMIT
 " (git #" STRINGIFY(RADIUSD_VERSION_COMMIT) ")"
 #endif
-", built on " __DATE__ " at " __TIME__;
+;
 
 static int rs_useful_codes[] = {
 	PW_CODE_ACCESS_REQUEST,			//!< RFC2865 - Authentication request

--- a/src/main/unittest.c
+++ b/src/main/unittest.c
@@ -48,7 +48,7 @@ char const *radiusd_version = "FreeRADIUS Version " RADIUSD_VERSION_STRING
 #ifdef RADIUSD_VERSION_COMMIT
 " (git #" STRINGIFY(RADIUSD_VERSION_COMMIT) ")"
 #endif
-", for host " HOSTINFO ", built on " __DATE__ " at " __TIME__;
+", for host " HOSTINFO "";
 
 /*
  *	Static functions.

--- a/src/modules/proto_dhcp/dhcpclient.c
+++ b/src/modules/proto_dhcp/dhcpclient.c
@@ -62,7 +62,7 @@ static char const *dhcpclient_version = "dhcpclient version " RADIUSD_VERSION_ST
 #ifdef RADIUSD_VERSION_COMMIT
 " (git #" STRINGIFY(RADIUSD_VERSION_COMMIT) ")"
 #endif
-", built on " __DATE__ " at " __TIME__;
+;
 
 /* structure to keep track of offered IP addresses */
 typedef struct dc_offer {

--- a/src/modules/rlm_eap/radeapclient.c
+++ b/src/modules/rlm_eap/radeapclient.c
@@ -1964,7 +1964,7 @@ int main(int argc, char **argv)
 			timeout = atof(optarg);
 			break;
 		case 'v':
-			printf("$Id$ built on "__DATE__ "at "__TIME__ "");
+			printf("$Id$");
 			exit(0);
 
 		case 'S':


### PR DESCRIPTION
"reproducible builds" is apparently a thing, and gcc
has started complaining