### PR TITLE
Master spec file

### DIFF
--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -651,7 +651,6 @@ fi
 %attr(644,root,radiusd) %config(noreplace) %{_sysconfdir}/raddb/dictionary
 %attr(640,root,radiusd) %config(noreplace) %{_sysconfdir}/raddb/clients.conf
 %attr(640,root,radiusd) %config(noreplace) %{_sysconfdir}/raddb/panic.gdb
-%attr(640,root,radiusd) %config(noreplace) %{_sysconfdir}/raddb/README.md
 %attr(640,root,radiusd) %config(noreplace) %{_sysconfdir}/raddb/radiusd.conf
 %attr(640,root,radiusd) %config(noreplace) %{_sysconfdir}/raddb/trigger.conf
 #%dir %attr(750,root,radiusd) %{_sysconfdir}/raddb/sql
@@ -758,7 +757,6 @@ fi
 %defattr(-,root,root)
 /usr/bin/*
 # man-pages
-%doc %{_mandir}/man1/radclient.1.gz
 %doc %{_mandir}/man1/radlast.1.gz
 %doc %{_mandir}/man1/radtest.1.gz
 %doc %{_mandir}/man1/radwho.1.gz

--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -67,7 +67,9 @@ BuildRequires: gdbm-devel
 %if %{?_with_freeradius_openssl:1}%{!?_with_freeradius_openssl:0}
 BuildRequires: freeradius-openssl, freeradius-openssl-devel
 %else
-BuildRequires: openssl, openssl-devel
+# Need openssl-perl for c_rehash, which is used in tests. We don't currently
+# run a test step, but other tooling obtains build requirements from here.
+BuildRequires: openssl, openssl-devel, openssl-perl
 %endif
 
 BuildRequires: libcurl-devel


### PR DESCRIPTION
CentOS crossbuilds aren't working due to missing openssl-perl package that supplies the c_rehash utility which is required for certificate tests. Added this as a BuildRequires dependency in the redhat spec file from which the packages for the Docker build images are derived.

Other trivial fixes to ensure successful rpmbuilds.