### PR TITLE
Fix listen.ipaddr to reference an IPv6-only host #2627

### DIFF
--- a/src/lib/util/inet.c
+++ b/src/lib/util/inet.c
@@ -734,13 +734,6 @@ int fr_inet_pton(fr_ipaddr_t *out, char const *value, ssize_t inlen, int af, boo
 			fr_strerror_printf("Invalid address");
 			return -1;
 		}
-
-		/*
-		 *	Fall through to resolving the address, using
-		 *	whatever address family they prefer.  If they
-		 *	don't specify an address family, force IPv4.
-		 */
-		if (af == AF_UNSPEC) af = AF_INET;
 	}
 
 	/*


### PR DESCRIPTION
Backport from v3.0.x https://github.com/FreeRADIUS/freeradius-server/pull/2627