### PR TITLE
Fix to DHCP encoding error when sub-option doesn't fit

### DIFF
--- a/src/protocols/dhcpv4/encode.c
+++ b/src/protocols/dhcpv4/encode.c
@@ -172,6 +172,10 @@ static ssize_t encode_rfc_hdr(uint8_t *out, ssize_t outlen,
 		if (len < 0) return len;
 		if (len == 0) {
 			FR_PROTO_TRACE("No more space in option");
+			if (out[1] == 0) {
+				/* Couldn't encode anything: don't leave behind these two octets. */
+				p -= 2;
+			}
 			break; /* Packed as much as we can */
 		}
 


### PR DESCRIPTION
Ask FreeRADIUS to encode several sub-options too long to fit in one option.
Then the first option is not properly encoded. There are two octets leftover (the beginning of the second sub-option).

Here is a fix.