### PR TITLE
Add a stored procedure for PostgreSQL rlm_sqlippool.

### DIFF
--- a/raddb/mods-config/sql/ippool/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool/postgresql/queries.conf
@@ -37,6 +37,17 @@ allocate_find = "\
 #	FOR UPDATE SKIP LOCKED"
 
 #
+#  Use a stored procedure to find the address. This requires PostgreSQL >= 9.5 as
+#  SKIP LOCKED is used.
+#
+# allocate_find = "\
+#  SELECT find_previous_or_new_framedipaddress( \
+#  	'%{control:${pool_name}}', \
+#  	'%{SQL-User-Name}', \
+#  	'%{Calling-Station-Id}' \
+#  	)"
+
+#
 #  If you prefer to allocate a random IP address every time, use this query instead
 #  Note: This is very slow if you have a lot of free IPs.
 #

--- a/raddb/mods-config/sql/ippool/postgresql/schema.sql
+++ b/raddb/mods-config/sql/ippool/postgresql/schema.sql
@@ -17,3 +17,62 @@ CREATE TABLE radippool (
 CREATE INDEX radippool_poolname_expire ON radippool USING btree (pool_name, expiry_time);
 CREATE INDEX radippool_framedipaddress ON radippool USING btree (framedipaddress);
 CREATE INDEX radippool_nasip_poolkey_ipaddress ON radippool USING btree (nasipaddress, pool_key, framedipaddress);
+
+
+--
+-- Use the following indexes and function if using the stored procedure to
+-- find the previously used address.
+--
+-- You may wish to set the ORDER BY expiry_time to DESC for the first two
+-- queries in order to assign the address that the user last had, rather
+-- than the oldest address the user had.
+--
+
+-- CREATE INDEX radippool_pool_name ON radippool USING btree (pool_name);
+-- CREATE INDEX radippool_username ON radippool USING btree (username);
+-- CREATE INDEX radippool_callingstationid ON radippool USING btree (callingstationid);
+
+-- CREATE OR REPLACE FUNCTION find_previous_or_new_framedipaddress (
+-- 	v_pool_name VARCHAR(64),
+-- 	v_username VARCHAR(64),
+-- 	v_callingstationid VARCHAR(64)
+-- )
+-- RETURNS inet
+-- LANGUAGE plpgsql
+-- AS $$
+-- DECLARE
+-- 	r_address inet;
+-- BEGIN
+-- 	SELECT framedipaddress INTO r_address
+--		FROM radippool
+--		WHERE radippool.pool_name = v_pool_name
+--			AND radippool.expiry_time < 'now'::timestamp(0)
+--			AND radippool.username = v_username
+--			AND radippool.callingstationid = v_callingstationid
+--		ORDER BY expiry_time
+--		LIMIT 1
+--		FOR UPDATE SKIP LOCKED;
+-- 	IF r_address <> NULL THEN
+-- 		RETURN r_address;
+-- 	END IF;
+--  SELECT framedipaddress INTO r_address
+--		FROM radippool
+--		WHERE radippool.pool_name = v_pool_name
+--			AND radippool.expiry_time < 'now'::timestamp(0)
+--			AND radippool.username = v_username
+--		ORDER BY expiry_time
+--		LIMIT 1
+--		FOR UPDATE SKIP LOCKED;
+-- 	IF r_address <> NULL THEN
+-- 		RETURN r_address;
+-- 	END IF;
+--  SELECT framedipaddress INTO r_address
+--		FROM radippool
+--		WHERE radippool.pool_name = v_pool_name
+--			AND radippool.expiry_time < 'now'::timestamp(0)
+--		ORDER BY expiry_time
+--		LIMIT 1
+--		FOR UPDATE SKIP LOCKED;
+-- 	RETURN r_address;
+-- END
+-- $$;


### PR DESCRIPTION
This matches the functionality of the existing example query which returns the users previous IP, if possible, however it runs approx 400x faster.

I have a modest test postgresql server, with 4GB RAM, and a radippool table with 2x65k address pools.

I have been testing with the queries to assign addresses. One example query assigns the user the previous address they had, and a new address if not. This is *very* slow, because of how the ORDER BY clause is formed. I have written a postgresql function and it vastly improves performance.

I have been testing a query which assigns simply the least recently used address, which I refer to here as "give me any address":
```
allocate_find = "\
  SELECT framedipaddress FROM ${ippool_table} \
  WHERE pool_name = '%{control:${pool_name}}' AND expiry_time < 'now'::timestamp(0) \
  ORDER BY expiry_time \
  LIMIT 1 \
  FOR UPDATE SKIP LOCKED"
```
I have a variant of this without ordering, as well.

A single execution of the "give me any address" query was taking approx 0.2-0.4ms on my system, and the "give me the previous address" was taking approx 145ms.

Running in a loop 1000x shows the same order of magnitude difference - however not quite the same. I believe this is because the DB caches the queries - I'm not completely sure.

Original query:
```
radius=# DO $$BEGIN
radius$#   FOR i IN 1..1000 LOOP
radius$#     PERFORM framedipaddress FROM radippool WHERE pool_name = 'CustomersNat-ipv4' AND expiry_time < 'now'::timestamp(0) ORDER BY (username <> 'test'), (callingstationid <> 'test'), expiry_time LIMIT 1 FOR UPDATE SKIP LOCKED;
radius$#   END LOOP;
radius$# END; $$;
DO
Time: 64665.157 ms (01:04.665)
```

New query:
```
radius=# DO $$BEGIN
radius$#   FOR i IN 1..1000 LOOP
radius$#     PERFORM find_previous_or_new_framedipaddress('CustomersNat-ipv4', 'test', 'test');
radius$#   END LOOP;
radius$# END; $$;
DO
Time: 162.592 ms
```

"Give me any address" query:
```
radius=#
radius=# DO $$BEGIN
radius$#   FOR i IN 1..1000 LOOP
radius$#     PERFORM framedipaddress FROM radippool WHERE pool_name = 'CustomersNat-ipv4' AND expiry_time < 'now'::timestamp(0) LIMIT 1 FOR UPDATE SKIP LOCKED;
radius$#   END LOOP;
radius$# END; $$;
DO
Time: 36.211 ms
```

"Give me any address" query with ordering:
```
radius=# DO $$BEGIN
radius$#   FOR i IN 1..1000 LOOP
radius$#     PERFORM framedipaddress FROM radippool WHERE pool_name = 'CustomersNat-ipv4' AND expiry_time < 'now'::timestamp(0) ORDER BY expiry_time LIMIT 1 FOR UPDATE SKIP LOCKED;
radius$#   END LOOP;
radius$# END; $$;
DO
Time: 70.142 ms
```

I have done testing with FreeRADIUS with these queries. I have a NAS simulator python script which simulates 100,000 users with 50 user/s disconnect/reconnects. My test RADIUS server runs in a different datacenter (approx 2ms away) from the database server.

I got the following times for getting 100,000 users online:

Old query: couldn't. 50 user/s churn was too much
New query: approx 2m30s
"Give me any address" query with ordering: approx 1m40s
"Give me any address" query without ordering: approx 6m

Oddly, asking the DB to order and give the "least recently used" address is faster over time than just giving any address. I'm not entirely clear why this is. Both start out handling approx 1000/s, and over time the unordered query degrades to around 500/s or so, from memory.

Either way, the new query I am submitting here is significantly faster than the previous one, to the point of being usable.

If it's interesting I can also include my ordered and unordered "Any Address" queries.