### PR TITLE
include command to generate an initial (empty) CRL

### DIFF
--- a/raddb/certs/Makefile
+++ b/raddb/certs/Makefile
@@ -78,7 +78,7 @@ ca.der: ca.pem
 
 ca.crl: ca.pem
 	$(OPENSSL) ca -gencrl -keyfile ca.key -cert ca.pem -config ./ca.cnf -out ca-crl.pem -key $(PASSWORD_CA)
-	$(OPENSSL) crl -in ca-crl.prm -outform der -out ca.crl
+	$(OPENSSL) crl -in ca-crl.pem -outform der -out ca.crl
 	rm ca-crl.pem
 
 ######################################################################

--- a/raddb/certs/Makefile
+++ b/raddb/certs/Makefile
@@ -34,7 +34,7 @@ all: index.txt serial dh server ca client
 client: client.pem
 
 .PHONY: ca
-ca: ca.der
+ca: ca.der ca.crl
 
 .PHONY: server
 server: server.pem server.vrfy
@@ -75,6 +75,11 @@ ca.key ca.pem: ca.cnf
 
 ca.der: ca.pem
 	$(OPENSSL) x509 -inform PEM -outform DER -in ca.pem -out ca.der
+
+ca.crl: ca.pem
+	$(OPENSSL) ca -gencrl -keyfile ca.key -cert ca.pem -config ./ca.cnf -out ca-crl.pem -key $(PASSWORD_CA)
+	$(OPENSSL) crl -in ca-crl.prm -outform der -out ca.crl
+	rm ca-crl.pem
 
 ######################################################################
 #
@@ -175,5 +180,5 @@ clean:
 #	Make a target that people won't run too often.
 #
 destroycerts:
-	rm -f *~ dh *.csr *.crt *.p12 *.der *.pem *.key index.txt* \
+	rm -f *~ dh *.csr *.crt *.p12 *.der *.pem *.key ca-crl.pem ca.crl index.txt* \
 			serial*  *\.0 *\.1


### PR DESCRIPTION
in case a supplicant wants to verify the CRL pointed to with crlDistributionPoint, it needs to exist and be at that URL. As for publishing it at the URL, we can't help the admin, but the creation is a simple openssl command.