### PR TITLE
Add attribute number 14 (HPE-Port-MA-Port-Mode)

### DIFF
--- a/share/dictionary/radius/dictionary.hp
+++ b/share/dictionary/radius/dictionary.hp
@@ -26,6 +26,7 @@ ATTRIBUTE	HP-Port-Client-Limit-Dot1x		10	integer
 ATTRIBUTE	HP-Port-Client-Limit-MA			11	integer
 ATTRIBUTE	HP-Port-Client-Limit-WA			12	integer
 ATTRIBUTE	HP-Port-Auth-Mode-Dot1x			13	integer
+ATTRIBUTE	HP-Port-MA-Port-Mode			14	integer
 ATTRIBUTE	HP-Port-Bounce-Host			23	integer
 ATTRIBUTE	HP-Captive-Portal-URL			24	string
 ATTRIBUTE	HP-User-Role				25	string


### PR DESCRIPTION
I have found out, that there is missing attribute in dictionary.

        <Attribute profile="in out" type="Unsigned32" name="HPE-Port-MA-Port-Mode" id="14">
          <ValidValues>
            <ValidValue enumOrdinal="0" value="User-Based"/>
            <ValidValue enumOrdinal="1" value="Port-Based"/>
          </ValidValues>
        </Attribute>