### PR TITLE
Implement query_timeout on socket read for rlm_postgresql

### DIFF
--- a/src/modules/rlm_sql/drivers/rlm_sql_postgresql/rlm_sql_postgresql.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_postgresql/rlm_sql_postgresql.c
@@ -297,7 +297,7 @@ static CC_HINT(nonnull) sql_rcode_t sql_query(rlm_sql_handle_t *handle, UNUSED r
 {
 	rlm_sql_postgres_conn_t *conn = handle->conn;
 	struct timeval timeout = {config->query_timeout, 0};
-	int sockfd;
+	int sockfd, r;
 	fd_set read_fd;
 	ExecStatusType status;
 	int numfields = 0;
@@ -326,8 +326,14 @@ static CC_HINT(nonnull) sql_rcode_t sql_query(rlm_sql_handle_t *handle, UNUSED r
 	while (PQisBusy(conn->db)) {
 		FD_ZERO(&read_fd);
 		FD_SET(sockfd, &read_fd);
-		if (!select(sockfd + 1, &read_fd, NULL, NULL, config->query_timeout ? &timeout : NULL)) {
+		r = select(sockfd + 1, &read_fd, NULL, NULL, config->query_timeout ? &timeout : NULL);
+		if (r == 0) {
 			ERROR("rlm_sql_postgresql: Socket read timeout after %d seconds", config->query_timeout);
+			return RLM_SQL_RECONNECT;
+		}
+		if (r < 0) {
+			if (errno == EINTR) continue;
+			ERROR("rlm_sql_postgresql: Failed in select: %s", fr_syserror(errno));
 			return RLM_SQL_RECONNECT;
 		}
 		if (!PQconsumeInput(conn->db)) {


### PR DESCRIPTION
Use the async interface provided by libpq so what can control our own blocking. In this way we are able to implement a configurable inactivity timeout since the blocking interface does not expose such a feature.