### PR TITLE
Update moonshot-targeted-ids

### DIFF
--- a/raddb/policy.d/moonshot-targeted-ids
+++ b/raddb/policy.d/moonshot-targeted-ids
@@ -77,6 +77,12 @@ moonshot_host_tid.post-auth {
 				Moonshot-MSTID-TargetedId !* ANY
 			}
 		}
+
+		#  Sanitise the control list to remove the internal attributes
+		update control {
+			Moonshot-MSTID-GSS-Acceptor !* ANY
+			Moonshot-MSTID-Namespace !* ANY
+		}
 	}
 }
 
@@ -118,6 +124,12 @@ moonshot_realm_tid.post-auth {
 				Moonshot-MSTID-TargetedId !* ANY
 			}
 		}
+
+		#  Sanitise the control list to remove the internal attributes
+		update control {
+			Moonshot-MSTID-GSS-Acceptor !* ANY
+			Moonshot-MSTID-Namespace !* ANY
+		}
 	}
 }
 
@@ -158,6 +170,12 @@ moonshot_coi_tid.post-auth {
 			update control {
 				Moonshot-MSTID-TargetedId !* ANY
 			}
+		}
+
+		#  Sanitise the control list to remove the internal attributes
+		update control {
+			Moonshot-MSTID-GSS-Acceptor !* ANY
+			Moonshot-MSTID-Namespace !* ANY
 		}
 	}
 }


### PR DESCRIPTION
Add sanitising of the control list for the two internal attributes that are otherwise left behind. As much as they are overwritten, there will always be a copy left at the end and that's Not Good (tm).