### PR TITLE
Fix the 'make reconfig' checks by src/modules/all.mk

### DIFF
--- a/src/modules/all.mk
+++ b/src/modules/all.mk
@@ -23,5 +23,7 @@ endif
 
 ifneq "$(MAKECMDGOALS)" "reconfig"
 src/modules/%/configure: src/modules/%/configure.ac
-	@echo WARNING - may need "'make reconfig'" for AUTOCONF $(dir $@)
+	${Q}if [ $< -nt $@ ]; then \
+		echo "WARNING - may need 'make reconfig' for AUTOCONF $(dir $@)"; \
+	fi
 endif


### PR DESCRIPTION
Show the warning messages only when `src/modules/*/configure.ac` is newer than `src/modules/*/configure`