### PR TITLE
Workaround duplicate User-Name

### DIFF
--- a/raddb/sites-available/abfab-tr-idp
+++ b/raddb/sites-available/abfab-tr-idp
@@ -61,6 +61,15 @@ post-auth {
 	#  The session-state attributes are automatically deleted after
 	#  an Access-Reject or Access-Accept is sent.
 	#
+	#  If both session-state and reply contain a User-Name attribute, remove
+	#  the one in the reply if it is just a copy of the one in the request, so
+	#  we don't end up with two User-Name attributes.
+
+	if (session-state:User-Name && reply:User-Name && request:User-Name && (reply:User-Name == request:User-Name)) {
+		update reply {
+			User-Name !* ANY
+		}
+	}
 	update {
 		&reply: += &session-state:
 	}

--- a/raddb/sites-available/default
+++ b/raddb/sites-available/default
@@ -718,6 +718,15 @@ post-auth {
 	#  The session-state attributes are automatically deleted after
 	#  an Access-Reject or Access-Accept is sent.
 	#
+	#  If both session-state and reply contain a User-Name attribute, remove
+	#  the one in the reply if it is just a copy of the one in the request, so
+	#  we don't end up with two User-Name attributes.
+
+	if (session-state:User-Name && reply:User-Name && request:User-Name && (reply:User-Name == request:User-Name)) {
+		update reply {
+			User-Name !* ANY
+		}
+	}
 	update {
 		&reply: += &session-state:
 	}


### PR DESCRIPTION
Workaround duplicate User-Name attributes when the inner-tunnel is providing an updated one.