### PR TITLE
Better don't use hardcoded values for the test dir and output

### DIFF
--- a/src/tests/digest/config/digest.conf
+++ b/src/tests/digest/config/digest.conf
@@ -1,23 +1,27 @@
-# -*- text -*-
+#  -*- text -*-
 #
-#	test configuration file.  Do not install.
+#  test configuration file.  Do not install.
 #
-# 	digest.conf	-- Virtual server configuration for testing radiusd.
-#
-#	$Id$
+#  $Id$
 #
 
-builddir = build/tests/digest
-logdir = ${builddir}
-maindir = raddb
-radacctdir = ${builddir}
-pidfile = ${builddir}/radiusd.pid
-panic_action = "gdb -batch -x ${maindir}/panic.gdb %e %p > ${builddir}/gdb.log 2>&1; cat /gdb.log"
+#
+#  Minimal radiusd.conf for testing
+#
 
-modconfdir = ${maindir}/mods-config
-certdir    = ${maindir}/certs
-cadir      = ${maindir}/certs
-test_port  = $ENV{TEST_PORT}
+testdir      = $ENV{TESTDIR}
+output       = $ENV{OUTPUT}
+run_dir      = ${output}
+raddb        = raddb
+pidfile      = ${run_dir}/radiusd.pid
+panic_action = "gdb -batch -x src/tests/panic.gdb %e %p > ${run_dir}/gdb.log 2>&1; cat ${run_dir}/gdb.log"
+
+maindir      = ${raddb}
+radacctdir   = ${run_dir}/radacct
+modconfdir   = ${maindir}/mods-config
+certdir      = ${maindir}/certs
+cadir        = ${maindir}/certs
+test_port    = $ENV{TEST_PORT}
 
 #  Only for testing!
 #  Setting this on a production system is a BAD IDEA.

--- a/src/tests/eapol_test/config/servers.conf
+++ b/src/tests/eapol_test/config/servers.conf
@@ -1,26 +1,27 @@
-# -*- text -*-
-##
-## test.conf	-- Virtual server configuration for testing radiusd.
-##
-##	$Id$
-##
+#  -*- text -*-
+#
+#  test configuration file.  Do not install.
+#
+#  $Id$
+#
 
-# test configuration file.  Do not install.  Delete at any time.
-testdir = src/tests/eapol_test/config
-logdir = build/tests/eapol_test
-maindir = raddb/
-radacctdir = ${testdir}
-pidfile = ${logdir}/radiusd.pid
-panic_action = "gdb -batch -x src/tests/panic.gdb %e %p > build/tests/eapol_test/gdb.log 2>&1; cat build/tests/eapol_test/gdb.log"
-security {
-        allow_vulnerable_openssl = yes
-}
+#
+#  Minimal radiusd.conf for testing EAP
+#
 
-modconfdir = ${maindir}mods-config
-certdir = ${maindir}/certs
-cadir   = ${maindir}/certs
+testdir      = $ENV{TESTDIR}
+output       = $ENV{OUTPUT}
+run_dir      = ${output}
+raddb        = raddb
+pidfile      = ${run_dir}/radiusd.pid
+panic_action = "gdb -batch -x src/tests/panic.gdb %e %p > ${run_dir}/gdb.log 2>&1; cat ${run_dir}/gdb.log"
 
-test_port = $ENV{TEST_PORT}
+maindir      = ${raddb}
+radacctdir   = ${run_dir}/radacct
+modconfdir   = ${maindir}/mods-config
+certdir      = ${maindir}/certs
+cadir        = ${maindir}/certs
+test_port    = $ENV{TEST_PORT}
 
 #  Only for testing!
 #  Setting this on a production system is a BAD IDEA.
@@ -57,7 +58,7 @@ modules {
 	#  Include the modules which are enabled for this particular
 	#  test.
 	#
-	$-INCLUDE ${testdir}/$ENV{METHOD}/mods-enabled/
+	$-INCLUDE ${testdir}/config/$ENV{METHOD}/mods-enabled/
 
 	eap {
 		#
@@ -99,7 +100,7 @@ modules {
 		#
 		#  This method MUST exist because we're running it.
 		#
-		$INCLUDE ${testdir}/$ENV{METHOD}/methods-enabled/$ENV{METHOD}
+		$INCLUDE ${testdir}/config/$ENV{METHOD}/methods-enabled/$ENV{METHOD}
 	}
 
 }
@@ -209,4 +210,4 @@ server inner-tunnel {
 #
 #  Some methods don't have a sites-enabld.  Tho arguably they should.
 #
-$-INCLUDE ${testdir}/$ENV{METHOD}/sites-enabled/$ENV{METHOD}
+$-INCLUDE ${testdir}/config/$ENV{METHOD}/sites-enabled/$ENV{METHOD}

--- a/src/tests/radiusd.mk
+++ b/src/tests/radiusd.mk
@@ -64,7 +64,7 @@ $(TEST).radiusd_kill: | ${2}
 #	Start radiusd instance
 #
 ${2}/radiusd.pid: ${2}
-	$$(eval RADIUSD_RUN := TEST_PORT=$(PORT) $$(RADIUSD_BIN) -Pxxx -d $(DIR)/config -n ${1} -D share/dictionary/ -l ${2}/radiusd.log)
+	$$(eval RADIUSD_RUN := TESTDIR=$(DIR) OUTPUT=$(OUTPUT) TEST_PORT=$(PORT) $$(RADIUSD_BIN) -Pxxx -d $(DIR)/config -n ${1} -D share/dictionary/ -l ${2}/radiusd.log)
 	${Q}rm -f ${2}/radiusd.log
 	${Q}if ! $$(RADIUSD_RUN); then \
 		echo "FAILED STARTING RADIUSD"; \

--- a/src/tests/radmin/config/control-socket.conf
+++ b/src/tests/radmin/config/control-socket.conf
@@ -1,17 +1,23 @@
+#  -*- text -*-
 #
-# src/tests/radmin/config/control-socket.conf configuration file.
-# Do not install.
+#  test configuration file.  Do not install.
+#
+#  $Id$
 #
 
 #
 #  Minimal radiusd.conf for testing radmin
 #
-raddb = raddb
-testdir = build/tests/radmin
-pidfile = ${testdir}/radiusd.pid
-panic_action = "gdb -batch -x src/tests/panic.gdb %e %p > ${testdir}/gdb.log 2>&1; cat ${testdir}/gdb.log"
-run_dir = build/tests/radmin
 
+testdir      = $ENV{TESTDIR}
+output       = $ENV{OUTPUT}
+run_dir      = ${output}
+raddb        = raddb
+pidfile      = ${run_dir}/radiusd.pid
+panic_action = "gdb -batch -x src/tests/panic.gdb %e %p > ${run_dir}/gdb.log 2>&1; cat ${run_dir}/gdb.log"
+
+#  Only for testing!
+#  Setting this on a production system is a BAD IDEA.
 security {
 	allow_vulnerable_openssl = yes
 }
@@ -54,7 +60,7 @@ server control {
 	listen {
 		transport = unix
 		unix {
-			filename = build/tests/radmin/control-socket.sock
+			filename = ${run_dir}/control-socket.sock
 #			peercred = no
 #			uid = radius
 #			gid = radius


### PR DESCRIPTION
We should use the exported vars $(OUTPUT) where the output of the test goes
and the $(DIR) to reference the dir where the test files can be found.