### PR TITLE
Don't generate certificates in a reproducible build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,7 @@ before_script:
 # Run CLANG analyzer if we're building with CLANG
   - if [ "${DO_BUILD}" = 'yes' -a "${COVERITY_SCAN_BRANCH}" != 1 -a ${CC} = 'clang' ]; then make -j8 scan && [ "$(find build/plist/ -name *.html)" = '' ]; fi
 script:
+  - if [ "${DO_BUILD}" = 'yes' -a "${COVERITY_SCAN_BRANCH}" != 1 -a "%{REPRODUCIBLE}" = 'yes' ]; then sh $HOME/freeradius/etc/raddb/certs/bootstrap; fi
   - if [ "${DO_BUILD}" = 'yes' -a "${COVERITY_SCAN_BRANCH}" != 1 ]; then make travis-test; fi
 #  - if [ "${DO_BUILD}" = 'no' ]; then make deb; fi
 # Build the doxygen documentation

--- a/Make.inc.in
+++ b/Make.inc.in
@@ -173,3 +173,8 @@ else
 	TESTBINDIR = ./$(BUILD_DIR)/bin
 	TESTBIN    = ./$(BUILD_DIR)/bin
 endif
+
+#
+#  With reproducible builds, do not generate certificates during installation
+#
+ENABLE_REPRODUCIBLE_BUILDS = @ENABLE_REPRODUCIBLE_BUILDS@

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,6 @@ travis-test: raddb/test.conf test
 	@rm -f raddb/test.conf
 	@$(MAKE) install
 	@perl -p -i -e 's/allow_vulnerable_openssl = no/allow_vulnerable_openssl = yes/' ${raddbdir}/radiusd.conf
-	@sh ${HOME}/freeradius/etc/raddb/certs
 	@${sbindir}/radiusd -XC
 endif
 

--- a/configure
+++ b/configure
@@ -655,6 +655,7 @@ RUSERS
 SNMPWALK
 SNMPGET
 PERL
+ENABLE_REPRODUCIBLE_BUILDS
 openssl_version_check_config
 WITH_DHCP
 modconfdir
@@ -5586,6 +5587,7 @@ else
 fi
 
 
+ENABLE_REPRODUCIBLE_BUILDS=no
 # Check whether --enable-reproducible-builds was given.
 if test "${enable_reproducible_builds+set}" = set; then :
   enableval=$enable_reproducible_builds;  case "$enableval" in
@@ -5594,12 +5596,14 @@ if test "${enable_reproducible_builds+set}" = set; then :
 $as_echo "#define ENABLE_REPRODUCIBLE_BUILDS 1" >>confdefs.h
 
     reproducible_builds=yes
+    ENABLE_REPRODUCIBLE_BUILDS=yes
     ;;
   *)
     reproducible_builds=no
   esac
 
 fi
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -619,6 +619,7 @@ AC_SUBST([openssl_version_check_config])
 dnl #
 dnl #  extra argument: --enable-reproducible-builds
 dnl #
+ENABLE_REPRODUCIBLE_BUILDS=no
 AC_ARG_ENABLE(reproducible-builds,
 [AS_HELP_STRING([--enable-reproducible-builds],
                 [ensure the build does not change each time])],
@@ -627,11 +628,13 @@ AC_ARG_ENABLE(reproducible-builds,
     AC_DEFINE(ENABLE_REPRODUCIBLE_BUILDS, [1],
               [Define to ensure each build is the same])
     reproducible_builds=yes
+    ENABLE_REPRODUCIBLE_BUILDS=yes
     ;;
   *)
     reproducible_builds=no
   esac ]
 )
+AC_SUBST(ENABLE_REPRODUCIBLE_BUILDS)
 
 
 dnl #############################################################

--- a/raddb/all.mk
+++ b/raddb/all.mk
@@ -123,8 +123,13 @@ $(R)$(raddbdir)/users: $(R)$(modconfdir)/files/authorize
 
 ifneq "$(LOCAL_CERT_PRODUCTS)" ""
 $(LOCAL_CERT_PRODUCTS):
+ifeq "$(ENABLE_REPRODUCIBLE_BUILDS)" "yes"
+	@echo BOOTSTRAP raddb/certs/ passwords.mk
+	@$(MAKE) -C $(R)$(raddbdir)/certs/ passwords.mk
+else
 	@echo BOOTSTRAP raddb/certs/
 	@$(MAKE) -C $(R)$(raddbdir)/certs/
+endif
 
 # Bootstrap is special
 $(R)$(raddbdir)/certs/bootstrap: | raddb/certs/bootstrap $(LOCAL_CERT_PRODUCTS)


### PR DESCRIPTION
This is something I've been meaning to do for a while.

[Fedora standards](https://fedoraproject.org/wiki/Packaging:Initial_Service_Setup#First-time_Service_Setup) have changed since FreeRADIUS was initially packaged. Now they want us to generate certificates [at first service start](https://bugzilla.redhat.com/show_bug.cgi?id=1672284) instead of at installation time. The default build process generates its own certificates (as part of `make install`), only for us to blow them away (to be created at RPM install time or at service start time).  

This changes the build process to not generate certificates only in reproducible environments (`--enable-reproducible-build`, as certificates generated at build time are unique and hence not reproducible).

If you'd like me to change this to gate behind a flag specifically for certificate generation (`--disable-cert-generation` or similar), I'm happy to update this. 

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`