### PR TITLE
mongo: Fix examples

### DIFF
--- a/raddb/mods-available/sql
+++ b/raddb/mods-available/sql
@@ -158,8 +158,16 @@ sql {
 #	password = "radpass"
 
 	# Connection info for Mongo
-	#
-#	server = "mongodb://USER:PASSWORD@192.16.0.2:PORT/?authSource=admin"
+	# Authentication Without SSL
+	#	server = "mongodb://USER:PASSWORD@192.16.0.2:PORT/DATABASE?authSource=admin&ssl=false"
+
+	# Authentication With SSL
+	#	server = "mongodb://USER:PASSWORD@192.16.0.2:PORT/DATABASE?authSource=admin&ssl=true"
+
+	# Authentication with Certificate
+	# Use this command for retrieve Derived username:
+	# openssl x509 -in mycert.pem -inform PEM -subject -nameopt RFC2253
+	# server = mongodb://<DERIVED USERNAME>@192.168.0.2:PORT/DATABASE?authSource=$external&ssl=true&authMechanism=MONGODB-X509
 
 	# Database table configuration for everything except Oracle
 	radius_db = "radius"

--- a/raddb/mods-config/sql/ippool/mongo/queries.conf
+++ b/raddb/mods-config/sql/ippool/mongo/queries.conf
@@ -1,6 +1,6 @@
 # -*- text -*-
 #
-#  ippool/mongo/queries.conf -- PostgreSQL queries for rlm_sqlippool
+#  ippool/mongo/queries.conf -- Mongo queries for rlm_sqlippool
 #
 #  $Id$
 
@@ -17,59 +17,59 @@ allocate_begin = ""
 #
 allocate_find = "db.mypool_collection.findAndModify( \
 	{ \
-	  query: {' \
-	    '$and': [ \
-	      { \
-	        'pool_name': '{Control:Pool-Name}' \
-	      }, \
-	      { \
-	        'nas_ip': '%{Nas-IP-Address}' \
-	      }, \
-	      { \
-	        '$or': [ \
-		  { \
-		    'calling_station_id': '%{Calling-Station-Id}' \
-		  }, \
-		  { \
-		    'locked': 0 \
-		  } \
-	        ] \
-	      } \
-	    ] \
-	  }, \
-	  update: { \
-	    'locked': 1', \
-	    'calling_station_id': '%{Calling-Station-Id'}' \
-	  }, \
-	  fields: { \
-	    '_id': 0, 'framed_ip_address': 1 \
-	  } \
- 	})"
+		'query': {' \
+			'$and': [ \
+				{ \
+					'pool_name': '{Control:Pool-Name}' \
+				}, \
+				{ \
+					'nas_ip': '%{Nas-IP-Address}' \
+				}, \
+				{ \
+					'$or': [ \
+						{ \
+							'calling_station_id': '%{Calling-Station-Id}' \
+						}, \
+						{ \
+							'locked': 0 \
+						} \
+					] \
+				} \
+			] \
+		}, \
+		'update': { \
+			'locked': 1', \
+			'calling_station_id': '%{Calling-Station-Id'}' \
+		}, \
+		'fields': { \
+			'_id': 0, 'framed_ip_address': 1 \
+		} \
+	})"
 
 allocate_update = ""
 
 allocate_clear = "db.mypool_collection.findAndModify( \
 	{ \
-	  query: { \
-	    '$and': [ \
-	      { \
-	        'pool_name': '%{Control:Pool-Name}' \
-	      }, \
-	      { \
-	        'nas_ip': '%{Nas-IP-Address}' \
-	      }, \
-	      { \
-	        'calling_station_id': '%{Calling-Station-Id}' \
-	      }, \
-	      { \
-	        'locked': 1 \
-	      } \
-	    ] \
-	  }, \
-	  update: { \
-	    'locked': 0, \
-	    calling_station_id': '' \
-	  } \
+		'query': { \
+			'$and': [ \
+				{ \
+					'pool_name': '%{Control:Pool-Name}' \
+				}, \
+				{ \
+					'nas_ip': '%{Nas-IP-Address}' \
+				}, \
+				{ \
+					'calling_station_id': '%{Calling-Station-Id}' \
+				}, \
+				{ \
+					'locked': 1 \
+				} \
+			] \
+		}, \
+		'update': { \
+			'locked': 0, \
+			'calling_station_id': '' \
+		} \
 	})"
 
 allocate_commit = ""

--- a/raddb/mods-config/sql/main/mongo/queries.conf
+++ b/raddb/mods-config/sql/main/mongo/queries.conf
@@ -57,40 +57,40 @@ sql_user_name = "%{User-Name}"
 #
 authorize_check_query = "db.mobiles.aggregate([ \
 	{ \
-	  '$match': { \
-	    'calling_station_id': '%{Calling-Station-id}', \
-	    'auth_blocked': 'false' \
-	  } \
+		'$match': { \
+			'calling_station_id': '%{Calling-Station-id}', \
+			'auth_blocked': 'false' \
+		} \
 	}, \
 	{ \
-	  '$addFields': { \
-	    'attributes.User-Name': '$usr', \
-	    'attributes.ClearText-Password': '$pwd', \
-	    'attributes.Cache-TTL': '$ttlcache', \
-	    'attributes.Enable-Roaming': '$roaming', \
-	    'attributes.Pool-Name': '$pool_name' \
-	   } \
- 	}, \
-	{ 
-	  '$project': { \
-	    'calling_station_id': 1, \
-	    'attributes': { \
-	      '$objectToArray': '$attributes' \
-	    } \
-	  } \
+		'$addFields': { \
+				'attributes.User-Name': '$usr', \
+				'attributes.ClearText-Password': '$pwd', \
+				'attributes.Cache-TTL': '$ttlcache', \
+				'attributes.Enable-Roaming': '$roaming', \
+				'attributes.Pool-Name': '$pool_name' \
+		} \
+	}, \
+	{
+		'$project': { \
+			'calling_station_id': 1, \
+			'attributes': { \
+				'$objectToArray': '$attributes' \
+			} \
+		} \
 	}, \
 	{ \
-	  '$unwind': '$attributes' \
+		'$unwind': '$attributes' \
 	}, \
 	{ \
-	  '$project': { \
-	    '_id': 0, \
-	    'attribute': '$attributes.k', \
-	    'value': '$attributes.v', \
-	    'op': ':=' \
-	  } \
+		'$project': { \
+			'_id': 0, \
+			'attribute': '$attributes.k', \
+			'value': '$attributes.v', \
+			'op': ':=' \
+		} \
 	} \
-    ])" \
+])" \
 
 # TBD: fill in things here
 authorize_reply_query = ""
@@ -130,132 +130,130 @@ authorize_reply_query = ""
 #######################################################################
 
 accounting {
-  reference = "%{tolower:type.%{Acct-Status-Type}.query}"
+	reference = "%{tolower:type.%{Acct-Status-Type}.query}"
 
-    type {
+	type {
 
-      start {
-        query = "db.connections.findAndModify({ \
-          query: { \
-            'calling_station_id': '%{Calling-Station-Id}', \
-              'pgw_node': '%{NAS-Identifier}', \
-              'acct_session_id': '%{Acct-Session-Id}', \
-          }, \
-          update: { \
-                    '$set': { \
-                      'update_date':  new Date(), \
-                        'ip': '%{Framed-IP-Address}', \
-                        'start_time': '%{Packet-Original-Timestamp}', \
-                    }, \
-                    '$push': { \
-                      'events_data': { \
-                        'event_id': ObjectId(), \
-                          'event_type': 'Accounting-Start', \
-                          'event_time': '%{Packet-Original-Timestamp}', \
-                          'creation_date': new Date(), \
-                      } \
-                    }, \
-                    '$setOnInsert': { \
-                      'pool_name': '%{Control:Pool-Name}', \
-                        'ip': '%{Framed-IP-Address}', \
-                        'closed': false, \
-                        'update_counter': 0, \
-                        'creation_date': new Date() \
-                    } \
-                  }, \
-          upsert: true \
-        })"
+		start {
+			query = "db.connections.findAndModify({ \
+				'query': { \
+					'calling_station_id': '%{Calling-Station-Id}', \
+					'pgw_node': '%{NAS-Identifier}', \
+					'acct_session_id': '%{Acct-Session-Id}', \
+				}, \
+				'update': { \
+					'$set': { \
+						'update_date':  { '$date': { '$numberLong': '%{expr: (%l * 1000) + (%M / 1000)}' } }, \
+						'ip': '%{Framed-IP-Address}', \
+						'start_time': '%{Packet-Original-Timestamp}', \
+					}, \
+					'$push': { \
+						'events_data': { \
+							'event_id': '%{sha256:%{tolower:%{Calling-Station-Id}', \
+							'event_type': 'Accounting-Start', \
+							'event_time': '%{Packet-Original-Timestamp}', \
+							'creation_date': { '$date': { '$numberLong': '%{expr: (%l * 1000) + (%M / 1000)}' } } \
+						} \
+					}, \
+					'$setOnInsert': { \
+						'pool_name': '%{Control:Pool-Name}', \
+						'ip': '%{Framed-IP-Address}', \
+						'closed': false, \
+						'update_counter': 0, \
+						'creation_date': { '$date': { '$numberLong': '%{expr: (%l * 1000) + (%M / 1000)}' }  } \
+					} \
+				}, \
+				'upsert': true \
+			})"
 
-        query = "db.simultaneous_connections.findAndModify({ \
-          query: { \
-               'pool_name': '%{Control:Pool-Name}', \
-          }, \
-          update: { \
-              '$inc': { \
-                     'conns_counter': 1 \
-              } \
-              '$setOnInsert': { \
-                 'pool_name': '%{Control:Pool-Name}', \
-                 'conns_counter': 1 \
-              }, \
-         }, \
-         upsert: true \
-        })"
-      # End Start
-      }
+			query = "db.simultaneous_connections.findAndModify({ \
+				'query': { \
+					'pool_name': '%{Control:Pool-Name}' \
+				}, \
+				'update': { \
+					'$inc': { \
+						'conns_counter': 1 \
+					} \
+					'$setOnInsert': { \
+						'pool_name': '%{Control:Pool-Name}', \
+							'conns_counter': 1 \
+					}, \
+				}, \
+				'upsert': true \
+			})"
+		# End Start
+		}
 
-      interim-update {
-        query = "db.connections.findAndModify({ \
-          query: { \
-             'calling_station_id': '%{Calling-Station-Id}', \
-             'pgw_node': '%{NAS-Identifier}', \
-             'acct_session_id': '%{Acct-Session-Id}', \
-          }, \
-          update: { \
-                    '$set': { \
-                      'update_date':  new Date(), \
-                      'last_upd_interim': '%{Packet-Original-Timestamp}', \
-                    }, \
-                    '$inc': { \
-                      'update_counter': 1 \
-                    }, \
-                    '$push': { \
-                      'events_data': { \
-                        'event_id': ObjectId(), \
-                          'event_type': 'Accounting-Interim-Update', \
-                          'event_time': '%{Packet-Original-Timestamp}', \
-                          'creation_date': new Date(), \
-                      } \
-                    }, \
-                    '$setOnInsert': { \
-                        'pool_name': '%{Control:Pool-Name}', \
-                        'ip': '%{Framed-IP-Address}', \
-                        'closed': false, \
-                        'creation_date': new Date() \
-                    } \
-                  }, \
-          upsert: true \
-        })"
+		interim-update {
+			query = "db.connections.findAndModify({ \
+				'query': { \
+					'calling_station_id': '%{Calling-Station-Id}', \
+						'pgw_node': '%{NAS-Identifier}', \
+						'acct_session_id': '%{Acct-Session-Id}' \
+				}, \
+				'update': { \
+					'$set': { \
+						'update_date':  { '$date': { '$numberLong': '%{expr: (%l * 1000) + (%M / 1000)}' } }, \
+						'last_upd_interim': '%{Packet-Original-Timestamp}' \
+					}, \
+					'$inc': { \
+						'update_counter': 1 \
+					}, \
+					'$push': { \
+						'events_data': { \
+							'event_id': '%{sha256:%{tolower:%{Calling-Station-Id}', \
+							'event_type': 'Accounting-Interim-Update', \
+							'event_time': '%{Packet-Original-Timestamp}', \
+							'creation_date': { '$date': { '$numberLong': '%{expr: (%l * 1000) + (%M / 1000)}' } } \
+						} \
+					}, \
+					'$setOnInsert': { \
+						'pool_name': '%{Control:Pool-Name}', \
+						'ip': '%{Framed-IP-Address}', \
+						'closed': false, \
+						'creation_date': { '$date': { '$numberLong': '%{expr: (%l * 1000) + (%M / 1000)}' } } \
+					} \
+				},
+				'upsert': true \
+			})"
+		# End Interim-Update
+		}
 
-      # End Interim-Update
-      }
+		stop {
+			query = "db.connections.findAndModify({ \
+				'query': { \
+					'calling_station_id': '%{Calling-Station-Id}', \
+					'pgw_node': '%{NAS-Identifier}', \
+					'acct_session_id': '%{Acct-Session-Id}' \
+				}, \
+				'update': { \
+					'$set': { \
+						'update_date':  { '$date': { '$numberLong': '%{expr: (%l * 1000) + (%M / 1000)}' } }, \
+						'stop_time': '%{Packet-Original-Timestamp}', \
+						'closed': true \
+					}, \
+					'$push': { \
+						'events_data': { \
+							'event_id': '%{sha256:%{tolower:%{Calling-Station-Id}', \
+							'event_type': 'Accounting-Stop', \
+							'event_time': '%{Packet-Original-Timestamp}', \
+							'creation_date': { '$date': { '$numberLong': '%{expr: (%l * 1000) + (%M / 1000)}' } } \
+						} \
+					}, \
+					'$setOnInsert': { \
+						'pool_name': '%{Control:Pool-Name}', \
+						'ip': '%{Framed-IP-Address}', \
+						'update_counter': 0, \
+						'creation_date': { '$date': { '$numberLong': '%{expr: (%l * 1000) + (%M / 1000)}' } } \
+					} \
+				}, \
+				'upsert': true \
+			})"
 
-      stop {
+		# End Stop
+		}
 
-        query = "db.connections.findAndModify({ \
-          query: { \
-             'calling_station_id': '%{Calling-Station-Id}', \
-             'pgw_node': '%{NAS-Identifier}', \
-             'acct_session_id': '%{Acct-Session-Id}', \
-          }, \
-          update: { \
-                    '$set': { \
-                      'update_date':  new Date(), \
-                      'stop_time': '%{Packet-Original-Timestamp}', \
-                      'closed': true \
-                    }, \
-                    '$push': { \
-                      'events_data': { \
-                        'event_id': ObjectId(), \
-                          'event_type': 'Accounting-Stop', \
-                          'event_time': '%{Packet-Original-Timestamp}', \
-                          'creation_date': new Date(), \
-                      } \
-                    }, \
-                    '$setOnInsert': { \
-                        'pool_name': '%{Control:Pool-Name}', \
-                        'ip': '%{Framed-IP-Address}', \
-                        'update_counter': 0, \
-                        'creation_date': new Date() \
-                    } \
-                  }, \
-          upsert: true \
-        })"
-
-      # End Stop
-      }
-
-    }
+	}
 }
 
 
@@ -266,25 +264,25 @@ accounting {
 #######################################################################
 
 post-auth {
-  query = "db.post_auth.findAndModify({ \
-            query: { \
-                  'calling_station_id': '%{Calling-Station-Id}', \
-                  'nas_ip': '%{NAS-Identifier}', \
-            }, \
-            update: { \
-                  '$set': { \
-                      'update_date': new Date(), \
-                      'last_event_ts': '%{Packet-Original-Timestamp}', \
-                  }, \
-                  '$inc': { \
-                      'reject_counter': 1 \
-                  }, \
-                  '$setOnInsert': { \
-                      'calling_station_id': '%{Calling-Station-Id}', \
-                      'nas_ip': '%{NAS-Identifier}', \
-                      'creation_date': new Date() \
-                  } \
-            }, \
-            upsert: true \
-       })"
+	query = "db.post_auth.findAndModify({ \
+		'query': { \
+			'calling_station_id': '%{Calling-Station-Id}', \
+			'nas_ip': '%{NAS-Identifier}' \
+		}, \
+		'update': { \
+			'$set': { \
+				'update_date':  { '$date': { '$numberLong': '%{expr: (%l * 1000) + (%M / 1000)}' } }, \
+				'last_event_ts': '%{Packet-Original-Timestamp}' \
+			}, \
+			'$inc': { \
+				'reject_counter': 1 \
+			}, \
+			'$setOnInsert': { \
+				'calling_station_id': '%{Calling-Station-Id}', \
+				'nas_ip': '%{NAS-Identifier}', \
+				'creation_date': { '$date': { '$numberLong': '%{expr: (%l * 1000) + (%M / 1000)}' } } \
+			} \
+		}, \
+		'upsert': true \
+	})"
 }


### PR DESCRIPTION
ObjectId() and Date() commands are not accepted by the low-level mongo JSON engine.
For the field 'date' it's needed to use $date command.
For replacing ObjectId() it is possible to use sha256 or any others hashing command.