### PR TITLE
Added new Patton Attribute

### DIFF
--- a/share/dictionary.patton
+++ b/share/dictionary.patton
@@ -20,6 +20,7 @@ ATTRIBUTE	Patton-Connect-Time			33	string
 ATTRIBUTE	Patton-Disconnect-Time			34	string
 ATTRIBUTE	Patton-Disconnect-Cause			35	integer
 ATTRIBUTE	Patton-Disconnect-Source		36	string
+ATTRIBUTE	Patton-Disconnect-Reason		37	string
 ATTRIBUTE	Patton-Called-Unique-Id			48	string
 ATTRIBUTE	Patton-Called-IP-Address		49	ipaddr
 ATTRIBUTE	Patton-Called-Numbering-Plan		50	string


### PR DESCRIPTION
Added new Patton Attribute called Patton-Disconnect-Reason (37). This attribute contains usually the same information as the Patton-Disconnect-Cause but in string format instead. This attribute is available on Patton device from version 3.13.0.