### PR TITLE
Fix FramedInterfaceId type in postgresql/queries.conf

### DIFF
--- a/raddb/mods-config/sql/main/postgresql/queries.conf
+++ b/raddb/mods-config/sql/main/postgresql/queries.conf
@@ -253,7 +253,7 @@ accounting {
 					NULLIF('%{Framed-IP-Address}', '')::inet, \
 					NULLIF('%{Framed-IPv6-Address}', '')::inet, \
 					NULLIF('%{Framed-IPv6-Prefix}', '')::inet, \
-					NULLIF('%{Framed-Interface-Id}', '')::inet, \
+					NULLIF('%{Framed-Interface-Id}', ''), \
 					NULLIF('%{Delegated-IPv6-Prefix}', '')::inet) \
 				ON CONFLICT (AcctUniqueId) \
 				DO UPDATE \
@@ -281,7 +281,7 @@ accounting {
 					FramedIPAddress = NULLIF('%{Framed-IP-Address}', '')::inet, \
 					FramedIPv6Address = NULLIF('%{Framed-IPv6-Address}', '')::inet, \
 					FramedIPv6Prefix = NULLIF('%{Framed-IPv6-Prefix}', '')::inet, \
-					FramedInterfaceId = NULLIF('%{Framed-Interface-Id}', '')::inet, \
+					FramedInterfaceId = NULLIF('%{Framed-Interface-Id}', ''), \
 					DelegatedIPv6Prefix = NULLIF('%{Delegated-IPv6-Prefix}', '')::inet, \
 					AcctSessionTime = %{%{Acct-Session-Time}:-NULL}, \
 					AcctInterval = (%{integer:Event-Timestamp} - EXTRACT(EPOCH FROM (COALESCE(AcctUpdateTime, AcctStartTime)))), \
@@ -323,7 +323,7 @@ accounting {
 					NULLIF('%{Framed-IP-Address}', '')::inet, \
 					NULLIF('%{Framed-IPv6-Address}', '')::inet, \
 					NULLIF('%{Framed-IPv6-Prefix}', '')::inet, \
-					NULLIF('%{Framed-Interface-Id}', '')::inet, \
+					NULLIF('%{Framed-Interface-Id}', ''), \
 					NULLIF('%{Delegated-IPv6-Prefix}', '')::inet) \
 				ON CONFLICT (AcctUniqueId) \
 				DO NOTHING"
@@ -345,7 +345,7 @@ accounting {
 					FramedIPAddress = NULLIF('%{Framed-IP-Address}', '')::inet, \
 					FramedIPv6Address = NULLIF('%{Framed-IPv6-Address}', '')::inet, \
 					FramedIPv6Prefix = NULLIF('%{Framed-IPv6-Prefix}', '')::inet, \
-					FramedInterfaceId = NULLIF('%{Framed-Interface-Id}', '')::inet, \
+					FramedInterfaceId = NULLIF('%{Framed-Interface-Id}', ''), \
 					DelegatedIPv6Prefix = NULLIF('%{Delegated-IPv6-Prefix}', '')::inet, \
 					ConnectInfo_stop = '%{Connect-Info}' \
 				WHERE AcctUniqueId = '%{Acct-Unique-Session-Id}' \
@@ -381,7 +381,7 @@ accounting {
 					NULLIF('%{Framed-IP-Address}', '')::inet, \
 					NULLIF('%{Framed-IPv6-Address}', '')::inet, \
 					NULLIF('%{Framed-IPv6-Prefix}', '')::inet, \
-					NULLIF('%{Framed-Interface-Id}', '')::inet, \
+					NULLIF('%{Framed-Interface-Id}', ''), \
 					NULLIF('%{Delegated-IPv6-Prefix}', '')::inet) \
 				ON CONFLICT (AcctUniqueId) \
 				DO NOTHING"
@@ -402,7 +402,7 @@ accounting {
 					FramedIPAddress = NULLIF('%{Framed-IP-Address}', '')::inet, \
 					FramedIPv6Address = NULLIF('%{Framed-IPv6-Address}', '')::inet, \
 					FramedIPv6Prefix = NULLIF('%{Framed-IPv6-Prefix}', '')::inet, \
-					FramedInterfaceId = NULLIF('%{Framed-Interface-Id}', '')::inet, \
+					FramedInterfaceId = NULLIF('%{Framed-Interface-Id}', ''), \
 					DelegatedIPv6Prefix = NULLIF('%{Delegated-IPv6-Prefix}', '')::inet, \
 					ConnectInfo_stop = '%{Connect-Info}' \
 				WHERE AcctUniqueId = '%{Acct-Unique-Session-Id}'"


### PR DESCRIPTION
This is an addendum to commit fb15efe88b1f06fed89fc7225cd24ceea52dbbbf,
which fixed the PostgreSQL schema file to include the correct
FramedInterfaceId type, but did not modify the queries which were
still casting all the instances to inet. That caused the following
error to show up:

```
rlm_sql_postgresql: Status: PGRES_FATAL_ERROR
rlm_sql_postgresql: 22P02: INVALID TEXT REPRESENTATION
(2) sql: rlm_sql_postgresql: ERROR:  invalid input syntax for type inet: "168:9a03:e9a9:56fa"
```

Edit: this error is also present in branch 3.0.x, where I have originally found it.