### PR TITLE
TLS: Treat SSL_read returning zero as an error

### DIFF
--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -3685,7 +3685,7 @@ fr_tls_status_t tls_application_data(tls_session_t *ssn, REQUEST *request)
 	 *      data buffer.
 	 */
 	err = SSL_read(ssn->ssl, ssn->clean_out.data, sizeof(ssn->clean_out.data));
-	if (err < 0) {
+	if (err <= 0) {
 		int code;
 
 		RDEBUG("SSL_read Error");
@@ -3708,8 +3708,6 @@ fr_tls_status_t tls_application_data(tls_session_t *ssn, REQUEST *request)
 		}
 		return FR_TLS_FAIL;
 	}
-
-	if (err == 0) RWDEBUG("No data inside of the tunnel");
 
 	/*
 	 *	Passed all checks, successfully decrypted data


### PR DESCRIPTION
As according to the doc, as well as other usage of it in our code.

OpenSSL doc link:
https://www.openssl.org/docs/manmaster/man3/SSL_read.html

In practice, I've encounter it when debugging eap-fast, where sometimes the supplicant would sent a tls-alert (as seen with wireshark), SSL_read would return 0, and we'd continue the eap session into a loop.