### PR TITLE
Add support for HP-user-role attribute

### DIFF
--- a/share/dictionary/radius/dictionary.hp
+++ b/share/dictionary/radius/dictionary.hp
@@ -28,6 +28,7 @@ ATTRIBUTE	HP-Port-Client-Limit-WA			12	integer
 ATTRIBUTE	HP-Port-Auth-Mode-Dot1x			13	integer
 ATTRIBUTE	HP-Port-Bounce-Host			23	integer
 ATTRIBUTE	HP-Captive-Portal-URL			24	string
+ATTRIBUTE	HP-User-Role			25	string
 
 # Client QoS attributes
 ATTRIBUTE	HP-Port-Priority-Regeneration-Table	40	string

--- a/share/dictionary/radius/dictionary.hp
+++ b/share/dictionary/radius/dictionary.hp
@@ -28,7 +28,7 @@ ATTRIBUTE	HP-Port-Client-Limit-WA			12	integer
 ATTRIBUTE	HP-Port-Auth-Mode-Dot1x			13	integer
 ATTRIBUTE	HP-Port-Bounce-Host			23	integer
 ATTRIBUTE	HP-Captive-Portal-URL			24	string
-ATTRIBUTE	HP-User-Role					25	string
+ATTRIBUTE	HP-User-Role				25	string
 
 # Client QoS attributes
 ATTRIBUTE	HP-Port-Priority-Regeneration-Table	40	string

--- a/share/dictionary/radius/dictionary.hp
+++ b/share/dictionary/radius/dictionary.hp
@@ -28,7 +28,7 @@ ATTRIBUTE	HP-Port-Client-Limit-WA			12	integer
 ATTRIBUTE	HP-Port-Auth-Mode-Dot1x			13	integer
 ATTRIBUTE	HP-Port-Bounce-Host			23	integer
 ATTRIBUTE	HP-Captive-Portal-URL			24	string
-ATTRIBUTE	HP-User-Role			25	string
+ATTRIBUTE	HP-User-Role					25	string
 
 # Client QoS attributes
 ATTRIBUTE	HP-Port-Priority-Regeneration-Table	40	string

--- a/share/dictionary/radius/dictionary.hp
+++ b/share/dictionary/radius/dictionary.hp
@@ -11,7 +11,7 @@
 VENDOR		HP				11
 
 #
-# Attributes supported by HP ProCurve wired networking devices
+# Attributes supported by HP ProCurve and Aruba wired networking devices
 #
 BEGIN-VENDOR	HP
 


### PR DESCRIPTION
Added support to send user-role for newer software versions of Aruba Switches (previously HP ProCurve), for example 2930F.