### PR TITLE
Remove call to redisReplyReaderGetError

### DIFF
--- a/src/modules/rlm_redis/rlm_redis.c
+++ b/src/modules/rlm_redis/rlm_redis.c
@@ -75,7 +75,7 @@ static void *mod_conn_create(TALLOC_CTX *ctx, void *instance)
 
 	if (conn && conn->err) {
 		ERROR("rlm_redis (%s): Problems with redisConnectWithTimeout('%s', %d, %d), %s",
-				inst->xlat_name, inst->hostname, inst->port, inst->query_timeout, redisReplyReaderGetError(conn));
+				inst->xlat_name, inst->hostname, inst->port, inst->query_timeout, redisReaderGetError(conn));
 		redisFree(conn);
 		return NULL;
 	}

--- a/src/modules/rlm_redis/rlm_redis.h
+++ b/src/modules/rlm_redis/rlm_redis.h
@@ -61,5 +61,10 @@ int rlm_redis_query(REDISSOCK **dissocket_p, REDIS_INST *inst,
 		    char const *query, REQUEST *request);
 int rlm_redis_finish_query(REDISSOCK *dissocket);
 
+/* Compatibility with older versions */
+#ifndef redisReaderGetError
+#define redisReaderGetError redisReplyReaderGetError
+#endif
+
 #endif	/* RLM_REDIS_H */
 


### PR DESCRIPTION
This was a backwards compitibility macro that has been replaced by
redisReaderGetError. Release v0.14.0 removed these macros.

Source: https://github.com/redis/hiredis/blob/master/CHANGELOG.md