### PR TITLE
Fix missing id column in radusergroup

### DIFF
--- a/raddb/mods-config/sql/main/mysql/schema.sql
+++ b/raddb/mods-config/sql/main/mysql/schema.sql
@@ -115,9 +115,11 @@ CREATE TABLE radreply (
 #
 
 CREATE TABLE radusergroup (
+  id int(11) unsigned NOT NULL auto_increment,
   username varchar(64) NOT NULL default '',
   groupname varchar(64) NOT NULL default '',
   priority int(11) NOT NULL default '1',
+  PRIMARY KEY  (id),
   KEY username (username(32))
 );
 


### PR DESCRIPTION
Some ORM drops support for table without primary key. I see missing id is only in MySQL schema.
