### PR TITLE
Update systemd units to depend on network-online

### DIFF
--- a/debian/freeradius.service
+++ b/debian/freeradius.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=FreeRADIUS multi-protocol policy server
-After=network.target
+After=network-online.target
 Documentation=man:radiusd(8) man:radiusd.conf(5) http://wiki.freeradius.org/ http://networkradius.com/doc/
 
 [Service]

--- a/redhat/radiusd.service
+++ b/redhat/radiusd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=FreeRADIUS multi-protocol policy server
-After=network.target
+After=network-online.target
 Documentation=man:radiusd(8) man:radiusd.conf(5) http://wiki.freeradius.org/ http://networkradius.com/doc/
 
 [Service]


### PR DESCRIPTION
Due to the use of `SO_BINDTODEVICE`, FreeRADIUS requires the address to be
up when binding to a specific IP address. In systemd, depending on
`network.target` is not sufficient to require the network to be up, so
FreeRADIUS can still fail to bind; instead, `network-online.target` is
required if the network is required to be online.

This manifests in errors such as:

    Error: Failed binding to auth address x.x.x.x port 1812 bound to
           server default: Cannot assign requested address

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1637275

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`



I'm slightly hesitant to add the `network-online.target` as I personally feel it should be configuration-specific (IMO, same with updating the service file to depend on MySQL, PostgreSQL, or any other backend targets -- that's up to the system administrator to depend on and correctly set). Alternatively, as discussed [here in the last footnote](https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/), `IP_FREEBIND` can be used, but that seems to be the exact opposite of what [listen wants to do](https://github.com/freeradius/freeradius-server/blob/v3.0.x/src/main/listen.c#L2411-L2430).

Also, if for whatever reason, the network fails to come online, FreeRADIUS will not be started. I'm not sure how much of a problem this is in practice. (e.g., binding to `0.0.0.0` or `127.0.0.1` won't strictly require `network-online.target` and might result in the service being unavailable for some users because systemd didn't attempt to start it because the network wasn't online for some reason).


Thoughts?

