### PR TITLE
Coa tunnel encrypt bugfix for v3.0.x

### DIFF
--- a/src/lib/radius.c
+++ b/src/lib/radius.c
@@ -961,21 +961,20 @@ static ssize_t vp2data_any(RADIUS_PACKET const *packet,
 				return -1;
 			}
 
-			if (lvalue) ptr[0] = TAG_VALID(vp->tag) ? vp->tag : TAG_NONE;
 			make_tunnel_passwd(ptr + lvalue, &len, data, len,
 					   room - lvalue,
 					   secret, original->vector);
-			len += lvalue;
 			break;
 		case PW_CODE_ACCOUNTING_REQUEST:
 		case PW_CODE_DISCONNECT_REQUEST:
 		case PW_CODE_COA_REQUEST:
-			ptr[0] = TAG_VALID(vp->tag) ? vp->tag : TAG_NONE;
-			make_tunnel_passwd(ptr + 1, &len, data, len, room - 1,
+			make_tunnel_passwd(ptr + lvalue, &len, data, len,
+					   room - lvalue,
 					   secret, packet->vector);
-			len += lvalue;
 			break;
 		}
+		if (lvalue) ptr[0] = TAG_VALID(vp->tag) ? vp->tag : TAG_NONE;
+		len += lvalue;
 		break;
 
 		/*

--- a/src/tests/unit/vendor.txt
+++ b/src/tests/unit/vendor.txt
@@ -36,3 +36,13 @@ data 1a 28 00 00 02 11 f2 22 01 01 01 00 01 02 03 04 0a 0b 0c 0d 05 20 06 00 00 
 decode 1a2800000211f22201010100010203040a0b0c0d05200600000504d2020200000000000000000000
 data Ascend-Data-Filter = "ip in forward srcip 1.2.3.4/5 dstip 10.11.12.13/32 tcp srcport = 5 dstport = 1234"
 
+# this untagged tunnel encrypted VSA is valid in both access accepts and CoA requests
+encode ERX-LI-Action = off
+decode -
+data ERX-LI-Action = off
+
+packet coa_request
+original null
+encode ERX-LI-Action = off
+decode -
+data ERX-LI-Action = off


### PR DESCRIPTION
We finally upgraded our production servers to v3.0 and noticed that LI CoA requests for our Juniper MXes stopped woring. The tunnel ecrypted VSAs could not be decrypted, even after double checking the passwords on both ends more than once ;-)

It turned out that this was due to a TAG_NONE being unconditionally added to the untagged attributes, but without changing the resulting length.

The bug is easy to reproduce using radclient and radsniff. radsniff should be able to decode this untagged tunnel encrypted attribute:
```
$ echo "ERX-LI-Action = off" | radclient -x -r1 -t0 [::1]:3799 coa foo
Sent CoA-Request Id 136 from [::]:53794 to [::1]:3799 length 46
        ERX-LI-Action = off
(0) No reply from server for ID 136 socket 3

# radsniff -x -p 3799 -i lo -s foo -c1 
Logging all events
Sniffing on (lo)
2019-04-03 14:25:27.295227 (1) CoA-Request Id 136 lo:::1:53794 -> ::1:3799 +0.000
        Attr-26.4874.58 = 0x00831cea963d7dc6aba0ddbbacaeb2da8722
        Authenticator-Field = 0xf300033237e656c95dd273d447a77b62
Captured 1 packets, exiting...
Done sniffing
```

The root cause appears to be code duplication, allowing different handling of tags depending on packet type.  The bug has probably gone unnoticed because of the rare combination of packet type and attribute flags, and the fact that there are no packet type dependent unit tests for attribute ecoding.

I've included a new unit test with the fix, to avoid future issues like this in the v3.0.x branch.  The test depends on a new radattr feature: Allow encoding for different packet types, with CoA request and access accepts being the only ones valid for now.