### PR TITLE
Fix for #2233

### DIFF
--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -444,6 +444,7 @@ static rlm_rcode_t do_python_single(REQUEST *request, PyObject *pFunc, char cons
 	PyObject	*pArgs = NULL;
 	int		ret;
 	int 		i;
+	VALUE_PAIR *proxy_reply_vps = NULL;
 
 	/* Default return value is "OK, continue" */
 	ret = RLM_MODULE_OK;
@@ -469,8 +470,9 @@ static rlm_rcode_t do_python_single(REQUEST *request, PyObject *pFunc, char cons
 
 		/* fill proxy vps */
 		if (request->proxy) {
+			proxy_reply_vps = request->proxy_reply == NULL ? NULL : request->proxy_reply->vps;
 			if (!mod_populate_vps(pArgs, 4, request->proxy->vps) ||
-			    !mod_populate_vps(pArgs, 5, request->proxy_reply->vps)) {
+			    !mod_populate_vps(pArgs, 5, proxy_reply_vps)) {
 				ret = RLM_MODULE_FAIL;
 				goto finish;
 			}


### PR DESCRIPTION
If home radius server is down `request->proxy_reply` will be empty,
and direct access to vps from proxy_reply can lead to segmentation
fault.
Added check for empty proxy_reply.