### PR TITLE
Clarify shebangs to be python2

### DIFF
--- a/scripts/radtee
+++ b/scripts/radtee
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from __future__ import with_statement 
 
 # RADIUS comparison tee v1.0

--- a/src/modules/rlm_python/example.py
+++ b/src/modules/rlm_python/example.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 #
 # Python module example file
 # Miguel A.L. Paraz <mparaz@mparaz.com>

--- a/src/modules/rlm_python/prepaid.py
+++ b/src/modules/rlm_python/prepaid.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 #
 # Example Python module for prepaid usage using MySQL
 

--- a/src/modules/rlm_python/radiusd.py
+++ b/src/modules/rlm_python/radiusd.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 #
 # Definitions for RADIUS programs
 #

--- a/src/modules/rlm_python/radiusd_test.py
+++ b/src/modules/rlm_python/radiusd_test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 #
 # Python module test
 # Miguel A.L. Paraz <mparaz@mparaz.com>


### PR DESCRIPTION
To align with [Fedora packaging standards](https://fedoraproject.org/wiki/Changes/Make_ambiguous_python_shebangs_error), replace all occurrences of `#!/usr/bin/env python` with `#!/usr/bin/env python2` as that is the correct interpreter.

The only file which could arguably be Python3-compatible is `src/modules/rlm_python/radiusd.py`, but I kept `python2` for consistency. 

Note that Python 2 support will be dropped [in the near future](https://fedoraproject.org/wiki/FinalizingFedoraSwitchtoPython3), with "near future" looking like 30 removing most all `python2` packages, 32 making `/usr/bin/python` point to `python3` and fully removing `python2` by 33. 

(29 will be shipped soon, 30 is the current `rawhide` release). 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`