### PR TITLE
Fix missing include dictionaries for:

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -23,6 +23,10 @@ FreeRADIUS 3.0.20 Wed 10 Apr 2019 09:00:00 EDT urgency=low
 	* Fix request and connection timeouts in rlm_rest.
 	* Fix systemd issues.  Patches from Daniele Rondina.
 	* Fixes from clang analyzer.
+	* Fix missing include for the dictionaries: alcatel.esam,
+	  altiga,alvarion.wimax.v2_2,aptis,asn,audiocodes,avaya,bristol,
+	  columbia_university,freedhcp,garderos,infoblox,motorola.illegal,
+	  starent.vsa1, telkom, wimax.wichorus.
 
 FreeRADIUS 3.0.19 Wed 10 Apr 2019 09:00:00 EDT urgency=high
 	Feature improvements

--- a/share/dictionary
+++ b/share/dictionary
@@ -126,6 +126,15 @@ $INCLUDE dictionary.rfc8559
 $INCLUDE dictionary.iana
 
 #
+#  Commented out because of attribute conflicts.
+#
+#$INCLUDE dictionary.alvarion.wimax.v2_2
+#$INCLUDE dictionary.nokia.conflict
+#$INCLUDE dictionary.openser
+#$INCLUDE dictionary.starent.vsa1
+#$INCLUDE dictionary.wimax.wichorus
+
+#
 #	Vendor dictionaries are listed after the standard ones.
 #
 $INCLUDE dictionary.3com
@@ -138,22 +147,29 @@ $INCLUDE dictionary.adtran
 $INCLUDE dictionary.aerohive
 $INCLUDE dictionary.airespace
 $INCLUDE dictionary.alcatel
-$INCLUDE dictionary.alcatel.sr
 $INCLUDE dictionary.alcatel-lucent.aaa
+$INCLUDE dictionary.alcatel.esam
+$INCLUDE dictionary.alcatel.sr
 $INCLUDE dictionary.alteon
+$INCLUDE dictionary.altiga
 $INCLUDE dictionary.alvarion
 $INCLUDE dictionary.apc
 $INCLUDE dictionary.aptilo
+$INCLUDE dictionary.aptis
 $INCLUDE dictionary.arbor
 $INCLUDE dictionary.arista
 $INCLUDE dictionary.aruba
-$INCLUDE dictionary.azaire
 $INCLUDE dictionary.ascend
+$INCLUDE dictionary.asn
+$INCLUDE dictionary.audiocodes
+$INCLUDE dictionary.avaya
+$INCLUDE dictionary.azaire
 $INCLUDE dictionary.bay
 $INCLUDE dictionary.bigswitch
 $INCLUDE dictionary.bintec
 $INCLUDE dictionary.bluecoat
 $INCLUDE dictionary.boingo
+$INCLUDE dictionary.bristol
 $INCLUDE dictionary.broadsoft
 $INCLUDE dictionary.brocade
 $INCLUDE dictionary.bskyb
@@ -172,36 +188,38 @@ $INCLUDE dictionary.cisco.asa
 #   Note : the altiga dictionary, not listed here, also uses the same Vendor ID
 #
 #$INCLUDE dictionary.cisco.vpn3000
-$INCLUDE dictionary.cisco.vpn5000
 $INCLUDE dictionary.cisco.bbsm
+$INCLUDE dictionary.cisco.vpn5000
 $INCLUDE dictionary.citrix
 $INCLUDE dictionary.clavister
 $INCLUDE dictionary.cnergee
 $INCLUDE dictionary.colubris
+$INCLUDE dictionary.columbia_university
 $INCLUDE dictionary.compatible
 $INCLUDE dictionary.cosine
 $INCLUDE dictionary.dante
 $INCLUDE dictionary.dellemc
-$INCLUDE dictionary.dlink
 $INCLUDE dictionary.digium
+$INCLUDE dictionary.dlink
 $INCLUDE dictionary.dragonwave
 $INCLUDE dictionary.efficientip
 $INCLUDE dictionary.eltex
 $INCLUDE dictionary.epygi
-$INCLUDE dictionary.erx
 $INCLUDE dictionary.equallogic
 $INCLUDE dictionary.ericsson
 $INCLUDE dictionary.ericsson.ab
 $INCLUDE dictionary.ericsson.packet.core.networks
+$INCLUDE dictionary.erx
 $INCLUDE dictionary.extreme
 $INCLUDE dictionary.f5
 $INCLUDE dictionary.fdxtended
-$INCLUDE dictionary.freeradius
-$INCLUDE dictionary.freeswitch
 $INCLUDE dictionary.force10
 $INCLUDE dictionary.fortinet
 $INCLUDE dictionary.foundry
+$INCLUDE dictionary.freeradius
+$INCLUDE dictionary.freeswitch
 $INCLUDE dictionary.gandalf
+$INCLUDE dictionary.garderos
 $INCLUDE dictionary.gemtek
 $INCLUDE dictionary.h3c
 $INCLUDE dictionary.hillstone
@@ -209,10 +227,11 @@ $INCLUDE dictionary.hp
 $INCLUDE dictionary.huawei
 $INCLUDE dictionary.iea
 $INCLUDE dictionary.infinera
+$INCLUDE dictionary.infoblox
 $INCLUDE dictionary.infonet
+$INCLUDE dictionary.ipunplugged
 $INCLUDE dictionary.issanni
 $INCLUDE dictionary.itk
-$INCLUDE dictionary.ipunplugged
 $INCLUDE dictionary.juniper
 $INCLUDE dictionary.karlnet
 $INCLUDE dictionary.kineto
@@ -236,18 +255,10 @@ $INCLUDE dictionary.navini
 $INCLUDE dictionary.netscreen
 $INCLUDE dictionary.networkphysics
 $INCLUDE dictionary.nexans
-$INCLUDE dictionary.ntua
 $INCLUDE dictionary.nokia
-#
-#  Commented out because of attribute conflicts.
-#
-#$INCLUDE dictionary.nokia.conflict
 $INCLUDE dictionary.nomadix
 $INCLUDE dictionary.nortel
-#
-#  Commented out because of attribute conflicts.
-#
-#$INCLUDE dictionary.openser
+$INCLUDE dictionary.ntua
 $INCLUDE dictionary.packeteer
 $INCLUDE dictionary.paloalto
 $INCLUDE dictionary.patton
@@ -263,11 +274,11 @@ $INCLUDE dictionary.redcreek
 $INCLUDE dictionary.riverbed
 $INCLUDE dictionary.riverstone
 $INCLUDE dictionary.roaringpenguin
-$INCLUDE dictionary.ruggedcom
 $INCLUDE dictionary.ruckus
+$INCLUDE dictionary.ruggedcom
 $INCLUDE dictionary.sangoma
-$INCLUDE dictionary.shasta
 $INCLUDE dictionary.sg
+$INCLUDE dictionary.shasta
 $INCLUDE dictionary.shiva
 $INCLUDE dictionary.siemens
 $INCLUDE dictionary.slipstream
@@ -278,12 +289,13 @@ $INCLUDE dictionary.springtide
 $INCLUDE dictionary.starent
 $INCLUDE dictionary.surfnet
 $INCLUDE dictionary.symbol
+$INCLUDE dictionary.t_systems_nova
 $INCLUDE dictionary.telebit
+$INCLUDE dictionary.telkom
 $INCLUDE dictionary.terena
 $INCLUDE dictionary.trapeze
 $INCLUDE dictionary.travelping
 $INCLUDE dictionary.tropos
-$INCLUDE dictionary.t_systems_nova
 $INCLUDE dictionary.ukerna
 $INCLUDE dictionary.unix
 $INCLUDE dictionary.usr
@@ -291,8 +303,8 @@ $INCLUDE dictionary.utstarcom
 $INCLUDE dictionary.valemount
 $INCLUDE dictionary.verizon
 $INCLUDE dictionary.versanet
-$INCLUDE dictionary.waverider
 $INCLUDE dictionary.walabi
+$INCLUDE dictionary.waverider
 $INCLUDE dictionary.wichorus
 $INCLUDE dictionary.wifialliance
 $INCLUDE dictionary.wimax


### PR DESCRIPTION
* alcatel.esam
* altiga
* alvarion.wimax.v2_2
* aptis
* asn
* audiocodes
* avaya
* bristol
* columbia_university
* freedhcp
* garderos
* infoblox
* starent.vsa1
* telkom
* wimax.wichorus