### PR TITLE
The dhcpv6 'packet_*.txt' should decode only the hex

### DIFF
--- a/src/tests/unit/protocols/dhcpv6/packet_AFTR-Name-rfc6334.txt
+++ b/src/tests/unit/protocols/dhcpv6/packet_AFTR-Name-rfc6334.txt
@@ -8,81 +8,34 @@
 #
 #  Based on https://github.com/the-tcpdump-group/tcpdump/blob/master/tests/dhcpv6-AFTR-Name-RFC6334.pcap
 #
+
 proto dhcpv6
 proto-dictionary dhcpv6
 
 #
-#  1. Solicit (Client -> Broadcast)
+#  1.
 #
-#  DHCPv6
-#    Message type: Solicit (1)
-#    Transaction ID: 0xd81eb8
-#    Client Identifier
-#    Option Request
-#    Elapsed time
-#    Identity Association for Prefix Delegation
-#
-encode-proto Packet-Type = Solicit, Transaction-ID = 0xd81eb8, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Option-Request = DNS-Servers, Option-Request = AFTR-Name, Elapsed-Time = 0, IA-PD-IAID = 33752069, IA-PD-T1 = 3600, IA-PD-T2 = 5400
-match 01 d8 1e b8 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 06 00 04 00 17 00 40 00 08 00 02 00 00 00 19 00 0c 02 03 04 05 00 00 0e 10 00 00 15 18
-
-decode-proto -
+decode-proto 01 d8 1e b8 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 06 00 04 00 17 00 40 00 08 00 02 00 00 00 19 00 0c 02 03 04 05 00 00 0e 10 00 00 15 18
 match Packet-Type = Solicit, Transaction-ID = 0xd81eb8, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Option-Request = DNS-Servers, Option-Request = AFTR-Name, Elapsed-Time = 0, IA-PD-IAID = 33752069, IA-PD-T1 = 3600, IA-PD-T2 = 5400
 
 #
-#  2. Advertise (Server -> Client)
+#  2.
 #
-#  DHCPv6
-#    Message type: Advertise (2)
-#    Transaction ID: 0xd81eb8
-#    Identity Association for Prefix Delegation
-#    Client Identifier
-#    Server Identifier
-#    Preference
-#    DNS recursive name server
-#    Dual-Stack Lite AFTR Name
-#
-encode-proto Packet-Type = Advertise, Transaction-ID = 0xd81eb8, IA-PD-IAID = 33752069, IA-PD-T1 = 150, IA-PD-T2 = 250, IA-PD-Options = 0x001a0019000000fa0000012c382a000001000101000000000000000000, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:01:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Preference = 10, DNS-Servers = 2a01::1, AFTR-Name = "aftr-name.mydomain.net"
-match 02 d8 1e b8 00 19 00 29 02 03 04 05 00 00 00 96 00 00 00 fa 00 1a 00 19 00 00 00 fa 00 00 01 2c 38 2a 00 00 01 00 01 01 00 00 00 00 00 00 00 00 00 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 00 00 00 3e 00 11 22 33 44 55 00 07 00 01 0a 00 17 00 10 2a 01 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 40 00 18 09 61 66 74 72 2d 6e 61 6d 65 08 6d 79 64 6f 6d 61 69 6e 03 6e 65 74 00
-
-decode-proto -
-match Packet-Type = Advertise, Transaction-ID = 0xd81eb8, IA-PD-IAID = 33752069, IA-PD-T1 = 150, IA-PD-T2 = 250, IA-PD-Options = 0x001a0019000000fa0000012c382a000001000101000000000000000000, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:01:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Preference = 10, DNS-Servers = 2a01::1, AFTR-Name = "aftr-name.mydomain.net"
+decode-proto 02 d8 1e b8 00 19 00 29 02 03 04 05 00 00 00 96 00 00 00 fa 00 1a 00 19 00 00 00 fa 00 00 01 2c 38 2a 00 00 01 00 01 01 00 00 00 00 00 00 00 00 00 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 18 3f 4e f0 00 11 22 33 44 55 00 07 00 01 0a 00 17 00 10 2a 01 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 40 00 18 09 61 66 74 72 2d 6e 61 6d 65 08 6d 79 64 6f 6d 61 69 6e 03 6e 65 74 00
+match Packet-Type = Advertise, Transaction-ID = 0xd81eb8, IA-PD-IAID = 33752069, IA-PD-T1 = 150, IA-PD-T2 = 250, IA-PD-Options = 0x001a0019000000fa0000012c382a000001000101000000000000000000, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Nov 21 2012 08:36:00 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Preference = 10, DNS-Servers = 2a01::1, AFTR-Name = "aftr-name.mydomain.net"
 
 #
-#  3. Request (Client -> Broadcast)
+#  3.
 #
-#  DHCPv6
-#    Message type: Request (3)
-#    Transaction ID: 0x1e291d
-#    Client Identifier
-#    Server Identifier
-#    Option Request
-#    Elapsed time
-#    Identity Association for Prefix Delegation
-#
-encode-proto Packet-Type = Request, Transaction-ID = 0x1e291d, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Option-Request = DNS-Servers, Option-Request = AFTR-Name, Elapsed-Time = 0, IA-PD-IAID = 33752069, IA-PD-T1 = 3600, IA-PD-T2 = 5400, IA-PD-Options = 0x001a001900001c2000001d4c382a000001000101000000000000000000
-match 03 1e 29 1d 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 00 00 00 02 00 11 22 33 44 55 00 06 00 04 00 17 00 40 00 08 00 02 00 00 00 19 00 29 02 03 04 05 00 00 0e 10 00 00 15 18 00 1a 00 19 00 00 1c 20 00 00 1d 4c 38 2a 00 00 01 00 01 01 00 00 00 00 00 00 00 00 00
-
-decode-proto -
-match Packet-Type = Request, Transaction-ID = 0x1e291d, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Option-Request = DNS-Servers, Option-Request = AFTR-Name, Elapsed-Time = 0, IA-PD-IAID = 33752069, IA-PD-T1 = 3600, IA-PD-T2 = 5400, IA-PD-Options = 0x001a001900001c2000001d4c382a000001000101000000000000000000
+decode-proto 03 1e 29 1d 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 18 3f 4e f0 00 11 22 33 44 55 00 06 00 04 00 17 00 40 00 08 00 02 00 00 00 19 00 29 02 03 04 05 00 00 0e 10 00 00 15 18 00 1a 00 19 00 00 1c 20 00 00 1d 4c 38 2a 00 00 01 00 01 01 00 00 00 00 00 00 00 00 00
+match Packet-Type = Request, Transaction-ID = 0x1e291d, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Nov 21 2012 08:36:00 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Option-Request = DNS-Servers, Option-Request = AFTR-Name, Elapsed-Time = 0, IA-PD-IAID = 33752069, IA-PD-T1 = 3600, IA-PD-T2 = 5400, IA-PD-Options = 0x001a001900001c2000001d4c382a000001000101000000000000000000
 
 #
-#  4. Solicit (Server -> Client)
+#  4.
 #
-#  DHCPv6
-#    Message type: Reply (7)
-#    Transaction ID: 0x1e291d
-#    Identity Association for Prefix Delegation
-#    Client Identifier
-#    Server Identifier
-#    Preference
-#    DNS recursive name server
-#    Dual-Stack Lite AFTR Name
-#
-encode-proto Packet-Type = Reply, Transaction-ID = 0x1e291d, IA-PD-IAID = 33752069, IA-PD-T1 = 150, IA-PD-T2 = 250, IA-PD-Options = 0x001a0019000000fa0000012c382a000001000101000000000000000000, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Preference = 10, DNS-Servers = 2a01::1, AFTR-Name = "aftr-name.mydomain.net"
-match 07 1e 29 1d 00 19 00 29 02 03 04 05 00 00 00 96 00 00 00 fa 00 1a 00 19 00 00 00 fa 00 00 01 2c 38 2a 00 00 01 00 01 01 00 00 00 00 00 00 00 00 00 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 00 00 00 02 00 11 22 33 44 55 00 07 00 01 0a 00 17 00 10 2a 01 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 40 00 18 09 61 66 74 72 2d 6e 61 6d 65 08 6d 79 64 6f 6d 61 69 6e 03 6e 65 74 00
-
-decode-proto -
-match Packet-Type = Reply, Transaction-ID = 0x1e291d, IA-PD-IAID = 33752069, IA-PD-T1 = 150, IA-PD-T2 = 250, IA-PD-Options = 0x001a0019000000fa0000012c382a000001000101000000000000000000, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Preference = 10, DNS-Servers = 2a01::1, AFTR-Name = "aftr-name.mydomain.net"
+decode-proto 07 1e 29 1d 00 19 00 29 02 03 04 05 00 00 00 96 00 00 00 fa 00 1a 00 19 00 00 00 fa 00 00 01 2c 38 2a 00 00 01 00 01 01 00 00 00 00 00 00 00 00 00 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 18 3f 4e f0 00 11 22 33 44 55 00 07 00 01 0a 00 17 00 10 2a 01 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 40 00 18 09 61 66 74 72 2d 6e 61 6d 65 08 6d 79 64 6f 6d 61 69 6e 03 6e 65 74 00
+match Packet-Type = Reply, Transaction-ID = 0x1e291d, IA-PD-IAID = 33752069, IA-PD-T1 = 150, IA-PD-T2 = 250, IA-PD-Options = 0x001a0019000000fa0000012c382a000001000101000000000000000000, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Nov 21 2012 08:36:00 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Preference = 10, DNS-Servers = 2a01::1, AFTR-Name = "aftr-name.mydomain.net"
 
 count
-match 18
+match 10
+

--- a/src/tests/unit/protocols/dhcpv6/packet_domain-list.txt
+++ b/src/tests/unit/protocols/dhcpv6/packet_domain-list.txt
@@ -8,24 +8,16 @@
 #
 #  Based on https://github.com/the-tcpdump-group/tcpdump/blob/master/tests/dhcpv6-domain-list.pcap
 #
+
 proto dhcpv6
 proto-dictionary dhcpv6
 
 #
-#  1. Reply (Client -> Broadcast)
+#  1.
 #
-#  DHCPv6
-#    Message type: Reply (7)
-#    Transaction ID: 0xaa56ce
-#    Client Identifier
-#    Server Identifier
-#    Domain Search List
-#
-encode-proto Packet-Type = Reply, Transaction-ID = 0xaa56ce, Client-ID-DUID = Client-ID-DUID-LLT, Client-ID-DUID-LLT-Hardware-Type = Client-ID-DUID-LLT-Ethernet, Client-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Client-ID-DUID-LLT-Ethernet-Address = 00:0c:29:38:f3:68, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:03 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x000c299ba153, Domain-List = "example.com", Domain-List = "sales.example.com", Domain-List = "eng.example.com"
-match 07 aa 56 ce 00 01 00 0e 00 01 00 01 00 00 00 02 00 0c 29 38 f3 68 00 02 00 0e 00 01 00 01 00 00 00 03 00 0c 29 9b a1 53 00 18 00 31 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 05 73 61 6c 65 73 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 03 65 6e 67 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00
-
-decode-proto -
-match Packet-Type = Reply, Transaction-ID = 0xaa56ce, Client-ID-DUID = Client-ID-DUID-LLT, Client-ID-DUID-LLT-Hardware-Type = Client-ID-DUID-LLT-Ethernet, Client-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Client-ID-DUID-LLT-Ethernet-Address = 00:0c:29:38:f3:68, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:03 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x000c299ba153, Domain-List = "example.com", Domain-List = "sales.example.com", Domain-List = "eng.example.com"
+decode-proto 07 aa 56 ce 00 01 00 0e 00 01 00 01 18 f0 0b 3f 00 0c 29 38 f3 68 00 02 00 0e 00 01 00 01 18 ef 95 1b 00 0c 29 9b a1 53 00 18 00 31 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 05 73 61 6c 65 73 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 03 65 6e 67 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00
+match Packet-Type = Reply, Transaction-ID = 0xaa56ce, Client-ID-DUID = Client-ID-DUID-LLT, Client-ID-DUID-LLT-Hardware-Type = Client-ID-DUID-LLT-Ethernet, Client-ID-DUID-LLT-Time = "Apr  4 2013 09:58:23 UTC", Client-ID-DUID-LLT-Ethernet-Address = 00:0c:29:38:f3:68, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Apr  4 2013 01:34:19 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x000c299ba153, Domain-List = "example.com", Domain-List = "sales.example.com", Domain-List = "eng.example.com"
 
 count
-match 6
+match 4
+

--- a/src/tests/unit/protocols/dhcpv6/packet_ia-na.txt
+++ b/src/tests/unit/protocols/dhcpv6/packet_ia-na.txt
@@ -15,38 +15,27 @@ proto-dictionary dhcpv6
 #
 #  1.
 #
-encode-proto Packet-Type = Solicit, Transaction-ID = 0x90b45c, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Option-Request = DNS-Servers, Option-Request = Domain-List, Elapsed-Time = 0, IA-NA-IAID = 33752069, IA-NA-T1 = 3600, IA-NA-T2 = 5400
-match 01 90 b4 5c 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 06 00 04 00 17 00 18 00 08 00 02 00 00 00 03 00 0c 02 03 04 05 00 00 0e 10 00 00 15 18
-
-decode-proto -
+decode-proto 01 90 b4 5c 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 06 00 04 00 17 00 18 00 08 00 02 00 00 00 03 00 0c 02 03 04 05 00 00 0e 10 00 00 15 18
 match Packet-Type = Solicit, Transaction-ID = 0x90b45c, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Option-Request = DNS-Servers, Option-Request = Domain-List, Elapsed-Time = 0, IA-NA-IAID = 33752069, IA-NA-T1 = 3600, IA-NA-T2 = 5400
 
 #
 #  2.
 #
-encode-proto Packet-Type = Advertise, Transaction-ID = 0x90b45c, IA-NA-IAID = 33752069, IA-NA-T1 = 3600, IA-NA-T2 = 5400, IA-NA-Options = 0x000500182a0000010001020038e6b22ec440acdf0000119400001c20, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan 01 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
-match 02 90 b4 5c 00 03 00 28 02 03 04 05 00 00 0e 10 00 00 15 18 00 05 00 18 2a 00 00 01 00 01 02 00 38 e6 b2 2e c4 40 ac df 00 00 11 94 00 00 1c 20 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 00 00 00 02 00 11 22 33 44 55
-
-decode-proto -
-match Packet-Type = Advertise, Transaction-ID = 0x90b45c, IA-NA-IAID = 33752069, IA-NA-T1 = 3600, IA-NA-T2 = 5400, IA-NA-Options = 0x000500182a0000010001020038e6b22ec440acdf0000119400001c20, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
+decode-proto 02 90 b4 5c 00 03 00 28 02 03 04 05 00 00 0e 10 00 00 15 18 00 05 00 18 2a 00 00 01 00 01 02 00 38 e6 b2 2e c4 40 ac df 00 00 11 94 00 00 1c 20 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 18 46 48 8c 00 11 22 33 44 55
+match Packet-Type = Advertise, Transaction-ID = 0x90b45c, IA-NA-IAID = 33752069, IA-NA-T1 = 3600, IA-NA-T2 = 5400, IA-NA-Options = 0x000500182a0000010001020038e6b22ec440acdf0000119400001c20, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Nov 26 2012 15:34:36 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
 
 #
 #  3.
 #
-encode-proto Packet-Type = Request, Transaction-ID = 0x2ffdd1, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan 01 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Option-Request = DNS-Servers, Option-Request = Domain-List, Elapsed-Time = 0, IA-NA-IAID = 33752069, IA-NA-T1 = 3600, IA-NA-T2 = 5400, IA-NA-Options = 0x000500182a0000010001020038e6b22ec440acdf00001c2000001d4c
-match 03 2f fd d1 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 00 00 00 02 00 11 22 33 44 55 00 06 00 04 00 17 00 18 00 08 00 02 00 00 00 03 00 28 02 03 04 05 00 00 0e 10 00 00 15 18 00 05 00 18 2a 00 00 01 00 01 02 00 38 e6 b2 2e c4 40 ac df 00 00 1c 20 00 00 1d 4c
-
-decode-proto -
-match Packet-Type = Request, Transaction-ID = 0x2ffdd1, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Option-Request = DNS-Servers, Option-Request = Domain-List, Elapsed-Time = 0, IA-NA-IAID = 33752069, IA-NA-T1 = 3600, IA-NA-T2 = 5400, IA-NA-Options = 0x000500182a0000010001020038e6b22ec440acdf00001c2000001d4c
+decode-proto 03 2f fd d1 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 18 46 48 8c 00 11 22 33 44 55 00 06 00 04 00 17 00 18 00 08 00 02 00 00 00 03 00 28 02 03 04 05 00 00 0e 10 00 00 15 18 00 05 00 18 2a 00 00 01 00 01 02 00 38 e6 b2 2e c4 40 ac df 00 00 1c 20 00 00 1d 4c
+match Packet-Type = Request, Transaction-ID = 0x2ffdd1, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Nov 26 2012 15:34:36 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Option-Request = DNS-Servers, Option-Request = Domain-List, Elapsed-Time = 0, IA-NA-IAID = 33752069, IA-NA-T1 = 3600, IA-NA-T2 = 5400, IA-NA-Options = 0x000500182a0000010001020038e6b22ec440acdf00001c2000001d4c
 
 #
 #  4.
 #
-encode-proto Packet-Type = Reply, Transaction-ID = 0x2ffdd1, IA-NA-IAID = 33752069, IA-NA-T1 = 3600, IA-NA-T2 = 5400, IA-NA-Options = 0x000500182a0000010001020038e6b22ec440acdf0000119400001c20, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan 01 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
-match 07 2f fd d1 00 03 00 28 02 03 04 05 00 00 0e 10 00 00 15 18 00 05 00 18 2a 00 00 01 00 01 02 00 38 e6 b2 2e c4 40 ac df 00 00 11 94 00 00 1c 20 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 00 00 00 02 00 11 22 33 44 55
-
-decode-proto -
-match Packet-Type = Reply, Transaction-ID = 0x2ffdd1, IA-NA-IAID = 33752069, IA-NA-T1 = 3600, IA-NA-T2 = 5400, IA-NA-Options = 0x000500182a0000010001020038e6b22ec440acdf0000119400001c20, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
+decode-proto 07 2f fd d1 00 03 00 28 02 03 04 05 00 00 0e 10 00 00 15 18 00 05 00 18 2a 00 00 01 00 01 02 00 38 e6 b2 2e c4 40 ac df 00 00 11 94 00 00 1c 20 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 18 46 48 8c 00 11 22 33 44 55
+match Packet-Type = Reply, Transaction-ID = 0x2ffdd1, IA-NA-IAID = 33752069, IA-NA-T1 = 3600, IA-NA-T2 = 5400, IA-NA-Options = 0x000500182a0000010001020038e6b22ec440acdf0000119400001c20, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Nov 26 2012 15:34:36 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
 
 count
-match 18
+match 10
+

--- a/src/tests/unit/protocols/dhcpv6/packet_ia-pd.txt
+++ b/src/tests/unit/protocols/dhcpv6/packet_ia-pd.txt
@@ -15,38 +15,27 @@ proto-dictionary dhcpv6
 #
 #  1.
 #
-encode-proto Packet-Type = Solicit, Transaction-ID = 0xe1e093, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Option-Request = DNS-Servers, Option-Request = Domain-List, Elapsed-Time = 0, IA-PD-IAID = 33752069, IA-PD-T1 = 3600, IA-PD-T2 = 5400
-match 01 e1 e0 93 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 06 00 04 00 17 00 18 00 08 00 02 00 00 00 19 00 0c 02 03 04 05 00 00 0e 10 00 00 15 18
-
-decode-proto -
+decode-proto 01 e1 e0 93 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 06 00 04 00 17 00 18 00 08 00 02 00 00 00 19 00 0c 02 03 04 05 00 00 0e 10 00 00 15 18
 match Packet-Type = Solicit, Transaction-ID = 0xe1e093, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Option-Request = DNS-Servers, Option-Request = Domain-List, Elapsed-Time = 0, IA-PD-IAID = 33752069, IA-PD-T1 = 3600, IA-PD-T2 = 5400
 
 #
 #  2.
 #
-encode-proto Packet-Type = Advertise, Transaction-ID = 0xe1e093, IA-PD-IAID = 33752069, IA-PD-T1 = 3600, IA-PD-T2 = 5400, IA-PD-Options = 0x001a00190000119400001c20382a000001000101000000000000000000, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan 01 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
-match 02 e1 e0 93 00 19 00 29 02 03 04 05 00 00 0e 10 00 00 15 18 00 1a 00 19 00 00 11 94 00 00 1c 20 38 2a 00 00 01 00 01 01 00 00 00 00 00 00 00 00 00 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 00 00 00 02 00 11 22 33 44 55
-
-decode-proto -
-match Packet-Type = Advertise, Transaction-ID = 0xe1e093, IA-PD-IAID = 33752069, IA-PD-T1 = 3600, IA-PD-T2 = 5400, IA-PD-Options = 0x001a00190000119400001c20382a000001000101000000000000000000, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
+decode-proto 02 e1 e0 93 00 19 00 29 02 03 04 05 00 00 0e 10 00 00 15 18 00 1a 00 19 00 00 11 94 00 00 1c 20 38 2a 00 00 01 00 01 01 00 00 00 00 00 00 00 00 00 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 18 46 49 99 00 11 22 33 44 55
+match Packet-Type = Advertise, Transaction-ID = 0xe1e093, IA-PD-IAID = 33752069, IA-PD-T1 = 3600, IA-PD-T2 = 5400, IA-PD-Options = 0x001a00190000119400001c20382a000001000101000000000000000000, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Nov 26 2012 15:39:05 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
 
 #
 #  3.
 #
-encode-proto Packet-Type = Request, Transaction-ID = 0x12b08a, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Option-Request = DNS-Servers, Option-Request = Domain-List, Elapsed-Time = 0, IA-PD-IAID = 33752069, IA-PD-T1 = 3600, IA-PD-T2 = 5400, IA-PD-Options = 0x001a001900001c2000001d4c382a000001000101000000000000000000
-match 03 12 b0 8a 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 00 00 00 02 00 11 22 33 44 55 00 06 00 04 00 17 00 18 00 08 00 02 00 00 00 19 00 29 02 03 04 05 00 00 0e 10 00 00 15 18 00 1a 00 19 00 00 1c 20 00 00 1d 4c 38 2a 00 00 01 00 01 01 00 00 00 00 00 00 00 00 00
-
-decode-proto -
-match Packet-Type = Request, Transaction-ID = 0x12b08a, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Option-Request = DNS-Servers, Option-Request = Domain-List, Elapsed-Time = 0, IA-PD-IAID = 33752069, IA-PD-T1 = 3600, IA-PD-T2 = 5400, IA-PD-Options = 0x001a001900001c2000001d4c382a000001000101000000000000000000
+decode-proto 03 12 b0 8a 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 18 46 49 99 00 11 22 33 44 55 00 06 00 04 00 17 00 18 00 08 00 02 00 00 00 19 00 29 02 03 04 05 00 00 0e 10 00 00 15 18 00 1a 00 19 00 00 1c 20 00 00 1d 4c 38 2a 00 00 01 00 01 01 00 00 00 00 00 00 00 00 00
+match Packet-Type = Request, Transaction-ID = 0x12b08a, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Nov 26 2012 15:39:05 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Option-Request = DNS-Servers, Option-Request = Domain-List, Elapsed-Time = 0, IA-PD-IAID = 33752069, IA-PD-T1 = 3600, IA-PD-T2 = 5400, IA-PD-Options = 0x001a001900001c2000001d4c382a000001000101000000000000000000
 
 #
 #  4.
 #
-encode-proto Packet-Type = Reply, Transaction-ID = 0x12b08a, IA-PD-IAID = 33752069, IA-PD-T1 = 3600, IA-PD-T2 = 5400, IA-PD-Options = 0x001a00190000119400001c20382a000001000101000000000000000000, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
-match 07 12 b0 8a 00 19 00 29 02 03 04 05 00 00 0e 10 00 00 15 18 00 1a 00 19 00 00 11 94 00 00 1c 20 38 2a 00 00 01 00 01 01 00 00 00 00 00 00 00 00 00 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 00 00 00 02 00 11 22 33 44 55
-
-decode-proto -
-match Packet-Type = Reply, Transaction-ID = 0x12b08a, IA-PD-IAID = 33752069, IA-PD-T1 = 3600, IA-PD-T2 = 5400, IA-PD-Options = 0x001a00190000119400001c20382a000001000101000000000000000000, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
+decode-proto 07 12 b0 8a 00 19 00 29 02 03 04 05 00 00 0e 10 00 00 15 18 00 1a 00 19 00 00 11 94 00 00 1c 20 38 2a 00 00 01 00 01 01 00 00 00 00 00 00 00 00 00 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 18 46 49 99 00 11 22 33 44 55
+match Packet-Type = Reply, Transaction-ID = 0x12b08a, IA-PD-IAID = 33752069, IA-PD-T1 = 3600, IA-PD-T2 = 5400, IA-PD-Options = 0x001a00190000119400001c20382a000001000101000000000000000000, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Nov 26 2012 15:39:05 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
 
 count
-match 18
+match 10
+

--- a/src/tests/unit/protocols/dhcpv6/packet_ia-ta.txt
+++ b/src/tests/unit/protocols/dhcpv6/packet_ia-ta.txt
@@ -15,38 +15,27 @@ proto-dictionary dhcpv6
 #
 #  1.
 #
-encode-proto Packet-Type = Solicit, Transaction-ID = 0x28b040, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Option-Request = DNS-Servers, Option-Request = Domain-List, Elapsed-Time = 0, IA-TA-IAID = 33752069
-match 01 28 b0 40 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 06 00 04 00 17 00 18 00 08 00 02 00 00 00 04 00 04 02 03 04 05
-
-decode-proto -
+decode-proto 01 28 b0 40 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 06 00 04 00 17 00 18 00 08 00 02 00 00 00 04 00 04 02 03 04 05
 match Packet-Type = Solicit, Transaction-ID = 0x28b040, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Option-Request = DNS-Servers, Option-Request = Domain-List, Elapsed-Time = 0, IA-TA-IAID = 33752069
 
 #
 #  2.
 #
-encode-proto Packet-Type = Advertise, Transaction-ID = 0x28b040, IA-TA-IAID = 33752069, IA-TA-Options = 0x000500182a000001000102005da2f92084c488cc0000119400001c20, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
-match 02 28 b0 40 00 04 00 20 02 03 04 05 00 05 00 18 2a 00 00 01 00 01 02 00 5d a2 f9 20 84 c4 88 cc 00 00 11 94 00 00 1c 20 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 00 00 00 02 00 11 22 33 44 55
-
-decode-proto -
-match Packet-Type = Advertise, Transaction-ID = 0x28b040, IA-TA-IAID = 33752069, IA-TA-Options = 0x000500182a000001000102005da2f92084c488cc0000119400001c20, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
+decode-proto 02 28 b0 40 00 04 00 20 02 03 04 05 00 05 00 18 2a 00 00 01 00 01 02 00 5d a2 f9 20 84 c4 88 cc 00 00 11 94 00 00 1c 20 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 18 46 47 f0 00 11 22 33 44 55
+match Packet-Type = Advertise, Transaction-ID = 0x28b040, IA-TA-IAID = 33752069, IA-TA-Options = 0x000500182a000001000102005da2f92084c488cc0000119400001c20, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Nov 26 2012 15:32:00 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
 
 #
 #  3.
 #
-encode-proto Packet-Type = Request, Transaction-ID = 0x2b0e45, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Option-Request = DNS-Servers, Option-Request = Domain-List, Elapsed-Time = 0, IA-TA-IAID = 33752069, IA-TA-Options = 0x000500182a000001000102005da2f92084c488cc00001c2000001d4c
-match 03 2b 0e 45 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 00 00 00 02 00 11 22 33 44 55 00 06 00 04 00 17 00 18 00 08 00 02 00 00 00 04 00 20 02 03 04 05 00 05 00 18 2a 00 00 01 00 01 02 00 5d a2 f9 20 84 c4 88 cc 00 00 1c 20 00 00 1d 4c
-
-decode-proto -
-match Packet-Type = Request, Transaction-ID = 0x2b0e45, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Option-Request = DNS-Servers, Option-Request = Domain-List, Elapsed-Time = 0, IA-TA-IAID = 33752069, IA-TA-Options = 0x000500182a000001000102005da2f92084c488cc00001c2000001d4c
+decode-proto 03 2b 0e 45 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 18 46 47 f0 00 11 22 33 44 55 00 06 00 04 00 17 00 18 00 08 00 02 00 00 00 04 00 20 02 03 04 05 00 05 00 18 2a 00 00 01 00 01 02 00 5d a2 f9 20 84 c4 88 cc 00 00 1c 20 00 00 1d 4c
+match Packet-Type = Request, Transaction-ID = 0x2b0e45, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Nov 26 2012 15:32:00 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455, Option-Request = DNS-Servers, Option-Request = Domain-List, Elapsed-Time = 0, IA-TA-IAID = 33752069, IA-TA-Options = 0x000500182a000001000102005da2f92084c488cc00001c2000001d4c
 
 #
 #  4.
 #
-encode-proto Packet-Type = Reply, Transaction-ID = 0x2b0e45, IA-TA-IAID = 33752069, IA-TA-Options = 0x000500182a000001000102005da2f92084c488cc0000119400001c20, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
-match 07 2b 0e 45 00 04 00 20 02 03 04 05 00 05 00 18 2a 00 00 01 00 01 02 00 5d a2 f9 20 84 c4 88 cc 00 00 11 94 00 00 1c 20 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 00 00 00 02 00 11 22 33 44 55
-
-decode-proto -
-match Packet-Type = Reply, Transaction-ID = 0x2b0e45, IA-TA-IAID = 33752069, IA-TA-Options = 0x000500182a000001000102005da2f92084c488cc0000119400001c20, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
+decode-proto 07 2b 0e 45 00 04 00 20 02 03 04 05 00 05 00 18 2a 00 00 01 00 01 02 00 5d a2 f9 20 84 c4 88 cc 00 00 11 94 00 00 1c 20 00 01 00 0a 00 03 00 01 00 01 02 03 04 05 00 02 00 0e 00 01 00 01 18 46 47 f0 00 11 22 33 44 55
+match Packet-Type = Reply, Transaction-ID = 0x2b0e45, IA-TA-IAID = 33752069, IA-TA-Options = 0x000500182a000001000102005da2f92084c488cc0000119400001c20, Client-ID-DUID = Client-ID-DUID-LL, Client-ID-DUID-LL-Hardware-Type = 1, Client-ID-DUID-LL-Address = 0x000102030405, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Nov 26 2012 15:32:00 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x001122334455
 
 count
-match 18
+match 10
+

--- a/src/tests/unit/protocols/dhcpv6/packet_ntp-server.txt
+++ b/src/tests/unit/protocols/dhcpv6/packet_ntp-server.txt
@@ -15,11 +15,9 @@ proto-dictionary dhcpv6
 #
 #  1.
 #
-encode-proto Packet-Type = Reply, Transaction-ID = 0xf69b57, Client-ID-DUID = Client-ID-DUID-LLT, Client-ID-DUID-LLT-Hardware-Type = Client-ID-DUID-LLT-Ethernet, Client-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Client-ID-DUID-LLT-Ethernet-Address = 00:0c:29:38:f3:68, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:03 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x000c299ba153, NTP-Server-Address = 2a01::1, NTP-Server-Multicast-Address = ff05::101, NTP-Server-FQDN = "ntp.example.com"
-match 07 f6 9b 57 00 01 00 0e 00 01 00 01 00 00 00 02 00 0c 29 38 f3 68 00 02 00 0e 00 01 00 01 00 00 00 03 00 0c 29 9b a1 53 00 38 00 3d 00 01 00 10 2a 01 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 02 00 10 ff 05 00 00 00 00 00 00 00 00 00 00 00 00 01 01 00 03 00 11 03 6e 74 70 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00
-
-decode-proto -
-match Packet-Type = Reply, Transaction-ID = 0xf69b57, Client-ID-DUID = Client-ID-DUID-LLT, Client-ID-DUID-LLT-Hardware-Type = Client-ID-DUID-LLT-Ethernet, Client-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Client-ID-DUID-LLT-Ethernet-Address = 00:0c:29:38:f3:68, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:03 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x000c299ba153, NTP-Server-Address = 2a01::1, NTP-Server-Multicast-Address = ff05::101, NTP-Server-FQDN = "ntp.example.com"
+decode-proto 07 f6 9b 57 00 01 00 0e 00 01 00 01 18 f0 0b 3f 00 0c 29 38 f3 68 00 02 00 0e 00 01 00 01 18 ef 95 1b 00 0c 29 9b a1 53 00 38 00 3d 00 01 00 10 2a 01 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 02 00 10 ff 05 00 00 00 00 00 00 00 00 00 00 00 00 01 01 00 03 00 11 03 6e 74 70 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00
+match Packet-Type = Reply, Transaction-ID = 0xf69b57, Client-ID-DUID = Client-ID-DUID-LLT, Client-ID-DUID-LLT-Hardware-Type = Client-ID-DUID-LLT-Ethernet, Client-ID-DUID-LLT-Time = "Apr  4 2013 09:58:23 UTC", Client-ID-DUID-LLT-Ethernet-Address = 00:0c:29:38:f3:68, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Apr  4 2013 01:34:19 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x000c299ba153, NTP-Server-Address = 2a01::1, NTP-Server-Multicast-Address = ff05::101, NTP-Server-FQDN = "ntp.example.com"
 
 count
-match 6
+match 4
+

--- a/src/tests/unit/protocols/dhcpv6/packet_sip-server-d.txt
+++ b/src/tests/unit/protocols/dhcpv6/packet_sip-server-d.txt
@@ -15,11 +15,9 @@ proto-dictionary dhcpv6
 #
 #  1.
 #
-encode-proto Packet-Type = Reply, Transaction-ID = 0x6890d8, Client-ID-DUID = Client-ID-DUID-LLT, Client-ID-DUID-LLT-Hardware-Type = Client-ID-DUID-LLT-Ethernet, Client-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Client-ID-DUID-LLT-Ethernet-Address = 00:0c:29:38:f3:68, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:03 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x000c299ba153, SIP-Server-Domain-Name-List = "sip1.my-domain.net", SIP-Server-Domain-Name-List = "sip2.example.com", SIP-Server-Domain-Name-List = "sip3.sub.my-domain.org"
-match 07 68 90 d8 00 01 00 0e 00 01 00 01 00 00 00 02 00 0c 29 38 f3 68 00 02 00 0e 00 01 00 01 00 00 00 03 00 0c 29 9b a1 53 00 15 00 3e 04 73 69 70 31 09 6d 79 2d 64 6f 6d 61 69 6e 03 6e 65 74 00 04 73 69 70 32 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 04 73 69 70 33 03 73 75 62 09 6d 79 2d 64 6f 6d 61 69 6e 03 6f 72 67 00
-
-decode-proto -
-match Packet-Type = Reply, Transaction-ID = 0x6890d8, Client-ID-DUID = Client-ID-DUID-LLT, Client-ID-DUID-LLT-Hardware-Type = Client-ID-DUID-LLT-Ethernet, Client-ID-DUID-LLT-Time = "Jan  1 2000 00:00:02 UTC", Client-ID-DUID-LLT-Ethernet-Address = 00:0c:29:38:f3:68, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Jan  1 2000 00:00:03 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x000c299ba153, SIP-Server-Domain-Name-List = "sip1.my-domain.net", SIP-Server-Domain-Name-List = "sip2.example.com", SIP-Server-Domain-Name-List = "sip3.sub.my-domain.org"
+decode-proto 07 68 90 d8 00 01 00 0e 00 01 00 01 18 f0 0b 3f 00 0c 29 38 f3 68 00 02 00 0e 00 01 00 01 18 ef 95 1b 00 0c 29 9b a1 53 00 15 00 3e 04 73 69 70 31 09 6d 79 2d 64 6f 6d 61 69 6e 03 6e 65 74 00 04 73 69 70 32 07 65 78 61 6d 70 6c 65 03 63 6f 6d 00 04 73 69 70 33 03 73 75 62 09 6d 79 2d 64 6f 6d 61 69 6e 03 6f 72 67 00
+match Packet-Type = Reply, Transaction-ID = 0x6890d8, Client-ID-DUID = Client-ID-DUID-LLT, Client-ID-DUID-LLT-Hardware-Type = Client-ID-DUID-LLT-Ethernet, Client-ID-DUID-LLT-Time = "Apr  4 2013 09:58:23 UTC", Client-ID-DUID-LLT-Ethernet-Address = 00:0c:29:38:f3:68, Server-ID-DUID = Server-ID-DUID-LLT, Server-ID-DUID-LLT-Hardware-Type = 1, Server-ID-DUID-LLT-Time = "Apr  4 2013 01:34:19 UTC", Server-ID-DUID-LLT-Link-Layer-Address = 0x000c299ba153, SIP-Server-Domain-Name-List = "sip1.my-domain.net", SIP-Server-Domain-Name-List = "sip2.example.com", SIP-Server-Domain-Name-List = "sip3.sub.my-domain.org"
 
 count
-match 6
+match 4
+


### PR DESCRIPTION
It was updated using the tool scripts/pcap2decode-proto.py

e.g:

```
./scripts/pcap2decode-proto.py -p dhcpv6 \
	-f ../tcpdump.git/tests/dhcpv6-ia-pd.pcap \
	> src/tests/unit/protocols/dhcpv6/packet_ia-pd.txt
```