### PR TITLE
Added Fabric-Attach VSA's to the Nortel Dictionary.

### DIFF
--- a/share/dictionary/radius/dictionary.nortel
+++ b/share/dictionary/radius/dictionary.nortel
@@ -19,6 +19,18 @@ ATTRIBUTE	Nortel-User-Role			110	string
 
 ATTRIBUTE	Nortel-Privilege-Level			166	integer
 
+ATTRIBUTE       Fabric-Attach-VLAN-Create               170     integer
+ATTRIBUTE       Fabric-Attach-VLAN-ISID                 171     string
+ATTRIBUTE       Fabric-Attach-VLAN-PVID                 172     integer
+
+ATTRIBUTE       Fabric-Attach-Switch-Mode               180     integer
+ATTRIBUTE       Fabric-Attach-Client-Id                 181     string
+ATTRIBUTE       Fabric-Attach-Client-Type               182     string
+ATTRIBUTE       Fabric-Attach-Client-PSK                183     integer
+ATTRIBUTE       Fabric-Attach-Client-Trust              184     integer
+ATTRIBUTE       Fabric-Attach-Client-Trusted-Binding    185     string
+ATTRIBUTE       Fabric-Attach-Service-Request           186     string
+
 ATTRIBUTE	Passport-Command-Scope			200	integer
 ATTRIBUTE	Passport-Command-Impact			201	integer
 ATTRIBUTE	Passport-Customer-Identifier		202	integer
@@ -27,6 +39,9 @@ ATTRIBUTE	Passport-AllowedOut-Access		204	integer
 ATTRIBUTE	Passport-Login-Directory		205	string
 ATTRIBUTE	Passport-Timeout-Protocol		206	integer
 ATTRIBUTE	Passport-Role				207	string
+
+VALUE   Fabric-Attach-VLAN-Create       No                      0
+VALUE   Fabric-Attach-VLAN-Create       Yes                     1
 
 VALUE	Nortel-Privilege-Level		VoiceMailAdmin		0
 VALUE	Nortel-Privilege-Level		ContactCenter		1


### PR DESCRIPTION
After consulting with Extreme support I have created a list of all VSA's that are related to Fabric-Attach VLAN's and ISID's. Please include them in the Nortel dictionary. 