### PR TITLE
issue 2395 sqlippool allocate clear v3

### DIFF
--- a/raddb/mods-available/sqlippool
+++ b/raddb/mods-available/sqlippool
@@ -28,6 +28,12 @@ sqlippool {
 	lease_duration = 3600
 
 	#
+	# Timeout between each consecutive 'allocate_clear' queries (default: 1s)
+	# This will avoid having too many deadlock issues, especially on MySQL backend.
+	#
+	allocate_clear_timeout = 1
+
+	#
 	#  As of 3.0.16, the 'ipv6 = yes' configuration is deprecated.
 	#  You should use the "attribute_name" configuration item
 	#  below, instead.


### PR DESCRIPTION
Thanks to this changes, it is now possible to specify the rate (in second) at which the allocate_clear statement should be run.

The default rate is 1 second (set in the config file) in order to be retro-compatible with the old configuration.