### PR TITLE
Added support for Eltex-AVPair to preprocess/vsa_hack

### DIFF
--- a/src/modules/rlm_preprocess/rlm_preprocess.c
+++ b/src/modules/rlm_preprocess/rlm_preprocess.c
@@ -113,8 +113,8 @@ static void cisco_vsa_hack(REQUEST *request)
 	     vp;
 	     vp = fr_cursor_next(&cursor)) {
 		vendorcode = vp->da->vendor;
-		if (!((vendorcode == 9) || (vendorcode == 6618))) {
-			continue; /* not a Cisco or Quintum VSA, continue */
+		if (!((vendorcode == 9) || (vendorcode == 6618) || (vendorcode == 35265))) {
+			continue; /* not a Cisco, Quintum or Eltex VSA, continue */
 		}
 
 		if (vp->da->type != PW_TYPE_STRING) {


### PR DESCRIPTION
Eltex have cloned the Cisco-AVPair attribute and called it Eltex-AVPair. As these attribtues are pretty awful and difficult to work with I added it to the vsa_hack code in rlm_preprocess.c. Here is the relevant part of the current Eltex dictionary:


VENDOR		Eltex				35265

BEGIN-VENDOR	Eltex

ATTRIBUTE	Eltex-AVPair				1	string
...

