### PR TITLE
rlm_python: Strip '-W*' from 'python-config --cflags'

### DIFF
--- a/src/modules/rlm_python/configure
+++ b/src/modules/rlm_python/configure
@@ -1255,7 +1255,7 @@ if test -n "$ac_init_help"; then
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
-  --with-rlm-python-config-bin=PATH   Path to python binary
+  --with-rlm-python-bin=PATH   Path to python binary
 
 Some influential environment variables:
   CC          C compiler command
@@ -2778,15 +2778,14 @@ test -n "$PYTHON_CONFIG_BIN" || PYTHON_CONFIG_BIN="not-found"
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: ${PYTHON_CONFIG_BIN}'s cflags were \"${python_cflags}\"" >&5
 $as_echo "$as_me: ${PYTHON_CONFIG_BIN}'s cflags were \"${python_cflags}\"" >&6;}
 
-									mod_cflags=`echo $python_cflags | sed -e '\
+								mod_cflags=`echo $python_cflags | sed -e '\
 		s/-I/-isystem/g;\
 		s/-isysroot[ =]\{0,1\}[^-]*//g;\
 		s/-O[[:digit:]][[:blank:]]*//g;\
 		s/-Wp,-D_FORTIFY_SOURCE=[[:digit:]]//g;\
 		s/-g[[:digit:]][[:space:]]*//g;\
 		s/-g[[:space:]]*//g;\
-		s/-Werror\([ =]\{0,1\}[^ ]*\)\{0,1\}//g;\
-		s/-Wall[[:space:]]//g;\
+		s/-W[^ ]*//g;\
 		s/-DNDEBUG[[:blank:]]*//g
 		'`
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: Sanitized cflags were \"${mod_cflags}\"" >&5
@@ -2824,6 +2823,10 @@ fi
 
 
 
+
+
+unset ac_cv_env_LIBS_set
+unset ac_cv_env_LIBS_value
 
 ac_config_files="$ac_config_files all.mk"
 
@@ -3981,4 +3984,5 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
+
 

--- a/src/modules/rlm_python/configure.ac
+++ b/src/modules/rlm_python/configure.ac
@@ -11,7 +11,7 @@ if test x$with_[]modname != xno; then
 	dnl extra argument: --with-rlm-python-config-bin
 	PYHTON_BIN=
 	AC_ARG_WITH(rlm-python-config-bin,
-	[  --with-rlm-python-config-bin=PATH   Path to python-config binary []],
+	[  --with-rlm-python-bin=PATH   Path to python binary []],
 	[ case "$withval" in
 	    no)
 		AC_MSG_ERROR(Need rlm-python-config-bin)
@@ -40,9 +40,8 @@ if test x$with_[]modname != xno; then
 	dnl # Strip optimisation flags (-O[0-9]?). We decide our optimisation level, not python.
 	dnl # -D_FORTIFY_SOURCE needs -O.
 	dnl # Strip debug symbol flags (-g[0-9]?). We decide on debugging symbols, not python
-	dnl # Strip -Werror
-	dnl # Strip -Wall, we decide what warnings are important
 	dnl # Strip -DNDEBUG
+	dnl # Strip -W*, we decide what warnings are important
 	mod_cflags=`echo $python_cflags | sed -e '\
 		s/-I/-isystem/g;\
 		s/-isysroot[[ =]]\{0,1\}[[^-]]*//g;\
@@ -50,8 +49,7 @@ if test x$with_[]modname != xno; then
 		s/-Wp,-D_FORTIFY_SOURCE=[[[:digit:]]]//g;\
 		s/-g[[[:digit:]]][[[:space:]]]*//g;\
 		s/-g[[[:space:]]]*//g;\
-		s/-Werror\([[ =]]\{0,1\}[[^ ]]*\)\{0,1\}//g;\
-		s/-Wall[[[:space:]]]//g;\
+		s/-W[[^ ]]*//g;\
 		s/-DNDEBUG[[[:blank:]]]*//g
 		'`
 	AC_MSG_NOTICE([Sanitized cflags were \"${mod_cflags}\"])


### PR DESCRIPTION
We explicit disable that as can be seen in $srcdir/configure.ac