### PR TITLE
Add support for dynamic Pool-Name attribute

### DIFF
--- a/raddb/mods-available/dhcp_sqlippool
+++ b/raddb/mods-available/dhcp_sqlippool
@@ -17,6 +17,9 @@ sqlippool dhcp_sqlippool {
 
 	ippool_table = "radippool"
 
+	# Name of the check item attribute to be used as a key in the SQL queries
+	pool_name = "Pool-Name"
+
 	lease_duration = 7200
 
 	# Client's MAC address is mapped to Calling-Station-Id in policy.conf
@@ -33,12 +36,12 @@ sqlippool dhcp_sqlippool {
 
 	sqlippool_log_exists = "DHCP: Existing IP: %{reply:Framed-IP-Address} (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
 
-	sqlippool_log_success = "DHCP: Allocated IP: %{reply:Framed-IP-Address} from %{control:Pool-Name} (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
+	sqlippool_log_success = "DHCP: Allocated IP: %{reply:Framed-IP-Address} from %{control:${..pool_name}} (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
 
 	sqlippool_log_clear = "DHCP: Released IP %{Framed-IP-Address} (did %{Called-Station-Id} cli %{Calling-Station-Id} user %{User-Name})"
 
-	sqlippool_log_failed = "DHCP: IP Allocation FAILED from %{control:Pool-Name} (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
+	sqlippool_log_failed = "DHCP: IP Allocation FAILED from %{control:${..pool_name}} (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
 
-	sqlippool_log_nopool = "DHCP: No Pool-Name defined (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
+	sqlippool_log_nopool = "DHCP: No ${..pool_name} defined (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
 
 }

--- a/raddb/mods-available/sqlippool
+++ b/raddb/mods-available/sqlippool
@@ -18,6 +18,9 @@ sqlippool {
 	#  reference expansions.
 	dialect = "mysql"
 
+	# Name of the check item attribute to be used as a key in the SQL queries
+	pool_name = "Pool-Name"
+
 	# SQL table to use for ippool range and lease info
 	ippool_table = "radippool"
 
@@ -85,13 +88,13 @@ sqlippool {
 	messages {
 		exists = "Existing IP: %{reply:${..attribute_name}} (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
 
-		success = "Allocated IP: %{reply:${..attribute_name}} from %{control:Pool-Name} (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
+		success = "Allocated IP: %{reply:${..attribute_name}} from %{control:${..pool_name}} (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
 
 		clear = "Released IP ${..attribute_name} (did %{Called-Station-Id} cli %{Calling-Station-Id} user %{User-Name})"
 
-		failed = "IP Allocation FAILED from %{control:Pool-Name} (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
+		failed = "IP Allocation FAILED from %{control:${..pool_name}} (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
 
-		nopool = "No Pool-Name defined (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
+		nopool = "No ${..pool_name} defined (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
 	}
 
 	$INCLUDE ${modconfdir}/sql/ippool/${dialect}/queries.conf

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -50,7 +50,7 @@ allocate_clear = "\
 allocate_find = "\
 	SELECT framedipaddress \
 	FROM ${ippool_table} \
-	WHERE pool_name = '%{control:Pool-Name}' \
+	WHERE pool_name = '%{control:${pool_name}}' \
 	AND (callingstationid = '%{Calling-Station-Id}' or callingstationid = '') \
 	ORDER BY \
 		(callingstationid <> '%{Calling-Station-Id}'), \
@@ -64,7 +64,7 @@ allocate_find = "\
 #allocate_find = "\
 #	SELECT framedipaddress \
 #	FROM ${ippool_table} \
-#	WHERE pool_name = '%{control:Pool-Name}' \
+#	WHERE pool_name = '%{control:${pool_name}}' \
 #	AND expiry_time < NOW() \
 #	ORDER BY RAND() \
 #	LIMIT 1 \
@@ -79,7 +79,7 @@ allocate_find = "\
 pool_check = "\
 	SELECT id \
 	FROM ${ippool_table} \
-	WHERE pool_name='%{control:Pool-Name}' \
+	WHERE pool_name='%{control:${pool_name}}' \
 	LIMIT 1"
 
 #

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -24,13 +24,13 @@ allocate_find = "\
 	WITH POOLS AS (\
 		SELECT * \
 		FROM ${ippool_table} \
-		WHERE pool_name = '%{control:Pool-Name}' \
+		WHERE pool_name = '%{control:${pool_name}}' \
 		AND (\
 			pool_key = '${pool_key}' \
 			OR expiry_time = (\
 				SELECT MIN(expiry_time) \
 				FROM ${ippool_table} \
-				WHERE pool_name = '%{control:Pool-Name}' \
+				WHERE pool_name = '%{control:${pool_name}}' \
 				AND expiry_time < CURRENT_TIMESTAMP AND pool_key != '${pool_key}'\
 			)\
 		)\
@@ -53,7 +53,7 @@ allocate_find = "\
 #  This function is available if you want to use multiple pools
 #
 #allocate_find = "\
-	SELECT msqlippool('%{SQL-User-Name}','%{control:Pool-Name}') \
+	SELECT msqlippool('%{SQL-User-Name}','%{control:${pool_name}}') \
 	FROM dual"
 
 #
@@ -67,7 +67,7 @@ allocate_find = "\
 #		FROM (\
 #			SELECT framedipaddress \
 #			FROM ${ippool_table} \
-#			WHERE pool_name = '%{control:Pool-Name}' \
+#			WHERE pool_name = '%{control:${pool_name}}' \
 #			AND expiry_time < CURRENT_TIMESTAMP \
 #			ORDER BY DBMS_RANDOM.VALUE\
 #		) \
@@ -86,7 +86,7 @@ allocate_find = "\
 #	FROM (\
 #		SELECT id \
 #		FROM ${ippool_table} \
-#		WHERE pool_name = '%{control:Pool-Name}'\
+#		WHERE pool_name = '%{control:${pool_name}}'\
 #	) WHERE ROWNUM = 1"
 
 #
@@ -128,7 +128,7 @@ start_update = "\
 	SET \
 		expiry_time = CURRENT_TIMESTAMP + INTERVAL '${lease_duration}' SECOND(1) \
 	WHERE nasipaddress = '%{NAS-IP-Address}' \
-	AND pool_name = '%{control:Pool-Name}' \
+	AND pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{Framed-IP-Address}'"
 
@@ -151,7 +151,7 @@ alive_update = "\
 	SET \
 		expiry_time = CURRENT_TIMESTAMP + INTERVAL '${lease_duration}' SECOND(1) \
 	WHERE pool_key = '${pool_key}' \
-	AND pool_name = '%{control:Pool-Name}' \
+	AND pool_name = '%{control:${pool_name}}' \
 	AND framedipaddress = '%{Framed-IP-Address}'"
 
 #

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -41,7 +41,7 @@ allocate_clear = "\
 allocate_find = "\
 	SELECT framedipaddress \
 	FROM ${ippool_table} \
-	WHERE pool_name = '%{control:Pool-Name}' \
+	WHERE pool_name = '%{control:${pool_name}}' \
 	AND (\
 		((expiry_time < datetime('now')) OR expiry_time IS NULL) \
 		OR (callingstationid = '%{Calling-Station-Id}') \
@@ -57,7 +57,7 @@ allocate_find = "\
 #
 #allocate_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} \
-#	WHERE pool_name = '%{control:Pool-Name}' \
+#	WHERE pool_name = '%{control:${pool_name}}' \
 #	AND expiry_time IS NULL \
 #	ORDER BY RAND() \
 #	LIMIT 1 \
@@ -72,7 +72,7 @@ allocate_find = "\
 pool_check = "\
 	SELECT id \
 	FROM ${ippool_table} \
-	WHERE pool_name='%{control:Pool-Name}' \
+	WHERE pool_name='%{control:${pool_name}}' \
 	LIMIT 1"
 
 #

--- a/raddb/mods-config/sql/ippool/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mysql/queries.conf
@@ -40,7 +40,7 @@ allocate_clear = "\
 #
 allocate_find = "\
 	SELECT framedipaddress FROM ${ippool_table} \
-	WHERE pool_name = '%{control:Pool-Name}' \
+	WHERE pool_name = '%{control:${pool_name}}' \
 	AND (expiry_time < NOW() OR expiry_time IS NULL) \
 	ORDER BY \
 		(username <> '%{User-Name}'), \
@@ -54,7 +54,7 @@ allocate_find = "\
 #
 #allocate_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} \
-#	WHERE pool_name = '%{control:Pool-Name}' \
+#	WHERE pool_name = '%{control:${pool_name}}' \
 #	AND expiry_time IS NULL \
 #	ORDER BY \
 #		RAND() \
@@ -70,7 +70,7 @@ allocate_find = "\
 pool_check = "\
 	SELECT id \
 	FROM ${ippool_table} \
-	WHERE pool_name='%{control:Pool-Name}' \
+	WHERE pool_name='%{control:${pool_name}}' \
 	LIMIT 1"
 
 #

--- a/raddb/mods-config/sql/ippool/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool/oracle/queries.conf
@@ -19,7 +19,7 @@ off_begin = "commit"
 allocate_find = "\
 	SELECT framedipaddress \
 	FROM ${ippool_table} \
-	WHERE pool_name = '%{control:Pool-Name}' \
+	WHERE pool_name = '%{control:${pool_name}}' \
 	AND expiry_time < current_timestamp \
 	AND rownum <= 1 \
 	ORDER BY \
@@ -32,7 +32,7 @@ allocate_find = "\
 #  This function is available if you want to use multiple pools
 #
 #allocate_find = "\
-#	SELECT msqlippool('%{SQL-User-Name}','%{control:Pool-Name}') \
+#	SELECT msqlippool('%{SQL-User-Name}','%{control:${pool_name}}') \
 #	FROM dual"
 
 #
@@ -41,7 +41,7 @@ allocate_find = "\
 #allocate_find = "\
 #	SELECT framedipaddress \
 #	FROM ${ippool_table} \
-#	WHERE pool_name = '%{control:Pool-Name}' \
+#	WHERE pool_name = '%{control:${pool_name}}' \
 #	AND expiry_time < current_timestamp \
 #	AND rownum <= 1 \
 #	ORDER BY RANDOM() \
@@ -58,7 +58,7 @@ pool_check = "\
 	FROM (\
 		SELECT id \
 		FROM ${ippool_table} \
-		WHERE pool_name='%{control:Pool-Name}'\
+		WHERE pool_name='%{control:${pool_name}}'\
 	) \
 	WHERE ROWNUM = 1"
 

--- a/raddb/mods-config/sql/ippool/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool/postgresql/queries.conf
@@ -12,7 +12,7 @@
 allocate_find = "\
 	SELECT framedipaddress \
 	FROM ${ippool_table} \
-	WHERE pool_name = '%{control:Pool-Name}' \
+	WHERE pool_name = '%{control:${pool_name}}' \
 	AND expiry_time < 'now'::timestamp(0) \
 	ORDER BY \
 		(username <> '%{SQL-User-Name}'), \
@@ -26,7 +26,7 @@ allocate_find = "\
 #
 allocate_find = "\
 	SELECT framedipaddress FROM ${ippool_table} \
-	WHERE pool_name = '%{control:Pool-Name}' AND expiry_time < 'now'::timestamp(0) \
+	WHERE pool_name = '%{control:${pool_name}}' AND expiry_time < 'now'::timestamp(0) \
 	ORDER BY RANDOM() \
 	LIMIT 1 \
 	FOR UPDATE"
@@ -40,7 +40,7 @@ allocate_find = "\
 pool_check = "\
 	SELECT id \
 	FROM ${ippool_table} \
-	WHERE pool_name='%{control:Pool-Name}' \
+	WHERE pool_name='%{control:${pool_name}}' \
 	LIMIT 1"
 
 #

--- a/raddb/mods-config/sql/ippool/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool/sqlite/queries.conf
@@ -39,7 +39,7 @@ allocate_clear = "\
 allocate_find = "\
 	SELECT framedipaddress \
 	FROM ${ippool_table} \
-	WHERE pool_name = '%{control:Pool-Name}' \
+	WHERE pool_name = '%{control:${pool_name}}' \
 	AND (expiry_time < datetime('now') OR expiry_time IS NULL) \
 	ORDER BY \
 		(username <> '%{User-Name}'), \
@@ -56,7 +56,7 @@ allocate_find = "\
 #allocate_find = "\
 #	SELECT framedipaddress \
 #	FROM ${ippool_table} \
-# 	WHERE pool_name = '%{control:Pool-Name}' \
+# 	WHERE pool_name = '%{control:${pool_name}}' \
 #	AND expiry_time IS NULL \
 #	ORDER BY RAND() \
 # 	LIMIT 1 \
@@ -71,7 +71,7 @@ allocate_find = "\
 pool_check = "\
 	SELECT id \
 	FROM ${ippool_table} \
-	WHERE pool_name='%{control:Pool-Name}' \
+	WHERE pool_name='%{control:${pool_name}}' \
 	LIMIT 1"
 
 #


### PR DESCRIPTION
Regarding issue #2282, I added the support to specify a custom Pool Name instead of the traditional *Pool-Name*.

the *pool_name* attribute in the sqlippool file (default: 'Pool-Name') can now be used to specify any other specific attribute to be used as Pool Name.