### PR TITLE
attr_filter: Don't permit FreeRADIUS-Response-Delay in reject

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -103,6 +103,8 @@ FreeRADIUS 3.0.18 Tue 17 Apr 2018 14:00:00 EDT urgency=low
 	  first member of the list, and now encodes all
 	  members.
 	* The "expr" module now skips more whitespace.
+	* Remove internal FreeRADIUS-Response-Delay attributes
+	  from attr_filter Access-Reject.
 
 FreeRADIUS 3.0.17 Tue 17 Apr 2018 14:00:00 EDT urgency=low
 	Feature improvements

--- a/raddb/mods-config/attr_filter/access_reject
+++ b/raddb/mods-config/attr_filter/access_reject
@@ -15,6 +15,4 @@ DEFAULT
 	Error-Cause =* ANY,
 	Reply-Message =* ANY,
 	MS-CHAP-Error =* ANY,
-	Proxy-State =* ANY,
-	FreeRADIUS-Response-Delay =* ANY,
-	FreeRADIUS-Response-Delay-USec =* ANY
+	Proxy-State =* ANY


### PR DESCRIPTION
No-op, but they're internal attributes so can't go in a reply
anyway, and cause a warning at every server start.