### PR TITLE
clarify which CA certs to include when using certificate_file without ca_file

### DIFF
--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -190,10 +190,14 @@ eap {
 		#  name.
 		#
 		#  If ca_file (below) is not used, then the
-		#  certificate_file below MUST include not
-		#  only the server certificate, but ALSO all
-		#  of the CA certificates used to sign the
-		#  server certificate.
+		#  certificate_file below SHOULD also include
+		#  all of the intermediate CA certificates used 
+		#  to sign the server certificate. Including the
+		#  ROOT CA certificate is not useful and merely
+		#  inflates the exchanged data volume during the
+		#  TLS negotiation.
+		#  If included, the intermediate CA certificates
+		#  have to come AFTER the server certificate.
 		#
 		certificate_file = ${certdir}/server.pem
 


### PR DESCRIPTION
Sending the root serves no useful purpose; the client has this root CA installed and verifies against that trust base, or it doesn't. No amount of sending it as part of the untrusted cert data will make the root CA any more or less trusted.
The previous wording was confusing for eduroam admins and consequently we see many who send a superfluous *root* certificate with their server cert. This typically costs another 1-2 roundtrips for no real purpose.
The new wording is more explicit that *intermediate* CAs are a good idea, but no root.