### PR TITLE
everybody loves fr_time_to_timeval() 

### DIFF
--- a/src/bin/radmin.c
+++ b/src/bin/radmin.c
@@ -454,7 +454,7 @@ static int cmd_uptime(FILE *fp, UNUSED FILE *fp_err, UNUSED void *ctx, UNUSED fr
 {
 	struct timeval now;
 
-	gettimeofday(&now, NULL);
+	fr_time_to_timeval(&now, fr_time());
 	fr_timeval_subtract(&now, &now, &start_time);
 
 	fprintf(fp, "Uptime: %u.%06u seconds\n",
@@ -942,7 +942,7 @@ int fr_radmin_start(main_config_t *config, bool cli)
 	radmin_ctx = talloc_init("radmin");
 	if (!radmin_ctx) return -1;
 
-	gettimeofday(&start_time, NULL);
+	fr_time_to_timeval(&start_time, fr_time());
 
 #ifdef USE_READLINE
 	memcpy(&rl_readline_name, &config->name, sizeof(rl_readline_name)); /* const issues on OSX */

--- a/src/bin/radsniff.c
+++ b/src/bin/radsniff.c
@@ -194,7 +194,7 @@ static void rs_time_print(char *out, size_t len, struct timeval const *t)
 	uint32_t usec;
 
 	if (!t) {
-		gettimeofday(&now, NULL);
+		fr_time_to_timeval(&now, fr_time());
 		t = &now;
 	}
 
@@ -2926,7 +2926,7 @@ int main(int argc, char *argv[])
 		 *  Insert our stats processor
 		 */
 		if (conf->stats.interval && conf->from_dev) {
-			gettimeofday(&now, NULL);
+			fr_time_to_timeval(&now, fr_time());
 			rs_install_stats_processor(stats, events, in, &now, false);
 		}
 	}

--- a/src/lib/redis/cluster.c
+++ b/src/lib/redis/cluster.c
@@ -1344,7 +1344,7 @@ static int cluster_node_find_live(fr_redis_cluster_node_t **live_node, fr_redis_
 	rad_assert(live->next);			/* There should be at least one */
 	if (live->next == 1) goto no_alts;	/* Weird, but conceivable */
 
-	gettimeofday(&now, NULL);
+	fr_time_to_timeval(&now, fr_time());
 
 	/*
 	 *	Weighted random selection

--- a/src/lib/server/exec.c
+++ b/src/lib/server/exec.c
@@ -471,7 +471,7 @@ int radius_readfrom_program(int fd, pid_t pid, int timeout,
 	 *	Read from the pipe until we doesn't get any more or
 	 *	until the message is full.
 	 */
-	gettimeofday(&start, NULL);
+	fr_time_to_timeval(&start, fr_time());
 	while (1) {
 		int rcode;
 		fd_set fds;
@@ -480,7 +480,7 @@ int radius_readfrom_program(int fd, pid_t pid, int timeout,
 		FD_ZERO(&fds);
 		FD_SET(fd, &fds);
 
-		gettimeofday(&when, NULL);
+		fr_time_to_timeval(&when, fr_time());
 		fr_timeval_subtract(&elapsed, &when, &start);
 		if (elapsed.tv_sec >= timeout) goto too_long;
 

--- a/src/lib/server/pool.c
+++ b/src/lib/server/pool.c
@@ -482,7 +482,7 @@ static fr_pool_connection_t *connection_spawn(fr_pool_t *pool, REQUEST *request,
 	this->in_use = in_use;
 
 	this->number = number;
-	gettimeofday(&this->last_reserved, NULL);
+	fr_time_to_timeval(&this->last_reserved, fr_time());
 	this->last_released = this->last_reserved;
 
 	/*
@@ -883,7 +883,7 @@ static void *connection_get_internal(fr_pool_t *pool, REQUEST *request, bool spa
 do_return:
 	pool->state.active++;
 	this->num_uses++;
-	gettimeofday(&this->last_reserved, NULL);
+	fr_time_to_timeval(&this->last_reserved, fr_time());
 	this->in_use = true;
 
 #ifdef PTHREAD_DEBUG
@@ -1393,7 +1393,7 @@ void fr_pool_connection_release(fr_pool_t *pool, REQUEST *request, void *conn)
 	/*
 	 *	Record when the connection was last released
 	 */
-	gettimeofday(&this->last_released, NULL);
+	fr_time_to_timeval(&this->last_reserved, fr_time());
 	pool->state.last_released = this->last_released;
 
 	/*
@@ -1520,7 +1520,7 @@ int fr_pool_connection_close(fr_pool_t *pool, REQUEST *request, void *conn)
 	/*
 	 *	Record the last time a connection was closed
 	 */
-	gettimeofday(&pool->state.last_closed, NULL);
+	fr_time_to_timeval(&pool->state.last_closed, fr_time());
 
 	ROPTIONAL(RINFO, INFO, "Deleting connection (%" PRIu64 ")", this->number);
 

--- a/src/lib/server/snmp.c
+++ b/src/lib/server/snmp.c
@@ -118,7 +118,7 @@ static int snmp_value_uptime_get(UNUSED TALLOC_CTX *ctx, fr_value_box_t *out, ND
 
 	rad_assert(map->da->type == FR_TYPE_UINT32);
 
-	gettimeofday(&now, NULL);
+	fr_time_to_timeval(&now, fr_time());
 	fr_timeval_subtract(&diff, &now, &uptime);
 
 	out->vb_uint32 = diff.tv_sec * 100;
@@ -135,7 +135,7 @@ static int snmp_config_reset_time_get(UNUSED TALLOC_CTX *ctx, fr_value_box_t *ou
 
 	rad_assert(map->da->type == FR_TYPE_UINT32);
 
-	gettimeofday(&now, NULL);
+	fr_time_to_timeval(&now, fr_time());
 	fr_timeval_subtract(&diff, &now, &reset_time);
 
 	out->vb_uint32 = diff.tv_sec * 100;
@@ -161,7 +161,7 @@ static int snmp_config_reset_set(NDEBUG_UNUSED fr_snmp_map_t const *map, UNUSED 
 	switch (in->vb_uint32) {
 	case FR_RADIUS_AUTH_SERV_CONFIG_RESET_VALUE_RESET:
 		main_loop_signal_self(RADIUS_SIGNAL_SELF_HUP);
-		gettimeofday(&reset_time, NULL);
+		fr_time_to_timeval(&reset_time, fr_time());
 		return 0;
 
 	default:
@@ -1110,7 +1110,7 @@ static int _fr_snmp_init(fr_snmp_map_t map[])
  */
 int fr_snmp_init(void)
 {
-	gettimeofday(&uptime, NULL);
+	fr_time_to_timeval(&uptime, fr_time());
 	reset_time = uptime;
 
 	if (fr_dict_autoload(snmp_dict) < 0) {

--- a/src/lib/tls/ocsp.c
+++ b/src/lib/tls/ocsp.c
@@ -438,13 +438,13 @@ int tls_ocsp_check(REQUEST *request, SSL *ssl,
 		goto finish;
 	}
 
-	gettimeofday(&when, NULL);
+	fr_time_to_timeval(&when, fr_time());
 	when.tv_sec += conf->timeout;
 
 	do {
 		rc = OCSP_sendreq_nbio(&resp, ctx);
 		if (conf->timeout) {
-			gettimeofday(&now, NULL);
+			fr_time_to_timeval(&now, fr_time());
 			if (fr_timeval_cmp(&now, &when) >= 0) break;
 		}
 	} while ((rc == -1) && BIO_should_retry(conn));
@@ -536,7 +536,7 @@ int tls_ocsp_check(REQUEST *request, SSL *ssl,
 		 *	Sometimes we already know what 'now' is depending
 		 *	on the code path, other times we don't.
 		 */
-		if (now.tv_sec == 0) gettimeofday(&now, NULL);
+		if (now.tv_sec == 0) fr_time_to_timeval(&now, fr_time());
 		if (tls_utils_asn1time_to_epoch(&next, next_update) < 0) {
 			RPEDEBUG("Failed parsing next_update time");
 			ocsp_status = OCSP_STATUS_SKIPPED;

--- a/src/modules/proto_detail/proto_detail_work.c
+++ b/src/modules/proto_detail/proto_detail_work.c
@@ -603,7 +603,7 @@ static ssize_t mod_write(fr_listen_t *li, void *packet_ctx, fr_time_t request_ti
 			goto fail;
 		}
 
-		gettimeofday(&now, NULL);
+		fr_time_delta_to_timeval(&now, fr_time());
 
 		if (track->count == 0) {
 			track->rt = inst->irt * USEC;

--- a/src/modules/rlm_redis_ippool/rlm_redis_ippool.c
+++ b/src/modules/rlm_redis_ippool/rlm_redis_ippool.c
@@ -617,7 +617,7 @@ static ippool_rcode_t redis_ippool_allocate(rlm_redis_ippool_t const *inst, REQU
 	rad_assert(key_prefix);
 	rad_assert(device_id);
 
-	gettimeofday(&now, NULL);
+	fr_time_to_timeval(&now, fr_time());
 
 	/*
 	 *	hiredis doesn't deal well with NULL string pointers
@@ -826,7 +826,7 @@ static ippool_rcode_t redis_ippool_update(rlm_redis_ippool_t const *inst, REQUES
 	vp_tmpl_t		range_rhs = { .name = "", .type = TMPL_TYPE_DATA, .tmpl_value_type = FR_TYPE_STRING, .quote = T_DOUBLE_QUOTED_STRING };
 	vp_map_t		range_map = { .lhs = inst->range_attr, .op = T_OP_SET, .rhs = &range_rhs };
 
-	gettimeofday(&now, NULL);
+	fr_time_to_timeval(&now, fr_time());
 
 	/*
 	 *	hiredis doesn't deal well with NULL string pointers
@@ -965,7 +965,7 @@ static ippool_rcode_t redis_ippool_release(rlm_redis_ippool_t const *inst, REQUE
 	fr_redis_rcode_t	status;
 	ippool_rcode_t		ret = IPPOOL_RCODE_SUCCESS;
 
-	gettimeofday(&now, NULL);
+	fr_time_to_timeval(&now, fr_time());
 
 	/*
 	 *	hiredis doesn't deal well with NULL string pointers

--- a/src/modules/rlm_redis_ippool/rlm_redis_ippool_tool.c
+++ b/src/modules/rlm_redis_ippool/rlm_redis_ippool_tool.c
@@ -1067,7 +1067,7 @@ static int driver_get_stats(ippool_tool_stats_t *out, void *instance, uint8_t co
 
 	MEM(replies = talloc_zero_array(inst, redisReply *, STATS_COMMANDS_TOTAL));
 
-	gettimeofday(&now, NULL);
+	fr_time_to_timeval(&now, fr_time());
 
 	for (s_ret = fr_redis_cluster_state_init(&state, &conn, inst->cluster, request, key, key_p - key, false);
 	     s_ret == REDIS_RCODE_TRY_AGAIN;
@@ -1701,7 +1701,7 @@ do { \
 
 			leases[i] = talloc_get_type_abort(leases[i], ippool_tool_lease_t);
 
-			gettimeofday(&now, NULL);
+			fr_time_to_timeval(&now, fr_time());
 			is_active = now.tv_sec <= leases[i]->next_event;
 			if (leases[i]->next_event) {
 				strftime(time_buff, sizeof(time_buff), "%b %e %Y %H:%M:%S %Z",

--- a/src/modules/rlm_sigtran/libosmo-m3ua/pcap.c
+++ b/src/modules/rlm_sigtran/libosmo-m3ua/pcap.c
@@ -75,7 +75,7 @@ int mtp_pcap_write_msu(int fd, const uint8_t *data, int length)
 		.orig_len   = length,
 	};
 
-	gettimeofday(&tv, NULL);
+	fr_time_to_timeval(&tv, fr_time());
 	payload_header.ts_sec = tv.tv_sec;
 	payload_header.ts_usec = tv.tv_usec;
 

--- a/src/tests/rbmonkey.c
+++ b/src/tests/rbmonkey.c
@@ -171,7 +171,8 @@ int main(UNUSED int argc, UNUSED char *argv[])
 	int n, rep;
 	uint32_t vals[MAXSIZE];
 	struct timeval now;
-	gettimeofday(&now, NULL);
+
+	fr_time_to_timeval(&now, fr_time());
 
 	/* TODO: make starting seed and repetitions a CLI option */
 	rep = REPS;

--- a/src/tests/util/message_set_test.c
+++ b/src/tests/util/message_set_test.c
@@ -375,7 +375,7 @@ int main(int argc, char *argv[])
 	if (debug_lvl) {
 		struct timeval start_t, end_t;
 
-		gettimeofday(&start_t, NULL);
+		fr_time_to_timeval(&start_t, fr_time());
 
 		/*
 		 *	Do another 10000 rounds of alloc / free.
@@ -388,7 +388,7 @@ int main(int argc, char *argv[])
 			free_blocks(ms, &seed, &start, &end);
 		}
 
-		gettimeofday(&end_t, NULL);
+		fr_time_to_timeval(&end_t, fr_time());
 
 		end_t.tv_sec -= start_t.tv_sec;
 		if (end_t.tv_sec > 0) {


### PR DESCRIPTION
After that, we've done with `gettimeofday()`

```
[jpereira@sugarloaf freeradius-server.git]$ grep --include '*.c' gettimeofday -r src/
src/lib/util/missing.c:int gettimeofday (struct timeval *tv, UNUSED void *tz)
src/lib/util/time.c:		(void) gettimeofday(&tv_realtime, NULL);
src/lib/util/udpfromto.c: *			gettimeofday will be used instead.
[jpereira@sugarloaf freeradius-server.git]$
```