### PR TITLE
travis: Let's validate also the doc build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ addons:
     # For newer libkqueue
     - sourceline: ppa:rjvbertin/misc
     packages:
+    - libjson-perl
     - autoconf
     - build-essential
     - clang-7
@@ -114,6 +115,8 @@ services:
 - redis-server
 before_install:
 - rvm --install --default --binary use 2.4
+- gem install asciidoctor
+- wget -q -O /tmp/pandoc.deb https://github.com/jgm/pandoc/releases/download/2.7.3/pandoc-2.7.3-1-amd64.deb && dpkg -i /tmp/pandoc.deb
 - if [ "${CC}" == 'gcc' ]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 && sudo update-alternatives --config gcc; fi
 - if [ "${CC}" == 'clang' ]; then sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-7 60 && sudo update-alternatives --config clang; fi
 - if [ "${CC}" == 'clang' ]; then sudo update-alternatives --install /usr/bin/llvm-symbolizer llvm-symbolizer /usr/bin/llvm-symbolizer-7 60 && sudo update-alternatives --config llvm-symbolizer; fi
@@ -122,7 +125,10 @@ before_install:
 before_script:
 - ./scripts/travis/build.sh
 script:
-- if [ "${DO_BUILD}" = 'yes' -a "${COVERITY_SCAN_BRANCH}" != 1 ]; then make travis-test;
+- if [ "${DO_BUILD}" = 'yes' -a "${COVERITY_SCAN_BRANCH}" != 1 ]; then
+  make travis-test;
   fi
-- if [ "${DO_BUILD}" = 'no' ]; then cd doc/source; doxygen 3>&1 1>&2 2>&3 | grep -iv
-  '^warning:' | tee doxygen_stderr.log && [ ! -n "$(cat doxygen_stderr.log)" ]; fi
+- if [ "${DO_BUILD}" = 'no' ]; then
+  make html 2>&1 | grep -E '.*(asciidoctor|pandoc).*(WARNING|FAILED|ERROR)' | tee asciidoc_stderr.log && [ ! -n "$(cat asciidoc_stderr.log)" ];
+  cd doc/source; doxygen 3>&1 1>&2 2>&3 | grep -iv '^warning:' | tee doxygen_stderr.log && [ ! -n "$(cat doxygen_stderr.log)" ];
+  fi


### PR DESCRIPTION
1. we can't use the distributed versions of asciidoctor and pandoc due to be too old.
2. the package libjson-perl is required by scripts/asciidoc/conf2adoc