### PR TITLE
Better "un-xlating" of value pairs where xlat is not supported

### DIFF
--- a/src/bin/radsniff.c
+++ b/src/bin/radsniff.c
@@ -1990,12 +1990,15 @@ static int rs_build_filter(VALUE_PAIR **out, char const *filter)
 	     vp;
 	     vp = fr_cursor_next(&cursor)) {
 		/*
-		 *	xlat expansion isn't supported here
+		 *	Xlat expansions are not supported. Convert xlat to value box (if possible).
 		 */
 		if (vp->type == VT_XLAT) {
+			fr_type_t type = vp->da->type;
+			if (fr_value_box_from_str(vp, &vp->data, &type, NULL, vp->xlat, -1, '\0', false) < 0) {
+				fr_perror("radsniff");
+				return -1;
+			}
 			vp->type = VT_DATA;
-			vp->vp_strvalue = vp->xlat;
-			vp->vp_length = talloc_array_length(vp->vp_strvalue) - 1;
 		}
 	}
 

--- a/src/lib/util/value.c
+++ b/src/lib/util/value.c
@@ -36,8 +36,8 @@
  *
  * - PRESENTATION format is what we print to the screen, and what we get from the user, databases
  *   and configuration files.
- *   - #fr_value_box_asprint is used to convert INTERNAL format PRESENTATION format.
- *   - #fr_value_box_from_str is used to convert from INTERNAL to PRESENTATION format.
+ *   - #fr_value_box_asprint is used to convert from INTERNAL to PRESENTATION format.
+ *   - #fr_value_box_from_str is used to convert from PRESENTATION to INTERNAL format.
  *
  * @copyright 2014-2017 The FreeRADIUS server project
  * @copyright 2017 Arran Cudbard-Bell <a.cudbardb@freeradius.org>


### PR DESCRIPTION
All kind of value pairs attributes can be VT_XLAT when read from input. We cannot assume they are strings or octets.
Better fail explicitly if the conversion is not possible.

For example, we will have:

dhcpclient: Invalid integer value "%{something}"

I fixed this issue in dhcpclient, radclient, and radsniff.

In addition, I corrected inaccurate comments in value.c about formats.