### PR TITLE
su to radiusd user/group when rotating logs

### DIFF
--- a/debian/freeradius.logrotate
+++ b/debian/freeradius.logrotate
@@ -9,6 +9,7 @@
 	notifempty
 
 	copytruncate
+	su freerad freerad
 }
 
 # (in order)
@@ -26,6 +27,7 @@
 	notifempty
 
 	nocreate
+	su freerad freerad
 }
 
 # There are different detail-rotating strategies you can use.  One is
@@ -45,4 +47,5 @@
 	notifempty
 
 	nocreate
+	su freerad freerad
 }

--- a/redhat/freeradius-logrotate
+++ b/redhat/freeradius-logrotate
@@ -9,6 +9,7 @@ rotate 4
 missingok
 compress
 delaycompress
+su radiusd radiusd
 
 #
 #  The main server log

--- a/scripts/logrotate/freeradius
+++ b/scripts/logrotate/freeradius
@@ -17,6 +17,7 @@
 	notifempty
 
 	copytruncate
+	su radiusd radiusd
 }
 
 # (in order)
@@ -34,6 +35,7 @@
 	notifempty
 
 	nocreate
+	su radiusd radiusd
 }
 
 # There are different detail-rotating strategies you can use.  One is
@@ -53,4 +55,5 @@
 	notifempty
 
 	nocreate
+	su radiusd radiusd
 }

--- a/suse/radiusd-logrotate
+++ b/suse/radiusd-logrotate
@@ -11,6 +11,7 @@ missingok
 compress
 delaycompress
 notifempty
+su radiusd radiusd
 
 #
 #  The main server log


### PR DESCRIPTION
The `su` directive to `logrotate` ensures that log rotation happens under the
owner of the logs. Otherwise, `logrotate` runs as `root:root`, potentially
enabling privilege escalation if a RCE is discovered against the
FreeRADIUS daemon.

This attack avenue seems quite unlikely to me. The other alternative is making the `/var/log/radiusd` directory owned by root. It seems like the `logrotate` method is better hygiene though. Thoughts?

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`