### PR TITLE
v3.0.x openssl fixups

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1222,6 +1222,7 @@ if test "x$WITH_OPENSSL" = xyes; then
       openssl/hmac.h \
       openssl/md5.h \
       openssl/md4.h \
+      openssl/rand.h \
       openssl/sha.h \
       openssl/ssl.h \
       openssl/ocsp.h \

--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -2743,7 +2743,9 @@ void tls_global_cleanup(void)
 #elif OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
 	ERR_remove_thread_state(NULL);
 #endif
+#ifndef OPENSSL_NO_ENGINE
 	ENGINE_cleanup();
+#endif
 	CONF_modules_unload(1);
 	ERR_free_strings();
 	EVP_cleanup();


### PR DESCRIPTION
These are just some fixups related to openssl support.

- The first commit adds a check for `openssl/rand.h`, whose macro `HAVE_OPENSSL_RAND_H` is checked in `src/main/tls.c`, `src/main/tls_listen.c`, and `src/modules/rlm_eap/types/rlm_eap_tls/rlm_eap_tls.c`.  It avoids this warning:
```
src/main/tls.c: In function 'tls_init_ctx':
src/main/tls.c:3198:9: warning: implicit declaration of function 'RAND_load_file'; did you mean 'CONF_load_bio'? [-Wimplicit-function-declaration]
   if (!(RAND_load_file(conf->random_file, 1024*10))) {
         ^~~~~~~~~~~~~~
         CONF_load_bio
```

- The second commit disables a call to `ENGINE_cleanup` which fails when compiled with an openssl library built without engine support.  Since there's no point in cleaning up something that was not loaded, the call was just guarded by `#ifndef OPENSSL_NO_ENGINE`, defined in `openssl/opensslconf.h` by openssl, when compiled without engine support.
```
src/main/tls.c: In function 'tls_global_cleanup':
src/main/tls.c:2680:2: warning: implicit declaration of function 'ENGINE_cleanup'; did you mean 'EVP_PBE_cleanup'? [-Wimplicit-function-declaration]
  ENGINE_cleanup();
  ^~~~~~~~~~~~~~
  EVP_PBE_cleanup
ld: /home/equeiroz/src/freeradius-server-release_3_0_17/build/objs/src/main/tls.o: in function `tls_global_cleanup':
tls.c:(.text+0x2ef6): undefined reference to `ENGINE_cleanup'
collect2: error: ld returned 1 exit status
```

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>