### PR TITLE
Safer openssl threads setup

### DIFF
--- a/src/include/radiusd.h
+++ b/src/include/radiusd.h
@@ -537,6 +537,10 @@ void	thread_pool_lock(void);
 void	thread_pool_unlock(void);
 void	thread_pool_queue_stats(int array[RAD_LISTEN_MAX], int pps[2]);
 
+#ifdef HAVE_OPENSSL_CRYPTO_H
+int	setup_ssl_mutexes(void);
+#endif
+
 #ifndef HAVE_PTHREAD_H
 #  define rad_fork(n) fork()
 #  define rad_waitpid(a,b) waitpid(a,b, 0)

--- a/src/main/radiusd.c
+++ b/src/main/radiusd.c
@@ -338,6 +338,15 @@ int main(int argc, char *argv[])
 	 */
 #ifdef HAVE_OPENSSL_CRYPTO_H
 	tls_global_init();
+	/*
+	 *  Set up the mutexes and enable the thread callbacks before individual modules
+	 *  .instantiate() would happen to do it. We need them ONLY if we're spawning,
+	 *  AND we're running normally.
+	 */
+	if (spawn_flag && !check_config && !setup_ssl_mutexes()) {
+		ERROR("FATAL: Failed to set up SSL mutexes");
+		exit(EXIT_FAILURE);
+	}
 #endif
 
 	/*

--- a/src/main/threads.c
+++ b/src/main/threads.c
@@ -244,13 +244,14 @@ static unsigned long get_ssl_id(void)
 #if OPENSSL_VERSION_NUMBER < 0x10000000L
 #define ssl_id_function get_ssl_id
 #define set_id_callback CRYPTO_set_id_callback
-
+#define get_id_callback CRYPTO_get_id_callback
 #else
 static void ssl_id_function(CRYPTO_THREADID *id)
 {
 	CRYPTO_THREADID_set_numeric(id, get_ssl_id());
 }
 #define set_id_callback CRYPTO_THREADID_set_callback
+#define get_id_callback CRYPTO_THREADID_get_callback
 #endif
 #endif
 
@@ -280,10 +281,12 @@ static int setup_ssl_mutexes(void)
 	}
 
 #ifdef HAVE_CRYPTO_SET_ID_CALLBACK
-	set_id_callback(ssl_id_function);
+	if (!get_id_callback())
+		set_id_callback(ssl_id_function);
 #endif
 #ifdef HAVE_CRYPTO_SET_LOCKING_CALLBACK
-	CRYPTO_set_locking_callback(ssl_locking_function);
+	if (!CRYPTO_get_locking_callback())
+		CRYPTO_set_locking_callback(ssl_locking_function);
 #endif
 
 	return 1;

--- a/src/main/threads.c
+++ b/src/main/threads.c
@@ -266,7 +266,7 @@ static void ssl_locking_function(int mode, int n, UNUSED char const *file, UNUSE
 }
 #endif
 
-static int setup_ssl_mutexes(void)
+int setup_ssl_mutexes(void)
 {
 	int i;
 
@@ -1046,18 +1046,6 @@ int thread_pool_init(CONF_SECTION *cs, bool *spawn_flag)
 		}
 	}
 #endif
-
-#ifdef HAVE_OPENSSL_CRYPTO_H
-	/*
-	 *	If we're linking with OpenSSL too, then we need
-	 *	to set up the mutexes and enable the thread callbacks.
-	 */
-	if (!setup_ssl_mutexes()) {
-		ERROR("FATAL: Failed to set up SSL mutexes");
-		return -1;
-	}
-#endif
-
 
 #ifndef WITH_GCD
 	/*


### PR DESCRIPTION
This prevents needless crashes or hard-to-debug behaviors, e.g., when using rlm_perl with a custom script which "requires" Net::SSLeay that would bootstrap XS code setting up openssl callbacks if not ready.
Furthermore, 1d9a6d6 ("do setup_ssl_mutexes() before modules_init()") will make all fair in the sense that we do not have to care any more about which module instantiation (sometimes unintentionally) will win the race to set up the callbacks in the first place. 