### PR TITLE
Print the test module dir and the test file

### DIFF
--- a/src/tests/eapol_test/all.mk
+++ b/src/tests/eapol_test/all.mk
@@ -48,7 +48,7 @@ $(eval $(call RADIUSD_SERVICE,servers,$(OUTPUT)))
 #	Print the disabled list.
 #
 $(IGNORED_EAP_TYPES):
-	@echo "EAPOL_TEST $@ - Disabled.  Enable by removing '$@' from 'IGNORED_EAP_TYPES' in src/tests/eapol_test/all.mk"
+	@echo "EAPOL-TEST $@ - Disabled.  Enable by removing '$@' from 'IGNORED_EAP_TYPES' in src/tests/eapol_test/all.mk"
 
 #
 #  Separate the dependencies here just to keep a bit clear.
@@ -59,7 +59,7 @@ test.eap.check: $(IGNORED_EAP_TYPES) | $(OUTPUT) $(GENERATED_CERT_FILES)
 #  Run EAP tests.
 #
 $(OUTPUT)/%.ok: $(DIR)/%.conf | $(GENERATED_CERT_FILES)
-	@echo "EAPOL_TEST $(notdir $(patsubst %.conf,%,$<))"
+	@echo "EAPOL-TEST $(notdir $(patsubst %.conf,%,$<))"
 	${Q}$(MAKE) --no-print-directory test.eap.radiusd_kill || true
 	${Q}$(MAKE) --no-print-directory METHOD=$(basename $(notdir $@)) test.eap.radiusd_start
 	${Q} [ -f $(dir $@)/radiusd.pid ] || exit 1

--- a/src/tests/modules/test.mk
+++ b/src/tests/modules/test.mk
@@ -50,8 +50,8 @@ endef
 #  ERROR line in the input.
 #
 $(BUILD_DIR)/tests/modules/%: src/tests/modules/%.unlang $(BUILD_DIR)/tests/modules/%.attrs $(TESTBINDIR)/unit_test_module | build.raddb
+	@echo "MODULE-TEST $(lastword $(subst /, ,$(dir $@))) $(basename $(notdir $@))"
 	${Q}mkdir -p $(dir $@)
-	@echo MODULE-TEST $(lastword $(subst /, ,$(dir $@))) $(basename $(notdir $@))
 	${Q}if ! MODULE_TEST_DIR=$(dir $<) MODULE_TEST_UNLANG=$< $(TESTBIN)/unit_test_module -D share/dictionary -d src/tests/modules/ -i "$@.attrs" -f "$@.attrs" -r "$@" -xxx > "$@.log" 2>&1 || ! test -f "$@"; then \
 		if ! grep ERROR $< 2>&1 > /dev/null; then \
 			cat "$@.log"; \

--- a/src/tests/unit/all.mk
+++ b/src/tests/unit/all.mk
@@ -34,7 +34,7 @@ $(FILES.$(TEST)): export TZ = GMT
 #
 $(OUTPUT)/%: $(DIR)/% $(TESTBINDIR)/unit_test_attribute
 	$(eval DIR:=${top_srcdir}/src/tests/unit)
-	@echo "UNIT-TEST $(subst $(DIR)/,,$<)"
+	@echo "UNIT-TEST $(lastword $(subst /, ,$(dir $@))) $(basename $(notdir $@))"
 	${Q}if ! $(TESTBIN)/unit_test_attribute -D $(top_srcdir)/share/dictionary -d $(DIR) -r "$@" $<; then \
 		echo "$(TESTBIN)/unit_test_attribute -D $(top_srcdir)/share/dictionary -d $(DIR) -r \"$@\" $<"; \
 		rm -f $(BUILD_DIR)/tests/test.unit; \


### PR DESCRIPTION
It will print like:

UNIT-TEST dhcpv6 rfc6939

Instead of:

UNIT-TEST src/tests/unit/protocols/dhcpv6/rfc6939.txt