### PR TITLE
Add tests for DHCPv6 packets / sip-server-d

### DIFF
--- a/src/tests/unit/protocols/dhcpv6/packet_sip-server-d.txt
+++ b/src/tests/unit/protocols/dhcpv6/packet_sip-server-d.txt
@@ -1,0 +1,26 @@
+#  -*- text -*-
+#  Copyright (C) 2019 Network RADIUS SARL <legal@networkradius.com>
+#  Version $Id$
+#
+#  Test vectors for DHCPv6 protocol
+#
+#  Based on https://github.com/the-tcpdump-group/tcpdump/blob/master/tests/dhcpv6-sip-server-d.pcap
+#
+
+proto dhcpv6
+proto-dictionary dhcpv6
+
+#
+#  1.
+#
+encode-proto Packet-Type = Reply, Transaction-ID = 0x6890d8, Client-ID-DUID = Client-ID-DUID-LLT, Client-ID-DUID-LLT-Hardware-Type = Client-ID-DUID-LLT-Ethernet, Client-ID-DUID-LLT-Time = "Apr  5 1983 09:58:23 UTC", Client-ID-DUID-LLT-Ethernet-Address = 00:0c:29:38:f3:68, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Apr  5 1983 01:34:19 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x000c299ba153, SIP-Server-Domain-Name-List = "sip1.my-domain.net", SIP-Server-Domain-Name-List = "sip2.example.com", SIP-Server-Domain-Name-List = "sip3.sub.my-domain.org"
+match 07 68 90 d8 00 01 00 0e 00 01 00 01 18 f0 0b 3f 00 0c 29 38 f3 68 00 02 00 0e 00 01 00 01 18 ef 95 1b 00 0c 29 9b a1 53 00 15 00 3e 04 73 69 70 31 09 6d 79 2d 64 6f 6d 61 69 6e 03 6e 65 74 00 04 73 69 70 32 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 04 73 69 70 33 03 73 75 62 09 6d 79 2d 64 6f 6d 61 69 6e 03 6f 72 67 00
+
+decode-proto -
+match Packet-Type = Reply, Transaction-ID = 0x6890d8, Client-ID-DUID = Client-ID-DUID-LLT, Client-ID-DUID-LLT-Hardware-Type = Client-ID-DUID-LLT-Ethernet, Client-ID-DUID-LLT-Time = "Apr  5 1983 09:58:23 UTC", Client-ID-DUID-LLT-Ethernet-Address = 00:0c:29:38:f3:68, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Apr  5 1983 01:34:19 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x000c299ba153, SIP-Server-Domain-Name-List = "sip1.my-domain.net", SIP-Server-Domain-Name-List = "sip2.example.com", SIP-Server-Domain-Name-List = "sip3.sub.my-domain.org"
+
+#
+#  eof
+#
+count
+match 6


### PR DESCRIPTION
Based on https://github.com/the-tcpdump-group/tcpdump/blob/master/tests/dhcpv6-sip-server-d.pcap