### PR TITLE
Better "un-xlating" of value pairs where xlat is not supported

### DIFF
--- a/src/lib/util/value.c
+++ b/src/lib/util/value.c
@@ -37,8 +37,8 @@
  *
  * - PRESENTATION format is what we print to the screen, and what we get from the user, databases
  *   and configuration files.
- *   - #fr_value_box_asprint is used to convert INTERNAL format PRESENTATION format.
- *   - #fr_value_box_from_str is used to convert from INTERNAL to PRESENTATION format.
+ *   - #fr_value_box_asprint is used to convert from INTERNAL to PRESENTATION format.
+ *   - #fr_value_box_from_str is used to convert from PRESENTATION to INTERNAL format.
  *
  * @copyright 2014-2017 The FreeRADIUS server project
  * @copyright 2017 Arran Cudbard-Bell <a.cudbardb@freeradius.org>

--- a/src/main/radclient.c
+++ b/src/main/radclient.c
@@ -473,10 +473,16 @@ static int radclient_init(TALLOC_CTX *ctx, rc_file_pair_t *files)
 			     vp;
 			     vp = fr_cursor_next(&cursor)) {
 			     again:
+				/*
+				 *	Xlat expansions are not supported. Convert xlat to value box (if possible).
+				 */
 				if (vp->type == VT_XLAT) {
+					fr_type_t type = vp->da->type;
+					if (fr_value_box_from_str(vp, &vp->data, &type, NULL, vp->xlat, -1, '\0', false) < 0) {
+						fr_perror("radclient");
+						goto error;
+					}
 					vp->type = VT_DATA;
-					vp->vp_strvalue = vp->xlat;
-					vp->vp_length = talloc_array_length(vp->vp_strvalue) - 1;
 				}
 
 				if ((vp->da == attr_response_packet_type) || (vp->da == attr_packet_type)) {
@@ -502,13 +508,15 @@ static int radclient_init(TALLOC_CTX *ctx, rc_file_pair_t *files)
 		     vp;
 		     vp = fr_cursor_next(&cursor)) {
 			/*
-			 *	Double quoted strings get marked up as xlat expansions,
-			 *	but we don't support that in request.
+			 *	Xlat expansions are not supported. Convert xlat to value box (if possible).
 			 */
 			if (vp->type == VT_XLAT) {
+				fr_type_t type = vp->da->type;
+				if (fr_value_box_from_str(vp, &vp->data, &type, NULL, vp->xlat, -1, '\0', false) < 0) {
+					fr_perror("radclient");
+					goto error;
+				}
 				vp->type = VT_DATA;
-				vp->vp_strvalue = vp->xlat;
-				vp->vp_length = talloc_array_length(vp->vp_strvalue) - 1;
 			}
 
 			/*

--- a/src/main/radsniff.c
+++ b/src/main/radsniff.c
@@ -1988,12 +1988,15 @@ static int rs_build_filter(VALUE_PAIR **out, char const *filter)
 	     vp;
 	     vp = fr_cursor_next(&cursor)) {
 		/*
-		 *	xlat expansion isn't supported here
+		 *	Xlat expansions are not supported. Convert xlat to value box (if possible).
 		 */
 		if (vp->type == VT_XLAT) {
+			fr_type_t type = vp->da->type;
+			if (fr_value_box_from_str(vp, &vp->data, &type, NULL, vp->xlat, -1, '\0', false) < 0) {
+				fr_perror("radsniff");
+				return -1;
+			}
 			vp->type = VT_DATA;
-			vp->vp_strvalue = vp->xlat;
-			vp->vp_length = talloc_array_length(vp->vp_strvalue) - 1;
 		}
 	}
 


### PR DESCRIPTION
All kind of value pairs attributes can be VT_XLAT when read from input. We cannot assume they are strings or octets.
Better fail explicitly if the conversion is not possible.

For example, we will have:

dhcpclient: Invalid integer value "%{something}"

I fixed this issue in dhcpclient, radclient, and radsniff.

In addition, I corrected inaccurate comments in value.c about formats.