### PR TITLE
change RuntimeDirectory to a location

### DIFF
--- a/redhat/radiusd.service
+++ b/redhat/radiusd.service
@@ -16,7 +16,7 @@ EnvironmentFile=-/etc/sysconfig/radiusd
 # We provide HOSTNAME here for convenience.
 Environment=HOSTNAME=%H
 
-RuntimeDirectory=/var/run/radiusd
+RuntimeDirectory=radiusd
 RuntimeDirectoryMode=0775
 ExecStartPre=/usr/sbin/radiusd $FREERADIUS_OPTIONS -Cxm -lstdout
 ExecStartPre=/usr/bin/chown radiusd:radiusd /var/run/radiusd


### PR DESCRIPTION
as per systemd docs and various other blogs, this value is the directory name relative to the parent path, not the fully defined path
with this change /var/run/radiusd will be created and used