### PR TITLE
Enable rlm_cache in authenticate section

### DIFF
--- a/src/modules/rlm_cache/rlm_cache.c
+++ b/src/modules/rlm_cache/rlm_cache.c
@@ -823,6 +823,7 @@ module_t rlm_cache = {
 	.detach		= mod_detach,
 	.methods = {
 		[MOD_AUTHORIZE]		= mod_cache_it,
+		[MOD_AUTHENTICATE]	= mod_cache_it,
 		[MOD_PREACCT]		= mod_cache_it,
 		[MOD_ACCOUNTING]	= mod_cache_it,
 		[MOD_PRE_PROXY]		= mod_cache_it,


### PR DESCRIPTION
Enable rlm_cache in authentication section.

I use rlm_cache in authentication section to set a value based on a the first authentication status (Combining authentication for MSCHAP/PEAP requests)  and take a decision in post-auth.