### PR TITLE
Update filter: reject double dots

### DIFF
--- a/raddb/policy.d/filter
+++ b/raddb/policy.d/filter
@@ -69,7 +69,7 @@ filter_username {
 		#
 		if (&User-Name =~ /\.\./ ) {
 			update request {
-				&Module-Failure-Message += 'User-Name contains multiple ..s'
+				&Module-Failure-Message += 'User-Name contains multiple dots (e.g. user@site..com)'
 			}
 			reject
 		}


### PR DESCRIPTION
Edit Module-Failure-Message to add clarity. Previous message ended with ".." which looks somewhat like an ellipsis giving the impression that the message has been truncated. New message replaces ".." with the word "dots" and adds an example.

We encountered this log message after an upgrade which changed the way things are escaped (related to the _correct_escapes_ option in radius.conf). Because we did not have _correct_escapes_ set to _yes_ we were triggering this failure message when using a simple username (i.e. "user") without a domain/realm being specified. Even though the log message displayed the username (which purportedly had two dots in it, even though it really didn't), it wasn't clear what we were tripping on. With _correct_escapes_ disabled (the default), the regex around "reject double dots" was matching on any character (the escapes in this regex were being ignored).