### PR TITLE
Allow parsing of 'float64' in configuration files

### DIFF
--- a/src/lib/server/cf_parse.c
+++ b/src/lib/server/cf_parse.c
@@ -424,6 +424,20 @@ int cf_pair_parse_value(TALLOC_CTX *ctx, void *out, UNUSED void *base, CONF_ITEM
 	}
 		break;
 
+	case FR_TYPE_FLOAT64:
+	{
+		double num;
+
+		if (sscanf(cp->value, "%lf", &num) != 1) {
+			cf_log_err(cp, "Failed parsing floating point number");
+			rcode = -1;
+			goto error;
+		}
+		cf_log_debug(cs, "%.*s%s = %f", PAIR_SPACE(cs), parse_spaces, cf_pair_attr(cp), num);
+		memcpy(out, &num, sizeof(num));
+	}
+		break;
+
 	default:
 		/*
 		 *	If we get here, it's a sanity check error.


### PR DESCRIPTION
This small patch adds support of type 'float64' in configuration file.

Rationale: precision of float32 is not always sufficient, even for what would seem to be very simple numbers.
For example: "88.005" when printed with the default precision shows "88.004997".