### PR TITLE
support for --without-tcp in process.c

### DIFF
--- a/src/main/process.c
+++ b/src/main/process.c
@@ -5214,7 +5214,7 @@ static void handle_signal_self(int flag)
 	}
 #endif
 
-#if defined(WITH_TCP) && defined(WITH_PROXY) && defined(HAVE_PTHREAD_H)
+#if defined(WITH_PROXY) && defined(HAVE_PTHREAD_H)
 	/*
 	 *	There are new listeners in the list.  Run
 	 *	event_new_fd() on them.


### PR DESCRIPTION
When compiling with "--without-tcp", the "#if defined(WITH_TCP)" on line 5217 appears to mean that we never initialize a socket for our proxies:

ERROR: (0) ERROR: Failing proxied request for user "realm\username", due to lack of any response from home server A.B.C.D port 1812
Auth:  (0) Login incorrect (Home Server failed to respond): 
Auth:  (0) Login incorrect (Failing proxied request for user 

Everything seems to work OK (after compiling and executing) without the check for WITH_TCP but my understanding of this code is very shallow.