### PR TITLE
Split out the dhcpv6.txt by dhcpv6_rfcXXX.txt

### DIFF
--- a/src/tests/unit/all.mk
+++ b/src/tests/unit/all.mk
@@ -33,7 +33,16 @@ FILES  := \
 	dhcpv6_rfc3315.txt \
 	dhcpv6_rfc3319.txt \
 	dhcpv6_rfc3646.txt \
+	dhcpv6_rfc4242.txt \
+	dhcpv6_rfc4280.txt \
+	dhcpv6_rfc4580.txt \
+	dhcpv6_rfc5678.txt \
+	dhcpv6_rfc5908.txt \
+	dhcpv6_rfc5970.txt \
 	dhcpv6_rfc6355.txt \
+	dhcpv6_rfc6610.txt \
+	dhcpv6_rfc7839.txt \
+	dhcpv6_rfc8156.txt \
 	regex.txt \
 	escape.txt \
 	condition.txt \

--- a/src/tests/unit/dhcpv6_rfc3315.txt
+++ b/src/tests/unit/dhcpv6_rfc3315.txt
@@ -129,5 +129,45 @@ match 00 02 00 0a 00 03 00 02 d3 4d 00 c0 ff ee
 decode-pair -
 match Server-ID-DUID = Server-ID-DUID-LL, Server-ID-DUID-LL-Hardware-Type = 2, Server-ID-DUID-LL-Address = 0xd34d00c0ffee
 
+#
+#  1 byte unsigned integer (uint8)
+#
+encode-pair Preference = 255
+match 00 07 00 01 ff
+
+encode-pair Preference = 0
+match 00 07 00 01 00
+
+#
+#  empty value. (only signal)
+#
+encode-pair Rapid-Commit = 0x
+match 00 0e 00 00
+
+decode-pair -
+match Rapid-Commit = 0x
+
+#
+#  Encode ipv6address
+#
+encode-pair Unicast = 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+match 00 0c 00 10 20 01 0d b8 85 a3 00 00 00 00 8a 2e 03 70 73 34
+
+# Scope should be ignored.  We use %0 as numbered scopes work everywhere, interfaces don't
+encode-pair Unicast = 2001:0db8:85a3:0000:0000:8a2e:0370:7334%0
+match 00 0c 00 10 20 01 0d b8 85 a3 00 00 00 00 8a 2e 03 70 73 34
+
+#
+#  Variable length octets array
+#
+encode-pair User-Class = 0x010203, User-Class = 0x02040810
+match 00 0f 00 0b 00 03 01 02 03 00 04 02 04 08 10
+
+encode-pair User-Class = 0x010203
+match 00 0f 00 05 00 03 01 02 03
+
+encode-pair User-Class = 0x, User-Class = 0x
+match 00 0f 00 04 00 00 00 00
+
 count
-match 26
+match 44

--- a/src/tests/unit/dhcpv6_rfc4242.txt
+++ b/src/tests/unit/dhcpv6_rfc4242.txt
@@ -1,0 +1,17 @@
+#
+#  Test vectors for DHCPv6
+#
+load dhcpv6
+dictionary-load dhcpv6
+
+#
+#  4 byte unsigned integer (uint32)
+#
+encode-pair Information-Refresh-Time = 99
+match 00 20 00 04 00 00 00 63
+
+decode-pair -
+match Information-Refresh-Time = 99
+
+count
+match 6

--- a/src/tests/unit/dhcpv6_rfc4280.txt
+++ b/src/tests/unit/dhcpv6_rfc4280.txt
@@ -1,0 +1,29 @@
+#
+#  Test vectors for DHCPv6
+#
+load dhcpv6
+dictionary-load dhcpv6
+
+#
+#  This attribute is NOT compressed!
+#
+encode-pair BCMCS-Server-Domain-Name-List = "www.example.com"
+match 00 21 00 11 03 77 77 77 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00
+
+decode-pair -
+match BCMCS-Server-Domain-Name-List = "www.example.com"
+
+encode-pair BCMCS-Server-Domain-Name-List = "www.example.com", BCMCS-Server-Domain-Name-List = "ftp.example.com"
+match 00 21 00 22 03 77 77 77 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 03 66 74 70 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00
+
+decode-pair -
+match BCMCS-Server-Domain-Name-List = "www.example.com", BCMCS-Server-Domain-Name-List = "ftp.example.com"
+
+encode-pair BCMCS-Server-Domain-Name-List = "www.example.com", BCMCS-Server-Domain-Name-List = "ftp.example.com", BCMCS-Server-Domain-Name-List = "ns.example.com"
+match 00 21 00 32 03 77 77 77 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 03 66 74 70 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 02 6e 73 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00
+
+decode-pair -
+match BCMCS-Server-Domain-Name-List = "www.example.com", BCMCS-Server-Domain-Name-List = "ftp.example.com", BCMCS-Server-Domain-Name-List = "ns.example.com"
+
+count
+match 14

--- a/src/tests/unit/dhcpv6_rfc4580.txt
+++ b/src/tests/unit/dhcpv6_rfc4580.txt
@@ -1,0 +1,30 @@
+#
+#  Test vectors for DHCPv6
+#
+load dhcpv6
+dictionary-load dhcpv6
+
+#
+#  Simple string type
+#
+encode-pair Subscriber-ID = "fred"
+match 00 26 00 04 66 72 65 64
+
+decode-pair -
+match Subscriber-ID = "fred"
+
+encode-pair Subscriber-ID = "bob", New-Posix-Timezone = "GB"
+match 00 26 00 03 62 6f 62 00 29 00 02 47 42
+
+decode-pair -
+no match Subscriber-ID = "bob", New-Posix-Timezone = "GB"
+
+# Zero length string
+encode-pair Subscriber-ID = ""
+match 00 26 00 00
+
+decode-pair -
+match Subscriber-ID = ""
+
+count
+match 14

--- a/src/tests/unit/dhcpv6_rfc5678.txt
+++ b/src/tests/unit/dhcpv6_rfc5678.txt
@@ -1,0 +1,29 @@
+#
+#  Test vectors for DHCPv6
+#
+load dhcpv6
+dictionary-load dhcpv6
+
+#
+#  TLV with array type values
+#
+encode-pair MOS-Address-IS = 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+match 00 36 00 14 00 01 00 10 20 01 0d b8 85 a3 00 00 00 00 8a 2e 03 70 73 34
+
+decode-pair -
+no match MOS-Address-IS = 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+
+encode-pair MOS-Address-IS = 2001:0db8:85a3:0000:0000:8a2e:0370:7334, MOS-Address-IS = 2001:0db8:85a3:0000:0000:8a2e:0370:7335
+match 00 36 00 24 00 01 00 20 20 01 0d b8 85 a3 00 00 00 00 8a 2e 03 70 73 34 20 01 0d b8 85 a3 00 00 00 00 8a 2e 03 70 73 35
+
+decode-pair -
+no match MOS-Address-IS = 2001:0db8:85a3:0000:0000:8a2e:0370:7334, MOS-Address-IS = 2001:0db8:85a3:0000:0000:8a2e:0370:7335
+
+encode-pair MOS-Address-IS = 2001:0db8:85a3:0000:0000:8a2e:0370:7334, MOS-Address-ES = 2001:0db8:85a3:0000:0000:8a2e:0370:7335
+match 00 36 00 28 00 01 00 10 20 01 0d b8 85 a3 00 00 00 00 8a 2e 03 70 73 34 00 03 00 10 20 01 0d b8 85 a3 00 00 00 00 8a 2e 03 70 73 35
+
+decode-pair -
+no match MOS-Address-IS = 2001:0db8:85a3:0000:0000:8a2e:0370:7334, MOS-Address-ES = 2001:0db8:85a3:0000:0000:8a2e:0370:7335
+
+count
+match 14

--- a/src/tests/unit/dhcpv6_rfc5908.txt
+++ b/src/tests/unit/dhcpv6_rfc5908.txt
@@ -1,0 +1,17 @@
+#
+#  Test vectors for DHCPv6
+#
+load dhcpv6
+dictionary-load dhcpv6
+
+#
+#  TLV with single values
+#
+encode-pair NTP-Server-Address = 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+match 00 38 00 14 00 01 00 10 20 01 0d b8 85 a3 00 00 00 00 8a 2e 03 70 73 34
+
+decode-pair -
+no match NTP-Server-Address = 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+
+count
+match 6

--- a/src/tests/unit/dhcpv6_rfc5970.txt
+++ b/src/tests/unit/dhcpv6_rfc5970.txt
@@ -1,0 +1,63 @@
+#
+#  Test vectors for DHCPv6
+#
+load dhcpv6
+dictionary-load dhcpv6
+
+#
+#  Array of strings, each substring should have a 16bit length field containing its length
+#
+encode-pair Bootfile-Param = "I LIKE CHICKEN", Bootfile-Param = "I LIKE LIVER"
+match 00 3c 00 1e 00 0e 49 20 4c 49 4b 45 20 43 48 49 43 4b 45 4e 00 0c 49 20 4c 49 4b 45 20 4c 49 56 45 52
+
+decode-pair -
+match Bootfile-Param = "I LIKE CHICKEN", Bootfile-Param = "I LIKE LIVER"
+
+# Still needs to add the length field with only one element
+encode-pair Bootfile-Param = "MEOW MIX MEOW MIX"
+match 00 3c 00 13 00 11 4d 45 4f 57 20 4d 49 58 20 4d 45 4f 57 20 4d 49 58
+
+decode-pair -
+match Bootfile-Param = "MEOW MIX MEOW MIX"
+
+encode-pair Bootfile-Param = ""
+match 00 3c 00 02 00 00
+
+decode-pair -
+no match Bootfile-Param = ""
+
+encode-pair Bootfile-Param = "", Bootfile-Param = "foo"
+match 00 3c 00 07 00 00 00 03 66 6f 6f
+
+decode-pair -
+match Bootfile-Param = "", Bootfile-Param = "foo"
+
+#
+#  Array of 16bit integers
+#
+encode-pair Client-Arch-Type = x86-BIOS, Client-Arch-Type = ARM-64-Uboot
+match 00 3d 00 04 00 00 00 16
+
+decode-pair -
+match Client-Arch-Type = x86-BIOS, Client-Arch-Type = ARM-64-Uboot
+
+#
+#  Two different arrays of 16bit integers
+#
+encode-pair Client-Arch-Type = x86-BIOS, Client-Arch-Type = ARM-64-Uboot, S46-Priority = DS-Lite, S46-Priority = MAP-E
+match 00 3d 00 04 00 00 00 16 00 6f 00 04 00 40 00 5e
+
+decode-pair -
+no match Client-Arch-Type = x86-BIOS, Client-Arch-Type = ARM-64-Uboot, S46-Priority = DS-Lite, S46-Priority = MAP-E
+
+#
+#  Array type with one element
+#
+encode-pair Client-Arch-Type = x86-BIOS
+match 00 3d 00 02 00 00
+
+decode-pair -
+match Client-Arch-Type = x86-BIOS
+
+count
+match 30

--- a/src/tests/unit/dhcpv6_rfc6610.txt
+++ b/src/tests/unit/dhcpv6_rfc6610.txt
@@ -1,0 +1,58 @@
+#
+#  Test vectors for DHCPv6
+#
+load dhcpv6
+dictionary-load dhcpv6
+
+#
+#  Encode ipv6prefix
+#
+encode-pair MIP6-Home-Net-Prefix = 2001:db8::/32
+match 00 47 00 05 20 20 01 0d b8
+
+decode-pair -
+no match MIP6-Home-Net-Prefix = 2001:db8::/32
+
+# Prefix truncates address portion
+encode-pair MIP6-Home-Net-Prefix = 2001:db8:00ff::/32
+match 00 47 00 05 20 20 01 0d b8
+
+decode-pair -
+no match MIP6-Home-Net-Prefix = 2001:db8:00ff::/32
+
+# Prefix longer than address portion
+encode-pair MIP6-Home-Net-Prefix = 2001:db8:00ff::/64
+match 00 47 00 09 40 20 01 0d b8 00 ff 00 00
+
+decode-pair -
+no match MIP6-Home-Net-Prefix = 2001:db8:00ff::/64
+
+encode-pair MIP6-Home-Net-Prefix = 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+match 00 47 00 11 80 20 01 0d b8 85 a3 00 00 00 00 8a 2e 03 70 73 34
+
+decode-pair -
+no match MIP6-Home-Net-Prefix = 2001:0db8:85a3:0000:0000:8a2e:0370:7334/128
+
+# Cast ipv6addr to 128bit prefix
+encode-pair MIP6-Home-Net-Prefix = 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+match 00 47 00 11 80 20 01 0d b8 85 a3 00 00 00 00 8a 2e 03 70 73 34
+
+decode-pair -
+no match MIP6-Home-Net-Prefix = 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+
+# 0 bit prefix
+encode-pair MIP6-Home-Net-Prefix = ::/0
+match 00 47 00 01 00
+
+decode-pair -
+no match MIP6-Home-Net-Prefix = ::/0
+
+# v4 address - Check the correct 4in6 prefix is added
+encode-pair MIP6-Home-Net-Prefix = ::ffff:192.168.0.1
+match 00 47 00 11 80 00 00 00 00 00 00 00 00 00 00 ff ff c0 a8 00 01
+
+decode-pair -
+no match MIP6-Home-Net-Prefix = ::ffff:192.168.0.1
+
+count
+match 30

--- a/src/tests/unit/dhcpv6_rfc7839.txt
+++ b/src/tests/unit/dhcpv6_rfc7839.txt
@@ -1,0 +1,17 @@
+#
+#  Test vectors for DHCPv6
+#
+load dhcpv6
+dictionary-load dhcpv6
+
+#
+#  2 byte unsigned integer (uint16)
+#
+encode-pair ANI-Access-Technology-Type = 3GPP2-NB-IOT
+match 00 69 00 02 00 0d
+
+decode-pair -
+match ANI-Access-Technology-Type = 3GPP2-NB-IOT
+
+count
+match 6

--- a/src/tests/unit/dhcpv6_rfc8156.txt
+++ b/src/tests/unit/dhcpv6_rfc8156.txt
@@ -1,0 +1,37 @@
+#
+#  Test vectors for DHCPv6
+#
+load dhcpv6
+dictionary-load dhcpv6
+
+#
+#  Date. Like a 32bit unix timestamp but starts from 1st Jan 2000 instead of 1st Jan 1970
+#
+encode-pair Failover-Expiration-Time = 0
+match 00 78 00 04 00 00 00 00
+
+decode-pair -
+match Failover-Expiration-Time = "Jan  1 1970 00:00:00 UTC"
+
+# Still less than 946080000 (30 years), so still 0 (we can't represent dates earlier than 1st Jan 2000)
+encode-pair Failover-Expiration-Time = 500
+match 00 78 00 04 00 00 00 00
+
+decode-pair -
+match Failover-Expiration-Time = "Jan  1 1970 00:00:00 UTC"
+
+encode-pair Failover-Expiration-Time = 946080000
+match 00 78 00 04 00 00 00 00
+
+decode-pair -
+match Failover-Expiration-Time = "Jan  1 1970 00:00:00 UTC"
+
+# 1st second of 1st Jan 2000
+encode-pair Failover-Expiration-Time = 946080001
+match 00 78 00 04 00 00 00 01
+
+decode-pair -
+match Failover-Expiration-Time = "Jan  1 1970 00:00:01 UTC"
+
+count
+match 18


### PR DESCRIPTION
1. Each test entry was moved to the respective rfc. e.g: dhcpv6_rfcXXX.txt
2. Added the `decode-pair -` for all tests.
3. The `dhcpv6.txt` still there.