### PR TITLE
Set TLSv1.2 as the maximum version for ABFAB (for now)

### DIFF
--- a/raddb/sites-available/abfab-tls
+++ b/raddb/sites-available/abfab-tls
@@ -21,6 +21,11 @@ listen {
 		ca_path = ${cadir}
 		cipher_list = "DEFAULT"
 
+		# Having a TLS configuration allowing both PSK and certificates at the
+		# same time does not work with OpenSSL 1.1 and TLS 1.3 at this time.
+		# We restrict ABFAB to TLS 1.2 until this is resolved
+		tls_max_version = 1.2
+
 		cache {
 			enable = no
 			lifetime = 24 # hours


### PR DESCRIPTION
It seems that a combined TLS configuration where both certificates and PSK
are acceptable does not work properly with OSSL 1.1 and TLSv1.3.

Hence, for now, we establish TLSv1.2 as our default.