### PR TITLE
Fix the %{explode:&ref <delim>} xlat function

### DIFF
--- a/src/lib/server/xlat_func.c
+++ b/src/lib/server/xlat_func.c
@@ -1709,7 +1709,7 @@ static ssize_t xlat_func_explode(TALLOC_CTX *ctx, char **out, size_t outlen,
 		return -1;
 	}
 
-	if (*p == '\0') goto arg_error;
+	if (*p == '\0' || p[1]) goto arg_error;
 
 	delim = *p;
 


### PR DESCRIPTION
As the documentation says `%{explode:&ref <delim>}`, let's inform
the user that the delim should be a single char