### PR TITLE
DEBUG: treat lengthy Tunnel-Password as fatal

### DIFF
--- a/src/modules/rlm_files/rlm_files.c
+++ b/src/modules/rlm_files/rlm_files.c
@@ -215,6 +215,18 @@ static int getusersfile(TALLOC_CTX *ctx, char const *filename, rbtree_t **ptree,
 			 */
 			for (vp = fr_cursor_init(&cursor, &entry->reply); vp; vp = fr_cursor_next(&cursor)) {
 				/*
+				 * If we're dealing with Tunnel-Password,
+				 * note that we're truncating it to 249 bytes.
+				 */
+				if (strcmp(vp->da->name, "Tunnel-Password") == 0) {
+					if (strlen(vp->data.strvalue) > 249) {
+						ERROR("[%s]:%d Refusing to accept Tunnel-Password with length longer than 249 characters.",
+						      filename, entry->lineno);
+						return -1;
+					}
+				}
+
+				/*
 				 *	If it's NOT a vendor attribute,
 				 *	and it's NOT a wire protocol
 				 *	and we ignore Fall-Through,


### PR DESCRIPTION
When the server is running in debug mode, treat a Tunnel-Password whose
length exceeds 249 characters as being a fatal error. This'll help to
diagnose connection failures caused by the otherwise silent truncation.

This is inside a giant block to reuse existing logic:

```c
if ((rad_debug_lvl) ||
      (compat_mode_str && (strcmp(compat_mode_str, "cistron") == 0))) {

....

}
```

It might be worthwhile (but a potentially breaking change) to always execute these checks. Note that it appears that `radclient` might do truncation of its own, but the server doesn't when computing the response, causing communication issues.

I'm guessing this was a side effect of d1cdce1b07d4630832f4e834d22ddc5d06557c5a (that the truncation was made silent) -- but the original function `make_tunnel_passwd` seems to have moved and I don't have a great place to put this logic any more. 

If this isn't the correct to put this check, do tell me.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`