### PR TITLE
conf2adoc: Fix - treat everything as literal

### DIFF
--- a/scripts/asciidoc/conf2adoc
+++ b/scripts/asciidoc/conf2adoc
@@ -178,7 +178,7 @@ sub process_file {
 			#  word individually, but that would also mess up (mildly)
 			#  whitespace.
 			#
-			$line =~ s/`$key`/$link/g;
+			$line =~ s/`\Q$key`/$link/g;
 		}
 
 		#


### PR DESCRIPTION
It will treat everything in between as literal when the input string has some special character. e.g: ()[]{}

for example the URL https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/WinArchive/[MS-SOH].pdf

`\Q - Quote (disable) pattern metacharacters`

