### PR TITLE
3.0.x - rest - curl option CURLOPT_CAINFO

### DIFF
--- a/raddb/mods-available/rest
+++ b/raddb/mods-available/rest
@@ -5,8 +5,18 @@ rest {
 	#  server.
 	#
 	tls {
-#		ca_file	= ${certdir}/cacert.pem
-#		ca_path	= ${certdir}
+		#  Certificate Authorities:
+		#  "ca_file" (libcurl option CURLOPT_ISSUERCERT).
+		#    File containing a single CA, which is the issuer of the server
+		#    certificate.
+		#  "ca_info_file" (libcurl option CURLOPT_CAINFO).
+		#    File containing a bundle of certificates, which allow to handle
+		#    certificate chain validation.
+		#  "ca_path" (libcurl option CURLOPT_CAPATH).
+		#    Directory holding CA certificates to verify the peer with.
+#		ca_file = ${certdir}/cacert.pem
+#		ca_info_file = ${certdir}/cacert_bundle.pem
+#		ca_path = ${certdir}
 
 #		certificate_file        = /path/to/radius.crt
 #		private_key_file	= /path/to/radius.key

--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -2148,6 +2148,10 @@ int rest_request_config(rlm_rest_t *instance, rlm_rest_section_t *section,
 		SET_OPTION(CURLOPT_ISSUERCERT, section->tls_ca_file);
 	}
 
+	if (section->tls_ca_info_file) {
+		SET_OPTION(CURLOPT_CAINFO, section->tls_ca_info_file);
+	}
+
 	if (section->tls_ca_path) {
 		SET_OPTION(CURLOPT_CAPATH, section->tls_ca_path);
 	}

--- a/src/modules/rlm_rest/rest.h
+++ b/src/modules/rlm_rest/rest.h
@@ -131,6 +131,7 @@ typedef struct rlm_rest_section_t {
 	char const		*tls_private_key_file;
 	char const		*tls_private_key_password;
 	char const		*tls_ca_file;
+	char const		*tls_ca_info_file;
 	char const		*tls_ca_path;
 	char const		*tls_random_file;
 	bool			tls_check_cert;

--- a/src/modules/rlm_rest/rlm_rest.c
+++ b/src/modules/rlm_rest/rlm_rest.c
@@ -36,6 +36,7 @@ RCSID("$Id$")
  */
 static CONF_PARSER tls_config[] = {
 	{ "ca_file", FR_CONF_OFFSET(PW_TYPE_FILE_INPUT, rlm_rest_section_t, tls_ca_file), NULL },
+	{ "ca_info_file", FR_CONF_OFFSET(PW_TYPE_FILE_INPUT, rlm_rest_section_t, tls_ca_info_file), NULL },
 	{ "ca_path", FR_CONF_OFFSET(PW_TYPE_FILE_INPUT, rlm_rest_section_t, tls_ca_path), NULL },
 	{ "certificate_file", FR_CONF_OFFSET(PW_TYPE_FILE_INPUT, rlm_rest_section_t, tls_certificate_file), NULL },
 	{ "private_key_file", FR_CONF_OFFSET(PW_TYPE_FILE_INPUT, rlm_rest_section_t, tls_private_key_file), NULL },


### PR DESCRIPTION
As proposed on the ML, this patch adds support for curl option
CURLOPT_CAINFO (through a new parameter "ca_info_file").
This new parameter can be used instead of "ca_file" (which sets curl
option CURLOPT_ISSUERCERT).
(They can also be used both at the same time.)

CURLOPT_CAINFO is useful to validate a chain of certificate authorities.
If this option is not set, curl will try to validate the CA chain using
a default location, and it may fail.

CURLOPT_ISSUERCERT is useful to check the issuer of the server
certificate.

For reference, see:
https://curl.haxx.se/libcurl/c/CURLOPT_ISSUERCERT.html
https://curl.haxx.se/libcurl/c/CURLOPT_CAINFO.html