### PR TITLE
start running integration tests on jenkins for v3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,6 @@ test: ${BUILD_DIR}/bin/radiusd ${BUILD_DIR}/bin/radclient tests.unit tests.xlat 
 
 #  Tests specifically for Travis.  We do a LOT more than just
 #  the above tests
-ifneq "$(findstring travis,${prefix})" ""
 travis-test: raddb/test.conf test
 	@FR_LIBRARY_PATH=./build/lib/local/.libs/ ./build/make/jlibtool --mode=execute ./build/bin/radiusd -xxxv -n test
 	@rm -f raddb/test.conf
@@ -97,7 +96,6 @@ travis-test: raddb/test.conf test
 	@perl -p -i -e 's/allow_vulnerable_openssl = no/allow_vulnerable_openssl = yes/' ${raddbdir}/radiusd.conf
 	@sh ${HOME}/freeradius/etc/raddb/certs
 	@${sbindir}/radiusd -XC
-endif
 
 #
 # The $(R) is a magic variable not defined anywhere in this source.

--- a/scripts/travis/Dockerfile
+++ b/scripts/travis/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:14.04
+RUN apt-get update && apt-get install -y curl
+RUN curl -sSL "https://build.travis-ci.org/files/gpg/couchbase-precise.asc" | sudo -E apt-key add -
+RUN echo "deb http://packages.couchbase.com/ubuntu precise precise/main" | sudo tee -a /etc/apt/sources.list >/dev/null
+RUN echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main" >> /etc/apt/sources.list
+RUN curl https://raw.githubusercontent.com/travis-ci/apt-source-safelist/master/keys/llvm-toolchain-trusty-5.0.asc | apt-key add -
+RUN apt-get update && apt-get -y upgrade
+RUN apt-get -yq --no-install-suggests --no-install-recommends install autoconf build-essential debhelper devscripts dh-make doxygen fakeroot gdb graphviz lintian pbuilder python-dev quilt libruby ruby-dev libcollectdclient-dev firebird-dev freetds-dev libcap-dev libcouchbase2-libevent libcouchbase-dev libcurl4-openssl-dev libgdbm-dev libhiredis-dev libidn11-dev libiodbc2-dev libiodbc2 libjson0 libjson0-dev libkrb5-dev libldap2-dev libmemcached-dev libmysqlclient-dev libpam0g-dev libpcap-dev libpcre3-dev libperl-dev libpq-dev libreadline-dev libsnmp-dev libssl-dev libtalloc-dev libtalloc2-dbg libunbound-dev libwbclient-dev libykclient-dev libyubikey-dev clang-5.0
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-5.0 100
+WORKDIR /usr/local/src/repositories

--- a/scripts/travis/Jenkinsfile
+++ b/scripts/travis/Jenkinsfile
@@ -1,0 +1,66 @@
+// Initialize a variable to hold the matrix of travis builds
+tmatrix = []
+
+/* This function takes a list of tests and builds closures for each test to
+* be run in it's own docker container. It's a little strange, and uses a 
+* functional programming trick (function currying) to create a closure that 
+* can be passed to the "parallel" function, which can only take one argument 
+* in this context 
+*/
+
+def buildClosures(arg) {
+    println arg.inspect()
+    def travisTests = arg
+    def closures = [:]
+    for (value in travisTests) {
+        final valueCopy = value
+        closures[value] = { testEnv_str ->
+            def(dir,testEnv) = testEnv_str.split(":")
+            stage("$testEnv") {
+                // Docker needs full privileges and capabilites to run the tests
+                // This passes the necessary arguments to "docker run"
+                travisImage.inside("--privileged --cap-add=ALL") {
+                    checkout([$class: 'GitSCM',\
+                    branches: [[name: scm.branches[0].name]],\
+                    doGenerateSubmoduleConfigurations: false,\
+                    extensions: [[$class: 'CleanCheckout'],\
+                        [$class: 'CleanBeforeCheckout'],\
+                        [$class: 'RelativeTargetDirectory', relativeTargetDir: dir]],\
+                    submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/FreeRADIUS/freeradius-server']]])
+                    sh "cd $dir ; export ${testEnv} ; bash scripts/travis/start.sh"
+                }
+            }
+        }.curry(value)
+    }
+    closures
+}
+
+/* This section does three things
+* 1. Checkout the repo for the necessary setup files
+* 2. Reads the test matrix from the .travis.yml and converts it into a list that
+*    can be passed to the buildClosures function
+* 3. runs each test matrix under gcc and clang in parallel.
+*/
+
+node {
+    cleanWs()
+    checkout scm
+    travis = readYaml(file: "./.travis.yml")
+    travisImage = docker.build("travis-image-${scm.branches[0].name}", "./scripts/travis/")
+    stage("clang tests") {
+        tmatrix = []
+        c = "clang"
+        travis["env"]["matrix"].eachWithIndex { t,i -> 
+            tmatrix << "${c}-${i}:CC=${c} ${t}"
+        }
+        parallel buildClosures(tmatrix)
+    }
+    stage("gcc tests") {
+        tmatrix = []
+        c = "gcc"
+        travis["env"]["matrix"].eachWithIndex { t,i -> 
+            tmatrix << "${c}-${i}:CC=${c} ${t}"
+        }
+        parallel buildClosures(tmatrix)
+    }
+}

--- a/scripts/travis/start.sh
+++ b/scripts/travis/start.sh
@@ -1,0 +1,37 @@
+##TODO rip this apart into "configure , make , make deb, make scan and make install" functions
+export PANIC_ACTION="gdb -batch -x raddb/panic.gdb %e %p 1>&0 2>&0"
+
+#Configure
+if [ "${DO_BUILD}" = 'yes' ]; then 
+    CFLAGS="${BUILD_CFLAGS}" ./configure -C\
+    --enable-werror \
+    --prefix=$HOME/freeradius\
+    --with-shared-libs=$LIBS_SHARED \
+    --with-threads=$LIBS_OPTIONAL \
+    --with-udpfromto=$LIBS_OPTIONAL \
+    --with-openssl=$LIBS_OPTIONAL \
+    --with-pcre=$LIBS_OPTIONAL \
+    --enable-reproducible-builds=${REPRODUCIBLE}
+fi
+
+if [ "${DO_BUILD}" = 'no' ]; then 
+    ./configure -C --without-modules
+fi
+
+# Make
+if [ "${DO_BUILD}" = 'yes' ]; then 
+    make -j8
+fi
+
+# Make scan
+if [ "${DO_BUILD}" = 'yes' -a ${CC} = 'clang' ]; then 
+    make -j8 scan && [ "$(find build/plist/ -name *.html)" = '' ]
+fi
+
+if [ "${DO_BUILD}" = 'yes' ]; then 
+    make travis-test
+fi
+
+if [ "${DO_BUILD}" = 'no' ]; then 
+    cd doc/source; doxygen 3>&1 1>&2 2>&3 | grep -iv '^warning:' | tee doxygen_stderr.log && [ ! -n "$(cat doxygen_stderr.log)" ]
+fi


### PR DESCRIPTION
This adds the functionality from the current v3.0.x travis tests to jenkins