### PR TITLE
Fix misleading error message

### DIFF
--- a/src/modules/rlm_realm/rlm_realm.c
+++ b/src/modules/rlm_realm/rlm_realm.c
@@ -175,11 +175,14 @@ static int check_for_realm(void *instance, REQUEST *request, REALM **returnrealm
 	/*
 	 *	Try querying for the dynamic realm.
 	 */
-	if (!realm && inst->trust_router) {
-		realm = tr_query_realm(request, realmname, inst->default_community, inst->rp_realm, inst->trust_router,
-				       inst->tr_port);
-	} else {
-		RDEBUG2("No trust router configured, skipping dynamic realm lookup");
+	if (!realm) {
+		if (inst->trust_router) {
+			realm = tr_query_realm(request, realmname, inst->default_community, inst->rp_realm,
+					       inst->trust_router, inst->tr_port);
+		}
+		else {
+			RDEBUG2("No trust router configured, skipping dynamic realm lookup");
+		}
 	}
 #endif
 


### PR DESCRIPTION
When the realm is already found, it still said that no TR was configured.