### PR TITLE
Import .pcap RADIUS tests from tcpdump project

### DIFF
--- a/src/tests/unit/protocols/radius/packet_radius-port1700.txt
+++ b/src/tests/unit/protocols/radius/packet_radius-port1700.txt
@@ -1,0 +1,26 @@
+#  -*- text -*-
+#  Copyright (C) 2019 Network RADIUS SARL <legal@networkradius.com>
+#  This work is licensed under CC-BY version 4.0 https://creativecommons.org/licenses/by/4.0
+#
+#  Version $Id$
+#
+#  Test vectors for RADIUS protocol
+#
+#  Based on https://github.com/the-tcpdump-group/tcpdump/blob/master/tests/RADIUS-port1700.pcap
+#
+
+proto radius
+proto-dictionary radius
+
+#
+#  1.
+#
+# [ Raw ]
+#   load      = '+\xa6\x00\x19\x7f\xbf\x02\xc6f+Y\x90\x83\x8a^n3\x1b?\xf0\x01\x05bob'
+#
+decode-proto 2b a6 00 19 7f bf 02 c6 66 2b 59 90 83 8a 5e 6e 33 1b 3f f0 01 05 62 6f 62
+match Packet-Type = CoA-Request, Packet-Authentication-Vector = 0x7fbf02c6662b5990838a5e6e331b3ff0, User-Name = "bob"
+
+count
+match 4
+

--- a/src/tests/unit/protocols/radius/packet_radius-rfc3162.txt
+++ b/src/tests/unit/protocols/radius/packet_radius-rfc3162.txt
@@ -1,0 +1,66 @@
+#  -*- text -*-
+#  Copyright (C) 2019 Network RADIUS SARL <legal@networkradius.com>
+#  This work is licensed under CC-BY version 4.0 https://creativecommons.org/licenses/by/4.0
+#
+#  Version $Id$
+#
+#  Test vectors for RADIUS protocol
+#
+#  Based on https://github.com/the-tcpdump-group/tcpdump/blob/master/tests/RADIUS-RFC3162.pcap
+#
+
+proto radius
+proto-dictionary radius
+
+#
+#  1.
+#
+# [ RADIUS ]
+#   code      = Access-Request
+#   id        = 240
+#   len       = 141
+#   authenticator= 2afdb090418ac6365298fbbb15e0fd2e
+#   \attributes\
+#    |[ Radius Attribute ]
+#    |  type      = User-Name
+#    |  len       = 5
+#    |  value     = 'bob'
+#    |[ Radius Attribute ]
+#    |  type      = User-Password
+#    |  len       = 18
+#    |  value     = 'E\xe8\xd5\xda\xea\xd8~@\x15\xe0\xfc\xc0\xec\x0f\x08\xa1'
+#    |[ Radius Attribute ]
+#    |  type      = NAS-IPv6-Address
+#    |  len       = 18
+#    |  value     = ' \x01\r\xb8\n\x0b\x12\xf0\x00\x00\x00\x00\x00\x00\x00\x01'
+#    |[ Radius Attribute ]
+#    |  type      = Framed-IPv6-Prefix
+#    |  len       = 20
+#    |  value     = '\x00@ \x01\r\xb8\n\x0b\x12\xf0\x00\x00\x00\x00\x00\x00\x00\x00'
+#    |[ Radius Attribute ]
+#    |  type      = Framed-IPv6-Prefix
+#    |  len       = 12
+#    |  value     = '\x00@ \x01\r\xb8\n\x0b\x12\xf0'
+#    |[ Radius Attribute ]
+#    |  type      = Framed-IPv6-Prefix
+#    |  len       = 4
+#    |  value     = '\x00\x00'
+#    |[ Radius Attribute ]
+#    |  type      = Framed-IPv6-Prefix
+#    |  len       = 3
+#    |  value     = '\x00'
+#    |[ Radius Attribute ]
+#    |  type      = Framed-IPv6-Prefix
+#    |  len       = 21
+#    |  value     = '\x00@ \x01\r\xb8\n\x0b\x12\xf0\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+#    |[ Radius Attribute ]
+#    |  type      = Framed-IPv6-Prefix
+#    |  len       = 20
+#    |  value     = '\x00\x81 \x01\r\xb8\n\x0b\x12\xf0\x00\x00\x00\x00\x00\x00\x00\x01'
+#
+decode-proto 01 f0 00 8d 2a fd b0 90 41 8a c6 36 52 98 fb bb 15 e0 fd 2e 01 05 62 6f 62 02 12 45 e8 d5 da ea d8 7e 40 15 e0 fc c0 ec 0f 08 a1 5f 12 20 01 0d b8 0a 0b 12 f0 00 00 00 00 00 00 00 01 61 14 00 40 20 01 0d b8 0a 0b 12 f0 00 00 00 00 00 00 00 00 61 0c 00 40 20 01 0d b8 0a 0b 12 f0 61 04 00 00 61 03 00 61 15 00 40 20 01 0d b8 0a 0b 12 f0 00 00 00 00 00 00 00 00 00 61 14 00 81 20 01 0d b8 0a 0b 12 f0 00 00 00 00 00 00 00 01
+match Packet-Type = Access-Request, Packet-Authentication-Vector = 0x2afdb090418ac6365298fbbb15e0fd2e, User-Name = "bob", User-Password = "\323\006\334\020\236%\004Z\005\246\373\344\354\033\212*", NAS-IPv6-Address = 2001:db8:a0b:12f0::1, Framed-IPv6-Prefix = 2001:db8:a0b:12f0::/64, Framed-IPv6-Prefix = 2001:db8:a0b:12f0::/64, Framed-IPv6-Prefix = ::/0, Attr-97 = 0x00, Attr-97 = 0x004020010db80a0b12f0000000000000000000, Attr-97 = 0x008120010db80a0b12f00000000000000001
+
+count
+match 4
+

--- a/src/tests/unit/protocols/radius/packet_radius-rfc4675.txt
+++ b/src/tests/unit/protocols/radius/packet_radius-rfc4675.txt
@@ -1,0 +1,195 @@
+#  -*- text -*-
+#  Copyright (C) 2019 Network RADIUS SARL <legal@networkradius.com>
+#  This work is licensed under CC-BY version 4.0 https://creativecommons.org/licenses/by/4.0
+#
+#  Version $Id$
+#
+#  Test vectors for RADIUS protocol
+#
+#  Based on https://github.com/the-tcpdump-group/tcpdump/blob/master/tests/RADIUS-RFC4675.pcap
+#
+
+proto radius
+proto-dictionary radius
+
+#
+#  1.
+#
+# [ RADIUS ]
+#   code      = Access-Request
+#   id        = 70
+#   len       = 80
+#   authenticator= f44757bc498c3393763a27d0b2393702
+#   \attributes\
+#    |[ Radius Attribute ]
+#    |  type      = User-Name
+#    |  len       = 12
+#    |  value     = 'bob-tagged'
+#    |[ Radius Attribute ]
+#    |  type      = User-Password
+#    |  len       = 18
+#    |  value     = '\xa3\x0e"\xb06\x9e\x89\xf8\x9e\xb6\xe0a,,<'
+#    |[ NAS-IP-Address ]
+#    |  type      = NAS-IP-Address
+#    |  len       = 6
+#    |  value     = 127.0.0.1
+#    |[ NAS-Port ]
+#    |  type      = NAS-Port
+#    |  len       = 6
+#    |  value     = 1
+#    |[ Message-Authenticator ]
+#    |  type      = Message-Authenticator
+#    |  len       = 18
+#    |  value     = ffb19e8ea9620aec372d7fa3b2c76287
+#
+decode-proto 01 46 00 50 f4 47 57 bc 49 8c 33 93 76 3a 27 d0 b2 39 37 02 01 0c 62 6f 62 2d 74 61 67 67 65 64 02 12 a3 0e 22 b0 36 9e 89 f8 9e b6 e0 61 2c 2c 3c 23 04 06 7f 00 00 01 05 06 00 00 00 01 50 12 ff b1 9e 8e a9 62 0a ec 37 2d 7f a3 b2 c7 62 87
+match Packet-Type = Access-Request, Packet-Authentication-Vector = 0xf44757bc498c3393763a27d0b2393702, User-Name = "bob-tagged", User-Password = "5\340+zBc\363\342\216\360\347E,8\276\250", NAS-IP-Address = 127.0.0.1, NAS-Port = 1, Message-Authenticator = 0xffb19e8ea9620aec372d7fa3b2c76287
+
+#
+#  2.
+#
+# [ RADIUS ]
+#   code      = Access-Accept
+#   id        = 70
+#   len       = 53
+#   authenticator= 766a0314eaf4b95f1ec271ae19cb3bdc
+#   \attributes\
+#    |[ Egress-VLANID ]
+#    |  type      = Egress-VLANID
+#    |  len       = 6
+#    |  value     = 822083707
+#    |[ Radius Attribute ]
+#    |  type      = Ingress-Filters
+#    |  len       = 6
+#    |  value     = '\x00\x00\x00\x01'
+#    |[ Radius Attribute ]
+#    |  type      = Egress-VLAN-Name
+#    |  len       = 11
+#    |  value     = '1vlanname'
+#    |[ Radius Attribute ]
+#    |  type      = User-Priority-Table
+#    |  len       = 10
+#    |  value     = 'abcdabcd'
+#
+decode-proto 02 46 00 35 76 6a 03 14 ea f4 b9 5f 1e c2 71 ae 19 cb 3b dc 38 06 31 00 00 7b 39 06 00 00 00 01 3a 0b 31 76 6c 61 6e 6e 61 6d 65 3b 0a 61 62 63 64 61 62 63 64
+match Packet-Type = Access-Accept, Packet-Authentication-Vector = 0x766a0314eaf4b95f1ec271ae19cb3bdc, Egress-VLANID = 822083707, Ingress-Filters = Enabled, Egress-VLAN-Name = "1vlanname", User-Priority-Table = 0x6162636461626364
+
+#
+#  3.
+#
+# [ RADIUS ]
+#   code      = Access-Request
+#   id        = 181
+#   len       = 82
+#   authenticator= 11851d8b1b483f54a864b703ea21f4dc
+#   \attributes\
+#    |[ Radius Attribute ]
+#    |  type      = User-Name
+#    |  len       = 14
+#    |  value     = 'bob-untagged'
+#    |[ Radius Attribute ]
+#    |  type      = User-Password
+#    |  len       = 18
+#    |  value     = '\xf9i\xa0\x07E=\x0f\x91\xbbXn\x8e\xd6y\xbfF'
+#    |[ NAS-IP-Address ]
+#    |  type      = NAS-IP-Address
+#    |  len       = 6
+#    |  value     = 127.0.0.1
+#    |[ NAS-Port ]
+#    |  type      = NAS-Port
+#    |  len       = 6
+#    |  value     = 1
+#    |[ Message-Authenticator ]
+#    |  type      = Message-Authenticator
+#    |  len       = 18
+#    |  value     = af8f6f9bd87d66d1c364ad3bfe9e525b
+#
+decode-proto 01 b5 00 52 11 85 1d 8b 1b 48 3f 54 a8 64 b7 03 ea 21 f4 dc 01 0e 62 6f 62 2d 75 6e 74 61 67 67 65 64 02 12 f9 69 a0 07 45 3d 0f 91 bb 58 6e 8e d6 79 bf 46 04 06 7f 00 00 01 05 06 00 00 00 01 50 12 af 8f 6f 9b d8 7d 66 d1 c3 64 ad 3b fe 9e 52 5b
+match Packet-Type = Access-Request, Packet-Authentication-Vector = 0x11851d8b1b483f54a864b703ea21f4dc, User-Name = "bob-untagged", User-Password = "o\207\251\3151\300u\213\253\036i\252\326m=\315", NAS-IP-Address = 127.0.0.1, NAS-Port = 1, Message-Authenticator = 0xaf8f6f9bd87d66d1c364ad3bfe9e525b
+
+#
+#  4.
+#
+# [ RADIUS ]
+#   code      = Access-Accept
+#   id        = 181
+#   len       = 43
+#   authenticator= e223a663823b20ccc18bcf90c3ecbe27
+#   \attributes\
+#    |[ Egress-VLANID ]
+#    |  type      = Egress-VLANID
+#    |  len       = 6
+#    |  value     = 838860923
+#    |[ Radius Attribute ]
+#    |  type      = Ingress-Filters
+#    |  len       = 6
+#    |  value     = '\x00\x00\x00\x02'
+#    |[ Radius Attribute ]
+#    |  type      = Egress-VLAN-Name
+#    |  len       = 11
+#    |  value     = '2vlanname'
+#
+decode-proto 02 b5 00 2b e2 23 a6 63 82 3b 20 cc c1 8b cf 90 c3 ec be 27 38 06 32 00 00 7b 39 06 00 00 00 02 3a 0b 32 76 6c 61 6e 6e 61 6d 65
+match Packet-Type = Access-Accept, Packet-Authentication-Vector = 0xe223a663823b20ccc18bcf90c3ecbe27, Egress-VLANID = 838860923, Ingress-Filters = Disabled, Egress-VLAN-Name = "2vlanname"
+
+#
+#  5.
+#
+# [ RADIUS ]
+#   code      = Access-Request
+#   id        = 90
+#   len       = 81
+#   authenticator= 8dd685f50f837e8ad29e9cc095261172
+#   \attributes\
+#    |[ Radius Attribute ]
+#    |  type      = User-Name
+#    |  len       = 13
+#    |  value     = 'bob-invalid'
+#    |[ Radius Attribute ]
+#    |  type      = User-Password
+#    |  len       = 18
+#    |  value     = 'Zr\xc9\x16\xf6\xf4\x9b\xbe\x89\xcen\nYi\xfe'
+#    |[ NAS-IP-Address ]
+#    |  type      = NAS-IP-Address
+#    |  len       = 6
+#    |  value     = 127.0.0.1
+#    |[ NAS-Port ]
+#    |  type      = NAS-Port
+#    |  len       = 6
+#    |  value     = 1
+#    |[ Message-Authenticator ]
+#    |  type      = Message-Authenticator
+#    |  len       = 18
+#    |  value     = c39fb2d328b7a55e41cc66bf89f1acd5
+#
+decode-proto 01 5a 00 51 8d d6 85 f5 0f 83 7e 8a d2 9e 9c c0 95 26 11 72 01 0d 62 6f 62 2d 69 6e 76 61 6c 69 64 02 12 5a 72 c9 16 f6 f4 9b be 89 ce 23 6e 0a 59 69 fe 04 06 7f 00 00 01 05 06 00 00 00 01 50 12 c3 9f b2 d3 28 b7 a5 5e 41 cc 66 bf 89 f1 ac d5
+match Packet-Type = Access-Request, Packet-Authentication-Vector = 0x8dd685f50f837e8ad29e9cc095261172, User-Name = "bob-invalid", User-Password = "̜\300܂\tᤙ\210$J\nM\353u", NAS-IP-Address = 127.0.0.1, NAS-Port = 1, Message-Authenticator = 0xc39fb2d328b7a55e41cc66bf89f1acd5
+
+#
+#  6.
+#
+# [ RADIUS ]
+#   code      = Access-Accept
+#   id        = 90
+#   len       = 43
+#   authenticator= fbaa7d05d009953514d00697da4d1dfc
+#   \attributes\
+#    |[ Egress-VLANID ]
+#    |  type      = Egress-VLANID
+#    |  len       = 6
+#    |  value     = 855638139
+#    |[ Radius Attribute ]
+#    |  type      = Ingress-Filters
+#    |  len       = 6
+#    |  value     = '\x00\x00\x00\x03'
+#    |[ Radius Attribute ]
+#    |  type      = Egress-VLAN-Name
+#    |  len       = 11
+#    |  value     = '3vlanname'
+#
+decode-proto 02 5a 00 2b fb aa 7d 05 d0 09 95 35 14 d0 06 97 da 4d 1d fc 38 06 33 00 00 7b 39 06 00 00 00 03 3a 0b 33 76 6c 61 6e 6e 61 6d 65
+match Packet-Type = Access-Accept, Packet-Authentication-Vector = 0xfbaa7d05d009953514d00697da4d1dfc, Egress-VLANID = 855638139, Ingress-Filters = 3, Egress-VLAN-Name = "3vlanname"
+
+count
+match 14
+

--- a/src/tests/unit/protocols/radius/packet_radius-rfc5176-2.txt
+++ b/src/tests/unit/protocols/radius/packet_radius-rfc5176-2.txt
@@ -1,0 +1,46 @@
+#  -*- text -*-
+#  Copyright (C) 2019 Network RADIUS SARL <legal@networkradius.com>
+#  This work is licensed under CC-BY version 4.0 https://creativecommons.org/licenses/by/4.0
+#
+#  Version $Id$
+#
+#  Test vectors for RADIUS protocol
+#
+#  Based on https://github.com/the-tcpdump-group/tcpdump/blob/master/tests/RADIUS-RFC5176-2.pcap
+#
+
+proto radius
+proto-dictionary radius
+
+#
+#  1.
+#
+# [ RADIUS ]
+#   code      = Access-Request
+#   id        = 200
+#   len       = 55
+#   authenticator= bc6e7022445e359835692c8c121c1985
+#   \attributes\
+#    |[ Radius Attribute ]
+#    |  type      = User-Name
+#    |  len       = 5
+#    |  value     = 'bob'
+#    |[ Radius Attribute ]
+#    |  type      = User-Password
+#    |  len       = 18
+#    |  value     = '\x12\xf4\x1b\xff\x81\r\xbe"\x94\xa8\xee\xdcb\xc5}\x03'
+#    |[ Radius Attribute ]
+#    |  type      = Error-Cause
+#    |  len       = 6
+#    |  value     = '\x00\x00\x00\xc9'
+#    |[ Radius Attribute ]
+#    |  type      = Error-Cause
+#    |  len       = 6
+#    |  value     = '\x00\x00\x00\xd1'
+#
+decode-proto 01 c8 00 37 bc 6e 70 22 44 5e 35 98 35 69 2c 8c 12 1c 19 85 01 05 62 6f 62 02 12 12 f4 1b ff 81 0d be 22 94 a8 ee dc 62 c5 7d 03 65 06 00 00 00 c9 65 06 00 00 00 d1
+match Packet-Type = Access-Request, Packet-Authentication-Vector = 0xbc6e7022445e359835692c8c121c1985, User-Name = "bob", User-Password = "\204\032\0225\365\360\3048\204\356\351\370b\321\377\210", Error-Cause = Residual-Context-Removed, Error-Cause = 209
+
+count
+match 4
+

--- a/src/tests/unit/protocols/radius/packet_radius-rfc5176.txt
+++ b/src/tests/unit/protocols/radius/packet_radius-rfc5176.txt
@@ -1,0 +1,71 @@
+#  -*- text -*-
+#  Copyright (C) 2019 Network RADIUS SARL <legal@networkradius.com>
+#  This work is licensed under CC-BY version 4.0 https://creativecommons.org/licenses/by/4.0
+#
+#  Version $Id$
+#
+#  Test vectors for RADIUS protocol
+#
+#  Based on https://github.com/the-tcpdump-group/tcpdump/blob/master/tests/RADIUS-RFC5176.pcap
+#
+
+proto radius
+proto-dictionary radius
+
+#
+#  1.
+#
+# [ Raw ]
+#   load      = '(\x01\x00&\xe1y-+J\xb3I\xf1\xa4\xc0\xfc\xc73\xd0\x91\xc1P\x12XQ=f(G\xe5\xf8sJ0\xdb\xda\xc8\xe4\xaf'
+#
+decode-proto 28 01 00 26 e1 79 2d 2b 4a b3 49 f1 a4 c0 fc c7 33 d0 91 c1 50 12 58 51 3d 66 28 47 e5 f8 73 4a 30 db da c8 e4 af
+match Packet-Type = Disconnect-Request, Packet-Authentication-Vector = 0xe1792d2b4ab349f1a4c0fcc733d091c1, Message-Authenticator = 0x58513d662847e5f8734a30dbdac8e4af
+
+#
+#  2.
+#
+# [ Raw ]
+#   load      = ")\x02\x00&;\xc9\xc3C\xf6\x89\x99\x07V\xb9lX:V\x89\nP\x12\xa7O\xa4\xbe\xa5\xe0\x8c\x87\x0e\xdbiC,'}\x17"
+#
+decode-proto 29 02 00 26 3b c9 c3 43 f6 89 99 07 56 b9 6c 58 3a 56 89 0a 50 12 a7 4f a4 be a5 e0 8c 87 0e db 69 43 2c 27 7d 17
+match Packet-Type = Disconnect-ACK, Packet-Authentication-Vector = 0x3bc9c343f689990756b96c583a56890a, Message-Authenticator = 0xa74fa4bea5e08c870edb69432c277d17
+
+#
+#  3.
+#
+# [ Raw ]
+#   load      = '*\x03\x00&\xd8g\xc3\x08\xc9\xc41\x12\xb3\xa6i\xa0\xe8\xc0\xab\x8cP\x12\x1b\xdb\xc1p\x92I\xed\xe4\xda(\x81"\xa0\x87\xb8\xae'
+#
+decode-proto 2a 03 00 26 d8 67 c3 08 c9 c4 31 12 b3 a6 69 a0 e8 c0 ab 8c 50 12 1b db c1 70 92 49 ed e4 da 28 81 22 a0 87 b8 ae
+match Packet-Type = Disconnect-NAK, Packet-Authentication-Vector = 0xd867c308c9c43112b3a669a0e8c0ab8c, Message-Authenticator = 0x1bdbc1709249ede4da288122a087b8ae
+
+#
+#  4.
+#
+# [ Raw ]
+#   load      = "+\x04\x00&_\x180\x9b\xe6|\xd6\x15\x0f\xe4\xc3\xa0\xb956\xc9P\x12'\x03\xee6|\xd0F\xd1\xdf\xbc_\xe5\xb3\xcf[\xbf"
+#
+decode-proto 2b 04 00 26 5f 18 30 9b e6 7c d6 15 0f e4 c3 a0 b9 35 36 c9 50 12 27 03 ee 36 7c d0 46 d1 df bc 5f e5 b3 cf 5b bf
+match Packet-Type = CoA-Request, Packet-Authentication-Vector = 0x5f18309be67cd6150fe4c3a0b93536c9, Message-Authenticator = 0x2703ee367cd046d1dfbc5fe5b3cf5bbf
+
+#
+#  5.
+#
+# [ Raw ]
+#   load      = ',\x05\x00&U\xabl\xb7\x8a\xa1a\xd6\x92u?\xa9\x13\x0cP\x19P\x12\xe4\xdf\xa9\xee\xdd\xf9\xd2\x16\xde+\xe1x\n\xdc\xbbs'
+#
+decode-proto 2c 05 00 26 55 ab 6c b7 8a a1 61 d6 92 75 3f a9 13 0c 50 19 50 12 e4 df a9 ee dd f9 d2 16 de 2b e1 78 0a dc bb 73
+match Packet-Type = CoA-ACK, Packet-Authentication-Vector = 0x55ab6cb78aa161d692753fa9130c5019, Message-Authenticator = 0xe4dfa9eeddf9d216de2be1780adcbb73
+
+#
+#  6.
+#
+# [ Raw ]
+#   load      = '-\x06\x00&@\xf2\x1b\xde\xe2z\x87\xa5\xd7W\xa3\x0b\xfe\xd6/(P\x12\x85%y\xe8\xe2\xe5\xdc\xbdx\x1a\x90\x07&j\x06\xa7'
+#
+decode-proto 2d 06 00 26 40 f2 1b de e2 7a 87 a5 d7 57 a3 0b fe d6 2f 28 50 12 85 25 79 e8 e2 e5 dc bd 78 1a 90 07 26 6a 06 a7
+match Packet-Type = CoA-NAK, Packet-Authentication-Vector = 0x40f21bdee27a87a5d757a30bfed62f28, Message-Authenticator = 0x852579e8e2e5dcbd781a9007266a06a7
+
+count
+match 14
+

--- a/src/tests/unit/protocols/radius/packet_radius.txt
+++ b/src/tests/unit/protocols/radius/packet_radius.txt
@@ -1,0 +1,235 @@
+#  -*- text -*-
+#  Copyright (C) 2019 Network RADIUS SARL <legal@networkradius.com>
+#  This work is licensed under CC-BY version 4.0 https://creativecommons.org/licenses/by/4.0
+#
+#  Version $Id$
+#
+#  Test vectors for RADIUS protocol
+#
+#  Based on https://github.com/the-tcpdump-group/tcpdump/blob/master/tests/RADIUS.pcap
+#
+
+proto radius
+proto-dictionary radius
+
+#
+#  1.
+#
+# [ RADIUS ]
+#   code      = Access-Request
+#   id        = 5
+#   len       = 139
+#   authenticator= ecfe3d2fe4473ec6299095ee46aedf77
+#   \attributes\
+#    |[ NAS-IP-Address ]
+#    |  type      = NAS-IP-Address
+#    |  len       = 6
+#    |  value     = 10.0.0.1
+#    |[ NAS-Port ]
+#    |  type      = NAS-Port
+#    |  len       = 6
+#    |  value     = 50012
+#    |[ NAS-Port-Type ]
+#    |  type      = NAS-Port-Type
+#    |  len       = 6
+#    |  value     = Ethernet
+#    |[ Radius Attribute ]
+#    |  type      = User-Name
+#    |  len       = 14
+#    |  value     = 'John.McGuirk'
+#    |[ Radius Attribute ]
+#    |  type      = Called-Station-Id
+#    |  len       = 19
+#    |  value     = '00-19-06-EA-B8-8C'
+#    |[ Radius Attribute ]
+#    |  type      = Calling-Station-Id
+#    |  len       = 19
+#    |  value     = '00-14-22-E9-54-5E'
+#    |[ Service-Type ]
+#    |  type      = Service-Type
+#    |  len       = 6
+#    |  value     = Framed
+#    |[ Framed-MTU ]
+#    |  type      = Framed-MTU
+#    |  len       = 6
+#    |  value     = 1500
+#    |[ EAP-Message ]
+#    |  type      = EAP-Message
+#    |  len       = 19
+#    |  \value     \
+#    |   |[ EAP ]
+#    |   |  code      = Response
+#    |   |  id        = 0
+#    |   |  len       = 17
+#    |   |  type      = Identity
+#    |   |  identity  = 'John.McGuirk'
+#    |[ Message-Authenticator ]
+#    |  type      = Message-Authenticator
+#    |  len       = 18
+#    |  value     = 28c5beb8842486da70db51316f9d7889
+#
+decode-proto 01 05 00 8b ec fe 3d 2f e4 47 3e c6 29 90 95 ee 46 ae df 77 04 06 0a 00 00 01 05 06 00 00 c3 5c 3d 06 00 00 00 0f 01 0e 4a 6f 68 6e 2e 4d 63 47 75 69 72 6b 1e 13 30 30 2d 31 39 2d 30 36 2d 45 41 2d 42 38 2d 38 43 1f 13 30 30 2d 31 34 2d 32 32 2d 45 39 2d 35 34 2d 35 45 06 06 00 00 00 02 0c 06 00 00 05 dc 4f 13 02 00 00 11 01 4a 6f 68 6e 2e 4d 63 47 75 69 72 6b 50 12 28 c5 be b8 84 24 86 da 70 db 51 31 6f 9d 78 89
+match Packet-Type = Access-Request, Packet-Authentication-Vector = 0xecfe3d2fe4473ec6299095ee46aedf77, NAS-IP-Address = 10.0.0.1, NAS-Port = 50012, NAS-Port-Type = Ethernet, User-Name = "John.McGuirk", Called-Station-Id = "00-19-06-EA-B8-8C", Calling-Station-Id = "00-14-22-E9-54-5E", Service-Type = Framed-User, Framed-MTU = 1500, EAP-Message = 0x02000011014a6f686e2e4d63477569726b, Message-Authenticator = 0x28c5beb8842486da70db51316f9d7889
+
+#
+#  2.
+#
+# [ RADIUS ]
+#   code      = Access-Challenge
+#   id        = 5
+#   len       = 109
+#   authenticator= f050649184625d36f14c9075b7a48b83
+#   \attributes\
+#    |[ Framed-IP-Address ]
+#    |  type      = Framed-IP-Address
+#    |  len       = 6
+#    |  value     = 255.255.255.254
+#    |[ Framed-MTU ]
+#    |  type      = Framed-MTU
+#    |  len       = 6
+#    |  value     = 576
+#    |[ Service-Type ]
+#    |  type      = Service-Type
+#    |  len       = 6
+#    |  value     = Framed
+#    |[ Radius Attribute ]
+#    |  type      = Reply-Message
+#    |  len       = 11
+#    |  value     = 'Hello, %u'
+#    |[ EAP-Message ]
+#    |  type      = EAP-Message
+#    |  len       = 24
+#    |  \value     \
+#    |   |[ EAP-MD5 ]
+#    |   |  code      = Request
+#    |   |  id        = 1
+#    |   |  len       = 22
+#    |   |  type      = MD5-Challenge
+#    |   |  value_size= 16
+#    |   |  value     = 266b0e9a58322f4d01ab25b35f879464
+#    |   |  optional_name= b''
+#    |[ Message-Authenticator ]
+#    |  type      = Message-Authenticator
+#    |  len       = 18
+#    |  value     = 11b5043c8a288758173133a5e07434cf
+#    |[ State ]
+#    |  type      = State
+#    |  len       = 18
+#    |  value     = c6d195032fdc30240f7313b231ef1d77
+#
+decode-proto 0b 05 00 6d f0 50 64 91 84 62 5d 36 f1 4c 90 75 b7 a4 8b 83 08 06 ff ff ff fe 0c 06 00 00 02 40 06 06 00 00 00 02 12 0b 48 65 6c 6c 6f 2c 20 25 75 4f 18 01 01 00 16 04 10 26 6b 0e 9a 58 32 2f 4d 01 ab 25 b3 5f 87 94 64 50 12 11 b5 04 3c 8a 28 87 58 17 31 33 a5 e0 74 34 cf 18 12 c6 d1 95 03 2f dc 30 24 0f 73 13 b2 31 ef 1d 77
+match Packet-Type = Access-Challenge, Packet-Authentication-Vector = 0xf050649184625d36f14c9075b7a48b83, Framed-IP-Address = 255.255.255.254, Framed-MTU = 576, Service-Type = Framed-User, Reply-Message = "Hello, %u", EAP-Message = 0x010100160410266b0e9a58322f4d01ab25b35f879464, Message-Authenticator = 0x11b5043c8a288758173133a5e07434cf, State = 0xc6d195032fdc30240f7313b231ef1d77
+
+#
+#  3.
+#
+# [ RADIUS ]
+#   code      = Access-Request
+#   id        = 6
+#   len       = 174
+#   authenticator= 6a6f38e6dae830304d2333e5d5364643
+#   \attributes\
+#    |[ NAS-IP-Address ]
+#    |  type      = NAS-IP-Address
+#    |  len       = 6
+#    |  value     = 10.0.0.1
+#    |[ NAS-Port ]
+#    |  type      = NAS-Port
+#    |  len       = 6
+#    |  value     = 50012
+#    |[ NAS-Port-Type ]
+#    |  type      = NAS-Port-Type
+#    |  len       = 6
+#    |  value     = Ethernet
+#    |[ Radius Attribute ]
+#    |  type      = User-Name
+#    |  len       = 14
+#    |  value     = 'John.McGuirk'
+#    |[ Radius Attribute ]
+#    |  type      = Called-Station-Id
+#    |  len       = 19
+#    |  value     = '00-19-06-EA-B8-8C'
+#    |[ Radius Attribute ]
+#    |  type      = Calling-Station-Id
+#    |  len       = 19
+#    |  value     = '00-14-22-E9-54-5E'
+#    |[ Service-Type ]
+#    |  type      = Service-Type
+#    |  len       = 6
+#    |  value     = Framed
+#    |[ Framed-MTU ]
+#    |  type      = Framed-MTU
+#    |  len       = 6
+#    |  value     = 1500
+#    |[ State ]
+#    |  type      = State
+#    |  len       = 18
+#    |  value     = c6d195032fdc30240f7313b231ef1d77
+#    |[ EAP-Message ]
+#    |  type      = EAP-Message
+#    |  len       = 36
+#    |  \value     \
+#    |   |[ EAP-MD5 ]
+#    |   |  code      = Response
+#    |   |  id        = 1
+#    |   |  len       = 34
+#    |   |  type      = MD5-Challenge
+#    |   |  value_size= 16
+#    |   |  value     = c9f9769597e320843f5f2af7b8f1c9bd
+#    |   |  optional_name= 4a6f686e2e4d63477569726b
+#    |[ Message-Authenticator ]
+#    |  type      = Message-Authenticator
+#    |  len       = 18
+#    |  value     = 2726e2713194ebf2bc894f6a6202af38
+#
+decode-proto 01 06 00 ae 6a 6f 38 e6 da e8 30 30 4d 23 33 e5 d5 36 46 43 04 06 0a 00 00 01 05 06 00 00 c3 5c 3d 06 00 00 00 0f 01 0e 4a 6f 68 6e 2e 4d 63 47 75 69 72 6b 1e 13 30 30 2d 31 39 2d 30 36 2d 45 41 2d 42 38 2d 38 43 1f 13 30 30 2d 31 34 2d 32 32 2d 45 39 2d 35 34 2d 35 45 06 06 00 00 00 02 0c 06 00 00 05 dc 18 12 c6 d1 95 03 2f dc 30 24 0f 73 13 b2 31 ef 1d 77 4f 24 02 01 00 22 04 10 c9 f9 76 95 97 e3 20 84 3f 5f 2a f7 b8 f1 c9 bd 4a 6f 68 6e 2e 4d 63 47 75 69 72 6b 50 12 27 26 e2 71 31 94 eb f2 bc 89 4f 6a 62 02 af 38
+match Packet-Type = Access-Request, Packet-Authentication-Vector = 0x6a6f38e6dae830304d2333e5d5364643, NAS-IP-Address = 10.0.0.1, NAS-Port = 50012, NAS-Port-Type = Ethernet, User-Name = "John.McGuirk", Called-Station-Id = "00-19-06-EA-B8-8C", Calling-Station-Id = "00-14-22-E9-54-5E", Service-Type = Framed-User, Framed-MTU = 1500, State = 0xc6d195032fdc30240f7313b231ef1d77, EAP-Message = 0x020100220410c9f9769597e320843f5f2af7b8f1c9bd4a6f686e2e4d63477569726b, Message-Authenticator = 0x2726e2713194ebf2bc894f6a6202af38
+
+#
+#  4.
+#
+# [ RADIUS ]
+#   code      = Access-Accept
+#   id        = 6
+#   len       = 97
+#   authenticator= fbba6a784c7decb314caf0f27944a37b
+#   \attributes\
+#    |[ Framed-IP-Address ]
+#    |  type      = Framed-IP-Address
+#    |  len       = 6
+#    |  value     = 255.255.255.254
+#    |[ Framed-MTU ]
+#    |  type      = Framed-MTU
+#    |  len       = 6
+#    |  value     = 576
+#    |[ Service-Type ]
+#    |  type      = Service-Type
+#    |  len       = 6
+#    |  value     = Framed
+#    |[ Radius Attribute ]
+#    |  type      = Reply-Message
+#    |  len       = 21
+#    |  value     = 'Hello, John.McGuirk'
+#    |[ EAP-Message ]
+#    |  type      = EAP-Message
+#    |  len       = 6
+#    |  \value     \
+#    |   |[ EAP ]
+#    |   |  code      = Success
+#    |   |  id        = 1
+#    |   |  len       = 4
+#    |[ Message-Authenticator ]
+#    |  type      = Message-Authenticator
+#    |  len       = 18
+#    |  value     = b9c4ae6213a71d32125ef7ca4e4c6360
+#    |[ Radius Attribute ]
+#    |  type      = User-Name
+#    |  len       = 14
+#    |  value     = 'John.McGuirk'
+#
+decode-proto 02 06 00 61 fb ba 6a 78 4c 7d ec b3 14 ca f0 f2 79 44 a3 7b 08 06 ff ff ff fe 0c 06 00 00 02 40 06 06 00 00 00 02 12 15 48 65 6c 6c 6f 2c 20 4a 6f 68 6e 2e 4d 63 47 75 69 72 6b 4f 06 03 01 00 04 50 12 b9 c4 ae 62 13 a7 1d 32 12 5e f7 ca 4e 4c 63 60 01 0e 4a 6f 68 6e 2e 4d 63 47 75 69 72 6b
+match Packet-Type = Access-Accept, Packet-Authentication-Vector = 0xfbba6a784c7decb314caf0f27944a37b, Framed-IP-Address = 255.255.255.254, Framed-MTU = 576, Service-Type = Framed-User, Reply-Message = "Hello, John.McGuirk", EAP-Message = 0x03010004, Message-Authenticator = 0xb9c4ae6213a71d32125ef7ca4e4c6360, User-Name = "John.McGuirk"
+
+count
+match 10
+


### PR DESCRIPTION
It was imported using scripts/pcap2decode-proto.py

e.g:

./scripts/pcap2decode-proto.py -p radius \
	-f ../tcpdump.git/tests/RADIUS-RFC4675.pcap \
	> src/tests/unit/protocols/radius/packet_radius-rfc4675.txt