### PR TITLE
SASL: Let configure SASL_SECPROPS per LDAP instance

### DIFF
--- a/raddb/mods-available/ldap
+++ b/raddb/mods-available/ldap
@@ -438,6 +438,12 @@ ldap {
 		chase_referrals = yes
 		rebind = yes
 
+		# SASL Security Properties (see SASL_SECPROPS in ldap.conf man page).
+		# Note - uncomment when using GSS-API sasl mechanism along with TLS
+		# encryption against Active-Directory LDAP servers (this disables
+		# sealing and signing at the GSS level as required by AD).
+		#sasl_secprops = 'noanonymous,noplain,maxssf=0'
+
 		#  Seconds to wait for LDAP query to finish. default: 20
 		res_timeout = 10
 

--- a/src/modules/rlm_ldap/ldap.c
+++ b/src/modules/rlm_ldap/ldap.c
@@ -1551,6 +1551,10 @@ void *mod_conn_create(TALLOC_CTX *ctx, void *instance)
 	}
 #endif /* HAVE_LDAP_START_TLS_S */
 
+	if (inst->sasl_secprops) {
+		do_ldap_option(LDAP_OPT_X_SASL_SECPROPS, "SASL_SECPROPS", inst->sasl_secprops);
+	}
+
 	status = rlm_ldap_bind(inst, NULL, &conn, conn->inst->admin_identity, conn->inst->admin_password,
 			       &(conn->inst->admin_sasl), false);
 	if (status != LDAP_PROC_SUCCESS) {

--- a/src/modules/rlm_ldap/ldap.h
+++ b/src/modules/rlm_ldap/ldap.h
@@ -123,6 +123,8 @@ typedef struct ldap_instance {
 
 	ldap_sasl	admin_sasl;			//!< SASL parameters used when binding as the admin.
 
+	const char	*sasl_secprops;			//!< SASL Security Properties to set.
+
 	char const	*dereference_str;		//!< When to dereference (never, searching, finding, always)
 	int		dereference;			//!< libldap value specifying dereferencing behaviour.
 

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -188,6 +188,8 @@ static CONF_PARSER option_config[] = {
 
 	{ "rebind", FR_CONF_OFFSET(PW_TYPE_BOOLEAN, rlm_ldap_t, rebind), NULL },
 
+	{ "sasl_secprops", FR_CONF_OFFSET(PW_TYPE_STRING, rlm_ldap_t, sasl_secprops), NULL },
+
 #ifdef LDAP_OPT_NETWORK_TIMEOUT
 	/* timeout on network activity */
 	{ "net_timeout", FR_CONF_OFFSET(PW_TYPE_INTEGER, rlm_ldap_t, net_timeout), "10" },


### PR DESCRIPTION
Active-Directory does not allow to use GSS-API signing / sealing when
over TLS (to avoid double encryption?).
While SASL_SECPROPS (or maxssf) coul be set globally via system's
ldap.conf, it is not enough if you want one instead to work with
TLS and the other without TLS but with signing and sealing of GSS-API.

Add a directive sasl_secprops, to allow setting it per instance.

See reference to MS bug at:
https://buildfarm.opencsw.org/source/xref/samba/source3/librpc/crypto/gse.c#303