### PR TITLE
Encoding of empty DHCP options

### DIFF
--- a/src/protocols/dhcpv4/encode.c
+++ b/src/protocols/dhcpv4/encode.c
@@ -59,7 +59,7 @@ static ssize_t encode_value(uint8_t *out, size_t outlen,
 	FR_PROTO_STACK_PRINT(tlv_stack, depth);
 	FR_PROTO_TRACE("%zu byte(s) available for value", outlen);
 
-	if (outlen < vp->vp_length) return 0;
+	if (outlen < vp->vp_length) return -1;	/* Not enough output buffer space. */
 
 	switch (tlv_stack[depth]->type) {
 	case FR_TYPE_UINT8:
@@ -169,8 +169,8 @@ static ssize_t encode_rfc_hdr(uint8_t *out, ssize_t outlen,
 		VALUE_PAIR *next;
 
 		len = encode_value(p, outlen - out[1], tlv_stack, depth, cursor);
-		if (len < 0) return len;
-		if (len == 0) {
+		if (len < -1) return len;
+		if (len == -1) {
 			FR_PROTO_TRACE("No more space in option");
 			if (out[1] == 0) {
 				/* Couldn't encode anything: don't leave behind these two octets. */

--- a/src/tests/unit/dhcpv4.txt
+++ b/src/tests/unit/dhcpv4.txt
@@ -41,3 +41,7 @@ data DHCP-Message-Type = DHCP-Discover, DHCP-Client-Identifier = 0x01001ceaadac1
 #
 encode-pair DHCP-Agent-Circuit-Id = 'oh hai this is an agent, how are you doing DHCP server? this is a really long agent circuit id, which will occupy most of the maximum size for an option so that the next sub option will not fit and a new option will be needed', DHCP-Agent-Remote-Id = 'trying to add a sub option agent remote id'
 data 52 e3 01 e1 6f 68 20 68 61 69 20 74 68 69 73 20 69 73 20 61 6e 20 61 67 65 6e 74 2c 20 68 6f 77 20 61 72 65 20 79 6f 75 20 64 6f 69 6e 67 20 44 48 43 50 20 73 65 72 76 65 72 3f 20 74 68 69 73 20 69 73 20 61 20 72 65 61 6c 6c 79 20 6c 6f 6e 67 20 61 67 65 6e 74 20 63 69 72 63 75 69 74 20 69 64 2c 20 77 68 69 63 68 20 77 69 6c 6c 20 6f 63 63 75 70 79 20 6d 6f 73 74 20 6f 66 20 74 68 65 20 6d 61 78 69 6d 75 6d 20 73 69 7a 65 20 66 6f 72 20 61 6e 20 6f 70 74 69 6f 6e 20 73 6f 20 74 68 61 74 20 74 68 65 20 6e 65 78 74 20 73 75 62 20 6f 70 74 69 6f 6e 20 77 69 6c 6c 20 6e 6f 74 20 66 69 74 20 61 6e 64 20 61 20 6e 65 77 20 6f 70 74 69 6f 6e 20 77 69 6c 6c 20 62 65 20 6e 65 65 64 65 64 52 2c 02 2a 74 72 79 69 6e 67 20 74 6f 20 61 64 64 20 61 20 73 75 62 20 6f 70 74 69 6f 6e 20 61 67 65 6e 74 20 72 65 6d 6f 74 65 20 69 64
+
+#  An empty option (Rapid Commit)
+encode-pair DHCP-Rapid-Commit = ''
+data 50 00


### PR DESCRIPTION
DHCP options can be empty.
See https://tools.ietf.org/html/rfc4039: "Rapid Commit" always has a len of 0.

The encoding doesn't support this currently.
(I think it worked before, but was broken by https://github.com/FreeRADIUS/freeradius-server/pull/2209 - my bad).

So here's another fix, to support encoding of empty DHCP options.

I also updated (and passed) the dhcp4 unit tests.