### PR TITLE
Remove "zombie_period" bound check against "response_window"

### DIFF
--- a/src/main/realms.c
+++ b/src/main/realms.c
@@ -450,7 +450,6 @@ void realm_home_server_sanitize(home_server_t *home, CONF_SECTION *cs)
 
 	FR_INTEGER_BOUND_CHECK("zombie_period", home->zombie_period, >=, 1);
 	FR_INTEGER_BOUND_CHECK("zombie_period", home->zombie_period, <=, 120);
-	FR_INTEGER_BOUND_CHECK("zombie_period", home->zombie_period, >=, (uint32_t) home->response_window.tv_sec);
 
 	FR_INTEGER_BOUND_CHECK("num_pings_to_alive", home->num_pings_to_alive, >=, 3);
 	FR_INTEGER_BOUND_CHECK("num_pings_to_alive", home->num_pings_to_alive, <=, 10);


### PR DESCRIPTION
Currently "zombie_period" cannot be smaller than "response_window", which makes
it impossible to setup quick fail-over upon a failure of the first home server.

For example, "response_window" is 30 seconds. And if there is no response
from the first home server, then it is a reasonable decision to give up
and fails over to the next server quickly. However changing "zombie_period"
to a small interval (like 1 sec) is not accepted due to the bound check of
"zombie_period >= response_window".

So simply removed the boundary check and allow any number (<1-120>) for
"zombie_period".
This should only affect the time to transit "zombie" to "dead" state.