### PR TITLE
rlm_redis: don't send junk to redis when we hit the max number of args

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -105,6 +105,7 @@ FreeRADIUS 3.0.18 Tue 17 Apr 2018 14:00:00 EDT urgency=low
 	* The "expr" module now skips more whitespace.
 	* Remove internal FreeRADIUS-Response-Delay attributes
 	  from attr_filter Access-Reject.
+	* Don't send junk to redis when maximum args reached.
 
 FreeRADIUS 3.0.17 Tue 17 Apr 2018 14:00:00 EDT urgency=low
 	Feature improvements

--- a/src/modules/rlm_redis/rlm_redis.c
+++ b/src/modules/rlm_redis/rlm_redis.c
@@ -238,6 +238,12 @@ int rlm_redis_query(REDISSOCK **dissocket_p, REDIS_INST *inst,
 	if (argc <= 0)
 		return -1;
 
+	if (argc >= (MAX_REDIS_ARGS - 1)) {
+		RERROR("rlm_redis (%s): query has too many parameters; increase "
+				"MAX_REDIS_ARGS and recompile", inst->xlat_name);
+		return -1;
+	}
+
 	dissocket = *dissocket_p;
 
 	DEBUG2("rlm_redis (%s): executing the query: \"%s\"", inst->xlat_name, query);

--- a/src/modules/rlm_redis/rlm_redis.h
+++ b/src/modules/rlm_redis/rlm_redis.h
@@ -55,7 +55,7 @@ typedef struct rlm_redis_t {
 } rlm_redis_t;
 
 #define MAX_QUERY_LEN			4096
-#define MAX_REDIS_ARGS			16
+#define MAX_REDIS_ARGS			32
 
 int rlm_redis_query(REDISSOCK **dissocket_p, REDIS_INST *inst,
 		    char const *query, REQUEST *request);


### PR DESCRIPTION
...and bump the max number of args, too. 'Cos I can easily hit it easily with HMSET listing a few attributes.