### PR TITLE
V3.0.x the documentation mentions a parameter ignore_null which doesn't exist in the realm module

### DIFF
--- a/raddb/sites-available/default
+++ b/raddb/sites-available/default
@@ -362,11 +362,7 @@ authorize {
 #	IPASS
 
 	#
-	#  If you are using multiple kinds of realms, you probably
-	#  want to set "ignore_null = yes" for all of them.
-	#  Otherwise, when the first style of realm doesn't match,
-	#  the other styles won't be checked.
-	#
+	# Look for realms in user@domain format
 	suffix
 #	ntdomain
 

--- a/raddb/sites-available/inner-tunnel
+++ b/raddb/sites-available/inner-tunnel
@@ -89,11 +89,8 @@ authorize {
 #	IPASS
 
 	#
-	#  If you are using multiple kinds of realms, you probably
-	#  want to set "ignore_null = yes" for all of them.
-	#  Otherwise, when the first style of realm doesn't match,
-	#  the other styles won't be checked.
-	#
+	#  Look for realms in user@domain format
+	# 
 	#  Note that proxying the inner tunnel authentication means
 	#  that the user MAY use one identity in the outer session
 	#  (e.g. "anonymous", and a different one here


### PR DESCRIPTION
So I deleted it and, to not leave the documentation entirely empty, spoke about "suffix" meaning user@domain format