### PR TITLE
docker: Add steps to install the dependencies to documentation build

### DIFF
--- a/scripts/docker/build-centos6/Dockerfile.deps
+++ b/scripts/docker/build-centos6/Dockerfile.deps
@@ -22,6 +22,23 @@ RUN rm /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
 RUN rm /etc/yum.repos.d/CentOS-SCLo-scl.repo
 
 #
+#  documentation build
+#
+
+#  - doxygen & JSON.pm
+RUN yum install -y doxygen graphviz perl-JSON
+#  - antora (npm needed)
+RUN curl -sL https://rpm.nodesource.com/setup_8.x | bash -
+RUN yum install -y nodejs
+RUN npm i -g @antora/cli@2.1 @antora/site-generator-default@2.1
+#  - pandoc
+RUN curl -o - -L $(curl -s https://api.github.com/repos/jgm/pandoc/releases/latest | grep "browser_download_url.*tar.gz" | cut -d '"' -f 4) | tar xzvf - -C /tmp/
+RUN mv /tmp/pandoc-*/bin/* /usr/local/bin
+#  - asciidoctor
+RUN yum install -y rubygems-devel
+RUN gem install asciidoctor
+
+#
 #  Setup a src dir in /usr/local
 #
 RUN mkdir -p /usr/local/src/repositories

--- a/scripts/docker/build-centos7/Dockerfile.deps
+++ b/scripts/docker/build-centos7/Dockerfile.deps
@@ -21,6 +21,22 @@ ENV CC=/opt/rh/devtoolset-8/root/usr/bin/gcc
 RUN rm /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo
 RUN rm /etc/yum.repos.d/CentOS-SCLo-scl.repo
 
+#
+#  documentation build
+#
+
+#  - doxygen & JSON.pm
+RUN yum install -y doxygen graphviz perl-JSON
+#  - antora (npm needed)
+RUN curl -sL https://rpm.nodesource.com/setup_8.x | bash -
+RUN yum install -y nodejs
+RUN npm i -g @antora/cli@2.1 @antora/site-generator-default@2.1
+#  - pandoc
+RUN curl -o - -L $(curl -s https://api.github.com/repos/jgm/pandoc/releases/latest | grep "browser_download_url.*tar.gz" | cut -d '"' -f 4) | tar xzvf - -C /tmp/
+RUN mv /tmp/pandoc-*/bin/* /usr/local/bin
+#  - asciidoctor
+RUN yum install -y rubygems-devel
+RUN gem install asciidoctor
 
 #
 #  Setup a src dir in /usr/local

--- a/scripts/docker/build-debian10/Dockerfile.deps
+++ b/scripts/docker/build-debian10/Dockerfile.deps
@@ -28,7 +28,25 @@ RUN apt-get update && \
 #  cmake to build libkqueue
     apt-get install -y cmake
 
+#
+#  documentation build
+#
 
+#  - doxygen & JSON.pm
+RUN apt-get install -y doxygen graphviz libjson-perl
+#  - antora (npm needed)
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install -y npm
+RUN npm i -g @antora/cli@2.1 @antora/site-generator-default@2.1
+#  - pandoc
+WORKDIR /tmp
+RUN curl -OL $(curl -s https://api.github.com/repos/jgm/pandoc/releases/latest | grep "browser_download_url.*deb" | cut -d '"' -f 4)
+RUN apt-get install -y ./pandoc-*.deb
+#  - asciidoctor
+RUN apt-get install -y ruby-dev
+RUN gem install asciidoctor
+
+# set default things
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${gccver} 50 \
                         --slave /usr/bin/g++ g++ /usr/bin/g++-${gccver} && \
     update-alternatives --config gcc

--- a/scripts/docker/build-debian8/Dockerfile.deps
+++ b/scripts/docker/build-debian8/Dockerfile.deps
@@ -28,6 +28,26 @@ RUN apt-get update && \
 #  eapol_test dependencies
     apt-get install -y libnl-3-dev libnl-genl-3-dev
 
+#
+#  documentation build
+#
+
+#  - doxygen & JSON.pm
+RUN apt-get install -y doxygen graphviz libjson-perl
+#  - antora (npm needed)
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install -y nodejs
+RUN npm i -g @antora/cli@2.1 @antora/site-generator-default@2.1
+#  - pandoc
+WORKDIR /tmp
+RUN curl -OL $(curl -s https://api.github.com/repos/jgm/pandoc/releases/latest | grep "browser_download_url.*deb" | cut -d '"' -f 4)
+RUN dpkg -i ./pandoc-*.deb
+RUN apt-get install -fy
+#  - asciidoctor
+RUN apt-get install -y ruby
+RUN gem install asciidoctor
+
+# set default things
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${gccver} 50 \
                         --slave /usr/bin/g++ g++ /usr/bin/g++-${gccver} && \
     update-alternatives --config gcc

--- a/scripts/docker/build-debian9/Dockerfile.deps
+++ b/scripts/docker/build-debian9/Dockerfile.deps
@@ -28,6 +28,25 @@ RUN apt-get update && \
 #  eapol_test dependencies
     apt-get install -y libnl-3-dev libnl-genl-3-dev
 
+#
+#  documentation build
+#
+
+#  - doxygen & JSON.pm
+RUN apt-get install -y doxygen graphviz libjson-perl
+#  - antora (npm needed)
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install -y npm
+RUN npm i -g @antora/cli@2.1 @antora/site-generator-default@2.1
+#  - pandoc
+WORKDIR /tmp
+RUN curl -OL $(curl -s https://api.github.com/repos/jgm/pandoc/releases/latest | grep "browser_download_url.*deb" | cut -d '"' -f 4)
+RUN apt-get install -y ./pandoc-*.deb
+#  - asciidoctor
+RUN apt-get install -y ruby-dev
+RUN gem install asciidoctor
+
+# set default things
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${gccver} 50 \
                         --slave /usr/bin/g++ g++ /usr/bin/g++-${gccver} && \
     update-alternatives --config gcc

--- a/scripts/docker/build-debiansid/Dockerfile.deps
+++ b/scripts/docker/build-debiansid/Dockerfile.deps
@@ -28,6 +28,25 @@ RUN apt-get update && \
 #  eapol_test dependencies
     apt-get install -y libnl-3-dev libnl-genl-3-dev
 
+#
+#  documentation build
+#
+
+#  - doxygen & JSON.pm
+RUN apt-get install -y doxygen graphviz libjson-perl
+#  - antora (npm needed)
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install -y npm
+RUN npm i -g @antora/cli@2.1 @antora/site-generator-default@2.1
+#  - pandoc
+WORKDIR /tmp
+RUN curl -OL $(curl -s https://api.github.com/repos/jgm/pandoc/releases/latest | grep "browser_download_url.*deb" | cut -d '"' -f 4)
+RUN apt-get install -y ./pandoc-*.deb
+#  - asciidoctor
+RUN apt-get install -y ruby-dev
+RUN gem install asciidoctor
+
+# set default things
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${gccver} 50 \
                         --slave /usr/bin/g++ g++ /usr/bin/g++-${gccver} && \
     update-alternatives --config gcc

--- a/scripts/docker/build-ubuntu14/Dockerfile.deps
+++ b/scripts/docker/build-ubuntu14/Dockerfile.deps
@@ -30,6 +30,26 @@ RUN apt-get update && \
 #  eapol_test dependencies
     apt-get install -y libnl-3-dev libnl-genl-3-dev
 
+#
+#  documentation build
+#
+
+#  - doxygen & JSON.pm
+RUN apt-get install -y doxygen graphviz libjson-perl
+#  - antora (npm needed)
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install -y nodejs
+RUN npm i -g @antora/cli@2.1 @antora/site-generator-default@2.1
+#  - pandoc
+WORKDIR /tmp
+RUN curl -OL $(curl -s https://api.github.com/repos/jgm/pandoc/releases/latest | grep "browser_download_url.*deb" | cut -d '"' -f 4)
+RUN dpkg -i ./pandoc-*.deb
+RUN apt-get install -fy
+#  - asciidoctor
+RUN apt-get install -y ruby-dev
+RUN gem install asciidoctor
+
+# set default things
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${gccver} 50 \
                         --slave /usr/bin/g++ g++ /usr/bin/g++-${gccver} && \
     update-alternatives --config gcc

--- a/scripts/docker/build-ubuntu16/Dockerfile.deps
+++ b/scripts/docker/build-ubuntu16/Dockerfile.deps
@@ -30,6 +30,25 @@ RUN apt-get update && \
 #  eapol_test dependencies
     apt-get install -y libnl-3-dev libnl-genl-3-dev
 
+#
+#  documentation build
+#
+
+#  - doxygen & JSON.pm
+RUN apt-get install -y doxygen graphviz libjson-perl
+#  - antora (npm needed)
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install -y nodejs
+RUN npm i -g @antora/cli@2.1 @antora/site-generator-default@2.1
+#  - pandoc
+WORKDIR /tmp
+RUN curl -OL $(curl -s https://api.github.com/repos/jgm/pandoc/releases/latest | grep "browser_download_url.*deb" | cut -d '"' -f 4)
+RUN apt-get install -y ./pandoc-*.deb
+#  - asciidoctor
+RUN apt-get install -y ruby-dev
+RUN gem install asciidoctor
+
+# set default things
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${gccver} 50 \
                         --slave /usr/bin/g++ g++ /usr/bin/g++-${gccver} && \
     update-alternatives --config gcc

--- a/scripts/docker/build-ubuntu18/Dockerfile.deps
+++ b/scripts/docker/build-ubuntu18/Dockerfile.deps
@@ -22,6 +22,23 @@ RUN apt-get update && \
 #  eapol_test dependencies
     apt-get install -y libnl-3-dev libnl-genl-3-dev
 
+#
+#  documentation build
+#
+
+#  - doxygen & JSON.pm
+RUN apt-get install -y doxygen graphviz libjson-perl
+#  - antora (npm needed)
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install -y nodejs
+RUN npm i -g @antora/cli@2.1 @antora/site-generator-default@2.1
+#  - pandoc
+WORKDIR /tmp
+RUN curl -OL $(curl -s https://api.github.com/repos/jgm/pandoc/releases/latest | grep "browser_download_url.*deb" | cut -d '"' -f 4)
+RUN apt-get install -y ./pandoc-*.deb
+#  - asciidoctor
+RUN apt-get install -y ruby-dev
+RUN gem install asciidoctor
 
 #
 #  Setup a src dir in /usr/local


### PR DESCRIPTION
It's necessary to install the latest package versions due to the distributions provide only old versions.