### PR TITLE
Add Cassandra SQL driver to be built by Jenkis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,7 @@ services:
 - redis-server
 before_install:
 - npm i -g @antora/cli@2.0 @antora/site-generator-default@2.0
+- sudo ./scripts/travis/cassandra-install.sh
 - rvm --install --default --binary use 2.4
 - gem install asciidoctor
 - wget -q -O /tmp/pandoc.deb https://github.com/jgm/pandoc/releases/download/2.7.3/pandoc-2.7.3-1-amd64.deb && sudo dpkg -i /tmp/pandoc.deb

--- a/scripts/travis/cassandra-install.sh
+++ b/scripts/travis/cassandra-install.sh
@@ -1,0 +1,42 @@
+#!/bin/sh -e
+
+libuv_ver="1.29.1"
+libuv_pkg="libuv1_${libuv_ver}-1_amd64.deb"
+
+cassandra_ver="2.13.0"
+cassandra_pkgs="cassandra-cpp-driver-dbg_${cassandra_ver}-1_amd64.deb
+                cassandra-cpp-driver-dev_${cassandra_ver}-1_amd64.deb
+                cassandra-cpp-driver_${cassandra_ver}-1_amd64.deb"
+
+ubuntu_ver="$(lsb_release -rs)"
+tmp_dir="/tmp/cassandra-$$"
+mkdir -p $tmp_dir
+
+do_exit() {
+	rm -rf $tmp_dir
+	exit $1
+}
+
+# Libuv
+libuv_url="https://downloads.datastax.com/cpp-driver/ubuntu/${ubuntu_ver}/dependencies/libuv/v${libuv_ver}/${libuv_pkg}"
+if ! wget -q -O "${tmp_dir}/${libuv_pkg}" "${libuv_url}"; then
+	echo "ERROR: Problems to fetch ${libuv_url}"
+	do_exit 1
+fi
+
+# Cassandra sdk
+for _deb in ${cassandra_pkgs}; do
+	_url="https://downloads.datastax.com/cpp-driver/ubuntu/${ubuntu_ver}/cassandra/v${cassandra_ver}/${_deb}"
+
+	if ! wget -q -O "${tmp_dir}/${_deb}" "${_url}"; then
+		echo "ERROR: Problems to fetch ${_url}"
+		do_exit 1
+	fi
+done
+
+if ! dpkg -i ${tmp_dir}/*.deb; then
+	echo "ERROR: Problems to install ${tmp_dir}/*.deb"
+	do_exit 1
+fi
+
+do_exit 0


### PR DESCRIPTION
* Add Cassandra SQL driver to be built by Jenkis
* rlm_sql_cassandra: Some functions were deprecated in 2.9