### PR TITLE
TLS: Allow partial certificate chain to trusted CA

### DIFF
--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -2914,6 +2914,9 @@ SSL_CTX *tls_init_ctx(fr_tls_server_conf_t *conf, int client)
 
 	/* Load the CAs we trust */
 load_ca:
+#if defined(X509_V_FLAG_PARTIAL_CHAIN)
+	X509_STORE_set_flags(SSL_CTX_get_cert_store(ctx), X509_V_FLAG_PARTIAL_CHAIN);
+#endif
 	if (conf->ca_file || conf->ca_path) {
 		if (!SSL_CTX_load_verify_locations(ctx, conf->ca_file, conf->ca_path)) {
 			tls_error_log(NULL, "Failed reading Trusted root CA list \"%s\"",


### PR DESCRIPTION
This lets for example to only trust a local sub CA
without having to trust the whole hierarchy.