### PR TITLE
radmin: Fix the command '?'

### DIFF
--- a/src/modules/proto_control/radmin.c
+++ b/src/modules/proto_control/radmin.c
@@ -539,7 +539,7 @@ static int radmin_help(UNUSED int count, UNUSED int key)
 
 	fprintf(stderr, "HELP %zd %s\n", len, cmd_buffer);
 
-	if (*cmd_buffer) {
+	if (len > 0) {
 		(void) fr_conduit_write(sockfd, FR_CONDUIT_HELP, cmd_buffer, len);
 	} else {
 		/*


### PR DESCRIPTION
We should validate the 'len' instead of the content to check
if could call their help.

e.g:

radmin> show debug level
3
radmin> ?
HELP 0 show debug level
radmin> ^C