### PR TITLE
su to radiusd user/group when rotating logs

### DIFF
--- a/debian/freeradius.logrotate
+++ b/debian/freeradius.logrotate
@@ -10,6 +10,7 @@
 	compress
 	delaycompress
 	notifempty
+	su freerad freerad
 }
 
 # Session monitoring utilities, session database modules and
@@ -24,6 +25,7 @@
 	compress
 	delaycompress
 	notifempty
+	su freerad freerad
 }
 
 # There are different detail-rotating strategies you can use.  One is
@@ -41,4 +43,5 @@
 	compress
 	delaycompress
 	notifempty
+	su freerad freerad
 }

--- a/redhat/freeradius-logrotate
+++ b/redhat/freeradius-logrotate
@@ -9,6 +9,7 @@
 	missingok
 	compress
 	delaycompress
+	su radiusd radiusd
 }
 
 # Session monitoring utilities, session database modules and
@@ -22,6 +23,7 @@
 	missingok
 	compress
 	delaycompress
+	su radiusd radiusd
 }
 
 # There are different detail-rotating strategies you can use.  One is
@@ -38,4 +40,5 @@
 	missingok
 	compress
 	delaycompress
+	su radiusd radiusd
 }

--- a/scripts/logrotate/freeradius
+++ b/scripts/logrotate/freeradius
@@ -13,6 +13,7 @@ missingok
 compress
 delaycompress
 notifempty
+su radiusd radiusd
 
 #
 #  The main server log

--- a/suse/radiusd-logrotate
+++ b/suse/radiusd-logrotate
@@ -11,6 +11,7 @@ missingok
 compress
 delaycompress
 notifempty
+su radiusd radiusd
 
 #
 #  The main server log


### PR DESCRIPTION
The su directive to logrotate ensures that log rotation happens under the
owner of the logs. Otherwise, logrotate runs as root:root, potentially
enabling privilege escalation if a RCE is discovered against the
FreeRADIUS daemon.

Forward port of #2666 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`