### PR TITLE
Implement dict-based input/output for rlm_python

### DIFF
--- a/raddb/mods-available/python
+++ b/raddb/mods-available/python
@@ -17,6 +17,10 @@ python {
 
 	module = example
 
+	# Pass all VPS lists as a 6-tuple to the callback
+	# (request, reply, config, state, proxy_req, proxy_reply)
+	# pass_all_vps = no
+
 	mod_instantiate = ${.module}
 #	func_instantiate = instantiate
 

--- a/raddb/mods-available/python
+++ b/raddb/mods-available/python
@@ -21,6 +21,12 @@ python {
 	# (request, reply, config, state, proxy_req, proxy_reply)
 	# pass_all_vps = no
 
+	# Pass all VPS lists as a dictionary to the callback
+	# Keys: "request", "reply", "config", "session-state", "proxy-request",
+	# 	    "proxy-reply"
+	# This option prevales over "pass_all_vps"
+	# pass_all_vps_dict = no
+
 	mod_instantiate = ${.module}
 #	func_instantiate = instantiate
 

--- a/raddb/mods-available/python
+++ b/raddb/mods-available/python
@@ -17,13 +17,13 @@ python {
 
 	module = example
 
-	# Pass all VPS lists as a 6-tuple to the callback
+	# Pass all VPS lists as a 6-tuple to the callbacks
 	# (request, reply, config, state, proxy_req, proxy_reply)
 	# pass_all_vps = no
 
-	# Pass all VPS lists as a dictionary to the callback
+	# Pass all VPS lists as a dictionary to the callbacks
 	# Keys: "request", "reply", "config", "session-state", "proxy-request",
-	# 	    "proxy-reply"
+	#       "proxy-reply"
 	# This option prevales over "pass_all_vps"
 	# pass_all_vps_dict = no
 

--- a/src/modules/rlm_python/example.py
+++ b/src/modules/rlm_python/example.py
@@ -7,26 +7,30 @@
 
 import radiusd
 
+# Check post_auth for the most complete example using different
+# input and output formats
+
 def instantiate(p):
   print "*** instantiate ***"
   print p
   # return 0 for success or -1 for failure
 
+
 def authorize(p):
   print "*** authorize ***"
-  print
   radiusd.radlog(radiusd.L_INFO, '*** radlog call in authorize ***')
   print
   print p
   print
   print radiusd.config
-  print
   return radiusd.RLM_MODULE_OK
+
 
 def preacct(p):
   print "*** preacct ***"
   print p
   return radiusd.RLM_MODULE_OK
+
 
 def accounting(p):
   print "*** accounting ***"
@@ -35,25 +39,53 @@ def accounting(p):
   print p
   return radiusd.RLM_MODULE_OK
 
+
 def pre_proxy(p):
   print "*** pre_proxy ***"
   print p
   return radiusd.RLM_MODULE_OK
+
 
 def post_proxy(p):
   print "*** post_proxy ***"
   print p
   return radiusd.RLM_MODULE_OK
 
+
 def post_auth(p):
   print "*** post_auth ***"
-  print p
-  return radiusd.RLM_MODULE_OK
+
+  # This is true when using pass_all_vps_dict
+  if type(p) is dict:
+    print "Request:", p["request"]
+    print "Reply:", p["reply"]
+    print "Config:", p["config"]
+    print "State:", p["session-state"]
+    print "Proxy-Request:", p["proxy-request"]
+    print "Proxy-Reply:", p["proxy-reply"]
+
+  else:
+    print p
+
+  # Dictionary representing changes we want to make to the different VPS
+  update_dict = {
+        "request": (("User-Password", ":=", "A new password"),),
+        "reply": (("Reply-Message", "The module is doing its job"),
+                  ("User-Name", "NewUserName")),
+        "config": (("Cleartext-Password", "A new password"),),
+  }
+
+  return radiusd.RLM_MODULE_OK, update_dict
+  # Alternatively, you could use the legacy 3-tuple output
+  # (only reply and config can be updated)
+  # return radiusd.RLM_MODULE_OK, update_dict["reply"], update_dict["config"]
+
 
 def recv_coa(p):
   print "*** recv_coa ***"
   print p
   return radiusd.RLM_MODULE_OK
+
 
 def send_coa(p):
   print "*** send_coa ***"

--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -96,6 +96,7 @@ typedef struct rlm_python_t {
 	PyObject	*pythonconf_dict;	//!< Configuration parameters defined in the module
 						//!< made available to the python script.
 	bool 		pass_all_vps;		//!< Pass all VPS lists (request, reply, config, state, proxy_req, proxy_reply)
+	bool 		pass_all_vps_dict;		//!< Pass all VPS lists as a dictionary rather than a tuple
 } rlm_python_t;
 
 /** Tracks a python module inst/thread state pair
@@ -136,6 +137,7 @@ static CONF_PARSER module_config[] = {
 	{ "python_path", FR_CONF_OFFSET(PW_TYPE_STRING, rlm_python_t, python_path), NULL },
 	{ "cext_compat", FR_CONF_OFFSET(PW_TYPE_BOOLEAN, rlm_python_t, cext_compat), "yes" },
 	{ "pass_all_vps", FR_CONF_OFFSET(PW_TYPE_BOOLEAN, rlm_python_t, pass_all_vps), "no" },
+	{ "pass_all_vps_dict", FR_CONF_OFFSET(PW_TYPE_BOOLEAN, rlm_python_t, pass_all_vps_dict), "no" },
 
 	CONF_PARSER_TERMINATOR
 };
@@ -438,10 +440,11 @@ error:
 	return false;
 }
 
-static rlm_rcode_t do_python_single(REQUEST *request, PyObject *pFunc, char const *funcname, bool pass_all_vps)
+static rlm_rcode_t do_python_single(REQUEST *request, PyObject *pFunc, char const *funcname, bool pass_all_vps, bool pass_all_vps_dict)
 {
 	PyObject	*pRet = NULL;
 	PyObject	*pArgs = NULL;
+	PyObject 	*pDictInput = NULL;
 	int		ret;
 	int 		i;
 
@@ -492,12 +495,28 @@ static rlm_rcode_t do_python_single(REQUEST *request, PyObject *pFunc, char cons
 	else for (i = 0; i < 6; i++) mod_populate_vps(pArgs, i, NULL);
 
 	/*
-	 * Call Python function. If pass_all_vps is true, a 6-tuple representing
-	 * (Request, Reply, Config, State, Proxy-Request, Proxy-Reply) is passed
-	 * as argument to the module callback.
-	 * Otherwise, a tuple representing just the request is passed.
+	 * Call Python function. If pass_all_vps_dict is true, a dictionary with the
+	 * appropriate "request", "reply"... keys is passed as argument to the
+	 * module callback.
+	 * Else, if pass_all_vps is true, a 6-tuple representing
+	 * (Request, Reply, Config, State, Proxy-Request, Proxy-Reply) is passed.
+	 * Otherwise, a tuple representing just the request is used.
 	 */
-	if (pass_all_vps)
+	if (pass_all_vps_dict) {
+		pDictInput = PyDict_New();
+		if (pDictInput == NULL ||
+		    PyDict_SetItemString(pDictInput, "request", PyTuple_GET_ITEM(pArgs, 0)) ||
+		    PyDict_SetItemString(pDictInput, "reply", PyTuple_GET_ITEM(pArgs, 1)) ||
+		    PyDict_SetItemString(pDictInput, "config", PyTuple_GET_ITEM(pArgs, 2)) ||
+		    PyDict_SetItemString(pDictInput, "session-state", PyTuple_GET_ITEM(pArgs, 3)) ||
+		    PyDict_SetItemString(pDictInput, "proxy-request", PyTuple_GET_ITEM(pArgs, 4)) ||
+		    PyDict_SetItemString(pDictInput, "proxy-reply", PyTuple_GET_ITEM(pArgs, 5))) {
+			ret = RLM_MODULE_FAIL;
+			goto finish;
+		}
+		pRet = PyObject_CallFunctionObjArgs(pFunc, pDictInput, NULL);
+	}
+	else if (pass_all_vps)
 		pRet = PyObject_CallFunctionObjArgs(pFunc, pArgs, NULL);
 	else
 		pRet = PyObject_CallFunctionObjArgs(pFunc, PyTuple_GET_ITEM(pArgs, 0), NULL);
@@ -602,6 +621,7 @@ static rlm_rcode_t do_python_single(REQUEST *request, PyObject *pFunc, char cons
 finish:
 	Py_XDECREF(pArgs);
 	Py_XDECREF(pRet);
+	Py_XDECREF(pDictInput);
 
 	return ret;
 }
@@ -731,7 +751,7 @@ static rlm_rcode_t do_python(rlm_python_t *inst, REQUEST *request, PyObject *pFu
 	RDEBUG3("Using thread state %p", this_thread->state);
 
 	PyEval_RestoreThread(this_thread->state);	/* Swap in our local thread state */
-	ret = do_python_single(request, pFunc, funcname, inst->pass_all_vps);
+	ret = do_python_single(request, pFunc, funcname, inst->pass_all_vps, inst->pass_all_vps_dict);
 	PyEval_SaveThread();
 
 	return ret;
@@ -1131,7 +1151,7 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 	/*
 	 *	Call the instantiate function.
 	 */
-	code = do_python_single(NULL, inst->instantiate.function, "instantiate", inst->pass_all_vps);
+	code = do_python_single(NULL, inst->instantiate.function, "instantiate", inst->pass_all_vps, inst->pass_all_vps_dict);
 	if (code < 0) {
 	error:
 		python_error_log();	/* Needs valid thread with GIL */
@@ -1153,7 +1173,7 @@ static int mod_detach(void *instance)
 	 */
 	PyEval_RestoreThread(inst->sub_interpreter);
 
-	ret = do_python_single(NULL, inst->detach.function, "detach", inst->pass_all_vps);
+	ret = do_python_single(NULL, inst->detach.function, "detach", inst->pass_all_vps, inst->pass_all_vps_dict);
 
 #define PYTHON_FUNC_DESTROY(_x) python_function_destroy(&inst->_x)
 	PYTHON_FUNC_DESTROY(instantiate);


### PR DESCRIPTION
Current rlm_python interface only allows writing to the "reply" and "config" VPS lists. While this is enough for most use cases, there are some scenarios where you might also want to be able to modify the request (for instance, if your module modifies the "User-Password" or User-Name" attribute). The Perl module allows modifying all the VPS lists so I thought this should be allowed also from Python.

This PR does not modify current behaviour. If a module provides a 5-tuple, the PR will take care of those extra 2 tuple items and process them as "request" and "state". But if an existing module is using the 3-tuple, it will see no difference.

The code updating the cached copies for username and password has been borrowed from the Perl version.