### PR TITLE
Include SKIP LOCKED queries as options for sqlippool, some notes, and some tidy up.

### DIFF
--- a/raddb/mods-config/sql/ippool/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mysql/queries.conf
@@ -66,6 +66,7 @@ allocate_find = "\
 
 #
 #  If you prefer to allocate a random IP address every time, use this query instead.
+#  Note: This is very slow if you have a lot of free IPs.
 #
 #allocate_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} \

--- a/raddb/mods-config/sql/ippool/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mysql/queries.conf
@@ -50,6 +50,21 @@ allocate_find = "\
 	FOR UPDATE"
 
 #
+#  The above query again, but with SKIP LOCKED. This requires MySQL >= 8.0.1,
+#  and InnoDB.
+#
+#allocate_find = "\
+#	SELECT framedipaddress FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' \
+#	AND (expiry_time < NOW() OR expiry_time IS NULL) \
+#	ORDER BY \
+#		(username <> '%{User-Name}'), \
+#		(callingstationid <> '%{Calling-Station-Id}'), \
+#		expiry_time \
+#	LIMIT 1 \
+#	FOR UPDATE SKIP LOCKED"
+
+#
 #  If you prefer to allocate a random IP address every time, use this query instead.
 #
 #allocate_find = "\
@@ -60,6 +75,19 @@ allocate_find = "\
 #		RAND() \
 #	LIMIT 1 \
 #	FOR UPDATE"
+
+#
+#  The above query again, but with SKIP LOCKED. This requires MySQL >= 8.0.1,
+#  and InnoDB.
+#
+#allocate_find = "\
+#	SELECT framedipaddress FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' \
+#	AND expiry_time IS NULL \
+#	ORDER BY \
+#		RAND() \
+#	LIMIT 1 \
+#	FOR UPDATE SKIP LOCKED"
 
 #
 #  If an IP could not be allocated, check to see if the pool exists or not

--- a/raddb/mods-config/sql/ippool/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool/oracle/queries.conf
@@ -29,6 +29,22 @@ allocate_find = "\
 	FOR UPDATE"
 
 #
+#  The above query again, but with SKIP LOCKED. This requires Oracle > 11g.
+#  It may work in 9i and 10g, but is not documented, so YMMV.
+#
+#allocate_find = "\
+#	SELECT framedipaddress \
+#	FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' \
+#	AND expiry_time < current_timestamp \
+#	AND rownum <= 1 \
+#	ORDER BY \
+#		(username <> '%{SQL-User-Name}'), \
+#		(callingstationid <> '%{Calling-Station-Id}'), \
+#		expiry_time \
+#	FOR UPDATE SKIP LOCKED"
+
+#
 #  This function is available if you want to use multiple pools
 #
 #allocate_find = "\
@@ -46,6 +62,19 @@ allocate_find = "\
 #	AND rownum <= 1 \
 #	ORDER BY RANDOM() \
 #	FOR UPDATE"
+
+#
+#  The above query again, but with SKIP LOCKED. This requires Oracle > 11g.
+#  It may work in 9i and 10g, but is not documented, so YMMV.
+#
+#allocate_find = "\
+#	SELECT framedipaddress \
+#	FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' \
+#	AND expiry_time < current_timestamp \
+#	AND rownum <= 1 \
+#	ORDER BY RANDOM() \
+#	FOR UPDATE SKIP LOCKED"
 
 #
 #  If an IP could not be allocated, check to see whether the pool exists or not

--- a/raddb/mods-config/sql/ippool/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool/oracle/queries.conf
@@ -53,6 +53,7 @@ allocate_find = "\
 
 #
 #  If you prefer to allocate a random IP address every time, use this query instead
+#  Note: This is very slow if you have a lot of free IPs.
 #
 #allocate_find = "\
 #	SELECT framedipaddress \

--- a/raddb/mods-config/sql/ippool/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool/postgresql/queries.conf
@@ -39,12 +39,12 @@ allocate_find = "\
 #
 #  If you prefer to allocate a random IP address every time, use this query instead
 #
-allocate_find = "\
-	SELECT framedipaddress FROM ${ippool_table} \
-	WHERE pool_name = '%{control:${pool_name}}' AND expiry_time < 'now'::timestamp(0) \
-	ORDER BY RANDOM() \
-	LIMIT 1 \
-	FOR UPDATE"
+#allocate_find = "\
+#	SELECT framedipaddress FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' AND expiry_time < 'now'::timestamp(0) \
+#	ORDER BY RANDOM() \
+#	LIMIT 1 \
+#	FOR UPDATE"
 
 #
 #  The above query again, but with SKIP LOCKED. This requires PostgreSQL >= 9.5.

--- a/raddb/mods-config/sql/ippool/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool/postgresql/queries.conf
@@ -22,6 +22,21 @@ allocate_find = "\
 	FOR UPDATE"
 
 #
+#  The above query again, but with SKIP LOCKED. This requires PostgreSQL >= 9.5.
+#
+#allocate_find = "\
+#	SELECT framedipaddress \
+#	FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' \
+#	AND expiry_time < 'now'::timestamp(0) \
+#	ORDER BY \
+#		(username <> '%{SQL-User-Name}'), \
+#		(callingstationid <> '%{Calling-Station-Id}'), \
+#		expiry_time \
+#	LIMIT 1 \
+#	FOR UPDATE SKIP LOCKED"
+
+#
 #  If you prefer to allocate a random IP address every time, use this query instead
 #
 allocate_find = "\
@@ -30,6 +45,16 @@ allocate_find = "\
 	ORDER BY RANDOM() \
 	LIMIT 1 \
 	FOR UPDATE"
+
+#
+#  The above query again, but with SKIP LOCKED. This requires PostgreSQL >= 9.5.
+#
+#allocate_find = "\
+#	SELECT framedipaddress FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' AND expiry_time < 'now'::timestamp(0) \
+#	ORDER BY RANDOM() \
+#	LIMIT 1 \
+#	FOR UPDATE SKIP LOCKED"
 
 #
 #  If an IP could not be allocated, check to see whether the pool exists or not

--- a/raddb/mods-config/sql/ippool/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool/postgresql/queries.conf
@@ -38,6 +38,7 @@ allocate_find = "\
 
 #
 #  If you prefer to allocate a random IP address every time, use this query instead
+#  Note: This is very slow if you have a lot of free IPs.
 #
 #allocate_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} \

--- a/raddb/mods-config/sql/ippool/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool/sqlite/queries.conf
@@ -51,6 +51,7 @@ allocate_find = "\
 #
 #   If you prefer to allocate a random IP address every time, i
 #   use this query instead
+#   Note: This is very slow if you have a lot of free IPs.
 #
 
 #allocate_find = "\


### PR DESCRIPTION
sqlippool uses `SELECT .. FOR UPDATE` queries, which in many configurations cannot run concurrently with other queries.
 - MySQL (even with InnoDB) locks the indexes used in the WHERE and ORDER BY parameters
 - The "assign the same IP address as before" query will wait for the lock to be released on all DBs.
-  The "random" queries will block on some DBs, and fail on others.

The `SKIP LOCKED` option on `FOR UPDATE` ignores locked rows in a `SELECT`. This means that queries can run concurrently. This significantly improves performance of the sqlippool module.

I have added additional query examples including `SKIP LOCKED`, after each of the relevant current examples. I considered replacing the current examples, however, a very recent version of MySQL is required (8.0.1+), and distros such as CentOS/RHEL don't ship a recent enough PostgreSQL (they ship 9.2.x, and 9.5 is required).


I have added some notes to the "random" queries. These run very slowly if you have large pools of free IPs. The `SELECT` runs, copies the results in to a temporary table, then sorts them randomly, then selects the first row. The copy and random sort are very costly. I intend to publish some more query options soon but I think a note here about this is helpful. My first instinct when reading these configs was that the random option would be faster than the "assign the same IP address as before" option - but it most definitely is not, so I think it's important to note.


I have also commented out the "random" query in the PostgreSQL config. It's commented out for the other DBs, not sure why it's not commented out in PostgreSQL. As this was the second in the file, does this mean it changes the default? Happy to scrub this if we don't want the default to change at this time.