### PR TITLE
New bandwidth rate-limits airspace attributes

### DIFF
--- a/share/dictionary.airespace
+++ b/share/dictionary.airespace
@@ -9,12 +9,21 @@
 VENDOR		Airespace			14179
 
 BEGIN-VENDOR	Airespace
-ATTRIBUTE	Airespace-Wlan-Id			1	integer
-ATTRIBUTE	Airespace-QOS-Level			2	integer
-ATTRIBUTE	Airespace-DSCP				3	integer
-ATTRIBUTE	Airespace-8021p-Tag			4	integer
-ATTRIBUTE	Airespace-Interface-Name		5	string
-ATTRIBUTE	Airespace-ACL-Name			6	string
+ATTRIBUTE	Airespace-Wlan-Id					1	integer
+ATTRIBUTE	Airespace-QOS-Level					2	integer
+ATTRIBUTE	Airespace-DSCP						3	integer
+ATTRIBUTE	Airespace-8021p-Tag					4	integer
+ATTRIBUTE	Airespace-Interface-Name				5	string
+ATTRIBUTE	Airespace-ACL-Name					6	string
+ATTRIBUTE	Airespace-Data-Bandwidth-Average-Contract		7	integer
+ATTRIBUTE	Airespace-Real-Time-Bandwidth-Average-Contract		8	integer
+ATTRIBUTE	Airespace-Data-Bandwidth-Burst-Contract			9	integer
+ATTRIBUTE	Airespace-Real-Time-Bandwidth-Burst-Contract		10	integer
+ATTRIBUTE	Airespace-Guest-Role-Name				11	string
+ATTRIBUTE	Airespace-Data-Bandwidth-Average-Contract-Upstream	13	integer
+ATTRIBUTE	Airespace-Real-Time-Bandwidth-Average-Contract-Upstream	14	integer
+ATTRIBUTE	Airespace-Data-Bandwidth-Burst-Contract-Upstream	15	integer
+ATTRIBUTE	Airespace-Real-Time-Bandwidth-Burst-Contract-Upstream	16	integer
 
 VALUE	Airespace-QOS-Level		Bronze			3
 VALUE	Airespace-QOS-Level		Silver			0


### PR DESCRIPTION
Bandwidth rate-limits attributes for airspace
Reference : https://community.cisco.com/t5/policy-and-access/freeradius-with-wlc-8-3-122-per-user-bandwidth-rate-limits/td-p/3839617