### PR TITLE
Fix truncated string

### DIFF
--- a/src/bin/unit_test_attribute.c
+++ b/src/bin/unit_test_attribute.c
@@ -615,7 +615,7 @@ static ssize_t load_proto_library(char const *proto_name)
 
 static ssize_t load_test_point_by_command(void **symbol, char *command, size_t offset, char const *dflt_symbol)
 {
-	char		buffer[128];
+	char		buffer[256];
 	char const	*p, *q;
 	char const	*symbol_name;
 	void		*dl_symbol;


### PR DESCRIPTION
The `buffer[128]` cannot fit the content passed trough `snpritnf()`, e.g: the `proto_name_prev` has 128 bytes.

gcc warning

```
CC src/bin/unit_test_attribute.c
src/bin/unit_test_attribute.c: In function ‘load_test_point_by_command’:
src/bin/unit_test_attribute.c:637:42: warning: ‘snprintf’ output may be truncated before the last format character [-Wformat-truncation=]
   snprintf(buffer, sizeof(buffer), "%s_%s", proto_name_prev, dflt_symbol);
                                          ^
src/bin/unit_test_attribute.c:637:3: note: ‘snprintf’ output 2 or more bytes (assuming 129) into a destination of size 128
   snprintf(buffer, sizeof(buffer), "%s_%s", proto_name_prev, dflt_symbol);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```