### PR TITLE
README: fix link to Network RADIUS

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ code, or documentation).
 
 Technical support, managed systems support, custom deployments,
 sponsored feature development and many other commercial services
-are available from [Network RADIUS](https://www.networkradius.com).
+are available from [Network RADIUS](https://networkradius.com).
 
 [CoverityStatus]: https://scan.coverity.com/projects/58/badge.svg?flat=1 "Coverity Status"
 [CoverityStatusLink]: https://scan.coverity.com/projects/58


### PR DESCRIPTION
SSL certificate is not issued to www.networkradius.com but
networkradius.org. Link to www.networkradius.com will cause SSL
certificate verification failure.