### PR TITLE
Add coa-relay site

### DIFF
--- a/raddb/mods-available/radius
+++ b/raddb/mods-available/radius
@@ -107,6 +107,17 @@ radius {
 #	no_connection_fail = no
 
 	#
+	#  originate::
+	#
+	#  Sometimes we are creating a request that is not for the purpose of
+	#  proxying another request, in which case we do not want to add a
+	#  Proxy-State attribute.
+	#
+	#  In some cases, such as originating a CoA or Disconnect request,
+	#  including Proxy-State may confuse the receiving NAS.
+#	originate = no
+
+	#
 	#  status_checks { ... }:: For "are you alive?" queries.
 	#
 	#  If the home server does not respond to proxied packets, the

--- a/raddb/sites-available/coa-relay
+++ b/raddb/sites-available/coa-relay
@@ -1,0 +1,283 @@
+# -*- text -*-
+######################################################################
+#
+#  This virtual server simplifies the process of sending CoA-Request or
+#  Disconnect-Request packets to a NAS.
+#
+#  This virtual server will receive CoA-Request or Disconnect-Request
+#  packets that contain *minimal* identifying information.  e.g. Just
+#  a User-Name, or maybe just an Acct-Session-Id attribute.  It will
+#  look up that information in a database in order to find the rest of
+#  the session data.  e.g. NAS-IP-Address, NAS-Identifier, NAS-Port,
+#  etc.  That information will be added to the packet, which will then
+#  be sent to the NAS.
+#
+#  This process is useful because NASes require the CoA packets to
+#  contain "session identification" attributes in order to to do CoA
+#  or Disconnect.  If the attributes aren't in the packet, then the
+#  NAS will NAK the request.  This NAK happens even if you ask to
+#  disconnect "User-Name = bob", and there is only one session with a
+#  "bob" active.
+#
+#  Using this virtual server makes the CoA or Disconnect process
+#  easier.  Just tell FreeRADIUS to disconnect "User-Name = bob", and
+#  FreeRADIUS will take care of adding the "session identification"
+#  attributes.
+#
+#  The process is as follows:
+#
+#    - A CoA/Disconnect-Request is received by FreeRADIUS.
+#    - The radacct table is searched for active sessions that match each of
+#      the provided identifier attributes: User-Name, Acct-Session-Id. The
+#      search returns the owning NAS and Acct-Unique-Id for the matching
+#      session/s.
+#    - We originate CoA/Disconenct-Requests containing the original content,
+#      filtered as required, with session identification added, to the
+#      corresponding NAS for each session.
+#
+#  This simplifies scripting directly against a set of NAS devices since a
+#  script need only send a single CoA/Disconnect to FreeRADIUS which will
+#  then:
+#
+#    - Lookup all active sessions belonging to a user, in the case that only a
+#      User-Name attribute is provided in the request
+#    - Populate all necessary session identifiers
+#    - Handle routing of the request to the correct NAS, in the case of a
+#      multi-NAS setup
+#
+#  For example, to disconnect a specific session:
+#
+#    $ echo 'Acct-Session-Id = "769df3 312343"' | \
+#      radclient -t 15 127.0.0.1 disconnect testing123
+#
+#  To perform a CoA update of all active sessions belonging to a user:
+#
+#    $ cat <<EOF | radclient -t 15 127.0.0.1 coa testing123
+#      User-Name = bob
+#      Cisco-AVPair = "subscriber:sub-qos-policy-out=q_out_uncapped"
+#      EOF
+#
+#  In addition to configuring and activating this site, instances of the radius
+#  client module must be created for each NAS, for example:
+#
+#      radius radius-originate-coa-192.0.2.1 {
+#	      type = CoA-Request
+#	      type = Disconnect-Request
+#	      transport = udp
+#	      udp {
+#		      ipaddr = 192.0.2.1
+#		      port = 1700
+#		      secret = "testing123"
+#	      }
+#
+#	      # We are "originating" these packets since including Proxy-State
+#	      # may confuse the NAS
+#	      originate = yes
+#
+#	      # Uncomment this to fire and forget, rather than wait and retry
+#	      # replicate = yes
+#      }
+#
+#  Refer to `mods-enabled/radius` as a detailed reference for configuring
+#  client access to each NAS.
+
+
+server coa {
+
+	namespace = radius
+
+	#  Listen on a local CoA port.
+	#
+	#  This uses the normal set of clients, with the same secret as for
+	#  authentication and accounting.
+	#
+	listen {
+		type = CoA-Request
+		type = Disconnect-Request
+		transport = udp
+		udp {
+			ipaddr = 127.0.0.1
+			port = 3799
+		}
+	}
+
+	#
+	#  Receive a CoA request
+	#
+	recv CoA-Request {
+		#
+		#  Lookup all active sessions matching User-Name and/or
+		#  Acct-Session-Id and send updates for each session
+		#
+		#  The query returns a single result in the format:
+		#
+		#  NasIpAddress1#AcctSessionId1|NasIPAddress2#AcctSessionId2|...
+		#
+		#  i.e. each session is separated by '|', and attributes
+		#  within a session are separated by '#'
+		#
+		#  You will likely have to update the SELECT to add in
+		#  any other "session identification" attributes
+		#  needed by the NAS.  These may include NAS-Port,
+		#  NAS-Identifier, etc.  Only the NAS vendor knows
+		#  what these attributes are unfortunately, so we
+		#  cannot give more detailed advice here.
+		#
+		update control {
+
+			#
+			#  Example MySQL lookup
+			#
+#			&Tmp-String-0 := "%{sql:SELECT IFNULL(GROUP_CONCAT(CONCAT(nasipaddress,'#',acctsessionid) separator '|'),'') FROM (SELECT * FROM radacct WHERE ('%{User-Name}'='' OR UserName='%{User-Name}') AND ('%{Acct-Session-Id}'='' OR acctsessionid = '%{Acct-Session-Id}') AND AcctStopTime IS NULL) a}"
+
+			#
+			#  Example PostgreSQL lookup
+			#
+#			&Tmp-String-0 := "%{sql:SELECT STRING_AGG(CONCAT(nasipaddress,'#',acctsessionid),'|') FROM (SELECT * FROM radacct WHERE ('%{User-Name}'='' OR UserName='%{User-Name}') AND ('%{Acct-Session-Id}'='' OR acctsessionid = '%{Acct-Session-Id}') AND AcctStopTime IS NULL) a}"
+
+			#
+			#  Keep a count of what we send.
+			#
+			&Tmp-Integer-0 := 0
+
+		}
+
+		#
+		#  Split the string and split into pieces.
+		#
+		if ("%{explode:&control:Tmp-String-0 |}") {
+
+			foreach &control:Tmp-String-0 {
+
+				#
+				#  Send an update for each session we find.
+				#
+				if ("%{Foreach-Variable-0}" =~ /([^#]*)#(.*)/) {
+
+					update control {
+
+						# NAS-IP-Address
+						&Tmp-IP-Address-0 := "%{1}"
+
+						# Acct-Session-Id
+						&Tmp-String-1 := "%{2}"
+
+					}
+
+					subrequest CoA-Request {
+
+						update request {
+
+							#
+							#  The subrequest begins empty, so initially copy all attributes
+							#  from the incoming request.
+							#
+							&request := &parent.request:[*]
+
+							#
+							#  Add/override the session identification attributes looked up
+							#
+							&Acct-Session-Id := &parent.control:Tmp-String-1
+
+							#
+							#  Some NASs want these, others don't
+							#
+							&Event-Timestamp := "%l"
+							&Message-Authenticator := 0x00
+
+						}
+
+						#
+						#  Remove attributes which will confuse the NAS
+						#
+						#  The NAS will "helpfully" NAK the packet
+						#  if it contains attributes which are NOT
+						#  "session identification" attributes.
+						#
+						filter request {
+
+							#
+							#  SQL-User-Name is a side-effect of the xlat
+							#
+							&SQL-User-Name !* ANY
+
+							#
+							#  Those attributes should be listed here
+							#
+							&Acct-Delay-Time !* ANY
+							&Proxy-State !* ANY
+
+							#
+							#  Uncomment if the NAS does not expect User-Name
+							#
+							#&User-Name !* ANY
+
+						}
+
+						#
+						#  Call the radius client module instance for the NAS-IP-Address
+						#
+						switch &parent.control:Tmp-IP-Address-0 {
+							#
+							#  Repeat this for each NAS
+							#
+							case "192.0.2.1" {
+
+								#
+								#  Increment count of sent updates
+								#
+								update parent.control {
+									&Tmp-Integer-0 := %{expr: %{parent.control:Tmp-Integer-0} + 1}
+								}
+
+								radius-originate-coa-192.0.2.1
+
+							}
+
+							#
+							#  Likely a missing "case" if we can't map NAS-IP-Address to a module
+							#
+							case {
+								update parent.control {
+									&Reply-Message += "Missing map for NAS: %{parent.control:Tmp-IP-Address-0}"
+								}
+							}
+
+						}  # subrequest
+
+					}
+
+				}
+			}  # foreach session
+		}
+
+
+		#
+		#  Report what we did
+		#
+		if (&control:Tmp-Integer-0) {
+			update reply {
+				&Reply-Message += "Sent updates for %{control:Tmp-Integer-0} active sessions"
+			}
+			ok
+		} else {
+			update reply {
+				&Reply-Message += "No active sessions found"
+			}
+			reject
+		}
+
+	}
+
+
+	#
+	#  Receive a Disconnect request
+	#
+	recv Disconnect-Request {
+		#
+		#  Populate this section as above, but use "subrequest Disconnect-Request"
+		#
+	}
+
+}
+

--- a/src/modules/rlm_radius/rlm_radius.c
+++ b/src/modules/rlm_radius/rlm_radius.c
@@ -128,6 +128,8 @@ static CONF_PARSER const module_config[] = {
 
 	{ FR_CONF_OFFSET("no_connection_fail", FR_TYPE_BOOL, rlm_radius_t, no_connection_fail) },
 
+	{ FR_CONF_OFFSET("originate", FR_TYPE_BOOL, rlm_radius_t, originate) },
+
 	{ FR_CONF_POINTER("status_checks", FR_TYPE_SUBSECTION, NULL), .subcs = (void const *) status_checks_config },
 
 	{ FR_CONF_OFFSET("max_connections", FR_TYPE_UINT32, rlm_radius_t, max_connections), .dflt = STRINGIFY(32) },

--- a/src/modules/rlm_radius/rlm_radius.c
+++ b/src/modules/rlm_radius/rlm_radius.c
@@ -855,4 +855,8 @@ module_t rlm_radius = {
 		[MOD_AUTHORIZE]		= mod_process,
 		[MOD_AUTHENTICATE]     	= mod_process,
 	},
+        .method_names = (module_method_names_t[]){
+                { CF_IDENT_ANY,       CF_IDENT_ANY,   mod_process },
+                MODULE_NAME_TERMINATOR
+        },
 };

--- a/src/modules/rlm_radius/rlm_radius.h
+++ b/src/modules/rlm_radius/rlm_radius.h
@@ -86,6 +86,7 @@ struct rlm_radius_t {
 	bool			replicate;	//!< are we ignoring responses?
 	bool			synchronous;	//!< are we doing synchronous proxying?
 	bool			no_connection_fail; //!< are we failing immediately on no connection?
+	bool			originate;  //!< are we originating packets rather than proxying?
 
 	dl_module_inst_t		*io_submodule;	//!< As provided by the transport_parse
 	fr_radius_client_io_t const *io;	//!< Easy access to the IO handle


### PR DESCRIPTION
I'm not sure whether the "Do not include Proxy-State in CoA/Disconnect-Requests" patch is required or desirable.

We don't need Proxy-State in the requests that we originate as we're not proxying. FR adds Proxy-State during IO so I don't think we can filter the attribute in the configuration.

However, the RFCs seem to indicate that NASs should accept a CoA/Disconnect and treat the Proxy-State as opaque data, so hopefully it's harmless in practise.

Perhaps we need a means to indicate whether we're proxying or originating requests?

Drop the patch if necessary.