### PR TITLE
add libfreeradius-eap-sim.so and libfreeradius-soh.so to libfreeradiu…

### DIFF
--- a/debian/libfreeradius4.install
+++ b/debian/libfreeradius4.install
@@ -1,7 +1,9 @@
 usr/lib/freeradius/libfreeradius-eap.so
+usr/lib/freeradius/libfreeradius-eap-sim.so
 usr/lib/freeradius/libfreeradius-radius.so
 usr/lib/freeradius/libfreeradius-server.so
 usr/lib/freeradius/libfreeradius-unlang.so
 usr/lib/freeradius/libfreeradius-tls.so
 usr/lib/freeradius/libfreeradius-util.so
 usr/lib/freeradius/libfreeradius-io.so
+usr/lib/freeradius/libfreeradius-soh.so


### PR DESCRIPTION
…s4 dpkg

without these libs, freeradius will not start and will complain about missing these libs.