### PR TITLE
Fix to fr_pair_list_afrom_file - file done

### DIFF
--- a/src/lib/util/pair.c
+++ b/src/lib/util/pair.c
@@ -1659,11 +1659,11 @@ int fr_pair_list_afrom_file(TALLOC_CTX *ctx, VALUE_PAIR **out, FILE *fp, bool *p
 
 	while (fgets(buf, sizeof(buf), fp) != NULL) {
 		/*
-		 *      If we get a '\n' by itself, we assume that's
-		 *      the end of that VP list.
+		 *	If we get a '\n' by itself, we assume that's
+		 *	the end of that VP list.
 		 */
 		if (buf[0] == '\n') {
-			if (vp) {
+			if (*out) {
 				*pfiledone = false;
 				return 0;
 			}


### PR DESCRIPTION
After fr_cursor_merge, local vp is NULL, so caller gets "*pfiledone = true" and will not read more than one value pair list.

Here is a fix.