### PR TITLE
home_server_addr_cmp does not compare src_ipaddr

### DIFF
--- a/src/main/realms.c
+++ b/src/main/realms.c
@@ -164,9 +164,6 @@ static int home_server_addr_cmp(void const *one, void const *two)
 	if (a->proto > b->proto) return +1;
 #endif
 
-	rcode = fr_ipaddr_cmp(&a->src_ipaddr, &b->src_ipaddr);
-	if (rcode != 0) return rcode;
-
 	return fr_ipaddr_cmp(&a->ipaddr, &b->ipaddr);
 }
 


### PR DESCRIPTION
In file realms.c, function home_server_addr_cmp() compares src_ipaddr. But function home_server_find () does not use src_ipaddr as part of the key for searching. Therefor when a home_server is created with src_ipaddr set to none-zero, then by using home_server_find(), get_home_server() will fail to get it. This results in radmin command "stats home_server (ipaddress) (port)" fails with message "ERROR: No such home server". 

Actually, a home server is identified by ip address and port and type,  src_ipaddr probably should not be part of the identities at all.