### PR TITLE
rlm_linelog : Don't seek if the linelog file is /dev/stdout 

### DIFF
--- a/src/modules/rlm_linelog/rlm_linelog.c
+++ b/src/modules/rlm_linelog/rlm_linelog.c
@@ -144,7 +144,7 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 		return -1;
 	}
 
-	inst->ef = exfile_init(inst, 256, 30, true);
+	inst->ef = exfile_init(inst, 256, 30, !(strcmp(inst->filename, "/dev/stdout") == 0) );
 	if (!inst->ef) {
 		cf_log_err_cs(conf, "Failed creating log file context");
 		return -1;


### PR DESCRIPTION
This pull request disables seek to the end of the file if the file is /dev/stdout. 

Helps to linelog to /dev/stdout which is a symlink to /proc/self/fd/1 