### PR TITLE
There is no corresponding attr for these two vals

### DIFF
--- a/share/dictionary/radius/dictionary.freedhcp
+++ b/share/dictionary/radius/dictionary.freedhcp
@@ -233,9 +233,6 @@ ATTRIBUTE	FreeDHCP-Cisco-TFTP-Server-IP-Addresses	150	ipaddr array
 
 ATTRIBUTE	FreeDHCP-End-Of-Options			255	byte
 
-VALUE	FreeDHCP-Opcode			Client-Message		1
-VALUE	FreeDHCP-Opcode			Server-Message		2
-
 VALUE	FreeDHCP-Message-Type		FreeDHCP-Discover	1
 VALUE	FreeDHCP-Message-Type		FreeDHCP-Offer		2
 VALUE	FreeDHCP-Message-Type		FreeDHCP-Request	3


### PR DESCRIPTION
It looks like a large part of the FreeDHCP dictionary was created with
find+replace magic from share/dictionary.dhcp (later renamed into
share/dictionary/dhcpv4/dictionary.rfc2131). These two values either
slipped through or their corresponding attribute wasn't added. In any
case there is no way to use them now. So let's just remove them.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>