### PR TITLE
parser: relax may-be-attr logic

### DIFF
--- a/src/main/parser.c
+++ b/src/main/parser.c
@@ -1214,10 +1214,6 @@ static ssize_t condition_tokenize(TALLOC_CTX *ctx, CONF_ITEM *ci, char const *st
 
 						if (c->data.map->lhs->name[i] == '-') {
 							hyphens++;
-							if (hyphens > 1) {
-								may_be_attr = false;
-								break;
-							}
 						}
 					}
 


### PR DESCRIPTION
we check for too many hyphens later

I encountered it when trying to register a pair-compare for a custom attribute and using it in unlang like:
if (My-Attr-X == "thing")

Though I think other attributes might have more than one hyphen.