### PR TITLE
rlm_lua: Moving to single table 'fr.{}'

### DIFF
--- a/src/modules/rlm_lua/lua.h
+++ b/src/modules/rlm_lua/lua.h
@@ -82,9 +82,10 @@ bool		fr_lua_isjit(lua_State *L);
 char const	*fr_lua_version(lua_State *L);
 
 /* aux.c */
-int		fr_lua_aux_jit_funcs_register(rlm_lua_t const *inst, lua_State *L);
-int		fr_lua_aux_funcs_register(rlm_lua_t const *inst, lua_State *L);
+int		fr_lua_aux_jit_log_register(rlm_lua_t const *inst, lua_State *L);
+int		fr_lua_aux_log_register(rlm_lua_t const *inst, lua_State *L);
 void		fr_lua_aux_set_inst(rlm_lua_t const *inst);
 rlm_lua_t const	*fr_lua_aux_get_inst(void);
 void		fr_lua_aux_set_request(REQUEST *request);
 REQUEST		*fr_lua_aux_get_request(void);
+void		fr_lua_aux_fr_register(lua_State *L);

--- a/src/modules/rlm_lua/lua.h
+++ b/src/modules/rlm_lua/lua.h
@@ -82,6 +82,7 @@ bool		fr_lua_isjit(lua_State *L);
 char const	*fr_lua_version(lua_State *L);
 
 /* aux.c */
+int 		fr_lua_aux_wrapper_fr_log(int type, char const *msg);
 int		fr_lua_aux_jit_log_register(rlm_lua_t const *inst, lua_State *L);
 int		fr_lua_aux_log_register(rlm_lua_t const *inst, lua_State *L);
 void		fr_lua_aux_set_inst(rlm_lua_t const *inst);

--- a/src/tests/modules/lua/auth.unlang
+++ b/src/tests/modules/lua/auth.unlang
@@ -1,6 +1,6 @@
 # fr.*
 lmod1_check_fr_istable
-if (!noop) {
+if (!ok) {
     test_fail
 } else {
     test_pass

--- a/src/tests/modules/lua/auth.unlang
+++ b/src/tests/modules/lua/auth.unlang
@@ -1,13 +1,13 @@
 # fr.*
 lmod1_check_fr_istable
-if (!ok) {
+if (!noop) {
     test_fail
 } else {
     test_pass
 }
 
 lmod2_check_fr_values
-if (!ok) {
+if (!noop) {
     test_fail
 } else {
     test_pass
@@ -27,21 +27,28 @@ if (!ok) {
     test_pass
 }
 
-lmod5_check_if_return_is_string_ok
-if (!ok) {
+lmod5_check_if_return_is_string_noop
+if (!noop) {
     test_fail
 } else {
     test_pass
 }
 
-lmod6_check_if_return_is_const_ok
-if (!ok) {
+lmod6_check_if_return_is_const_noop
+if (!noop) {
     test_fail
 } else {
     test_pass
 }
 
 lmod7_check_fr_overwrite
+if (!noop) {
+    test_fail
+} else {
+    test_pass
+}
+
+lmod8_check_request
 if (!noop) {
     test_fail
 } else {

--- a/src/tests/modules/lua/mod1.lua
+++ b/src/tests/modules/lua/mod1.lua
@@ -4,5 +4,5 @@ function authorize()
 		return "fail"
 	end
 
-	return "noop"
+	return fr.rcode.ok
 end

--- a/src/tests/modules/lua/mod1.lua
+++ b/src/tests/modules/lua/mod1.lua
@@ -1,8 +1,8 @@
 function authorize()
 	if not type(fr) == "table" then
 		print("error: the 'fr' should be a table")
-		return fr.fail
+		return "fail"
 	end
 
-	return fr.ok
+	return "noop"
 end

--- a/src/tests/modules/lua/mod2.lua
+++ b/src/tests/modules/lua/mod2.lua
@@ -1,17 +1,18 @@
 function authorize()
-	for k, v in pairs(fr) do
-		-- print("debug: table fr = { k: "..k.. "=("..type(k).."), v: "..v.."=("..type(v)..") }")
-
-		if not type(k) == "string" then
-			print("error: the k should be a string")
-			return fr.fail
-		end
-
-		if not type(v) == "number" then
-			print("error: the v should be a number")
-			return fr.fail
-		end
+	if not type(fr.rcode) == "table" then 
+		print("error: The 'fr.rcode.{}' should be table")
+		return fr.rcode.fail
 	end
 
-	return fr.ok
+	if not type(fr.log) == "table" then 
+		print("error: The 'fr.log.{}' should be table")
+		return fr.rcode.fail
+	end
+
+	if not type(fr.request) == "table" then 
+		print("error: The 'fr.request.{}' should be table")
+		return fr.rcode.fail
+	end
+
+	return fr.rcode.noop
 end

--- a/src/tests/modules/lua/mod3.lua
+++ b/src/tests/modules/lua/mod3.lua
@@ -1,8 +1,8 @@
 function authorize()
-	for k, v in request.pairs() do
+	for k, v in fr.request.pairs() do
 		if k == "Framed-IPv6-Prefix" and v == "11:22:33:44:55:66:77:88/128" then
-			return fr.ok
+			return fr.rcode.ok
 		end
 	end
-	return fr.fail
+	return fr.rcode.fail
 end

--- a/src/tests/modules/lua/mod4.lua
+++ b/src/tests/modules/lua/mod4.lua
@@ -1,8 +1,8 @@
 function authorize()
-	for k, v in request.pairs() do
+	for k, v in fr.request.pairs() do
 		if k == "User-Name" and v == "caipirinha" then
-			return fr.ok
+			return fr.rcode.ok
 		end
 	end
-	return fr.fail
+	return fr.rcode.fail
 end

--- a/src/tests/modules/lua/mod5.lua
+++ b/src/tests/modules/lua/mod5.lua
@@ -1,3 +1,3 @@
 function authorize()
-	return fr.ok
+	return "noop"
 end

--- a/src/tests/modules/lua/mod6.lua
+++ b/src/tests/modules/lua/mod6.lua
@@ -1,3 +1,3 @@
 function authorize()
-	return "ok"
+	return fr.rcode.noop
 end

--- a/src/tests/modules/lua/mod7.lua
+++ b/src/tests/modules/lua/mod7.lua
@@ -1,6 +1,7 @@
 function authorize()
-	print("mod7: trying to overwrite fr.noop with 12345 (current value "..fr.noop..")")
-	fr.noop = 12345
-	print("mod7: Checking the fr.noop value: "..fr.noop)
-	return fr.noop
+	print("mod7: trying to overwrite fr.noop with 12345 (current value "..fr.rcode.noop..")")
+	fr.rcode.noop = 12345
+	print("mod7: Checking the fr.noop value: "..fr.rcode.noop)
+
+	return fr.rcode.noop
 end

--- a/src/tests/modules/lua/mod8.lua
+++ b/src/tests/modules/lua/mod8.lua
@@ -28,6 +28,9 @@ function authorize()
 	print("for k,v in pairs(fr.log)")
 	for k,v in pairs(fr.log) do print("\t"..k, v) end
 	print()
+	fr.log.debug("Powered by Luajit+FFI & fr_log()")
+	fr.log.debug = "Tapioca"
+	fr.log.debug("Powered by Luajit+FFI & fr_log()")
 
 	-- fr.request {}
 	print("# fr.request.{}")

--- a/src/tests/modules/lua/mod8.lua
+++ b/src/tests/modules/lua/mod8.lua
@@ -1,0 +1,42 @@
+function authorize()
+	print("#mod8.lua: init")
+
+	-- fr {}
+	print("# fr.{}")
+	print("type(fr) = " .. type(fr))
+	print("for k,v in pairs(fr)")
+	for k,v in pairs(fr) do print("\t"..k, v) end
+	print()
+
+	-- fr.rcode {}
+	print("# fr.rcode.{}")
+	print("type(fr.rcode) = " .. type(fr.rcode))
+	print("\tfr.rcode.noop       = " .. fr.rcode.noop)
+	print("\tfr.rcode.handled    = " .. fr.rcode.handled)
+	print("\tfr.rcode.ok         = " .. fr.rcode.ok)
+	print("\tfr.rcode.reject     = " .. fr.rcode.reject)
+	print("\tfr.rcode.fail       = " .. fr.rcode.fail)
+	print("\tfr.rcode.invalid    = " .. fr.rcode.invalid)
+	print("\tfr.rcode.userlock   = " .. fr.rcode.userlock)
+	print("\tfr.rcode.notfound   = " .. fr.rcode.notfound)
+	print("\tfr.rcode.updated    = " .. fr.rcode.updated)
+	print()
+
+	-- fr.log {}
+	print("# fr.log.{}")
+	print("type(fr.log) = " .. type(fr.log))
+	print("for k,v in pairs(fr.log)")
+	for k,v in pairs(fr.log) do print("\t"..k, v) end
+	print()
+
+	-- fr.request {}
+	print("# fr.request.{}")
+	print("type(fr.request) = " .. type(fr.request))
+	print("for k,v in fr.request.pairs()")
+	for k,v in fr.request.pairs() do print("\t"..k, v) end
+	print()
+
+	print("#mod8.lua: returning fr.rcode.noop")
+
+	return fr.rcode.noop
+end

--- a/src/tests/modules/lua/module.conf
+++ b/src/tests/modules/lua/module.conf
@@ -1,4 +1,4 @@
-    lua lmod1_check_fr_istable {
+lua lmod1_check_fr_istable {
     filename = "src/tests/modules/lua/mod1.lua"
     func_authorize = authorize
 }
@@ -18,12 +18,12 @@ lua lmod4_request_check_user {
     func_authorize = authorize
 }
 
-lua lmod5_check_if_return_is_string_ok {
+lua lmod5_check_if_return_is_string_noop {
     filename = "src/tests/modules/lua/mod5.lua"
     func_authorize = authorize
 }
 
-lua lmod6_check_if_return_is_const_ok {
+lua lmod6_check_if_return_is_const_noop {
     filename = "src/tests/modules/lua/mod6.lua"
     func_authorize = authorize
 }
@@ -33,4 +33,9 @@ lua lmod7_check_fr_overwrite {
     func_authorize = authorize
 }
 
+# testing the "fr.request" table
+lua lmod8_check_request {
+    filename = "src/tests/modules/lua/mod8.lua"
+    func_authorize = authorize
+}
 


### PR DESCRIPTION
Now we have the tables.

fr.log.{ debug(), info(), warn(), error() }
fr.request.{} Copy of the current REQUEST
fr.rcode.{} Constants with all return codes.