### PR TITLE
OCSP fixes v4

### DIFF
--- a/src/lib/tls/ocsp.c
+++ b/src/lib/tls/ocsp.c
@@ -331,6 +331,11 @@ int tls_ocsp_check(REQUEST *request, SSL *ssl,
 		break;
 	}
 
+	if (issuer_cert == NULL) {
+		RWDEBUG("Could not get issuer certificate");
+		goto skipped;
+	}
+
 	/*
 	 *	Setup logging for this OCSP operation
 	 */

--- a/src/lib/tls/validate.c
+++ b/src/lib/tls/validate.c
@@ -324,11 +324,12 @@ int tls_validate_cert_cb(int ok, X509_STORE_CTX *x509_ctx)
 	 */
 	if (my_ok && conf->ocsp.enable){
 		RDEBUG2("Starting OCSP Request");
-		if (X509_STORE_CTX_get1_issuer(&issuer_cert, x509_ctx, cert) != 1) {
-			RERROR("Couldn't get issuer_cert for %s", common_name);
-		} else {
-			my_ok = tls_ocsp_check(request, ssl, conf->ocsp.store, issuer_cert, cert, &(conf->ocsp), false);
+		issuer_cert = X509_STORE_CTX_get0_current_issuer(x509_ctx);
+		if (issuer_cert == NULL) {
+			RDEBUG("Couldn't get issuer_cert for %s", common_name);
 		}
+
+		my_ok = tls_ocsp_check(request, ssl, conf->ocsp.store, issuer_cert, cert, &(conf->ocsp), false);
 	}
 #endif
 


### PR DESCRIPTION
Fixes from PR #2160 for v4 branch (somewhat simplified).

Some logs from the different stages:
Initial, ocsp skipped although softfail set to false
https://pastebin.com/L80vNmzc
After first patch, ocsp not skipped:
https://pastebin.com/L7zCnEwQ
After second patch, we succeed to get issuer cert (fails just because it can't connect):
https://pastebin.com/tUStSWM9