### PR TITLE
rlm_couchbase: The API expects timeout in microseconds

### DIFF
--- a/src/modules/rlm_couchbase/mod.c
+++ b/src/modules/rlm_couchbase/mod.c
@@ -77,7 +77,7 @@ void *mod_conn_create(TALLOC_CTX *ctx, void *instance, struct timeval const *tim
 
 	/* create instance */
 	cb_error = couchbase_init_connection(&cb_inst, inst->server, inst->bucket, inst->username,
-					inst->password, FR_TIMEVAL_TO_MS(timeout));
+					inst->password, FR_TIMEVAL_TO_MS(timeout) * 1000);
 
 	/* check couchbase instance */
 	if (cb_error != LCB_SUCCESS) {


### PR DESCRIPTION
As can be seen in https://github.com/couchbaselabs/expiry-notifier/blob/master/node_modules/couchbase/deps/lcb/man/man3couchbase/lcb_cntl.3couchbase.txt#L59