### PR TITLE
Fix the dictionary conflict

### DIFF
--- a/share/dictionary/snmp/dictionary
+++ b/share/dictionary/snmp/dictionary
@@ -6,7 +6,7 @@
 # Version:	$Id$
 #
 
-PROTOCOL	SNMP	3	format=4
+PROTOCOL	SNMP	7	format=4
 BEGIN-PROTOCOL	SNMP
 
 $INCLUDE dictionary.freeradius


### PR DESCRIPTION
* Changing the SNMP dictionary id due to the previous conflict with the DHCPv6 id.