### PR TITLE
add reproducible builds configure option

### DIFF
--- a/configure
+++ b/configure
@@ -758,6 +758,7 @@ with_openssl
 with_openssl_lib_dir
 with_openssl_include_dir
 enable_openssl_version_check
+enable_reproducible_builds
 with_talloc_lib_dir
 with_talloc_include_dir
 with_pcap_lib_dir
@@ -1406,6 +1407,8 @@ Optional Features:
   --disable-openssl-version-check
                           disable vulnerable OpenSSL version check
 
+  --enable-reproducible-builds
+                          ensure the build does not change each time
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -5519,6 +5522,22 @@ $as_echo "#define ENABLE_OPENSSL_VERSION_CHECK 1" >>confdefs.h
 	allow_vulnerable_openssl = no"
 else
   openssl_version_check_config=
+fi
+
+
+# Check whether --enable-reproducible-builds was given.
+if test "${enable_reproducible_builds+set}" = set; then :
+  enableval=$enable_reproducible_builds;  case "$enableval" in
+  yes)
+
+$as_echo "#define ENABLE_REPRODUCIBLE_BUILDS 1" >>confdefs.h
+
+    reproducible_builds=yes
+    ;;
+  *)
+    reproducible_builds=no
+  esac
+
 fi
 
 
@@ -12708,6 +12727,10 @@ done
 subdirs="$subdirs $mysubdirs"
 
 
+
+if test "x$reproducible_builds" != "xyes"; then
+  CFLAGS="-Wno-date-time $CFLAGS"
+fi
 
 if test "x$werror" == "xyes"; then
   CFLAGS="-Werror $CFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -609,6 +609,23 @@ else
 fi
 AC_SUBST([openssl_version_check_config])
 
+dnl #
+dnl #  extra argument: --enable-reproducible-builds
+dnl #
+AC_ARG_ENABLE(reproducible-builds,
+[AS_HELP_STRING([--enable-reproducible-builds],
+                [ensure the build does not change each time])],
+[ case "$enableval" in
+  yes)
+    AC_DEFINE(ENABLE_REPRODUCIBLE_BUILDS, [1],
+              [Define to ensure each build is the same])
+    reproducible_builds=yes
+    ;;
+  *)
+    reproducible_builds=no
+  esac ]
+)
+
 
 dnl #############################################################
 dnl #
@@ -2221,6 +2238,14 @@ dnl #  if you do.
 dnl #
 AC_CONFIG_SUBDIRS($mysubdirs)
 AC_SUBST(MODULES)
+
+dnl #
+dnl #  If reproducible builds are not enabled, disable
+dnl #  -Wdate-time so the compiler doesn't croak.
+dnl #
+if test "x$reproducible_builds" != "xyes"; then
+  CFLAGS="-Wno-date-time $CFLAGS"
+fi
 
 dnl #############################################################
 dnl #

--- a/debian/rules
+++ b/debian/rules
@@ -99,7 +99,8 @@ endif
 		--with-iodbc-include-dir='/usr/include/iodbc' \
 		--without-rlm_eap_ikev2 \
 		--without-rlm_sql_oracle \
-		--without-rlm_sql_unixodbc
+		--without-rlm_sql_unixodbc \
+		--enable-reproducible-builds
 
 	rm config.guess
 	mv config.guess.dist config.guess

--- a/src/include/autoconf.h.in
+++ b/src/include/autoconf.h.in
@@ -12,6 +12,9 @@
 /* Define to 1 to have OpenSSL version check enabled */
 #undef ENABLE_OPENSSL_VERSION_CHECK
 
+/* Define to ensure each build is the same */
+#undef ENABLE_REPRODUCIBLE_BUILDS
+
 /* Define if your processor stores words with the most significant byte first
    */
 #undef FR_BIG_ENDIAN

--- a/src/main/radclient.c
+++ b/src/main/radclient.c
@@ -77,6 +77,9 @@ static char const *radclient_version = "radclient version " RADIUSD_VERSION_STRI
 #ifdef RADIUSD_VERSION_COMMIT
 " (git #" STRINGIFY(RADIUSD_VERSION_COMMIT) ")"
 #endif
+#ifndef ENABLE_REPRODUCIBLE_BUILDS
+", built on " __DATE__ " at " __TIME__
+#endif
 ;
 
 static void NEVER_RETURNS usage(void)

--- a/src/main/radiusd.c
+++ b/src/main/radiusd.c
@@ -63,7 +63,11 @@ char const *radiusd_version = "FreeRADIUS Version " RADIUSD_VERSION_STRING
 #ifdef RADIUSD_VERSION_COMMIT
 " (git #" STRINGIFY(RADIUSD_VERSION_COMMIT) ")"
 #endif
-", for host " HOSTINFO "";
+", for host " HOSTINFO
+#ifndef ENABLE_REPRODUCIBLE_BUILDS
+", built on " __DATE__ " at " __TIME__
+#endif
+;
 
 static pid_t radius_pid;
 

--- a/src/main/radmin.c
+++ b/src/main/radmin.c
@@ -70,6 +70,9 @@ static char const *radmin_version = "radmin version " RADIUSD_VERSION_STRING
 #ifdef RADIUSD_VERSION_COMMIT
 " (git #" STRINGIFY(RADIUSD_VERSION_COMMIT) ")"
 #endif
+#ifndef ENABLE_REPRODUCIBLE_BUILDS
+", built on " __DATE__ " at " __TIME__
+#endif
 ;
 
 

--- a/src/main/radsniff.c
+++ b/src/main/radsniff.c
@@ -60,6 +60,9 @@ static char const *radsniff_version = "radsniff version " RADIUSD_VERSION_STRING
 #ifdef RADIUSD_VERSION_COMMIT
 " (git #" STRINGIFY(RADIUSD_VERSION_COMMIT) ")"
 #endif
+#ifndef ENABLE_REPRODUCIBLE_BUILDS
+", built on " __DATE__ " at " __TIME__
+#endif
 ;
 
 static int rs_useful_codes[] = {

--- a/src/main/unittest.c
+++ b/src/main/unittest.c
@@ -48,7 +48,11 @@ char const *radiusd_version = "FreeRADIUS Version " RADIUSD_VERSION_STRING
 #ifdef RADIUSD_VERSION_COMMIT
 " (git #" STRINGIFY(RADIUSD_VERSION_COMMIT) ")"
 #endif
-", for host " HOSTINFO "";
+", for host " HOSTINFO
+#ifndef ENABLE_REPRODUCIBLE_BUILDS
+", built on " __DATE__ " at " __TIME__
+#endif
+;
 
 /*
  *	Static functions.

--- a/src/modules/proto_dhcp/dhcpclient.c
+++ b/src/modules/proto_dhcp/dhcpclient.c
@@ -62,6 +62,9 @@ static char const *dhcpclient_version = "dhcpclient version " RADIUSD_VERSION_ST
 #ifdef RADIUSD_VERSION_COMMIT
 " (git #" STRINGIFY(RADIUSD_VERSION_COMMIT) ")"
 #endif
+#ifndef ENABLE_REPRODUCIBLE_BUILDS
+", built on " __DATE__ " at " __TIME__
+#endif
 ;
 
 /* structure to keep track of offered IP addresses */

--- a/src/modules/rlm_eap/radeapclient.c
+++ b/src/modules/rlm_eap/radeapclient.c
@@ -1964,7 +1964,12 @@ int main(int argc, char **argv)
 			timeout = atof(optarg);
 			break;
 		case 'v':
-			printf("$Id$");
+			printf("$Id$"
+#ifndef ENABLE_REPRODUCIBLE_BUILDS
+			", built on " __DATE__ " at " __TIME__
+#endif
+			"\n"
+			);
 			exit(0);
 
 		case 'S':


### PR DESCRIPTION
Put date and time back again, with an option to disable them.

Packages build cleanly on Debian 7,8 and 9, and Ubuntu 14.04,16.04 and 17.10 :-)
