### PR TITLE
Update 'check.doc' target to use the input as a file.

### DIFF
--- a/doc/all.mk
+++ b/doc/all.mk
@@ -121,7 +121,14 @@ clean.doc:
 #	Sanity checks
 #
 check.doc:
-	${Q}./scripts/checks/missing-xlat-doc.sh
+	${Q}echo "TEST-DOC XLAT CHECK";                                           \
+	check_xlatA="${top_srcdir}/scripts/checks/missing-xlat-doc.txt";          \
+	check_xlatB="${BUILD_DIR}/tests/missing-xlat-doc.txt";                    \
+	./scripts/checks/missing-xlat-doc.sh > $${check_xlatB};                   \
+	if ! diff $${check_xlatA} $${check_xlatB}; then                           \
+		echo "FAILED: XLAT'S MISSING CHECKS: $$check_xlatA != $$check_xlatB"; \
+		exit 1;                                                               \
+	fi
 
 .PHONY: tests.doc
 tests.doc:

--- a/scripts/checks/missing-xlat-doc.sh
+++ b/scripts/checks/missing-xlat-doc.sh
@@ -1,37 +1,15 @@
 #!/bin/bash
 # Script used to verify the xlat funcs vs documentation
 
-# everything here will be ignored.
-ignore_funcs="trigger|test"
-
-# ignore rlm_dict xlat's
-ignore_funcs="$ignore_funcs|attr|attr_by_num|attr_by_oid|attr_num|vendor|vendor"
-
 # main()
+xlat_api_funcs="xlat_register|xlat_async_register"
 src_dir="src/"
 doc_xlat="doc/"
-tmp_file="/tmp/missing-xlat-doc.$$"
-ret=0
 
-grep --include "*.c" -E '(xlat_register|xlat_async_register).*"' -r $src_dir 2>&1 | \
-	grep -vE "($ignore_funcs)" | perl -lpe 's/^.*"(.*)".*$/\1/' | sort | uniq | \
+grep --include "*.c" -E "($xlat_api_funcs).*\"" -r $src_dir 2>&1 | \
+	perl -lpe 's/^.*"(.*)".*$/\1/' | sort | uniq | \
 while read _d; do
 	if ! grep -q "%{$_d:" --include "*.adoc" -r $doc_xlat 2>&1; then
-		echo "%{$_d:...}" >> $tmp_file
+		echo "%{$_d:...}"
 	fi
 done
-
-echo "****************************************************************"
-echo " WARNING: Ignoring documentation for the xlat's: $ignore_funcs"
-echo "****************************************************************"
-
-if [ -s "$tmp_file" ]; then
-	echo "****************************************************************"
-	echo " ERROR: The below xlat's functions are not documented in $doc_xlat"
-	echo "****************************************************************"
-	cat $tmp_file
-	ret=1
-fi
-
-rm -f $tmp_file
-exit $ret

--- a/scripts/checks/missing-xlat-doc.txt
+++ b/scripts/checks/missing-xlat-doc.txt
@@ -1,0 +1,8 @@
+%{attr:...}
+%{attr_by_num:...}
+%{attr_by_oid:...}
+%{attr_num:...}
+%{test:...}
+%{trigger:...}
+%{vendor:...}
+%{vendor_num:...}


### PR DESCRIPTION
The list of expected missing xlat's calls should be versioned
in scripts/checks/missing-xlat-doc.txt