### PR TITLE
Fix sqlippool pgsql procedure, and PgPool load balancing

### DIFF
--- a/raddb/mods-config/sql/ippool/postgresql/procedure.sql
+++ b/raddb/mods-config/sql/ippool/postgresql/procedure.sql
@@ -31,7 +31,7 @@ BEGIN
 	ORDER BY expiry_time
 	LIMIT 1
 	FOR UPDATE SKIP LOCKED;
-	IF r_address <> NULL THEN
+	IF r_address IS NOT NULL THEN
 		RETURN r_address;
 	END IF;
  SELECT framedipaddress INTO r_address
@@ -42,7 +42,7 @@ BEGIN
 	ORDER BY expiry_time
 	LIMIT 1
 	FOR UPDATE SKIP LOCKED;
-	IF r_address <> NULL THEN
+	IF r_address IS NOT NULL THEN
 		RETURN r_address;
 	END IF;
  SELECT framedipaddress INTO r_address

--- a/raddb/mods-config/sql/ippool/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool/postgresql/queries.conf
@@ -41,7 +41,14 @@ allocate_find = "\
 #  SKIP LOCKED is used.  See `procedure.sql` in this directory for the
 #  indices and stored procedure used by this query.
 #
+#  The "NO LOAD BALANCE" comment is included here to indicate to a PgPool
+#  system that this needs to be a write transaction. PgPool itself cannot
+#  detect this from the statement alone. If you are using PgPool and do not
+#  have this comment, the query may go to a read only server, and will fail.
+#  This has no negative effect if you are not using PgPool.
+#
 # allocate_find = "\
+#  /*NO LOAD BALANCE*/ \
 #  SELECT find_previous_or_new_framedipaddress( \
 #  	'%{control:${pool_name}}', \
 #  	'%{SQL-User-Name}', \


### PR DESCRIPTION
This PR fixes a bug I had in an earlier version of the PostgreSQL stored procedure when comparing NULL, and, adds a fix for PgPool users who are using the stored procedure.

Patched duplicate of #2562 