### PR TITLE
doc: Add 'update-check.doc' target to update scripts/checks/*.txt db

### DIFF
--- a/doc/all.mk
+++ b/doc/all.mk
@@ -120,6 +120,11 @@ clean.doc:
 #
 #	Sanity checks
 #
+update-check.doc:
+	${Q}echo "TEST-DOC UPDATE XLAT & RADDB DATABASE"
+	${Q}./scripts/checks/missing-xlat-doc.sh > ${top_srcdir}/scripts/checks/missing-xlat-doc.txt
+	${Q}./scripts/checks/missing-raddb-mod-conf.sh > ${top_srcdir}/scripts/checks/missing-raddb-mod-conf.txt
+
 check.doc:
 	${Q}echo "TEST-DOC XLAT CHECK";                                           \
 	check_xlatA="${top_srcdir}/scripts/checks/missing-xlat-doc.txt";          \

--- a/scripts/checks/missing-raddb-mod-conf.txt
+++ b/scripts/checks/missing-raddb-mod-conf.txt
@@ -2,7 +2,6 @@ WARNING: Module src/modules/rlm_dict has no raddb/mods-available/dict
 WARNING: raddb/mods-available/files has no reference for: auth_usersfile
 WARNING: raddb/mods-available/files has no reference for: postauth_usersfile
 WARNING: raddb/mods-available/files has no reference for: postproxy_usersfile
-WARNING: raddb/mods-available/radius has no reference for: ignore_response
 WARNING: raddb/mods-available/radius has no reference for: ipv4addr
 WARNING: raddb/mods-available/radius has no reference for: ipv6addr
 WARNING: raddb/mods-available/radius has no reference for: src_ipv4addr


### PR DESCRIPTION
It will update the files scripts/checks/missing-raddb-mod-conf.txt and scripts/checks/missing-xlat-doc.txt used to keep the current documentation state of xlat and raddb FR_CONF keys state.