### PR TITLE
Add libssl1.1 as patched for Heartbleed

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -54,9 +54,9 @@ endif
 
 # Add dependency on distribution specific version of openssl that fixes Heartbleed (CVE-2014-0160).
 ifeq ($(shell dpkg-vendor --derives-from Ubuntu && echo yes),yes)
-       SUBSTVARS = -Vdist:Depends="libssl1.0.0 (>= 1.0.1f-1ubuntu2)"
+       SUBSTVARS = -Vdist:Depends="libssl1.0.0 (>= 1.0.1f-1ubuntu2) | libssl1.1"
 else
-       SUBSTVARS = -Vdist:Depends="libssl1.0.0 (>= 1.0.1e-2+deb7u5) | libssl1.0.2"
+       SUBSTVARS = -Vdist:Depends="libssl1.0.0 (>= 1.0.1e-2+deb7u5) | libssl1.0.2 | libssl1.1"
 endif
 
 include /usr/share/quilt/quilt.make


### PR DESCRIPTION
Generated packages are marked with these dependencies that are not possible in Debian Buster (since there is no libssl1.0 whatsoever. Adding libssl1.1 solved the issue.