### PR TITLE
subjectAltName in v3 extensions

### DIFF
--- a/raddb/certs/client.cnf
+++ b/raddb/certs/client.cnf
@@ -56,12 +56,14 @@ organizationName	= Example Inc
 emailAddress		= user.example@example.org
 commonName		= Example user
 
-# Should be the user's NAI as per RFC 5216 (EAP-TLS)
-subjectAltName		= user@example.org
-
 [ v3_client ]
 basicConstraints	= CA:FALSE
 keyUsage		= nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage	= 1.3.6.1.5.5.7.3.2
 crlDistributionPoints	= URI:http://www.example.com/example_ca.crl
 authorityInfoAccess	= OCSP;URI:http://www.example.org/ocsp
+subjectAltName		= @alt_names
+
+# Should be the user's NAI as per RFC 5216 (EAP-TLS)
+[ alt_names ]
+email.1 = user@example.org

--- a/raddb/certs/server.cnf
+++ b/raddb/certs/server.cnf
@@ -54,7 +54,7 @@ localityName		= Somewhere
 organizationName	= Example Inc
 emailAddress		= admin@example.org
 commonName		= "Example Server Certificate"
-subjectAltName		= radius.example.org
+
 
 [ v3_radius ]
 basicConstraints	= CA:FALSE
@@ -62,3 +62,7 @@ keyUsage		= nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage	= 1.3.6.1.5.5.7.3.1
 crlDistributionPoints	= URI:http://www.example.com/example_ca.crl
 authorityInfoAccess	= OCSP;URI:http://www.example.org/ocsp
+subjectAltName		= @alt_names
+
+[ alt_names ]
+DNS.1 = radius.example.org


### PR DESCRIPTION
The previous location of subjectAltName does not seem to do anything and generated certificates did not contain any SAN information during my testing.