### PR TITLE
use correct CA password when not the default "whatever"

### DIFF
--- a/raddb/certs/Makefile
+++ b/raddb/certs/Makefile
@@ -87,7 +87,8 @@ dh:
 rsa/ca.key rsa/ca.pem: ca.cnf | $(OUTPUT_DIRS)
 	@[ -f index.txt ] || $(MAKE) index.txt
 	@[ -f serial ] || $(MAKE) serial
-	openssl req -new -x509 -keyout rsa/ca.key -out rsa/ca.pem -config ./ca.cnf -days $(CA_DEFAULT_DAYS)
+	openssl req -new -x509 -keyout rsa/ca.key -out rsa/ca.pem -config ./ca.cnf -days $(CA_DEFAULT_DAYS) \
+	-passin pass:$(PASSWORD_CA) -passout pass:$(PASSWORD_CA)
 
 rsa/ca.der: rsa/ca.pem
 	openssl x509 -inform PEM -outform DER -in rsa/ca.pem -out rsa/ca.der


### PR DESCRIPTION
without passin and passout, the CA passphrase is taken from ca.cnf where it is "whatever". In passwords.mk it defaults to "whatever" as well so that is usually okay.
However when changing the password in passwords.mk, the CA is still generated with "whatever" but subsequent cert generation commands try to use the custom password -> failure.