### PR TITLE
doc: Fix the topic level0 for Unlang docs

### DIFF
--- a/doc/unlang/break.adoc
+++ b/doc/unlang/break.adoc
@@ -1,5 +1,4 @@
-
-== The break Statement
+= The break Statement
 
 .Syntax
 [source,unlang]

--- a/doc/unlang/call.adoc
+++ b/doc/unlang/call.adoc
@@ -1,5 +1,4 @@
-
-== The call Statement
+= The call Statement
 
 [source,unlang]
 ----

--- a/doc/unlang/case.adoc
+++ b/doc/unlang/case.adoc
@@ -1,5 +1,4 @@
-
-== The case Statement
+= The case Statement
 
 .Syntax
 [source,unlang]

--- a/doc/unlang/cond_and.adoc
+++ b/doc/unlang/cond_and.adoc
@@ -1,5 +1,4 @@
-
-== The && Operator
+= The && Operator
 
 .Syntax
 [source,unlang]

--- a/doc/unlang/cond_attr.adoc
+++ b/doc/unlang/cond_attr.adoc
@@ -1,5 +1,4 @@
-
-== The &Attribute-Name Reference
+= The &Attribute-Name Reference
 
 .Syntax
 [source,unlang]

--- a/doc/unlang/cond_cmp.adoc
+++ b/doc/unlang/cond_cmp.adoc
@@ -1,5 +1,4 @@
-
-== Conditional Comparisons
+= Conditional Comparisons
 
 .Syntax
 [source,unlang]
@@ -35,7 +34,7 @@ only exceptions are the link:regex.adoc[regular expression] operators,
 which interpret the `lhs` as a printable string, and the `rhs` as a
 regular expression.
 
-=== IP Address Comparisons
+== IP Address Comparisons
 
 The type-specific comparisons operate as expected for most data types.
 The only exception is data types that are IP addresses or IP address
@@ -55,7 +54,7 @@ The syntax allows conditions such as `192.0.2.1 < 192.0.2/24`.  This
 condition will return `true`, as the IP address `192.0.2.1' is within
 the network `192.0.2/24`.
 
-=== Casting
+== Casting
 
 In some situations, it is useful to force the left side to be
 interpreted as a particular data type.

--- a/doc/unlang/cond_data.adoc
+++ b/doc/unlang/cond_data.adoc
@@ -1,5 +1,4 @@
-
-== The data Operator
+= The data Operator
 
 .Syntax
 [source,unlang]

--- a/doc/unlang/cond_eq.adoc
+++ b/doc/unlang/cond_eq.adoc
@@ -1,5 +1,4 @@
-
-== The == Operator
+= The == Operator
 
 `(data-1 == data-2)`
 

--- a/doc/unlang/cond_module.adoc
+++ b/doc/unlang/cond_module.adoc
@@ -1,5 +1,4 @@
-
-== The module-code Operator
+= The module-code Operator
 
 .Syntax
 [source,unlang]

--- a/doc/unlang/cond_not.adoc
+++ b/doc/unlang/cond_not.adoc
@@ -1,5 +1,4 @@
-
-== The ! Operator
+= The ! Operator
 
 .Syntax
 [source,unlang]

--- a/doc/unlang/cond_or.adoc
+++ b/doc/unlang/cond_or.adoc
@@ -1,5 +1,4 @@
-
-== The || Operator
+= The || Operator
 
 .Syntax
 [source,unlang]

--- a/doc/unlang/cond_para.adoc
+++ b/doc/unlang/cond_para.adoc
@@ -1,5 +1,4 @@
-
-== The ( ) Operator
+= The ( ) Operator
 
 .Syntax
 [source,unlang]

--- a/doc/unlang/condition.adoc
+++ b/doc/unlang/condition.adoc
@@ -1,5 +1,4 @@
-
-== Conditional Expressions
+= Conditional Expressions
 
 Conditions are evaluated when parsing link:if.adoc[if] and
 link:elsif.adoc[elsif] statements.  These conditions allow the server to

--- a/doc/unlang/data.adoc
+++ b/doc/unlang/data.adoc
@@ -1,5 +1,4 @@
-
-== Data Types
+= Data Types
 
 Unlang supports a number of data types. These data types can be used
 in conditional expressions or when assigning a value to an attribute.
@@ -27,7 +26,7 @@ Run a script, and interpret the result as the data type.
 Similar processing rules are applied when parsing assignments and
 comparisons, for all attributes and data types.
 
-=== Basic Data Types
+== Basic Data Types
 
 The following data types are "basic" data types.  They are fixed-size,
 and encapsulate simple concepts such as "integer" or "IP address".
@@ -61,7 +60,7 @@ values which can be compared, or assigned to one attribute.
 | uint64	| 64-bit unsigned integer
 |=====
 
-=== Structural Data Types
+== Structural Data Types
 
 The following data types are "structural", in that they form
 parent-child relationships between attributes.  These data types can
@@ -78,7 +77,7 @@ only be used in the dictionaries.  These data types cannot be used in
 | vsa		| Encapsulation of vendor-specific attributes
 |=====
 
-=== Protocol-Specific Data Types
+== Protocol-Specific Data Types
 
 The following data types are used only in certain protocols.  These
 attributes can generally be used only in the dictionaries.  They

--- a/doc/unlang/data_char.adoc
+++ b/doc/unlang/data_char.adoc
@@ -1,5 +1,4 @@
-
-== Character Escaping
+= Character Escaping
 
 The quotation characters in the above string data types can be
 escaped by using the backslash, or `\,` character. The backslash

--- a/doc/unlang/data_double.adoc
+++ b/doc/unlang/data_double.adoc
@@ -1,5 +1,4 @@
-
-== Double-Quoted Strings
+= Double-Quoted Strings
 
 `"string"`
 

--- a/doc/unlang/data_ip.adoc
+++ b/doc/unlang/data_ip.adoc
@@ -1,5 +1,4 @@
-
-== IP Addresses
+= IP Addresses
 
 .Examples
 

--- a/doc/unlang/data_numb.adoc
+++ b/doc/unlang/data_numb.adoc
@@ -1,5 +1,4 @@
-
-== Numbers
+= Numbers
 
 .Examples
 

--- a/doc/unlang/detach.adoc
+++ b/doc/unlang/detach.adoc
@@ -1,5 +1,4 @@
-
-== The detach Statement
+= The detach Statement
 
 .Syntax
 [source,unlang]
@@ -32,7 +31,7 @@ subrequest Disconnect-Request {
 }
 ----
 
-=== Child Lifetime
+== Child Lifetime
 
 The lifetime of the child request is normally limited by the lifetime
 of the parent request.  The default configuration has

--- a/doc/unlang/else.adoc
+++ b/doc/unlang/else.adoc
@@ -1,5 +1,4 @@
-
-== The else Statement
+= The else Statement
 
 .Syntax
 [source,unlang]

--- a/doc/unlang/elsif.adoc
+++ b/doc/unlang/elsif.adoc
@@ -1,5 +1,4 @@
-
-== The elsif Statement
+= The elsif Statement
 
 .Syntax
 [source,unlang]

--- a/doc/unlang/filter.adoc
+++ b/doc/unlang/filter.adoc
@@ -1,4 +1,4 @@
-== The filter Statement
+= The filter Statement
 
 .Syntax
 [source,unlang]
@@ -44,7 +44,7 @@ filter reply {
 }
 ----
 
-=== Lists
+== Lists
 
 The _<list>_ field sets the attribute list that will be filter.  If
 the _<list>_ qualifier is omitted, then each entry inside of the
@@ -53,7 +53,7 @@ the _<list>_ qualifier is omitted, then each entry inside of the
 
 Please see the link:list.adoc[list] page for valid list names.
 
-=== Server Attributes
+== Server Attributes
 
 The _<server-attribute>_ field is an attribute name, such as
 `&Reply-Message`.  The attribute name may also be prefixed with a
@@ -63,13 +63,13 @@ of the `filter` section.
 NOTE: In version 3, the leading `&` was optional.  In version 4, the
 leading `&` is required.
 
-=== Editing Operators
+== Editing Operators
 
 The `<op>` field is used to define how the values are filtered
 Different operators allow attributes to be added, deleted, or
 replaced, as defined below.
 
-=== Filtering Operators
+== Filtering Operators
 
 The following operators may also be used in addition to the ones
 listed above. These operators use the _<server-attribute>_ and
@@ -108,7 +108,7 @@ this functionality has been removed.  Instead, version 4 only performs
 _filtering_ of the attributes.  That is, the filtering operators will
 modify or delete attributes, but they will never create an attribute.
 
-=== Values
+== Values
 
 The _<value>_ field is the value which is used to filter the
 _<server-attribute>_.  The interpretation of the _<value>_ field

--- a/doc/unlang/foreach.adoc
+++ b/doc/unlang/foreach.adoc
@@ -1,5 +1,4 @@
-
-== The foreach Statement
+= The foreach Statement
 
 .Syntax
 [source,unlang]

--- a/doc/unlang/group.adoc
+++ b/doc/unlang/group.adoc
@@ -1,5 +1,4 @@
-
-== The group Statement
+= The group Statement
 
 [source,unlang]
 ----

--- a/doc/unlang/if.adoc
+++ b/doc/unlang/if.adoc
@@ -1,5 +1,4 @@
-
-== The if Statement
+= The if Statement
 
 .Syntax
 [source,unlang]

--- a/doc/unlang/keywords.adoc
+++ b/doc/unlang/keywords.adoc
@@ -1,10 +1,9 @@
-
-== Keywords in Unlang
+= Keywords in Unlang
 
 The following tables list the keywords used in `Unlang`.  These keywords
 implement the "flow control" of the policies.
 
-=== Flow Control Keywords
+== Flow Control Keywords
 
 The _flow control_ keywords allow _if / then / else_ checks, simple
 looping, etc.
@@ -23,7 +22,7 @@ looping, etc.
 | link:switch.adoc[switch]   | Check for multiple values.
 |=====
 
-=== Attribute Editing Keywords
+== Attribute Editing Keywords
 
 The _attribute editing_ keywords allow policies to add, delete, and
 modify attributes in any list or packet.
@@ -37,7 +36,7 @@ modify attributes in any list or packet.
 | link:update.adoc[update]   | Add attributes to a list
 |=====
 
-=== Grouping Keywords
+== Grouping Keywords
 
 The _grouping_ keywords allow policies to be organized into groups,
 including load-balancing.
@@ -52,7 +51,7 @@ including load-balancing.
 | link:redundant-load-balance.adoc[redundant-load-balance] | Define a redundant group with fail-over and load balancing.
 |=====
 
-=== Parent-Child Keywords
+== Parent-Child Keywords
 
 The _parent-child_ keywords allow for creation of parent-child
 relationships between requests.
@@ -83,7 +82,7 @@ impossible to create before.
 | link:subrequest.adoc[subrequest] | Create a child request
 |=====
 
-=== Module Keywords
+== Module Keywords
 
 The _module_ keywords refer pre-packaged libraries that implement
 specific functionality, such as connecting to SQL, LDAP, etc.  The

--- a/doc/unlang/list.adoc
+++ b/doc/unlang/list.adoc
@@ -1,4 +1,4 @@
-== Attribute Lists
+= Attribute Lists
 
 An attribute list contains a set of attributes.  The allowed lists
 are:

--- a/doc/unlang/load-balance.adoc
+++ b/doc/unlang/load-balance.adoc
@@ -1,5 +1,4 @@
-
-== The load-balance Statement
+= The load-balance Statement
 
 [source,unlang]
 ----

--- a/doc/unlang/map.adoc
+++ b/doc/unlang/map.adoc
@@ -1,5 +1,4 @@
-
-== The map Statement
+= The map Statement
 
 [source,unlang]
 ----

--- a/doc/unlang/module.adoc
+++ b/doc/unlang/module.adoc
@@ -1,5 +1,4 @@
-
-== The module Statement
+= The module Statement
 
 .Syntax
 [source,unlang]

--- a/doc/unlang/module_builtin.adoc
+++ b/doc/unlang/module_builtin.adoc
@@ -1,5 +1,4 @@
-
-== Built-in Modules
+= Built-in Modules
 
 In some cases, it is useful to reject a request immediately or
 perform another action on it.  The built-in modules can be used to perform these actions.  These modules are named for the return codes given in the

--- a/doc/unlang/module_method.adoc
+++ b/doc/unlang/module_method.adoc
@@ -1,5 +1,4 @@
-
-== The module.method Statement
+= The module.method Statement
 
 .Syntax
 [source,unlang]

--- a/doc/unlang/parallel.adoc
+++ b/doc/unlang/parallel.adoc
@@ -1,5 +1,4 @@
-
-== The parallel Statement
+= The parallel Statement
 
 [source,unlang]
 ----
@@ -53,7 +52,7 @@ parallel {
 }
 ----
 
-=== Child Requests are Independent
+== Child Requests are Independent
 
 Each module or subsection runs as a new child request, i.e. a
 link:subrequest.adoc[subrequest].  Each child request is an identical
@@ -101,7 +100,7 @@ parallel {
 }
 ----
 
-=== Subrequests are Synchronous
+== Subrequests are Synchronous
 
 Execution of the parent request is paused while each child request is
 running.  The parent request continues execution once all of the the
@@ -111,7 +110,7 @@ Unlike the link:subrequest.adoc[subrequest] keyword, the child
 requests of a `parallel` section cannot be made asynchronous via the
 link:detach.adoc[detach] keyword.
 
-=== parallel empty
+== parallel empty
 
 The `parallel empty { ... }` syntax creates empty child requests.
 These requests contain no attributes.  Attributes in the child request
@@ -152,7 +151,7 @@ parallel empty {
 }
 ----
 
-=== parallel detach
+== parallel detach
 
 The `parallel detach { ... }` syntax creates child requests which are
 immediately detached from the parent request.  Each child request
@@ -190,7 +189,7 @@ parallel detach {
 }
 ----
 
-=== Exiting Early from a Parallel Section
+== Exiting Early from a Parallel Section
 
 In some situations, it may be useful to exit early from a parallel
 section.  For example, to proxy a packet to multiple destinations, and

--- a/doc/unlang/redundant-load-balance.adoc
+++ b/doc/unlang/redundant-load-balance.adoc
@@ -1,5 +1,4 @@
-
-== The redundant-load-balance Statement
+= The redundant-load-balance Statement
 
 [source,unlang]
 ----

--- a/doc/unlang/redundant.adoc
+++ b/doc/unlang/redundant.adoc
@@ -1,5 +1,4 @@
-
-== The redundant Statement
+= The redundant Statement
 
 [source,unlang]
 ----

--- a/doc/unlang/regex.adoc
+++ b/doc/unlang/regex.adoc
@@ -1,5 +1,4 @@
-
-== Regular Expression Comparisons
+= Regular Expression Comparisons
 
 .Example
 [source,unlang]

--- a/doc/unlang/return.adoc
+++ b/doc/unlang/return.adoc
@@ -1,5 +1,4 @@
-
-== The return Statement
+= The return Statement
 
 .Syntax
 [source,unlang]

--- a/doc/unlang/string_backticks.adoc
+++ b/doc/unlang/string_backticks.adoc
@@ -1,5 +1,4 @@
-
-== Backtick-quoted string
+= Backtick-quoted string
 
 `{backtick}string{backtick}`
 

--- a/doc/unlang/string_double.adoc
+++ b/doc/unlang/string_double.adoc
@@ -1,5 +1,4 @@
-
-== Double Quoted Strings
+= Double Quoted Strings
 
 `"string"`
 
@@ -10,7 +9,7 @@ within double quotes can include spaces.
 NOTE: Most values retrieved from external datastores will be treated implicitly
 as double-quoted strings.
 
-=== Escape sequences
+== Escape sequences
 
 Escape sequences allow the inclusion of characters that may be difficult to
 represent in datastores, or the FreeRADIUS configuration files.

--- a/doc/unlang/string_single.adoc
+++ b/doc/unlang/string_single.adoc
@@ -1,5 +1,4 @@
-
-== Single Quoted Strings
+= Single Quoted Strings
 
 `'string'`
 

--- a/doc/unlang/string_unquoted.adoc
+++ b/doc/unlang/string_unquoted.adoc
@@ -1,5 +1,4 @@
-
-== Unquoted Strings
+= Unquoted Strings
 
 Where a series of characters cannot be parsed as a decimal number,
 they are interpreted as a simple string composed of one word. This

--- a/doc/unlang/subrequest.adoc
+++ b/doc/unlang/subrequest.adoc
@@ -1,5 +1,4 @@
-
-== The subrequest Statement
+= The subrequest Statement
 
 [source,unlang]
 ----
@@ -52,7 +51,7 @@ subrequest Disconnect-Request {
 }
 ----
 
-=== Changing Protocols
+== Changing Protocols
 
 The `subrequest` keyword can also be used to change protocols.  For
 example, the server can receive a RADIUS `Access-Request`, and then
@@ -73,7 +72,7 @@ subrequest dhcpv4.DHCP-Discover {
 }
 ----
 
-=== Subrequests are Synchronous
+== Subrequests are Synchronous
 
 Execution of the parent request is paused while the child request is
 running.  The parent request continues execution once the child request

--- a/doc/unlang/switch.adoc
+++ b/doc/unlang/switch.adoc
@@ -1,5 +1,4 @@
-
-== The switch Statement
+= The switch Statement
 
 .Syntax
 [source,unlang]

--- a/doc/unlang/update.adoc
+++ b/doc/unlang/update.adoc
@@ -1,4 +1,4 @@
-== The update Statement
+= The update Statement
 
 .Syntax
 [source,unlang]
@@ -44,7 +44,7 @@ update reply {
 }
 ----
 
-=== Lists
+== Lists
 
 The _<list>_ field sets the attribute list that will be updated.  If
 the _<list>_ qualifier is omitted, then each entry inside of the
@@ -53,7 +53,7 @@ the _<list>_ qualifier is omitted, then each entry inside of the
 
 Please see the link:list.adoc[list] page for valid list names.
 
-=== Server Attributes
+== Server Attributes
 
 The _<server-attribute>_ field is an attribute name, such as
 `&Reply-Message`.  The attribute name may also be prefixed with a
@@ -63,7 +63,7 @@ of the `update` section.
 NOTE: In version 3, the leading `&` was optional.  In version 4, the
 leading `&` is required.
 
-=== Editing Operators
+== Editing Operators
 
 The `<op>` field is used to define how the attribute is processed.
 Different operators allow attributes to be added, deleted, or
@@ -101,7 +101,7 @@ update reply {
 }
 ----
 
-=== Values
+== Values
 
 The _<value>_ field is the value which is assigned to the
 _<server-attribute>_.  The interpretation of the _<value>_ field

--- a/doc/unlang/xlat.adoc
+++ b/doc/unlang/xlat.adoc
@@ -1,5 +1,4 @@
-
-== String Expansion
+= String Expansion
 
 String expansion is a feature that allows strings to dynamically
 define their value at run time. For historical reasons, these string

--- a/doc/unlang/xlat_attribute.adoc
+++ b/doc/unlang/xlat_attribute.adoc
@@ -1,5 +1,4 @@
-
-== Attribute References
+= Attribute References
 
 Attributes in a list may be referenced via one of the following two
 syntaxes:

--- a/doc/unlang/xlat_character.adoc
+++ b/doc/unlang/xlat_character.adoc
@@ -1,18 +1,17 @@
-
-== Single Letter Expansions
+= Single Letter Expansions
 
 The following are single letter expansions.  These expansions do not
 use the typical `%{...}` format.  Instead, they are short-cuts for
 simple, common cases.
 
-### Miscellaneous
+== Miscellaneous
 
 `%%`::
 
 Returns `%`.
 
 
-### Current Time
+== Current Time
 
 `%c`::
 
@@ -25,7 +24,7 @@ The microsecond component of the current epoch time. This is an unsigned
 decimal number. It should be used with time-based calculations.
 
 
-### Request Time
+== Request Time
 
 `%l`::
 

--- a/doc/unlang/xlat_condition.adoc
+++ b/doc/unlang/xlat_condition.adoc
@@ -1,5 +1,4 @@
-
-== Conditional Syntax
+= Conditional Syntax
 
 Conditional syntax similar to that used in Unix shells may also be
 used:

--- a/doc/unlang/xlat_module.adoc
+++ b/doc/unlang/xlat_module.adoc
@@ -1,5 +1,4 @@
-
-== Module References
+= Module References
 
 Individual modules may be referenced via the following syntax:
 

--- a/doc/unlang/xlat_predefined.adoc
+++ b/doc/unlang/xlat_predefined.adoc
@@ -1,4 +1,3 @@
-
 = Pre-defined Expansions
 
 In addition to storing attribute references, the server has a number


### PR DESCRIPTION
The *.adoc files should have the first title starting with '=' (called as level0 in the asciidoc documentation)