### PR TITLE
rlm_cache: Move from AVPs to methods

### DIFF
--- a/raddb/mods-available/cache
+++ b/raddb/mods-available/cache
@@ -13,24 +13,133 @@
 #  information will then have the cached values added to the request.
 #
 #  The module can cache a fixed set of attributes per key.
-#  It can be listed in any `recv` or `send` section.
+#  It can be listed in any `recv {...}` or `send {...}` section.
 #
 #  NOTE: If you want to have different things cached for different
 #  sections, you will need to define multiple instances of the module,
 #  via `cache <nameN> { ... }`.
 #
-#  [options="header,autowidth"]
-#  |===
-#  | Option    | Description
-#  | `ok`      | if it found or created a cache entry.
-#  | `updated` | if it merged a cached entry.
-#  | `noop`    | if it did nothing.
-#  | `fail`    | on error.
-#  |===
 #
 
 #
-#  ## Default instance
+#  ## Default Instance
+#
+
+#
+#  ### Configuration
+#
+#  This module supports a number of runtime configuration parameter
+#  represented by attributes in the `&control:` list.
+#
+#  &control:Cache-TTL:: Sets the TTL of an entry to be created, or
+#   modifies the TTL of an existing entry.
+#
+#  [options="header,autowidth"]
+#  |===
+#  | Condition            | Description
+#  | `Cache-TTL` of > `0` | Set the TTL of the entry to the new value
+#                           (and reset the expiry timer).
+#  | `Cache-TTL` of < `0` | Expire the existing entry and create a new
+#                           one with TTL set to `Cache-TTL` * `-1`.
+#  | `Cache-TTL` of `0`   | Expire the existing entry and create a new one.
+#  |===
+#
+#  ### Methods
+#
+#  cache.status:: Verify the cache entry status.
+#
+#  [options="header,autowidth"]
+#  |===
+#  | Return     | Description
+#  | `ok`       | if a cache entry was found.
+#  | `notfound` | if no cache entry was found.
+#  |===
+#
+#  cache.lookup:: Same as `cache.status`, But if the cache entry exists it will be loaded.
+#
+#  [options="header,autowidth"]
+#  |===
+#  | Return     | Description
+#  | `updated`  | if a cache entry was found and loaded.
+#  | `notfound` | if no cache entry was found.
+#  |===
+#
+#  cache.add:: Create a new entry.
+#
+#  [options="header,autowidth"]
+#  |===
+#  | Return     | Description
+#  | `ok`       | if we added cache entry.
+#  | `noop`     | if a cache entry ready exists.
+#  |===
+#
+#  cache.merge:: If entry exists (and is valid), it will be merged
+#  with the current request.
+#
+#  [options="header,autowidth"]
+#  |===
+#  | Return     | Description
+#  | `updated`  | if a cache entry was found and loaded.
+#  | `notfound` | if no cache entry was found.
+#  | `noop`     | if a cache entry ready merged (nothing to do).
+#  |===
+#
+#  cache.merge.new:: Merge new cache entries into the current request. Useful if results of
+#  execs or expansions are stored directly in the cache.
+#
+#  [options="header,autowidth"]
+#  |===
+#  | Return     | Description
+#  | `updated`  | if a cache entry was found and loaded.
+#  | `notfound` | if no cache entry was found.
+#  | `noop`     | if a cache entry ready merged (nothing to do).
+#  |===
+#
+#  ### Examples
+#
+#  ```
+#  # Add a cache entry
+#  update {
+#    &control:Cache-TTL := 3600 # 1h
+#  }
+#  cache.add
+#  if (ok) {
+#    ..added
+#  }
+#
+#  # Get the cache status
+#  cache.status
+#  if (ok) {
+#    ..Exist a cache entry
+#  }
+#
+#  # Load the cache entry
+#  cache.lookup
+#  if (updated) {
+#    ..loaded
+#  }
+#
+#  # Merge the entries
+#  update {
+#    &control:Cache-TTL := 1800 # 30m
+#  }
+#  cache.merge.new
+#  if (updated) {
+#    ..merged
+#  }
+#  ```
+#
+#  [NOTE]
+#  ====
+#  * This is evaluated before `Cache-TTL`, so entries being expired
+#  may first be merged.
+#  * All runtime configuration attributes will be removed from the
+#  `&control:` list after any cache method is called.
+#  ====
+#
+
+#
+#  ## Drivers
 #
 cache {
 	#
@@ -204,52 +313,4 @@ cache {
 		#  Add your own value for `Class`.
 		&reply:Class := "%{randstr:ssssssssssssssssssssssssssssssss}"
 	}
-
-	#
-	#  This module supports a number of runtime configuration parameters
-	#  represented by attributes in the `&control:` list.
-	#
-	#  &control:Cache-TTL:: Sets the TTL of an entry to be created, or
-	#   modifies the TTL of an existing entry.
-	#
-	#  [options="header,autowidth"]
-	#  |===
-	#  | Condition            | Description
-	#  | `Cache-TTL` of > `0` | Set the TTL of the entry to the new value
-	#                           (and reset the expiry timer).
-	#  | `Cache-TTL` of < `0` | Expire the existing entry and create a new
-	#                           one with TTL set to `Cache-TTL` * `-1`.
-	#  | `Cache-TTL` of `0`   | Expire the existing entry and create a new one.
-	#  |===
-	#
-	#  &control:Cache-Status-Only:: If present and set to `yes` will
-	#  prevent a new entry from being created, and existing entries from
-	#  being merged. It will also alter the module's return codes.
-	#
-	#   * The module will return `ok` if a cache entry was found.
-	#   * The module will return `notfound` if no cache entry was found.
-	#
-	#  NOTE: If this is set to `yes`, no other cache control attributes will
-	#  be honoured, but they will still be cleared.
-	#
-	#  &control:Cache-Allow-Insert:: If present and set to `no` will
-	#  prevent a new entry from being created. If not present or set
-	#  to `yes`, and no entry exists, a new one will be created.
-	#  This is evaluated after `Cache-TTL`, so expired entries may be
-	#  recreated.
-	#
-	#  &control:Cache-Allow-Merge:: If present and set to `no` will
-	#  prevent existing entries from being merged. If not present or
-	#  set to `yes`, and an entry exists (and is valid), it will be
-	#  merged with the current request.
-	#  This is evaluated before `Cache-TTL`, so entries being expired
-	#  may first be merged.
-	#
-	#  &control:Cache-Merge-New:: If present and set to `yes` will merge new
-	#  cache entries into the current request. Useful if results of execs or
-	#  expansions are stored directly in the cache.
-	#
-	#  NOTE: All runtime configuration attributes will be removed from the
-	#  `&control:` list after the cache module is called.
-	#
 }

--- a/raddb/policy.d/eap
+++ b/raddb/policy.d/eap
@@ -2,7 +2,7 @@
 #	Response caching to handle proxy failovers
 #
 Xeap.authorize {
-	cache_eap
+	cache_eap.lookup
 	if (ok) {
 		#
 		#	Expire previous cache entry
@@ -11,7 +11,7 @@ Xeap.authorize {
 			update control {
 				&Cache-TTL := 0
 			}
-			cache_eap
+			cache_eap.merge
 
 			update control {
 				&State !* ANY
@@ -33,12 +33,12 @@ Xeap.authenticate {
 		handled = 1
 	}
 	if (handled) {
-		cache_eap.authorize
+		cache_eap.add
 
 		handled
 	}
 
-	cache_eap.authorize
+	cache_eap.merge
 }
 
 #

--- a/raddb/sites-available/tls-cache
+++ b/raddb/sites-available/tls-cache
@@ -44,10 +44,7 @@ server tls-cache {
 	#  and will just cause the server to emit a warning.
 	#
 	load tls-session {
-		update control {
-			Cache-Allow-Insert := no
-		}
-		cache_tls_session
+		cache_tls_session.lookup
 	}
 
 	#
@@ -67,7 +64,7 @@ server tls-cache {
 		update control {
 			Cache-TTL := 0
 		}
-		cache_tls_session
+		cache_tls_session.add
 	}
 
 	#
@@ -82,9 +79,8 @@ server tls-cache {
 	clear tls-session {
 		update control {
 			Cache-TTL := 0
-			Cache-Allow-Insert := no
 		}
-		cache_tls_session
+		cache_tls_session.delete
 	}
 
 	#
@@ -98,10 +94,7 @@ server tls-cache {
 	#  To force OCSP validation failure, it should return 'reject'.
 	#
 	load ocsp-state {
-		update control {
-			Cache-Allow-Insert := no
-		}
-		cache_ocsp
+		cache_ocsp.lookup
 	}
 
 	#
@@ -118,8 +111,7 @@ server tls-cache {
 	store ocsp-state {
 		update control {
 			Cache-TTL := "%{expr:&reply:TLS-OCSP-Next-Update * -1}"
-			Cache-Allow-Merge := no
 		}
-		cache_ocsp
+		cache_ocsp.add
 	}
 }

--- a/src/modules/rlm_cache/rlm_cache.h
+++ b/src/modules/rlm_cache/rlm_cache.h
@@ -84,6 +84,19 @@ typedef struct {
 	vp_map_t		*maps;			//!< Head of the maps list.
 } rlm_cache_entry_t;
 
+typedef struct {
+	uint8_t			buffer[1024];	//!< Buffer used to store the 'key'.
+	uint8_t const		*key;		//!< Key used to identify entry.
+	ssize_t			key_len;	//!< Length of key data.
+
+	uint32_t		ttl;		//!< the TTL of an entry.
+	bool 			set_ttl;	//!< If the 'Cache-TTL' was set.
+	bool 			expire;		//!< Free a cache entry.
+	rlm_cache_entry_t	*entry;		//!< The current 'entry' instance.
+	rlm_cache_handle_t	*handle;	//!< The current 'handle' instance.
+} rlm_cache_bucket_t;
+#define CACHE_BUCKET_INIT { { '\0', }, NULL, -1, -1, false, false, NULL, NULL }
+
 /** Allocate a new cache entry
  *
  */

--- a/src/tests/modules/cache_rbtree/cache-bin.unlang
+++ b/src/tests/modules/cache_rbtree/cache-bin.unlang
@@ -19,7 +19,7 @@ if (&Tmp-String-1 == "foo\000bar\000baz") {
 }
 
 # 1. Store the entry
-cache_bin_key_octets
+cache_bin_key_octets.add
 if (ok) {
 	test_pass
 }
@@ -34,7 +34,7 @@ update {
 }
 
 # 2. Should create a *new* entry and not update the existing one
-cache_bin_key_octets
+cache_bin_key_octets.add
 if (ok) {
 	test_pass
 }
@@ -52,7 +52,7 @@ update {
   	&Tmp-Octets-0 := 0xaa00bb00cc00dd00
 }
 
-cache_bin_key_octets
+cache_bin_key_octets.lookup
 if (updated) {
 	test_pass
 }
@@ -83,7 +83,7 @@ update {
   	&Tmp-Octets-0 := 0xaa00bb00cc00ee00
 }
 
-cache_bin_key_octets
+cache_bin_key_octets.lookup
 if (updated) {
 	test_pass
 }
@@ -119,7 +119,7 @@ update {
 	&Tmp-String-1 := "foo\000bar\000baz"
 }
 
-cache_bin_key_ipaddr
+cache_bin_key_ipaddr.add
 if (ok) {
 	test_pass
 }
@@ -134,7 +134,7 @@ update {
 	&Tmp-String-1 := "bar\000baz"
 }
 
-cache_bin_key_ipaddr
+cache_bin_key_ipaddr.add
 if (ok) {
 	test_pass
 }
@@ -151,7 +151,7 @@ update {
 	&Tmp-IP-Address-0 := 192.168.0.1
 }
 
-cache_bin_key_ipaddr
+cache_bin_key_ipaddr.lookup
 if (updated) {
 	test_pass
 }
@@ -182,7 +182,7 @@ update {
 	&Tmp-IP-Address-0 := 192.168.0.2
 }
 
-cache_bin_key_ipaddr
+cache_bin_key_ipaddr.lookup
 if (updated) {
 	test_pass
 }

--- a/src/tests/modules/cache_rbtree/cache-logic.unlang
+++ b/src/tests/modules/cache_rbtree/cache-logic.unlang
@@ -13,7 +13,7 @@ update control {
 	&control:Tmp-String-1 := 'cache me'
 }
 
-cache
+cache.add
 if (!ok) {
 	test_fail
 }
@@ -30,10 +30,7 @@ else {
 }
 
 # 2. Check status-only works correctly (should return ok and consume attribute)
-update control {
-	&Cache-Status-Only := 'yes'
-}
-cache
+cache.status
 if (!ok) {
 	test_fail
 }
@@ -41,16 +38,9 @@ else {
 	test_pass
 }
 
-# 3.
-if (&control:Cache-Status-Only) {
-	test_fail
-}
-else {
-	test_pass
-}
 
-# 4. Retrieve the entry (should be copied to request list)
-cache
+# 3. Retrieve the entry (should be copied to request list)
+cache.lookup
 if (!updated) {
 	test_fail
 }
@@ -58,7 +48,7 @@ else {
 	test_pass
 }
 
-# 5.
+# 4.
 if (&request:Tmp-String-1 != &control:Tmp-String-1) {
 	test_fail
 }
@@ -66,12 +56,12 @@ else {
 	test_pass
 }
 
-# 6. Retrieving the entry should not expire it
+# 5. Retrieving the entry should not expire it
 update request {
 	&Tmp-String-1 !* ANY
 }
 
-cache
+cache.lookup
 if (!updated) {
 	test_fail
 }
@@ -79,7 +69,7 @@ else {
 	test_pass
 }
 
-# 7.
+# 6.
 if (&request:Tmp-String-1 != &control:Tmp-String-1) {
 	test_fail
 }
@@ -87,13 +77,8 @@ else {
 	test_pass
 }
 
-# 8. Force expiry of the entry
-update control {
-	&Cache-Allow-Merge := no
-	&Cache-Allow-Insert := no
-	&Cache-TTL := 0
-}
-cache
+# 7. Delete the entry
+cache.delete
 if (!ok) {
 	test_fail
 }
@@ -101,11 +86,8 @@ else {
 	test_pass
 }
 
-# 9. Check status-only works correctly (should return notfound and consume attribute)
-update control {
-	&Cache-Status-Only := 'yes'
-}
-cache
+# 8. Check status-only works correctly (should return notfound and consume attribute)
+cache.status
 if (!notfound) {
 	test_fail
 }
@@ -113,20 +95,8 @@ else {
 	test_pass
 }
 
-# 10.
-if (&control:Cache-Status-Only) {
-	test_fail
-}
-else {
-	test_pass
-}
-
-# 11. Check merge-only works correctly (should return notfound and consume attribute)
-update control {
-	&Cache-Allow-Merge := 'yes'
-	&Cache-Allow-Insert := 'no'
-}
-cache
+# 9. Check merge-only works correctly (should return notfound and consume attribute)
+cache.merge
 if (!notfound) {
 	test_fail
 }
@@ -134,19 +104,8 @@ else {
 	test_pass
 }
 
-# 12.
-if (&control:Cache-Allow-Merge) {
-	test_fail
-}
-else {
-	test_pass
-}
-
-# 13. ...and check the entry wasn't recreated
-update control {
-	&Cache-Status-Only := 'yes'
-}
-cache
+# 10. ...and check the entry wasn't recreated
+cache.status
 if (!notfound) {
 	test_fail
 }
@@ -154,11 +113,11 @@ else {
 	test_pass
 }
 
-# 14. This should still allow the creation of a new entry
+# 11. This should still allow the creation of a new entry
 update control {
 	&Cache-TTL := -1
 }
-cache
+cache.add
 if (!ok) {
 	test_fail
 }
@@ -166,16 +125,16 @@ else {
 	test_pass
 }
 
-# 15.
-cache
-if (!updated) {
+# 12. We have nothing to do if it is ready added.
+cache.add
+if (!noop) {
 	test_fail
 }
 else {
 	test_pass
 }
 
-# 16.
+# 13.
 if (&Cache-TTL) {
 	test_fail
 }
@@ -183,7 +142,7 @@ else {
 	test_pass
 }
 
-# 17.
+# 14.
 if (&request:Tmp-String-1 != &control:Tmp-String-1) {
 	test_fail
 }
@@ -195,11 +154,11 @@ update control {
 	&Tmp-String-1 := 'cache me2'
 }
 
-# 18. Updating the Cache-TTL shouldn't make things go boom (we can't really check if it works)
+# 15. Updating the Cache-TTL shouldn't make things go boom (we can't really check if it works)
 update control {
 	&Cache-TTL := 30
 }
-cache
+cache.merge
 if (!updated) {
 	test_fail
 }
@@ -207,7 +166,7 @@ else {
 	test_pass
 }
 
-# 19. Request Tmp-String-1 shouldn't have been updated yet
+# 16. Request Tmp-String-1 shouldn't have been updated yet
 if (&request:Tmp-String-1 == &control:Tmp-String-1) {
 	test_fail
 }
@@ -215,11 +174,11 @@ else {
 	test_pass
 }
 
-# 20. Check that a new entry is created
+# 17. Check that a new entry is created
 update control {
 	&Cache-TTL := -1
 }
-cache
+cache.merge
 if (!updated) {
 	test_fail
 }
@@ -227,7 +186,17 @@ else {
 	test_pass
 }
 
-# 21. Request Tmp-String-1 still shouldn't have been updated yet
+
+# 18.
+cache.lookup
+if (!updated) {
+	test_fail
+}
+else {
+	test_pass
+}
+
+# 19. Request Tmp-String-1 should now have been updated
 if (&request:Tmp-String-1 == &control:Tmp-String-1) {
 	test_fail
 }
@@ -235,30 +204,12 @@ else {
 	test_pass
 }
 
-# 22.
-cache
-if (!updated) {
-	test_fail
-}
-else {
-	test_pass
-}
-
-# 23. Request Tmp-String-1 should now have been updated
-if (&request:Tmp-String-1 != &control:Tmp-String-1) {
-	test_fail
-}
-else {
-	test_pass
-}
-
-# 24. Check Cache-Merge = yes works as expected (should update current request)
+# 20. Check cache.merge.new (should update current request)
 update control {
 	&Tmp-String-1 := 'cache me3'
 	&Cache-TTL := -1
-	&Cache-Merge-New := yes
 }
-cache
+cache.merge.new
 if (!updated) {
 	test_fail
 }
@@ -266,7 +217,7 @@ else {
 	test_pass
 }
 
-# 25. Request Tmp-String-1 should now have been updated
+# 21. Request Tmp-String-1 should now have been updated
 if (&request:Tmp-String-1 != &control:Tmp-String-1) {
 	test_fail
 }
@@ -274,7 +225,7 @@ else {
 	test_pass
 }
 
-# 26. Check Cache-Entry-Hits is updated as we expect
+# 22. Check Cache-Entry-Hits is updated as we expect
 if (&request:Cache-Entry-Hits != 0) {
 	test_fail
 }
@@ -282,10 +233,11 @@ else {
 	test_pass
 }
 
-cache
+cache.lookup
 if (&request:Cache-Entry-Hits != 1) {
 	test_fail
 }
 else {
 	test_pass
 }
+

--- a/src/tests/modules/cache_rbtree/cache-update.unlang
+++ b/src/tests/modules/cache_rbtree/cache-update.unlang
@@ -25,7 +25,7 @@ update control {
 	&control:Tmp-String-1 := 'cache me'
 }
 
-cache_update
+cache_update.add
 if (!ok) {
 	test_fail
 }
@@ -34,7 +34,7 @@ else {
 }
 
 # Merge
-cache_update
+cache_update.merge
 if (updated) {
 	test_pass
 }


### PR DESCRIPTION
The new methods to interact with cache module are:

cache.status
cache.add
cache.lookup
cache.delete
cache.merge
cache.merge.new
