### PR TITLE
radclient "-i" didn't work, so just remove it to save confusion

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -31,6 +31,7 @@ FreeRADIUS 3.0.17 Thu 11 Jan 2018 12:00:00 EST urgency=low
 	  not Stripped-User-Name.
 	* RedHat Systemd updates.  Fixes #2184
 	* Use correct API for State variable in rlm_securid.
+	* Remove broken radclient option "-i".
 
 FreeRADIUS 3.0.16 Thu 11 Jan 2018 12:00:00 EST urgency=low
 	Feature improvements

--- a/src/main/radclient.c
+++ b/src/main/radclient.c
@@ -58,7 +58,6 @@ static fr_ipaddr_t client_ipaddr;
 static uint16_t client_port = 0;
 
 static int sockfd;
-static int last_used_id = -1;
 
 #ifdef WITH_TCP
 static char const *proto = NULL;
@@ -96,7 +95,6 @@ static void NEVER_RETURNS usage(void)
 	fprintf(stderr, "                         If a second file is provided, it will be used to verify responses\n");
 	fprintf(stderr, "  -F                     Print the file name, packet number and reply code.\n");
 	fprintf(stderr, "  -h                     Print usage help information.\n");
-	fprintf(stderr, "  -i <id>                Set request id to 'id'.  Values may be 0..255\n");
 	fprintf(stderr, "  -n <num>               Send N requests/s\n");
 	fprintf(stderr, "  -p <num>               Send 'num' packets from a file in parallel.\n");
 	fprintf(stderr, "  -q                     Do not print anything out.\n");
@@ -1195,7 +1193,7 @@ int main(int argc, char **argv)
 		exit(1);
 	}
 
-	while ((c = getopt(argc, argv, "46c:d:D:f:Fhi:n:p:qr:sS:t:vx"
+	while ((c = getopt(argc, argv, "46c:d:D:f:Fhn:p:qr:sS:t:vx"
 #ifdef WITH_TCP
 		"P:"
 #endif
@@ -1245,15 +1243,6 @@ int main(int argc, char **argv)
 
 		case 'F':
 			print_filename = true;
-			break;
-
-		case 'i':	/* currently broken */
-			if (!isdigit((int) *optarg))
-				usage();
-			last_used_id = atoi(optarg);
-			if ((last_used_id < 0) || (last_used_id > 255)) {
-				usage();
-			}
 			break;
 
 		case 'n':


### PR DESCRIPTION
There's no current way to tell fr_packet_list_id_alloc to use a particular ID, and fr_packet_socket_t isn't available to us to change the ID after it's been allocated.

If anyone really needs to do this for testing it can be temporarily hacked into send_one_packet().

Might be what #2179 meant, though the issue wasn't clear.