### PR TITLE
get git url from job configuration

### DIFF
--- a/scripts/travis/Jenkinsfile
+++ b/scripts/travis/Jenkinsfile
@@ -26,7 +26,7 @@ def buildClosures(arg) {
                     extensions: [[$class: 'CleanCheckout'],\
                         [$class: 'CleanBeforeCheckout'],\
                         [$class: 'RelativeTargetDirectory', relativeTargetDir: dir]],\
-                    submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/FreeRADIUS/freeradius-server']]])
+                    submoduleCfg: [], userRemoteConfigs: [[url: scm.userRemoteConfigs[0].url]]])
                     sh "cd $dir ; export ${testEnv} ; bash scripts/travis/startservice.sh"
                 }
             }
@@ -45,6 +45,7 @@ def buildClosures(arg) {
 node {
     cleanWs()
     checkout scm
+    echo scm.userRemoteConfigs[0].url
     travis = readYaml(file: "./.travis.yml")
     travisImage = docker.build("travis-image", "./scripts/travis/")
     stage("clang tests") {


### PR DESCRIPTION
This change just makes it easier to test jenkins configurations without having to change the URL to match the jenkins configuration.

NB: This requires the following script permissions if run in the jenkins Groovy Sandbox:
method hudson.plugins.git.GitSCM getUserRemoteConfigs
method hudson.plugins.git.UserRemoteConfig getUrl