### PR TITLE
Add tests for DHCPv6 packets / ntp-server

### DIFF
--- a/src/tests/unit/protocols/dhcpv6/packet_ntp-server.txt
+++ b/src/tests/unit/protocols/dhcpv6/packet_ntp-server.txt
@@ -1,0 +1,26 @@
+#  -*- text -*-
+#  Copyright (C) 2019 Network RADIUS SARL <legal@networkradius.com>
+#  Version $Id$
+#
+#  Test vectors for DHCPv6 protocol
+#
+#  Based on https://github.com/the-tcpdump-group/tcpdump/blob/master/tests/dhcpv6-ntp-server.pcap
+#
+
+proto dhcpv6
+proto-dictionary dhcpv6
+
+#
+#  1.
+#
+encode-proto Packet-Type = Reply, Transaction-ID = 0xf69b57, Client-ID-DUID = Client-ID-DUID-LLT, Client-ID-DUID-LLT-Hardware-Type = Client-ID-DUID-LLT-Ethernet, Client-ID-DUID-LLT-Time = "Apr  5 1983 09:58:23 UTC", Client-ID-DUID-LLT-Ethernet-Address = 00:0c:29:38:f3:68, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Apr  5 1983 01:34:19 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x000c299ba153, NTP-Server-Address = 2a01::1, NTP-Server-Multicast-Address = ff05::101, NTP-Server-FQDN = "ntp.example.com"
+match 07 f6 9b 57 00 01 00 0e 00 01 00 01 18 f0 0b 3f 00 0c 29 38 f3 68 00 02 00 0e 00 01 00 01 18 ef 95 1b 00 0c 29 9b a1 53 00 38 00 3d 00 01 00 10 2a 01 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 02 00 10 ff 05 00 00 00 00 00 00 00 00 00 00 00 00 01 01 00 03 00 11 03 6e 74 70 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00
+
+decode-proto -
+match Packet-Type = Reply, Transaction-ID = 0xf69b57, Client-ID-DUID = Client-ID-DUID-LLT, Client-ID-DUID-LLT-Hardware-Type = Client-ID-DUID-LLT-Ethernet, Client-ID-DUID-LLT-Time = "Apr  5 1983 09:58:23 UTC", Client-ID-DUID-LLT-Ethernet-Address = 00:0c:29:38:f3:68, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Apr  5 1983 01:34:19 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x000c299ba153, NTP-Server-Address = 2a01::1, NTP-Server-Multicast-Address = ff05::101, NTP-Server-FQDN = "ntp.example.com"
+
+#
+#  eof
+#
+count
+match 6


### PR DESCRIPTION
Based on https://github.com/the-tcpdump-group/tcpdump/blob/master/tests/dhcpv6-ntp-server.pcap