### PR TITLE
 Don't bootstrap Redis cluster config when pool->start is 0

### DIFF
--- a/src/include/pool.h
+++ b/src/include/pool.h
@@ -142,6 +142,8 @@ void	fr_pool_enable_triggers(fr_pool_t *pool,
 
 struct timeval fr_pool_timeout(fr_pool_t *pool);
 
+int fr_pool_start(fr_pool_t *pool);
+
 void const *fr_pool_opaque(fr_pool_t *pool);
 
 void	fr_pool_ref(fr_pool_t *pool);

--- a/src/main/pool.c
+++ b/src/main/pool.c
@@ -1154,6 +1154,16 @@ struct timeval fr_pool_timeout(fr_pool_t *pool)
 	return pool->connect_timeout;
 }
 
+/** Connection pool get start
+ *
+ * @param[in] pool to get connection start for.
+ * @return the connection start value configured for the pool.
+ */
+int fr_pool_start(fr_pool_t *pool)
+{
+	return pool->start;
+}
+
 /** Return the opaque data associated with a connection pool
  *
  * @param pool to return data for.


### PR DESCRIPTION
Redis cluster node & slot configuration should not be retrieved when the corresponding pool's start value is 0