### PR TITLE
Add Oracle session pool to rlm_sql oracle driver v3

### DIFF
--- a/raddb/mods-available/sql
+++ b/raddb/mods-available/sql
@@ -143,6 +143,28 @@ sql {
 		}
 	}
 
+	#
+	#	Configuration for Oracle Session pool.
+	#
+	oracle {
+		spool {
+			# Specifies the minimum number of sessions in the session pool.
+			min = ${...pool.min}
+			
+			# Specifies the maximum number of sessions that can be opened in the session pool
+			max = ${...pool.max}
+			
+			# Specifies the increment for sessions to be started if the current number of sessions are less than max
+			inc = ${...pool.spare}
+			
+			# The sessions idle time (in seconds) (0 disable)
+			timeout = 0
+			
+			# Statement cache size for each of the sessions in a session pool
+			statement_cache_size = 64
+		}
+	}
+
 	# Connection info:
 	#
 #	server = "localhost"


### PR DESCRIPTION
backport from v4
Adding support for receiving connections using the built-in oracle client session mechanism.
Changing the function of preparing a query for execution from OCIStmtPrepare to OCIStmtPrepare2, since this function was deprecated beginning with Oracle Database 12c Release 2 (12.2).
This breaks the ability to use Oracle client below 10g