### PR TITLE
implemented redis query and connect timeout

### DIFF
--- a/raddb/mods-available/redis
+++ b/raddb/mods-available/redis
@@ -19,6 +19,9 @@ redis {
 	#  We recommend using a strong password.
 #	password = thisisreallysecretandhardtoguess
 
+	#  Set connection and query timeout for rlm_redis
+	query_timeout = 5
+
 	#
 	#  Information for the connection pool.  The configuration items
 	#  below are the same for all modules which use the new

--- a/src/modules/rlm_redis/rlm_redis.h
+++ b/src/modules/rlm_redis/rlm_redis.h
@@ -47,6 +47,7 @@ typedef struct rlm_redis_t {
 	uint16_t		port;
 	uint32_t		database;
 	char const		*password;
+	uint16_t		query_timeout;
 	fr_connection_pool_t	*pool;
 
 	int (*redis_query)(REDISSOCK **dissocket_p, REDIS_INST *inst, char const *query, REQUEST *request);


### PR DESCRIPTION
Somewhere in policy I use redis xlat in unlang like this:

`%{redis:SET radauth.%{request:User-Name} 1 EX 60}`

and later on

`%{redis:DEL radauth.%{request:User-Name}}`

Everything works as expected until REDIS server (running on separate machine in our architecture) becomes unreachable. When that happens it blocks our `authorize` and `preacct` sections holding those `%{redis}` queries.
Because those two queries arent mission critical I decided to implement parameter similar to that in `mods-available/sql` called `query_timeout`. So when REDIS service becomes unreachable the `%{redis}` xlat is blocking only for `query_timeout` seconds and then unlang carries on with exection.

```
query_timeout = 2 in mods-enabled/redis
redis server is unreachable (simulated this by placing DROP rule in iptables)

(10) Thu Dec 14 22:03:45 2017: Debug: # Executing section authorize from file /opt/freeradius/etc/raddb/sites-enabled/default
(10) Thu Dec 14 22:03:45 2017: Debug:   authorize {
(10) Thu Dec 14 22:03:47 2017: Debug:     EXPAND %{redis:SET radauth.%{request:User-Name} 1 EX 60}
(10) Thu Dec 14 22:03:47 2017: Debug:        -->
(10) Thu Dec 14 22:03:47 2017: Debug:     [preprocess] = ok
(10) Thu Dec 14 22:03:47 2017: Debug:     [chap] = noop
...stuff...
```

