### PR TITLE
Include some feedback when trust router server is not responding

### DIFF
--- a/src/modules/rlm_realm/trustrouter.c
+++ b/src/modules/rlm_realm/trustrouter.c
@@ -625,10 +625,13 @@ REALM *tr_query_realm(REQUEST *request, char const *realm,
 	pthread_mutex_unlock(&tidc_mutex);
 
 	/* If we weren't able to get a response from the trust router server, goto cleanup (hence return NULL realm) */
-	if (!rv) goto cleanup;
+	if (!rv) {
+		DEBUG2("Could not connect with TR server, rv = %d\n", rv);
+		pair_make_reply("Reply-Message", "Could not connect with Trust Router server", T_OP_SET);
+	}
 
 	/* If we got a response but it is an error one, include a Reply-Message and Error-Cause attributes */
-	if (cookie.result != TID_SUCCESS) {
+	else if (cookie.result != TID_SUCCESS) {
 		DEBUG2("TID response is error, rc = %d: %s.\n", cookie.result,
 		       cookie.err_msg?cookie.err_msg:"(NO ERROR TEXT)");
 		if (cookie.err_msg)


### PR DESCRIPTION
So far, if FreeRadius failed to contact the Trust Router server, it just returned Access-Reject.
This made this error indistinguible from an authentication failure.
Just adding something meaningful in the Reply-Message