### PR TITLE
Fix startup crash when running outside of gdb on BSD systems

### DIFF
--- a/src/lib/util/debug.c
+++ b/src/lib/util/debug.c
@@ -112,11 +112,19 @@ static struct rlimit init_core_limit;
 
 static TALLOC_CTX *talloc_autofree_ctx;
 
+/*
+ * On BSD systems, ptrace(PT_DETACH) uses a third argument for
+ * resume address, with the magic value (void *)1 to resume where
+ * process stopped. Specifying NULL there leads to a crash because
+ * process resumes at address 0.
+ */  
 #ifdef HAVE_SYS_PTRACE_H
 #  ifdef __linux__
 #    define _PTRACE(_x, _y) ptrace(_x, _y, NULL, NULL)
+#    define _PTRACE_DETACH(_x) ptrace(PT_DETACH, _x, NULL, NULL)
 #  else
 #    define _PTRACE(_x, _y) ptrace(_x, _y, NULL, 0)
+#    define _PTRACE_DETACH(_x) ptrace(PT_DETACH, _x, (void *)1, NULL)
 #  endif
 
 #  ifdef HAVE_CAPABILITY_H
@@ -340,7 +348,7 @@ DIAG_ON(deprecated-declarations);
 			}
 
 			/* Detach */
-			_PTRACE(PT_DETACH, ppid);
+			_PTRACE_DETACH(ppid);
 			exit(0);
 		}
 


### PR DESCRIPTION
On BSD systems, ptrace(PT_DETACH) uses a third argument for
resume address, with the magic value (void *)1 to resume where
process stopped. Specifying NULL there leads to a crash because
process resumes at address 0.

We introduce an OS-dependent _PTRACE_DETACH macro to specify
third argument as NULL on Linux and (void *)1 on other systems.
Always using (void *)1 could be another solution, since basic
tests suggests passing (void *)1 as third argument on Linux
does not cause harm.