### PR TITLE
debian packaging fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,18 @@ ifeq "0" "1"
 .error GNU Make is required to build FreeRADIUS
 endif
 
+#
+#  We require Make.inc, UNLESS the target is "make deb"
+#
+#  Since "make deb" re-runs configure... there's no point in
+#  requiring the developer to run configure *before* making
+#  the debian packages.
+#
+ifneq "$(MAKECMDGOALS)" "deb"
 $(if $(wildcard Make.inc),,$(error Missing 'Make.inc' Run './configure [options]' and retry))
 
 include Make.inc
+endif
 
 MFLAGS += --no-print-directory
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,9 @@ endif
 export DESTDIR := $(R)
 
 # And over-ride all of the other magic.
+ifneq "$(MAKECMDGOALS)" "deb"
 include scripts/boiler.mk
+endif
 
 #
 #  To work around OpenSSL issues with travis.

--- a/debian/freeradius-config.postrm
+++ b/debian/freeradius-config.postrm
@@ -22,7 +22,7 @@ case "$1" in
 			dpkg-statoverride --remove /etc/freeradius
 		fi
 
-		rmdir --ignore-fail-on-non-empty /etc/freeradius
+		test -d /etc/freeradius && rmdir --ignore-fail-on-non-empty /etc/freeradius
 		;;
 	*)
 		;;

--- a/debian/freeradius-dhcp.postinst
+++ b/debian/freeradius-dhcp.postinst
@@ -5,7 +5,7 @@ set -e
 case "$1" in
   configure)
         if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
-          invoke-rc.d freeradius force-reload
+          invoke-rc.d freeradius force-reload || true
         else
           /etc/init.d/freeradius force-reload
         fi

--- a/debian/freeradius-iodbc.postinst
+++ b/debian/freeradius-iodbc.postinst
@@ -5,7 +5,7 @@ set -e
 case "$1" in
   configure)
         if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
-          invoke-rc.d freeradius force-reload
+          invoke-rc.d freeradius force-reload || true
         else
           /etc/init.d/freeradius force-reload
         fi

--- a/debian/freeradius-krb5.postinst
+++ b/debian/freeradius-krb5.postinst
@@ -5,7 +5,7 @@ set -e
 case "$1" in
   configure)
         if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
-          invoke-rc.d freeradius force-reload
+          invoke-rc.d freeradius force-reload || true
         else
           /etc/init.d/freeradius force-reload
         fi

--- a/debian/freeradius-ldap.postinst
+++ b/debian/freeradius-ldap.postinst
@@ -5,7 +5,7 @@ set -e
 case "$1" in
   configure)
         if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
-          invoke-rc.d freeradius force-reload
+          invoke-rc.d freeradius force-reload || true
         else
           /etc/init.d/freeradius force-reload
         fi

--- a/debian/freeradius-memcached.postinst
+++ b/debian/freeradius-memcached.postinst
@@ -5,7 +5,7 @@ set -e
 case "$1" in
   configure)
         if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
-          invoke-rc.d freeradius force-reload
+          invoke-rc.d freeradius force-reload || true
         else
           /etc/init.d/freeradius force-reload
         fi

--- a/debian/freeradius-mysql.postinst
+++ b/debian/freeradius-mysql.postinst
@@ -5,7 +5,7 @@ set -e
 case "$1" in
   configure)
         if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
-          invoke-rc.d freeradius force-reload
+          invoke-rc.d freeradius force-reload || true
         else
           /etc/init.d/freeradius force-reload
         fi

--- a/debian/freeradius-postgresql.postinst
+++ b/debian/freeradius-postgresql.postinst
@@ -5,7 +5,7 @@ set -e
 case "$1" in
   configure)
         if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
-          invoke-rc.d freeradius force-reload
+          invoke-rc.d freeradius force-reload || true
         else
           /etc/init.d/freeradius force-reload
         fi

--- a/debian/freeradius-redis.postinst
+++ b/debian/freeradius-redis.postinst
@@ -5,7 +5,7 @@ set -e
 case "$1" in
   configure)
         if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
-          invoke-rc.d freeradius force-reload
+          invoke-rc.d freeradius force-reload || true
         else
           /etc/init.d/freeradius force-reload
         fi

--- a/debian/freeradius-rest.postinst
+++ b/debian/freeradius-rest.postinst
@@ -5,7 +5,7 @@ set -e
 case "$1" in
   configure)
         if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
-          invoke-rc.d freeradius force-reload
+          invoke-rc.d freeradius force-reload || true
         else
           /etc/init.d/freeradius force-reload
         fi

--- a/debian/freeradius-yubikey.postinst
+++ b/debian/freeradius-yubikey.postinst
@@ -5,7 +5,7 @@ set -e
 case "$1" in
   configure)
         if [ -x "`which invoke-rc.d 2>/dev/null`" ]; then
-          invoke-rc.d freeradius force-reload
+          invoke-rc.d freeradius force-reload || true
         else
           /etc/init.d/freeradius force-reload
         fi


### PR DESCRIPTION
Don't bork if the server is not running when installing a module package, which commonly happens on first install.

Backport of "make deb" fix from v4.0.x so it's not necessary to run configure first.
  
Don't fail package removal of freeradius-config if /etc/freeradius has already been removed.