### PR TITLE
Allow listen.ipaddr to reference an IPv6-only host

### DIFF
--- a/src/lib/misc.c
+++ b/src/lib/misc.c
@@ -607,13 +607,6 @@ int fr_pton(fr_ipaddr_t *out, char const *value, ssize_t inlen, int af, bool res
 			fr_strerror_printf("Invalid address");
 			return -1;
 		}
-
-		/*
-		 *	Fall through to resolving the address, using
-		 *	whatever address family they prefer.  If they
-		 *	don't specify an address family, force IPv4.
-		 */
-		if (af == AF_UNSPEC) af = AF_INET;
 	}
 
 	/*


### PR DESCRIPTION
In 5452b13cefa3b30f1da467ff5d68b3c1aa471188, these lines were added
which effectively result in a listen.ipaddr only allowing hostnames to
resolve to IPv4 addresses. With a hostname with only a IPv6 address,
it'll bail with the error message:

```
radiusd: #### Opening IP addresses and Ports ####
listen {
        type = "auth"
Failed resolving "ipv6.cipherboy.com" to IPv4 address:
    Name or service not known
```

This directly contradicts the language in the default configuration
file, so support resolving both IPv4-only and IPv6-only hostnames.


`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`


---------------------------------

With this change, the following situations were tested:

1. `listen.ipaddr = ipv6.cipherboy.com` works as expected:
    ```
    # radiusd -X
    <snip>
    Listening on auth address ::1 port 1812 bound to server default
    Listening on acct address ::1 port 1813 bound to server default
    <snip>
    ```
    ```
    # lsof -i
    radiusd  7697    root    9u  IPv6 246574      0t0  UDP localhost:radius 
    radiusd  7697    root   10u  IPv6 246576      0t0  UDP localhost:radius-acct 
    ```
2. `listen.ipaddr = ipv4.cipherboy.com` works as expected:
    ```
    # radiusd -X
    <snip>
    Listening on auth address 127.0.0.1 port 1812 bound to server default
    Listening on acct address 127.0.0.1 port 1813 bound to server default
    <snip>
    ```
    ```
    # lsof -i
    radiusd  7702    root    9u  IPv4 246591      0t0  UDP localhost:radius 
    radiusd  7702    root   10u  IPv4 246593      0t0  UDP localhost:radius-acct 
    ```
3. `listen.ipv6addr = ipv4.cipherboy.com` fails as expected:
    ```
    # radiusd -X
    <snip>
    Failed resolving "ipv4.cipherboy.com" to IPv6 address: Name or service not known
    <snip>
    ```
4. `listen.ipv6addr = ipv6.cipherboy.com` works as expected:
    ```
    # radiusd -X
    <snip>
    Listening on auth address ::1 port 1812 bound to server default
    Listening on acct address ::1 port 1813 bound to server default
    <snip>
    ```
    ```
    # lsof -i
    radiusd  7733    root    9u  IPv6 246718      0t0  UDP localhost:radius 
    radiusd  7733    root   10u  IPv6 246720      0t0  UDP localhost:radius-acct 
    ```
5. `listen.ipv4addr = ipv6.cipherboy.com` fails as expected:
    ```
    # radiusd -X
    <snip>
    Failed resolving "ipv6.cipherboy.com" to IPv4 address: Name or service not known
    <snip>
    ```
6. `listen.ipv4addr = ipv4.cipherboy.com` works as expected:
    ```
    # radiusd -X
    <snip>
    Listening on auth address 127.0.0.1 port 1812 bound to server default
    Listening on acct address 127.0.0.1 port 1813 bound to server default
    <snip>
    ```
    ```
    # lsof -i
    radiusd  7742    root    9u  IPv4 246743      0t0  UDP localhost:radius 
    radiusd  7742    root   10u  IPv4 246745      0t0  UDP localhost:radius-acct 
    ```