### PR TITLE
EKU: Extract raw EKU OIDs into attributes

### DIFF
--- a/share/dictionary.freeradius.internal
+++ b/share/dictionary.freeradius.internal
@@ -533,8 +533,9 @@ ATTRIBUTE	TLS-Client-Cert-X509v3-Basic-Constraints 1930	string
 ATTRIBUTE	TLS-Client-Cert-Subject-Alt-Name-Dns	1931	string
 ATTRIBUTE	TLS-Client-Cert-Subject-Alt-Name-Upn	1932	string
 ATTRIBUTE	TLS-PSK-Identity			1933	string
+ATTRIBUTE	TLS-Client-Cert-X509v3-Extended-Key-Usage-OID 1936	string
 
-# 1934 - 1939: reserved for future cert attributes
+# 1937 - 1939: reserved for future cert attributes
 
 # 1940 - 1949: reserved for TLS session caching, mostly in 3.1
 


### PR DESCRIPTION
This helps with matching a single OID regardless of its name.

Currently, the EKU attribute is a comma separated list of mixed OIDs and names (as known to ossl), e.g. 
TLS-Client-Cert-X509v3-Extended-Key-Usage += 1.2.250.1.4.1.311.21.8.16553884.13926527.9456536.14411893.1032733.83.1698795.44, 1.3.6.1.4.1.311.10.3.8, 1.3.6.1.4.1.311.10.3.6, TLS Web Client Authentication, E-mail Protection, Microsoft Encrypted File System

While with this patch, it adds and attribute for each OID, like:
TLS-Client-Cert-X509v3-Extended-Key-Usage-OID += 1.3.6.1.4.1.311.10.3.8
TLS-Client-Cert-X509v3-Extended-Key-Usage-OID += 1.3.6.1.4.1.311.10.3.6
TLS-Client-Cert-X509v3-Extended-Key-Usage-OID += 1.3.6.1.5.5.7.3.2
...

Thanks!