### PR TITLE
Show when log config has errors and don't quit on deprecated items

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -93,6 +93,8 @@ FreeRADIUS 3.0.18 Tue 17 Apr 2018 14:00:00 EDT urgency=low
 	  list.  Patch from Christian Hesse.
 	* Fix crash with CoA packets/  Fixes #2304.
 	* Fix crash in rlm_exec with CoA.  Fixes #2328.
+	* Print errors while parsing the log config, and don't
+	  quit when deprecated log settings are found.
 
 FreeRADIUS 3.0.17 Tue 17 Apr 2018 14:00:00 EDT urgency=low
 	Feature improvements

--- a/src/main/mainconfig.c
+++ b/src/main/mainconfig.c
@@ -884,7 +884,10 @@ do {\
 	 *	set it now.
 	 */
 	if (default_log.dst == L_DST_NULL) {
-		if (cf_section_parse(cs, NULL, startup_server_config) < 0) {
+		default_log.dst = L_DST_STDERR;
+		default_log.fd = STDERR_FILENO;
+
+		if (cf_section_parse(cs, NULL, startup_server_config) == -1) {
 			fprintf(stderr, "%s: Error: Failed to parse log{} section.\n",
 				main_config.name);
 			cf_file_free(cs);
@@ -898,6 +901,7 @@ do {\
 			return -1;
 		}
 
+		default_log.fd = -1;
 		default_log.dst = fr_str2int(log_str2dst, radlog_dest,
 					      L_DST_NUM_DEST);
 		if (default_log.dst == L_DST_NUM_DEST) {


### PR DESCRIPTION
As parsing the log section happens before logging is configured,
any errors that happen don't get displayed. If logging has been
configured on the command line then the log section isn't read at
all, so again the errors are not found. Set the log destination
temporarily so that the errors are printed to stderr.

cf_section_parse returns -2 for deprecated items, so behave in the
same way as the rest of the config and just ignore them.