### PR TITLE
conf2adoc: Fix the '-*- text -*-' regex

### DIFF
--- a/scripts/asciidoc/conf2adoc
+++ b/scripts/asciidoc/conf2adoc
@@ -52,7 +52,7 @@ sub process_file {
 		#
 		#  Skip editor commands
 		#
-		if (/^# -\*- text -\*-/) {
+		if (/^#\s*-\*- text -\*-/) {
 			next;
 		}
 


### PR DESCRIPTION
The commit c96eda99fd1f941d7a02e8c933fc3cad202f23c7 broken that regex.