### PR TITLE
H3C dictionnary: Add newly-found attributes

### DIFF
--- a/share/dictionary.h3c
+++ b/share/dictionary.h3c
@@ -19,6 +19,9 @@ BEGIN-VENDOR	H3C
 ATTRIBUTE	H3C-Input-Peak-Rate			1	integer
 ATTRIBUTE	H3C-Input-Average-Rate			2	integer
 ATTRIBUTE	H3C-Input-Basic-Rate			3	integer
+ATTRIBUTE	H3C-Output-Peak-Rate			4	integer
+ATTRIBUTE	H3C-Output-Average-Rate			5	integer
+ATTRIBUTE	H3C-Output-Basic-Rate			6	integer
 ATTRIBUTE	H3C-Remanent-Volume			15	integer
 ATTRIBUTE	H3C-Command				20	integer
 


### PR DESCRIPTION
Add some newly-found H3C attributes based respective
product-specific "Security Configuration Guides".

This compilation/crosschecking is based H3C documentation for
these devices: H3C S5500-HI switches and S12500 switches.

Remarks:
Does not stick with H3C's use of of underline in attribute naming.