### PR TITLE
Add support for Downloadable user roles

### DIFF
--- a/share/dictionary/radius/dictionary.hp
+++ b/share/dictionary/radius/dictionary.hp
@@ -29,6 +29,7 @@ ATTRIBUTE	HP-Port-Auth-Mode-Dot1x			13	integer
 ATTRIBUTE	HP-Port-Bounce-Host			23	integer
 ATTRIBUTE	HP-Captive-Portal-URL			24	string
 ATTRIBUTE	HP-User-Role				25	string
+ATTRIBUTE	HPE-CPPM-Role				27	string
 
 # Client QoS attributes
 ATTRIBUTE	HP-Port-Priority-Regeneration-Table	40	string


### PR DESCRIPTION
Add support for downloadable user roles for Aruba Switches (ex HP ProCurve switches).