### PR TITLE
rlm_rediswho: Fix some missing Acct-Status-Type fields

### DIFF
--- a/src/modules/rlm_rediswho/rlm_rediswho.c
+++ b/src/modules/rlm_rediswho/rlm_rediswho.c
@@ -72,6 +72,9 @@ static CONF_PARSER module_config[] = {
 	{ FR_CONF_POINTER("Start", FR_TYPE_SUBSECTION, NULL), .subcs = section_config },
 	{ FR_CONF_POINTER("Interim-Update", FR_TYPE_SUBSECTION, NULL), .subcs = section_config },
 	{ FR_CONF_POINTER("Stop", FR_TYPE_SUBSECTION, NULL), .subcs = section_config },
+	{ FR_CONF_POINTER("Accounting-On", FR_TYPE_SUBSECTION, NULL), .subcs = section_config },
+	{ FR_CONF_POINTER("Accounting-Off", FR_TYPE_SUBSECTION, NULL), .subcs = section_config },
+	{ FR_CONF_POINTER("Failed", FR_TYPE_SUBSECTION, NULL), .subcs = section_config },
 
 	CONF_PARSER_TERMINATOR
 };


### PR DESCRIPTION
Based on the rfc2866, we are missing those Acct-Status-Type fields.