### PR TITLE
Print usage and exit when -N used with invalid IP.

### DIFF
--- a/src/main/radwho.c
+++ b/src/main/radwho.c
@@ -233,7 +233,7 @@ int main(int argc, char **argv)
 			showname = 0;
 			break;
 		case 'N':
-			if (inet_pton(AF_INET, optarg, &nas_ip_address) < 0) {
+			if (inet_pton(AF_INET, optarg, &nas_ip_address) <= 0) {
 				usage(1);
 			}
 			break;


### PR DESCRIPTION
# Issue type
- [ ] Defect - Crash or memory corruption.
- [ ] Defect - Non compliance with a standards document, or incorrect API usage.
- [x] Defect - Unexpected behaviour (obvious or verified by project member).
- [ ] Feature request.

# Defect/Feature description
The command-line argument supplied with the -N option is supposed to be an IP address for filtering purposes, and is passed to inet_pton() to be validated.  However, the return value from inet_pton() is not checked properly; it will be zero if input string is invalid, but radwho only checks for a negative value.  (The return will never be negative in this case, because the address family AF_INET parameter is always valid.)

## How to reproduce issue
`radwho -N foo`
Should output help/usage text and exit, but instead proceeds to look for radutmp file.

## Commit message from pull request
Check for all possible error return values from inet_pton(),
particularly zero, as this indicates an invalid IP address was
passed in the input string, whereas -1 is returned only when the
address family parameter is invalid, which is never the case
here because it's always AF_INET.