### PR TITLE
Add Moonshot-OTP-Secret attribute definition

### DIFF
--- a/share/dictionary.ukerna
+++ b/share/dictionary.ukerna
@@ -24,5 +24,5 @@ ATTRIBUTE	Moonshot-TR-COI-TargetedId		140	string
 ATTRIBUTE	Moonshot-MSTID-GSS-Acceptor		141	string
 ATTRIBUTE	Moonshot-MSTID-Namespace		142	string
 ATTRIBUTE	Moonshot-MSTID-TargetedId		143	string
-
+ATTRIBUTE	Moonshot-OTP-Secret			144	string
 END-VENDOR UKERNA


### PR DESCRIPTION
Add this attribute definition to be used as a means of defining per-user OTP secrets for Moonshot.
