### PR TITLE
various jenkinsfile fixes

### DIFF
--- a/scripts/jenkins/Jenkinsfile
+++ b/scripts/jenkins/Jenkinsfile
@@ -46,20 +46,20 @@ def buildClosures(arg) {
                 stage("build-${platform}") {
                     rebuild = detectChanges()
                     docker.build("${platform}-master-test","${rebuild} -f ./scripts/docker/build-${platform}/Dockerfile.deps ./scripts/docker/build-${platform}").inside {
-                        checkout([$class: 'GitSCM', branches: [[name: '*/master']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'CleanBeforeCheckout'],[$class: 'RelativeTargetDirectory', relativeTargetDir: "${platform}/build"]], submoduleCfg: [], userRemoteConfigs: [[url: 'https://github.com/freeradius/freeradius-server']]])
+                        checkout([$class: 'GitSCM', branches: scm.branches, userRemoteConfigs: scm.userRemoteConfigs, extensions: [[$class: 'CleanBeforeCheckout'],[$class: 'RelativeTargetDirectory', relativeTargetDir: "${platform}/build"],[$class: 'CloneOption', depth: 0, noTags: false, reference: '', shallow: false]], submoduleCfg: []])
                         sh "cat /etc/os-release || cat /etc/redhat-release"
+                        def commit_num = readFile("./build-number").trim()
                         dir("${platform}/build") {
                             if (platform.contains("centos")) {
-                                sh 'export COMMIT_NUM=$(git describe --tags --long --match "release_*" --match "branch_*" | sed -e \'s/^.*-\\([0-9]*\\)-g[0-9a-f]*/\\1/\')  ; sed -i -e "s/^Release: .*$/Release: $COMMIT_NUM/" redhat/freeradius.spec'
-                                sh 'QA_RPATHS=0x0003 RADIUSD_VERSION_STRING=$(cat VERSION) make rpm'
+                                sh "sed -i -e \"s/^Release:.*\$/Release: ${commit_num}/\" redhat/freeradius.spec"
                                 sh 'RADIUSD_VERSION_STRING=$(cat VERSION) make rpm'
                                 sh "mv rpmbuild/RPMS/x86_64/*.rpm .."
                             } else {
                                 sh "apt-get install -y unixodbc-dev"
-                                sh label: '', script: '''version=$(dpkg-parsechangelog | grep "^Version: " | awk \'{print $2}\')
-                                commit_num=$(git describe --tags --long --match "release_*"  --match "branch_*" | sed -e \'s/^.*-\\([0-9]*\\)-g[0-9a-f]*/\\1/\')
-                                commit_msg="$(git log --oneline -1 $GIT_COMMIT)"
-                                dch -b -v ${version}-${commit_num} "$commit_msg"'''
+                                def version = sh (script: "dpkg-parsechangelog | grep '^Version: ' | awk '{print \$2}'", returnStdout: true).trim()
+                                def commit_msg = sh (script: "git log --oneline -1 \$GIT_COMMIT", returnStdout: true).trim()
+
+                                sh "dch -b -v ${version}-${commit_num} \"${commit_msg}\""
                                 sh "make deb"
                             }
                         }
@@ -73,7 +73,7 @@ def buildClosures(arg) {
 
 node {
     checkout scm
-    sh "echo $BUILD_NUMBER > build-number"
+    sh (script: "git describe --tags --long --match 'release_*' --match 'branch_*' | sed -e \'s/^.*-\\([0-9]*\\)-g[0-9a-f]*/\\1/\' > build-number")
     parallel buildClosures(platforms)
     archiveArtifacts artifacts: 'build-number , **/*.deb , **/*.changes , **/*.rpm', onlyIfSuccessful: true
     cleanWs()


### PR DESCRIPTION
Mainly so that the updaterepo jenkins job will pick up the correct build number when creating the various package repositories.

Also this ensures that all checkout jobs inherit from the jenkins configuration