### PR TITLE
Add missing CoA option in man pages

### DIFF
--- a/man/man1/radclient.1
+++ b/man/man1/radclient.1
@@ -142,7 +142,7 @@ on the command-line is ignored.
 .IP acct\ |\ auth\ |\ status\ |\ coa\ |\ disconnect\ |\ auto
 Use \fBauth\fP to send an authentication packet (Access-Request),
 \fBacct\fP to send an accounting packet (Accounting-Request),
-\fBstatus\fP to send an status packet (Status-Server), \fBcoa\fP
+\fBstatus\fP to send a status packet (Status-Server), \fBcoa\fP
 to send a change-of-authorization packet (CoA-Request), or
 \fBdisconnect\fP to send a disconnection packet (Disconnect-Request).
 Instead of these values, you can also use a decimal code here. For example,

--- a/man/man1/radclient.1
+++ b/man/man1/radclient.1
@@ -142,10 +142,11 @@ on the command-line is ignored.
 .IP acct\ |\ auth\ |\ status\ |\ coa\ |\ disconnect\ |\ auto
 Use \fBauth\fP to send an authentication packet (Access-Request),
 \fBacct\fP to send an accounting packet (Accounting-Request),
-\fBstatus\fP to send an status packet (Status-Server), or
-\fBdisconnect\fP to send a disconnection request. Instead of these
-values, you can also use a decimal code here. For example, code 12 is
-also \fBStatus-Server\fP.
+\fBstatus\fP to send an status packet (Status-Server), \fBcoa\fP
+to send a change-of-authorization packet (CoA-Request), or
+\fBdisconnect\fP to send a disconnection packet (Disconnect-Request).
+Instead of these values, you can also use a decimal code here. For example,
+code 12 is also \fBStatus-Server\fP.
 
 The RADIUS attributes read by \fIradclient\fP can contain the special
 attribute \fBPacket-Type\fP.  If this attribute exists, then that type

--- a/man/man1/radclient.1
+++ b/man/man1/radclient.1
@@ -31,7 +31,7 @@ radclient - send packets to a RADIUS server, show reply
 .IR timeout ]
 .RB [ \-v ]
 .RB [ \-x ]
-\fIserver {acct|auth|status|disconnect|auto} secret\fP
+\fIserver {acct|auth|status|coa|disconnect|auto} secret\fP
 .SH DESCRIPTION
 \fBradclient\fP is a radius client program. It can send arbitrary radius
 packets to a radius server, then shows the reply. It can be used to
@@ -139,7 +139,7 @@ attribute \fBPacket-Dst-Port\fP.  If this attribute exists, then that
 UDP port is where the packet is sent, and the \fB:port\fP specified
 on the command-line is ignored.
 
-.IP acct\ |\ auth\ |\ status\ |\ disconnect\ |\ auto
+.IP acct\ |\ auth\ |\ status\ |\ coa\ |\ disconnect\ |\ auto
 Use \fBauth\fP to send an authentication packet (Access-Request),
 \fBacct\fP to send an accounting packet (Accounting-Request),
 \fBstatus\fP to send an status packet (Status-Server), or


### PR DESCRIPTION
Hello,

I noticed this option was present in `--help` but not in man page.

I want to give a more complete description of what do `coa` option but I'm confused after reading [RFC 5176](https://tools.ietf.org/html/rfc5176#section-2) and [Disconnect Messages in FreeRADIUS's wiki](https://wiki.freeradius.org/protocol/Disconnect%20Messages) when I see ports in use:

```console
$ cat disconnect.text 
Calling-Station-Id = "%%calling%%"

## use 1700 as default port
$ sed "s/%%calling%%/00:11:22:33:44:66/" disconnect.text | radclient -r 1 -x 192.168.122.90 disconnect secret                                                                  
Sent Disconnect-Request Id 36 from 0.0.0.0:33607 to 192.168.122.90:1700 length 39
        Calling-Station-Id = "00:11:22:33:44:66"
(0) No reply from server for ID 36 socket 3

## use 3799 as default port
$ sed "s/%%calling%%/00:11:22:33:44:66/" disconnect.text | radclient -r 1 -x 192.168.122.90 coa secret                                                                         
Sent CoA-Request Id 46 from 0.0.0.0:41731 to 192.168.122.90:3799 length 39
        Calling-Station-Id = "00:11:22:33:44:66"
(0) No reply from server for ID 46 socket 3
```
I suppose that `disconnect` and `coa` command should use 3799 as default port.