### PR TITLE
added new Lancom VSAs

### DIFF
--- a/share/dictionary/radius/dictionary.lancom
+++ b/share/dictionary/radius/dictionary.lancom
@@ -39,5 +39,7 @@ ATTRIBUTE	LCS-VPN-IPv6-Rule			23	string
 ATTRIBUTE	LCS-Routing-Tag				24	integer
 ATTRIBUTE	LCS-IKEv2-IPv4-Route			25	string
 ATTRIBUTE	LCS-IKEv2-IPv6-Route			26	string
+ATTRIBUTE	LCS-IKEv2-DNS-Domain			27	string
+ATTRIBUTE	LCS-Load-Balancer			28	string
 
 END-VENDOR   Lancom


### PR DESCRIPTION
added two new Lancom VSAs, usable beginning with LCOS 10.40:
LCS-IKEv2-DNS-Domain and LCS-Load-Balancer