### PR TITLE
create an initial, empty CRL in DER encoding

### DIFF
--- a/raddb/certs/Makefile
+++ b/raddb/certs/Makefile
@@ -34,7 +34,7 @@ all: index.txt serial dh server ca client
 client: client.pem
 
 .PHONY: ca
-ca: ca.der
+ca: ca.der ca.crl
 
 .PHONY: server
 server: server.pem server.vrfy
@@ -75,6 +75,11 @@ ca.key ca.pem: ca.cnf
 
 ca.der: ca.pem
 	$(OPENSSL) x509 -inform PEM -outform DER -in ca.pem -out ca.der
+
+ca.crl: ca.pem
+	$(OPENSSL) ca -gencrl -keyfile ca.key -cert ca.pem -config ./ca.cnf -out ca-crl.pem -key $(PASSWORD_CA)
+	$(OPENSSL) crl -in ca-crl.pem -outform der -out ca.crl
+	rm ca-crl.pem
 
 ######################################################################
 #
@@ -176,4 +181,4 @@ clean:
 #
 destroycerts:
 	rm -f *~ dh *.csr *.crt *.p12 *.der *.pem *.key index.txt* \
-			serial*  *\.0 *\.1
+			serial*  *\.0 *\.1 ca-crl.pem ca.crl


### PR DESCRIPTION
If a user wants to deploy his CA, the URL in crlDistributionPoints should actually contain a DER-encoded CRL file. We create it here; the admin still needs to actually deploy the file at the URL chosen.