### PR TITLE
Allow driver specific escape methods in rlm_sql

### DIFF
--- a/raddb/mods-config/sql/main/mysql/queries.conf
+++ b/raddb/mods-config/sql/main/mysql/queries.conf
@@ -4,9 +4,13 @@
 #
 #  $Id$
 
+# Use the driver specific SQL escape method
+driver_specific_escape = "yes"
+
 # Safe characters list for sql queries. Everything else is replaced
 # with their mime-encoded equivalents.
 # The default list should be ok
+# Using 'driver_specific_escape' is preferred
 #safe_characters = "@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_: /"
 
 #######################################################################

--- a/raddb/mods-config/sql/main/postgresql/queries.conf
+++ b/raddb/mods-config/sql/main/postgresql/queries.conf
@@ -4,9 +4,13 @@
 #
 #  $Id$
 
+# Use the driver specific SQL escape method
+driver_specific_escape = "yes"
+
 # Safe characters list for sql queries. Everything else is replaced
 # with their mime-encoded equivalents.
 # The default list should be ok
+# Using 'driver_specific_escape' is preferred
 # safe_characters = "@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_: /"
 
 #######################################################################

--- a/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c
@@ -736,7 +736,7 @@ static int sql_affected_rows(rlm_sql_handle_t *handle, UNUSED rlm_sql_config_t *
 static size_t sql_escape_func(UNUSED REQUEST *request, char *out, size_t outlen, char const *in, void *arg)
 {
 	size_t			inlen;
-	rlm_sql_handle_t	*handle = arg;
+	rlm_sql_handle_t	*handle = talloc_get_type_abort(arg, rlm_sql_handle_t);
 	rlm_sql_mysql_conn_t	*conn = handle->conn;
 
 	/* Check for potential buffer overflow */

--- a/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c
@@ -733,6 +733,21 @@ static int sql_affected_rows(rlm_sql_handle_t *handle, UNUSED rlm_sql_config_t *
 	return mysql_affected_rows(conn->sock);
 }
 
+static size_t sql_escape_func(UNUSED REQUEST *request, char *out, size_t outlen, char const *in, void *arg)
+{
+	size_t			inlen;
+	rlm_sql_handle_t	*handle = arg;
+	rlm_sql_mysql_conn_t	*conn = handle->conn;
+
+	/* Check for potential buffer overflow */
+	inlen = strlen(in);
+	if ((inlen * 2 + 1) > outlen) return 0;
+	/* Prevent integer overflow */
+	if ((inlen * 2 + 1) <= inlen) return 0;
+
+	return mysql_real_escape_string(conn->sock, out, in, inlen);
+}
+
 
 /* Exported to rlm_sql */
 extern rlm_sql_module_t rlm_sql_mysql;
@@ -752,5 +767,6 @@ rlm_sql_module_t rlm_sql_mysql = {
 	.sql_free_result		= sql_free_result,
 	.sql_error			= sql_error,
 	.sql_finish_query		= sql_finish_query,
-	.sql_finish_select_query	= sql_finish_query
+	.sql_finish_select_query	= sql_finish_query,
+	.sql_escape_func		= sql_escape_func
 };

--- a/src/modules/rlm_sql/drivers/rlm_sql_postgresql/rlm_sql_postgresql.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_postgresql/rlm_sql_postgresql.c
@@ -505,6 +505,28 @@ static int sql_affected_rows(rlm_sql_handle_t * handle, UNUSED rlm_sql_config_t 
 	return conn->affected_rows;
 }
 
+static size_t sql_escape_func(UNUSED REQUEST *request, char *out, size_t outlen, char const *in, void *arg)
+{
+	size_t			inlen, ret;
+	rlm_sql_handle_t	*handle = arg;
+	rlm_sql_postgres_conn_t	*conn = handle->conn;
+	int			err;
+
+	/* Check for potential buffer overflow */
+	inlen = strlen(in);
+	if ((inlen * 2 + 1) > outlen) return 0;
+	/* Prevent integer overflow */
+	if ((inlen * 2 + 1) <= inlen) return 0;
+
+	ret = PQescapeStringConn(conn->db, out, in, inlen, &err);
+	if (err) {
+		REDEBUG("Error escaping string \"%s\": %s", in, PQerrorMessage(conn->db));
+		return 0;
+	}
+
+	return ret;
+}
+
 /* Exported to rlm_sql */
 extern rlm_sql_module_t rlm_sql_postgresql;
 rlm_sql_module_t rlm_sql_postgresql = {
@@ -520,5 +542,6 @@ rlm_sql_module_t rlm_sql_postgresql = {
 	.sql_error			= sql_error,
 	.sql_finish_query		= sql_free_result,
 	.sql_finish_select_query	= sql_free_result,
-	.sql_affected_rows		= sql_affected_rows
+	.sql_affected_rows		= sql_affected_rows,
+	.sql_escape_func		= sql_escape_func
 };

--- a/src/modules/rlm_sql/drivers/rlm_sql_postgresql/rlm_sql_postgresql.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_postgresql/rlm_sql_postgresql.c
@@ -508,7 +508,7 @@ static int sql_affected_rows(rlm_sql_handle_t * handle, UNUSED rlm_sql_config_t 
 static size_t sql_escape_func(UNUSED REQUEST *request, char *out, size_t outlen, char const *in, void *arg)
 {
 	size_t			inlen, ret;
-	rlm_sql_handle_t	*handle = arg;
+	rlm_sql_handle_t	*handle = talloc_get_type_abort(arg, rlm_sql_handle_t);
 	rlm_sql_postgres_conn_t	*conn = handle->conn;
 	int			err;
 

--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -378,7 +378,7 @@ static int generate_sql_clients(rlm_sql_t *inst)
 static size_t sql_escape_func(UNUSED REQUEST *request, char *out, size_t outlen,
 			      char const *in, void *arg)
 {
-	rlm_sql_handle_t *handle = arg;
+	rlm_sql_handle_t *handle = talloc_get_type_abort(arg, rlm_sql_handle_t);
 	rlm_sql_t *inst = handle->inst;
 	size_t len = 0;
 
@@ -490,7 +490,7 @@ static size_t sql_escape_func(UNUSED REQUEST *request, char *out, size_t outlen,
 static size_t sql_escape_for_xlat_func(REQUEST *request, char *out, size_t outlen, char const *in, void *arg)
 {
 	size_t			ret;
-	rlm_sql_t		*inst = arg;
+	rlm_sql_t		*inst = talloc_get_type_abort(arg, rlm_sql_t);
 	rlm_sql_handle_t	*handle;
 
 	handle = fr_connection_get(inst->pool);

--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -110,6 +110,7 @@ static const CONF_PARSER module_config[] = {
 #endif
 	{ "safe-characters", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_DEPRECATED, rlm_sql_config_t, allowed_chars), NULL },
 	{ "safe_characters", FR_CONF_OFFSET(PW_TYPE_STRING, rlm_sql_config_t, allowed_chars), "@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_: /" },
+	{ "driver_specific_escape", FR_CONF_OFFSET(PW_TYPE_BOOLEAN, rlm_sql_config_t, driver_specific_escape), "no" },
 
 	/*
 	 *	This only works for a few drivers.
@@ -1076,7 +1077,7 @@ do { \
 	 *	Either use the module specific escape function
 	 *	or our default one.
 	 */
-	inst->sql_escape_func = inst->module->sql_escape_func ?
+	inst->sql_escape_func = inst->module->sql_escape_func && inst->config->driver_specific_escape ?
 				inst->module->sql_escape_func :
 				sql_escape_func;
 

--- a/src/modules/rlm_sql/rlm_sql.h
+++ b/src/modules/rlm_sql/rlm_sql.h
@@ -212,6 +212,8 @@ typedef struct rlm_sql_module_t {
 
 	sql_rcode_t (*sql_finish_query)(rlm_sql_handle_t *handle, rlm_sql_config_t *config);
 	sql_rcode_t (*sql_finish_select_query)(rlm_sql_handle_t *handle, rlm_sql_config_t *config);
+
+	xlat_escape_t	sql_escape_func;
 } rlm_sql_module_t;
 
 struct sql_inst {

--- a/src/modules/rlm_sql/rlm_sql.h
+++ b/src/modules/rlm_sql/rlm_sql.h
@@ -126,6 +126,7 @@ typedef struct sql_config {
 								//!< stale sessions.
 
 	char const		*allowed_chars;			//!< Chars which done need escaping..
+	bool			driver_specific_escape;		//!< Use the driver specific SQL escape method
 	uint32_t		query_timeout;			//!< How long to allow queries to run for.
 
 	char const		*connect_query;			//!< Query executed after establishing


### PR DESCRIPTION
After a discussion on the mailing list these last two days: this patch backports the driver specific escape modules for SQL from master to v3.0.x.

This change will break backwards compatibility, since the escape mechanism will be changed. It will need an extra config option, turn the new behaviour on in the default config, turn it off in the defaults in the code, so new installations will use the improved escape methods, while current installations keep using the old version.