### PR TITLE
radclient.c support for compiling using --without-tcp

### DIFF
--- a/src/main/radclient.c
+++ b/src/main/radclient.c
@@ -355,10 +355,10 @@ static int radclient_init(TALLOC_CTX *ctx, rc_file_pair_t *files)
 		request->packet->src_ipaddr = client_ipaddr;
 		request->packet->src_port = client_port;
 		request->packet->dst_ipaddr = server_ipaddr;
-		request->packet->dst_port = server_port;
 		request->packet->proto = ipproto;
 #endif
 
+		request->packet->dst_port = server_port;
 		request->files = files;
 		request->packet->id = -1; /* allocate when sending */
 		request->num = num++;


### PR DESCRIPTION
### Suggested Patch for src/main/radclient.c
Up until some unknown time ago, the freeradius source could not be compiled using --without-tcp.  Thus, in radclient.c, "#ifdef WITH_TCP" was always true and it was the case that "request->packet->dst_port = server_port;" was always included.

Today, if you compile using --without-tcp, that instruction will not be executed and "request->packet->dst_port" will not get set when we pass a port as part of the command-line argument.  Please be skeptical about this but it looks like it might be as simple as this change.
 (I apologize for my earlier trouble in trying to create this pull request)