### PR TITLE
Red Hat systemd tmpfile

### DIFF
--- a/redhat/freeradius-tmpfiles.conf
+++ b/redhat/freeradius-tmpfiles.conf
@@ -1,0 +1,1 @@
+D /var/run/radiusd 0710 radiusd radiusd -

--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -389,7 +389,7 @@ touch $RPM_BUILD_ROOT/var/log/radius/{radutmp,radius.log}
 # For systemd based systems, that define _unitdir, install the radiusd unit
 %if %{?_unitdir:1}%{!?_unitdir:0}
 install -D -m 755 redhat/radiusd.service $RPM_BUILD_ROOT/%{_unitdir}/radiusd.service
-install -D -m 0644 %{SOURCE104} %{buildroot}%{_sysconfdir}/tmpfiles.d/radiusd.conf
+install -D -m 0644 %{SOURCE104} $RPM_BUILD_ROOT/%{_prefix}/lib/tmpfiles.d/radiusd.conf
 # For SystemV install the init script
 %else
 install -D -m 755 redhat/freeradius-radiusd-init $RPM_BUILD_ROOT/%{initddir}/radiusd
@@ -501,6 +501,7 @@ fi
 
 %if %{?_unitdir:1}%{!?_unitdir:0}
 %{_unitdir}/radiusd.service
+%{_prefix}/lib/tmpfiles.d/radiusd.conf
 %else
 %{initddir}/radiusd
 %endif

--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -42,6 +42,7 @@ Source100: freeradius-radiusd-init
 
 Source102: freeradius-logrotate
 Source103: freeradius-pam-conf
+Source104: freeradius-tmpfiles.conf
 
 Obsoletes: freeradius-devel
 Obsoletes: freeradius-libs
@@ -388,6 +389,7 @@ touch $RPM_BUILD_ROOT/var/log/radius/{radutmp,radius.log}
 # For systemd based systems, that define _unitdir, install the radiusd unit
 %if %{?_unitdir:1}%{!?_unitdir:0}
 install -D -m 755 redhat/radiusd.service $RPM_BUILD_ROOT/%{_unitdir}/radiusd.service
+install -D -m 0644 %{SOURCE104} %{buildroot}%{_sysconfdir}/tmpfiles.d/radiusd.conf
 # For SystemV install the init script
 %else
 install -D -m 755 redhat/freeradius-radiusd-init $RPM_BUILD_ROOT/%{initddir}/radiusd


### PR DESCRIPTION
This pull request adds functionality that exists in the tweaked specfile for Fedora systems. Without this modification, `/var/run/radiusd` gets wiped out upon reboot, meaning the `radiusd` daemon is unable to start. A build from the stock FreeRADIUS specfile is therefore unsafe on systemd-enabled systems.

While it is possible to build from Fedora SRPMs, they tend to lag behind the latest stable upstream release so I think it would be wise to include this modification in the upstream source.

Happy to clarify anything or make amendments as necessary.