### PR TITLE
rlm_python: Add hack to bypass bug with 'pythoh2.7-config' in the OSX

### DIFF
--- a/src/modules/rlm_python/configure
+++ b/src/modules/rlm_python/configure
@@ -2774,6 +2774,9 @@ test -n "$PYTHON_CONFIG_BIN" || PYTHON_CONFIG_BIN="not-found"
 		fail="python-config"
 	fi
 
+				old_CFLAGS="$CFLAGS"
+	unset CFLAGS
+
 	python_cflags=`${PYTHON_CONFIG_BIN} --cflags`
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: ${PYTHON_CONFIG_BIN}'s cflags were \"${python_cflags}\"" >&5
 $as_echo "$as_me: ${PYTHON_CONFIG_BIN}'s cflags were \"${python_cflags}\"" >&6;}
@@ -2821,6 +2824,8 @@ $as_echo "$as_me: WARNING: FAILURE: rlm_python requires: $fail." >&2;};
 		targetname=""
 	fi
 fi
+
+export CFLAGS="$old_CFLAGS"
 
 
 

--- a/src/modules/rlm_python/configure.ac
+++ b/src/modules/rlm_python/configure.ac
@@ -32,6 +32,12 @@ if test x$with_[]modname != xno; then
 		fail="python-config"
 	fi
 
+	dnl #
+	dnl # It is necessary due to a weird behavior with 'python-config'
+	dnl #
+	old_CFLAGS="$CFLAGS"
+	unset CFLAGS
+
 	python_cflags=`${PYTHON_CONFIG_BIN} --cflags`
 	AC_MSG_NOTICE([${PYTHON_CONFIG_BIN}'s cflags were \"${python_cflags}\"])
 
@@ -85,6 +91,8 @@ if test x"$fail" != x""; then
 		targetname=""
 	fi
 fi
+
+export CFLAGS="$old_CFLAGS"
 
 AC_SUBST(mod_ldflags)
 AC_SUBST(mod_cflags)


### PR DESCRIPTION
As discussed with Arran. the 'python2.7-config' has a weird bug on the
OSX that if you have CFLAGS="..." declared with whatever content you get
the below behavior.

$ python2.7-config --cflags | grep -o "\-arch [^ ]*"
$ CFLAGS='whatever' python2.7-config --cflags | grep -o "\-arch [^ ]*"
-arch x86_64
-arch i386
$

It results to break the build.