### PR TITLE
Properly check tidc_send_request return value

### DIFF
--- a/src/modules/rlm_realm/trustrouter.c
+++ b/src/modules/rlm_realm/trustrouter.c
@@ -144,7 +144,7 @@ static bool tidc_send_recv(const char *trustrouter, int port, const char *rpreal
 	/* Send TIDC request */
 	rcode = tidc_send_request(global_tidc, conn, gssctx, (char *) rprealm, (char *) realm_name,
 				  (char *) community, &tr_response_func, cookie);
-	if (rcode > 0) {
+	if (rcode < 0) {
 		DEBUG2("Error in tidc_send_request, rc = %d.", rcode);
 		return false;
 	}


### PR DESCRIPTION
tidc_send_request returns -1 on failure and 0 on success.
For some reason during the writing of the rekeying code this comparison was switched. Fixing.