### PR TITLE
Fix double free in rlm_sql acct_redundant

### DIFF
--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -1439,7 +1439,6 @@ static int acct_redundant(rlm_sql_t *inst, REQUEST *request, sql_acct_section_t 
 		if (!*expanded) {
 			RDEBUG("Ignoring null query");
 			rcode = RLM_MODULE_NOOP;
-			talloc_free(expanded);
 
 			goto finish;
 		}


### PR DESCRIPTION
Do not free "expanded" buffer twice in "acct_redundant" in rlm_sql.c.
This fixes a crash in the case of an accounting packet not matching a
Start entry in the database.

See also https://bugzilla.redhat.com/show_bug.cgi?id=1540580

Found and fixed by Benoit Welterlen.