### PR TITLE
Change Extended-Location-Policy-Rules to string

### DIFF
--- a/share/dictionary.rfc5580
+++ b/share/dictionary.rfc5580
@@ -22,7 +22,7 @@ ATTRIBUTE	Operator-Name				126	string
 ATTRIBUTE	Location-Information			127	octets
 ATTRIBUTE	Location-Data				128	octets
 ATTRIBUTE	Basic-Location-Policy-Rules		129	octets
-ATTRIBUTE	Extended-Location-Policy-Rules		130	octets
+ATTRIBUTE	Extended-Location-Policy-Rules		130	string
 
 #
 #  Really a bit-packed field


### PR DESCRIPTION
The description in the RFC implies the text is printable and not a
binary value:

   The Ruleset Reference field of this attribute is of variable length.
   It contains a URI that indicates where the richer ruleset can be
   found.  This URI SHOULD use the HTTPS URI scheme.  As a deviation
   from [RFC4119], this field only contains a reference and does not
   carry an attached, extended ruleset.  This modification is motivated
   by the size limitations imposed by RADIUS.