### PR TITLE
Fix typo `qnew client` -> `new client`

### DIFF
--- a/raddb/sites-available/default
+++ b/raddb/sites-available/default
@@ -263,7 +263,7 @@ server default {
 			#  dynamic clients.
 			#
 			#  If set to `true`, then packets from unknown
-			#  clients are passed through the `qnew
+			#  clients are passed through the `new
 			#  client` subsection below.  See that section
 			#  for more information about how dynamic
 			#  clients work.


### PR DESCRIPTION
Hello, developers.
Please review this PR.