### PR TITLE
Master: SQL IP Pools support for MS SQL

### DIFF
--- a/raddb/mods-config/sql/ippool/mssql/procedure.sql
+++ b/raddb/mods-config/sql/ippool/mssql/procedure.sql
@@ -1,0 +1,139 @@
+--
+-- A stored procedure to reallocate a user's previous address, otherwise
+-- provide a free address.
+--
+-- Using this SP reduces the usual set dialogue of queries to a single
+-- query:
+--
+--   BEGIN TRAN; "SELECT FOR UPDATE"; UPDATE; COMMIT TRAN;  ->  EXEC sp
+--
+-- The stored procedure is executed on an database instance within a single
+-- round trip which often leads to reduced deadlocking and significant
+-- performance improvements especially on multi-master clusters, perhaps even
+-- by an order of magnitude or more.
+--
+-- To use this stored procedure the corresponding queries.conf statements must
+-- be configured as follows:
+--
+-- allocate_begin = ""
+-- allocate_find = "\
+--      EXEC fr_allocate_previous_or_new_framedipaddress \
+--              @v_pool_name = '%{control:${pool_name}}', \
+--              @v_username = '%{User-Name}', \
+--              @v_callingstationid = '%{Calling-Station-Id}', \
+--              @v_nasipaddress = '%{NAS-IP-Address}', \
+--              @v_pool_key = '${pool_key}', \
+--              @v_lease_duration = ${lease_duration} \
+--      "
+-- allocate_update = ""
+-- allocate_commit = ""
+--
+
+CREATE INDEX UserName_CallingStationId ON radippool(pool_name,UserName,CallingStationId)
+GO
+
+CREATE OR ALTER PROCEDURE fr_allocate_previous_or_new_framedipaddress
+	@v_pool_name VARCHAR(64),
+	@v_username VARCHAR(64),
+	@v_callingstationid VARCHAR(64),
+	@v_nasipaddress VARCHAR(15),
+	@v_pool_key VARCHAR(64),
+	@v_lease_duration INT
+AS
+	BEGIN
+
+		-- MS SQL lacks a "SELECT FOR UPDATE" statement, and its table
+		-- hints do not provide a direct means to implement the row-level
+		-- read lock needed to guarentee that concurrent queries do not
+		-- select the same Framed-IP-Address for allocation to distinct
+		-- users.
+		--
+		-- The "WITH cte AS ( SELECT ... ) UPDATE cte ... OUTPUT INTO"
+		-- patterns in this procedure body compensate by wrapping
+		-- the SELECT in a synthetic UPDATE which locks the row.
+
+		DECLARE @r_address_tab TABLE(id VARCHAR(15));
+		DECLARE @r_address VARCHAR(15);
+
+		BEGIN TRAN;
+
+		-- Reissue an existing IP address lease when re-authenticating a session
+		--
+		WITH cte AS (
+			SELECT TOP(1) FramedIPAddress
+			FROM radippool
+			WHERE pool_name = @v_pool_name
+				AND expiry_time > CURRENT_TIMESTAMP
+				AND UserName = @v_username
+				AND CallingStationId = @v_callingstationid
+		)
+		UPDATE cte WITH (rowlock, readpast)
+		SET FramedIPAddress = FramedIPAddress
+		OUTPUT INSERTED.FramedIPAddress INTO @r_address_tab;
+		SELECT @r_address = id FROM @r_address_tab;
+
+		-- Reissue an user's previous IP address, provided that the lease is
+		-- available (i.e. enable sticky IPs)
+		--
+		-- When using this SELECT you should delete the one above. You must also
+		-- set allocate_clear = "" in queries.conf to persist the associations
+		-- for expired leases.
+		--
+		-- WITH cte AS (
+		-- 	SELECT TOP(1) FramedIPAddress
+		-- 	FROM radippool
+		-- 	WHERE pool_name = @v_pool_name
+		-- 		AND UserName = @v_username
+		-- 		AND CallingStationId = @v_callingstationid
+		-- )
+		-- UPDATE cte WITH (rowlock, readpast)
+		-- SET FramedIPAddress = FramedIPAddress
+		-- OUTPUT INSERTED.FramedIPAddress INTO @r_address_tab;
+		-- SELECT @r_address = id FROM @r_address_tab;
+
+		-- If we didn't reallocate a previous address then pick the least
+		-- recently used address from the pool which maximises the likelihood
+		-- of re-assigning the other addresses to their recent user
+		--
+		IF @r_address IS NULL
+		BEGIN
+			WITH cte AS (
+				SELECT TOP(1) FramedIPAddress
+				FROM radippool
+				WHERE pool_name = @v_pool_name
+					AND ( expiry_time < CURRENT_TIMESTAMP OR expiry_time IS NULL )
+				ORDER BY
+					expiry_time
+			)
+			UPDATE cte WITH (rowlock, readpast)
+			SET FramedIPAddress = FramedIPAddress
+			OUTPUT INSERTED.FramedIPAddress INTO @r_address_tab;
+			SELECT @r_address = id FROM @r_address_tab;
+		END
+
+		-- Return nothing if we failed to allocated an address
+		--
+		IF @r_address IS NULL
+		BEGIN
+			COMMIT TRAN;
+			RETURN;
+		END
+
+		-- Update the pool having allocated an IP address
+		--
+		UPDATE radippool
+		SET
+			NASIPAddress = @v_nasipaddress,
+			pool_key = @v_pool_key,
+			CallingStationId = @v_callingstationid,
+			UserName = @v_username,
+			expiry_time = DATEADD(SECOND,@v_lease_duration,CURRENT_TIMESTAMP)
+		WHERE framedipaddress = @r_address;
+
+		COMMIT TRAN;
+
+		-- Return the address that we allocated
+		SELECT @r_address;
+
+	END
+GO

--- a/raddb/mods-config/sql/ippool/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mssql/queries.conf
@@ -1,0 +1,183 @@
+# -*- text -*-
+#
+#  ippool/mssql/queries.conf -- MSSQL queries for rlm_sqlippool
+#
+#  $Id$
+
+# MSSQL-specific syntax
+allocate_begin = "BEGIN TRAN"
+allocate_commit = "COMMIT TRAN"
+
+#
+#  This series of queries allocates an IP address
+#
+#allocate_clear = "\
+#	UPDATE ${ippool_table} \
+#	SET \
+#		NASIPAddress = '', \
+#		pool_key = 0, \
+#		CallingStationId = '', \
+#		UserName = '', \
+#		expiry_time = NULL \
+#	WHERE pool_key = '${pool_key}'"
+
+#
+#  (Note: If your pool_key is set to Calling-Station-Id and not NAS-Port
+#  then you may wish to delete the "AND nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'
+#  from the WHERE clause)
+#
+allocate_clear = "\
+	UPDATE ${ippool_table} \
+	SET \
+		NASIPAddress = '', \
+		pool_key = 0, \
+		CallingStationID = '', \
+		UserName = '', \
+		expiry_time = NULL \
+	WHERE expiry_time <= DATEADD(SECOND,-1,CURRENT_TIMESTAMP) \
+	AND NASIPAddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"
+
+#
+#  The ORDER BY clause of this query tries to allocate the same IP-address
+#  which user had last session...
+#
+allocate_find = "\
+	WITH cte AS ( \
+		SELECT TOP(1) FramedIPAddress FROM ${ippool_table} \
+		WHERE pool_name = '%{control:${pool_name}}' \
+		AND ( expiry_time < CURRENT_TIMESTAMP OR expiry_time IS NULL ) \
+		OR ( NASIPAddress = '%{NAS-IP-Address}' AND pool_key = '${pool_key}' ) \
+		ORDER BY \
+			CASE WHEN UserName = '%{User-Name}' THEN 0 ELSE 1 END, \
+			CASE WHEN CallingStationId = '%{Calling-Station-Id}' THEN 0 ELSE 1 END, \
+			expiry_time \
+	) \
+	UPDATE cte WITH (rowlock, readpast) \
+	SET FramedIPAddress = FramedIPAddress \
+	OUTPUT INSERTED.FramedIPAddress"
+
+#
+#  If you prefer to allocate a random IP address every time, use this query instead.
+#  Note: This is very slow if you have a lot of free IPs.
+#
+#allocate_find = "\
+#	WITH cte AS ( \
+#		SELECT TOP(1) FramedIPAddress FROM ${ippool_table} \
+#		WHERE pool_name = '%{control:${pool_name}}' \
+#		AND ( \
+#			expiry_time < CURRENT_TIMESTAMP OR expiry_time IS NULL \
+#		) \
+#		ORDER BY \
+#			newid() \
+#	) \
+#	UPDATE cte WITH (rowlock, readpast) \
+#	SET FramedIPAddress = FramedIPAddress \
+#	OUTPUT INSERTED.FramedIPAddress"
+
+#
+#  If an IP could not be allocated, check to see if the pool exists or not
+#  This allows the module to differentiate between a full pool and no pool
+#  Note: If you are not running redundant pool modules this query may be
+#  commented out to save running this query every time an ip is not allocated.
+#
+pool_check = "\
+	SELECT TOP(1) id \
+	FROM ${ippool_table} \
+	WHERE pool_name='%{control:${pool_name}}'"
+
+#
+#  This is the final IP Allocation query, which saves the allocated ip details.
+#
+allocate_update = "\
+	UPDATE ${ippool_table} \
+	SET \
+		NASIPAddress = '%{NAS-IP-Address}', pool_key = '${pool_key}', \
+		CallingStationId = '%{Calling-Station-Id}', \
+		UserName = '%{User-Name}', expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
+	WHERE FramedIPAddress = '%I'"
+
+#
+#  Use a stored procedure to find AND allocate the address. Read and customise
+#  `procedure.sql` in this directory to determine the optimal configuration.
+#
+#allocate_begin = ""
+#allocate_find = "\
+#	EXEC fr_allocate_previous_or_new_framedipaddress \
+#		@v_pool_name = '%{control:${pool_name}}', \
+#		@v_username = '%{User-Name}', \
+#		@v_callingstationid = '%{Calling-Station-Id}', \
+#		@v_nasipaddress = '%{NAS-IP-Address}', \
+#		@v_pool_key = '${pool_key}', \
+#		@v_lease_duration = ${lease_duration} \
+#	"
+#allocate_update = ""
+#allocate_commit = ""
+
+#
+#  This series of queries frees an IP number when an accounting START record arrives.
+#
+start_update = "\
+	UPDATE ${ippool_table} \
+	SET \
+		expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
+	WHERE NASIPAddress = '%{NAS-IP-Address}' \
+	AND pool_key = '${pool_key}' \
+	AND UserName = '%{User-Name}' \
+	AND CallingStationId = '%{Calling-Station-Id}' \
+	AND FramedIPAddress = '%{${attribute_name}}'"
+
+#
+#  Free an IP when an accounting STOP record arrives
+#
+stop_clear = "\
+	UPDATE ${ippool_table} \
+	SET \
+		NASIPAddress = '', \
+		pool_key = 0, \
+		CallingStationId = '', \
+		UserName = '', \
+		expiry_time = NULL \
+	WHERE NASIPAddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}' \
+	AND pool_key = '${pool_key}' \
+	AND UserName = '%{User-Name}' \
+	AND CallingStationId = '%{Calling-Station-Id}' \
+	AND FramedIPAddress = '%{${attribute_name}}'"
+
+#
+#  Update the expiry time for an IP when an accounting ALIVE record arrives
+#
+alive_update = "\
+	UPDATE ${ippool_table} \
+	SET \
+		expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
+	WHERE NASIPAddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}' \
+	AND pool_key = '${pool_key}' \
+	AND UserName = '%{User-Name}' \
+	AND CallingStationId = '%{Calling-Station-Id}' \
+	AND FramedIPAddress = '%{${attribute_name}}'"
+
+#
+#  Frees all IPs allocated to a NAS when an accounting ON record arrives
+#
+on_clear = "\
+	UPDATE ${ippool_table} \
+	SET \
+		NASIPAddress = '', \
+		pool_key = 0, \
+		CallingStationId = '', \
+		UserName = '', \
+		expiry_time = NULL \
+	WHERE NASIPAddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"
+
+#
+#  Frees all IPs allocated to a NAS when an accounting OFF record arrives
+#
+off_clear = "\
+	UPDATE ${ippool_table} \
+	SET \
+		NASIPAddress = '', \
+		pool_key = 0, \
+		CallingStationId = '', \
+		UserName = '', \
+		expiry_time = NULL \
+	WHERE NASIPAddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"

--- a/raddb/mods-config/sql/ippool/mssql/schema.sql
+++ b/raddb/mods-config/sql/ippool/mssql/schema.sql
@@ -1,0 +1,25 @@
+--
+-- Table structure for table 'radippool'
+--
+CREATE TABLE radippool (
+  id                    int IDENTITY (1,1) NOT NULL,
+  pool_name             varchar(30) NOT NULL,
+  FramedIPAddress       varchar(15) NOT NULL default '',
+  NASIPAddress          varchar(15) NOT NULL default '',
+  CalledStationId       VARCHAR(32) NOT NULL,
+  CallingStationId      VARCHAR(30) NOT NULL,
+  expiry_time           DATETIME NULL default NULL,
+  UserName              varchar(64) NOT NULL default '',
+  pool_key              varchar(30) NOT NULL default '',
+  PRIMARY KEY (id)
+)
+GO
+
+CREATE INDEX poolname_expire ON radippool(pool_name, expiry_time)
+GO
+
+CREATE INDEX FramedIPAddress ON radippool(FramedIPAddress)
+GO
+
+CREATE INDEX NASIPAddress_poolkey_FramedIPAddress ON radippool(NASIPAddress, pool_key, FramedIPAddress)
+GO

--- a/raddb/mods-config/sql/main/mssql/schema.sql
+++ b/raddb/mods-config/sql/main/mssql/schema.sql
@@ -1,110 +1,53 @@
-/***************************************************************************
- * $Id$		   *
- *									   *
- * db_mssql.sql                 					   *
- *                                                                         *
- * Database schema for MSSQL server					   *
- *									   *
- * To load:								   *
- *  isql -S db_ip_addr -d db_name -U db_login -P db_passwd -i db_mssql.sql *
- *									   *
- * Based on: db_mysql.sql (Mike Machado <mike@innercite.com>)		   *
- *									   *
- *					Dmitri Ageev <d_ageev@ortcc.ru>    *
- ***************************************************************************/
+-- $Id$d$
+--
+-- schela.sql   rlm_sql - FreeRADIUS SQL Module
+--
+-- Database schema for MSSQL rlm_sql module
+--
+-- To load:
+--  isql -S db_ip_addr -d db_name -U db_login -P db_passwd -i db_mssql.sql
+--
+-- Based on: db_mysql.sql (Mike Machado <mike@innercite.com>)
+--
+--					Dmitri Ageev <d_ageev@ortcc.ru>
+--
 
-/****** Object:  Table [radacct]    Script Date: 26.03.02 16:55:17 ******/
+
+--
+-- Table structure for table 'radacct'
+--
+
 CREATE TABLE [radacct] (
 	[RadAcctId] [numeric](21, 0) IDENTITY (1, 1) NOT NULL,
-	[AcctSessionId] [varchar] (64) NOT NULL ,
-	[AcctUniqueId] [varchar] (32) NOT NULL ,
-	[UserName] [varchar] (64) NOT NULL ,
-	[GroupName] [varchar] (64) NOT NULL ,
+	[AcctSessionId] [varchar] (64) NOT NULL,
+	[AcctUniqueId] [varchar] (32) NOT NULL,
+	[UserName] [varchar] (64) NOT NULL,
+	[GroupName] [varchar] (64) NOT NULL,
 	[Realm] [varchar] (64) NOT NULL,
-	[NASIPAddress] [varchar] (15) NOT NULL ,
-	[NASPortId] [varchar] (15) NULL ,
-	[NASPortType] [varchar] (32) NULL ,
-	[AcctStartTime] [datetime] NOT NULL ,
-	[AcctStopTime] [datetime] NOT NULL ,
-	[AcctSessionTime] [bigint] NULL ,
-	[AcctAuthentic] [varchar] (32) NULL ,
-	[ConnectInfo_start] [varchar] (32) NULL ,
-	[ConnectInfo_stop] [varchar] (32) NULL ,
-	[AcctInputOctets] [bigint] NULL ,
-	[AcctOutputOctets] [bigint] NULL ,
-	[CalledStationId] [varchar] (30) NOT NULL ,
-	[CallingStationId] [varchar] (30) NOT NULL ,
-	[AcctTerminateCause] [varchar] (32) NOT NULL ,
-	[ServiceType] [varchar] (32) NULL ,
-	[FramedProtocol] [varchar] (32) NULL ,
-	[FramedIPAddress] [varchar] (15) NOT NULL ,
-	[FramedIPv6Address] [varchar] (45) NOT NULL ,
-	[FramedIPv6Prefix] [varchar] (45) NOT NULL ,
-	[FramedInterfaceId] [varchar] (44) NOT NULL ,
-	[DelegatedIPv6Prefix] [varchar] (45) NOT NULL ,
-	[AcctStartDelay] [int] NULL ,
+	[NASIPAddress] [varchar] (15) NOT NULL,
+	[NASPortId] [varchar] (15) NULL,
+	[NASPortType] [varchar] (32) NULL,
+	[AcctStartTime] [datetime] NOT NULL,
+	[AcctStopTime] [datetime] NOT NULL,
+	[AcctSessionTime] [bigint] NULL,
+	[AcctAuthentic] [varchar] (32) NULL,
+	[ConnectInfo_start] [varchar] (32) NULL,
+	[ConnectInfo_stop] [varchar] (32) NULL,
+	[AcctInputOctets] [bigint] NULL,
+	[AcctOutputOctets] [bigint] NULL,
+	[CalledStationId] [varchar] (30) NOT NULL,
+	[CallingStationId] [varchar] (30) NOT NULL,
+	[AcctTerminateCause] [varchar] (32) NOT NULL,
+	[ServiceType] [varchar] (32) NULL,
+	[FramedProtocol] [varchar] (32) NULL,
+	[FramedIPAddress] [varchar] (15) NOT NULL,
+	[FramedIPv6Address] [varchar] (45) NOT NULL,
+	[FramedIPv6Prefix] [varchar] (45) NOT NULL,
+	[FramedInterfaceId] [varchar] (44) NOT NULL,
+	[DelegatedIPv6Prefix] [varchar] (45) NOT NULL,
+	[AcctStartDelay] [int] NULL,
 	[AcctStopDelay] [int] NULL
 ) ON [PRIMARY]
-GO
-
-/****** Object:  Table [radcheck]    Script Date: 26.03.02 16:55:17 ******/
-CREATE TABLE [radcheck] (
-	[id] [int] IDENTITY (1, 1) NOT NULL ,
-	[UserName] [varchar] (64) NOT NULL ,
-	[Attribute] [varchar] (32) NOT NULL ,
-	[Value] [varchar] (253) NOT NULL ,
-	[op] [char] (2) NULL
-) ON [PRIMARY]
-GO
-
-/****** Object:  Table [radgroupcheck]    Script Date: 26.03.02 16:55:17 ******/
-CREATE TABLE [radgroupcheck] (
-	[id] [int] IDENTITY (1, 1) NOT NULL ,
-	[GroupName] [varchar] (64) NOT NULL ,
-	[Attribute] [varchar] (32) NOT NULL ,
-	[Value] [varchar] (253) NOT NULL ,
-	[op] [char] (2) NULL
-) ON [PRIMARY]
-GO
-
-/****** Object:  Table [radgroupreply]    Script Date: 26.03.02 16:55:17 ******/
-CREATE TABLE [radgroupreply] (
-	[id] [int] IDENTITY (1, 1) NOT NULL ,
-	[GroupName] [varchar] (64) NOT NULL ,
-	[Attribute] [varchar] (32) NOT NULL ,
-	[Value] [varchar] (253) NOT NULL ,
-	[op] [char] (2) NULL ,
-	[prio] [int] NOT NULL
-) ON [PRIMARY]
-GO
-
-/****** Object:  Table [radreply]    Script Date: 26.03.02 16:55:18 ******/
-CREATE TABLE [radreply] (
-	[id] [int] IDENTITY (1, 1) NOT NULL ,
-	[UserName] [varchar] (64) NOT NULL ,
-	[Attribute] [varchar] (32) NOT NULL ,
-	[Value] [varchar] (253) NOT NULL ,
-	[op] [char] (2) NULL
-) ON [PRIMARY]
-GO
-
-/****** Object:  Table [radusergroup]    Script Date: 26.03.02 16:55:18 ******/
-CREATE TABLE [radusergroup] (
-	[id] [int] IDENTITY (1, 1) NOT NULL ,
-	[UserName] [varchar] (64) NOT NULL ,
-	[GroupName] [varchar] (64) NULL ,
-	[Priority] [int] NULL
-) ON [PRIMARY]
-GO
-
-/****** Object:  Table [radusergroup]    Script Date: 16.04.08 19:44:11 ******/
-CREATE TABLE [radpostauth] (
-	[id] [int] IDENTITY (1, 1) NOT NULL ,
-	[userName] [varchar] (64) NOT NULL ,
-	[pass] [varchar] (64) NOT NULL ,
-	[reply] [varchar] (32) NOT NULL ,
-	[authdate] [datetime] NOT NULL
-)
 GO
 
 ALTER TABLE [radacct] WITH NOCHECK ADD
@@ -136,10 +79,61 @@ ALTER TABLE [radacct] WITH NOCHECK ADD
 	CONSTRAINT [DF_radacct_DelegatedIPv6Prefix] DEFAULT ('') FOR [DelegatedIPv6Prefix],
 	CONSTRAINT [DF_radacct_AcctStartDelay] DEFAULT (null) FOR [AcctStartDelay],
 	CONSTRAINT [DF_radacct_AcctStopDelay] DEFAULT (null) FOR [AcctStopDelay],
-	CONSTRAINT [PK_radacct] PRIMARY KEY  NONCLUSTERED
+	CONSTRAINT [PK_radacct] PRIMARY KEY NONCLUSTERED
 	(
 		[RadAcctId]
-	)  ON [PRIMARY]
+	) ON [PRIMARY]
+GO
+
+CREATE INDEX [UserName] ON [radacct]([UserName]) ON [PRIMARY]
+GO
+
+CREATE INDEX [FramedIPAddress] ON [radacct]([FramedIPAddress]) ON [PRIMARY]
+GO
+
+CREATE INDEX [FramedIPv6Address] ON [radacct]([FramedIPv6Address]) ON [PRIMARY]
+GO
+
+CREATE INDEX [FramedIPv6Prefix] ON [radacct]([FramedIPv6Prefix]) ON [PRIMARY]
+GO
+
+CREATE INDEX [FramedInterfaceId] ON [radacct]([FramedInterfaceId]) ON [PRIMARY]
+GO
+
+CREATE INDEX [DelegatedIPv6Prefix] ON [radacct]([DelegatedIPv6Prefix]) ON [PRIMARY]
+GO
+
+CREATE INDEX [AcctSessionId] ON [radacct]([AcctSessionId]) ON [PRIMARY]
+GO
+
+CREATE UNIQUE INDEX [AcctUniqueId] ON [radacct]([AcctUniqueId]) ON [PRIMARY]
+GO
+
+CREATE INDEX [AcctStartTime] ON [radacct]([AcctStartTime]) ON [PRIMARY]
+GO
+
+CREATE INDEX [AcctStopTime] ON [radacct]([AcctStopTime]) ON [PRIMARY]
+GO
+
+CREATE INDEX [NASIPAddress] ON [radacct]([NASIPAddress]) ON [PRIMARY]
+GO
+
+/* For use by onoff */
+CREATE INDEX [RadacctBulkClose] ON [radacct]([NASIPAddress],[AcctStartTime]) WHERE [AcctStopTime] IS NULL ON [PRIMARY]
+GO
+
+
+--
+-- Table structure for table 'radacct'
+--
+
+CREATE TABLE [radcheck] (
+	[id] [int] IDENTITY (1, 1) NOT NULL ,
+	[UserName] [varchar] (64) NOT NULL ,
+	[Attribute] [varchar] (32) NOT NULL ,
+	[Value] [varchar] (253) NOT NULL ,
+	[op] [char] (2) NULL
+) ON [PRIMARY]
 GO
 
 ALTER TABLE [radcheck] WITH NOCHECK ADD
@@ -147,10 +141,27 @@ ALTER TABLE [radcheck] WITH NOCHECK ADD
 	CONSTRAINT [DF_radcheck_Attribute] DEFAULT ('') FOR [Attribute],
 	CONSTRAINT [DF_radcheck_Value] DEFAULT ('') FOR [Value],
 	CONSTRAINT [DF_radcheck_op] DEFAULT (null) FOR [op],
-	CONSTRAINT [PK_radcheck] PRIMARY KEY  NONCLUSTERED
+	CONSTRAINT [PK_radcheck] PRIMARY KEY NONCLUSTERED
 	(
 		[id]
-	)  ON [PRIMARY]
+	) ON [PRIMARY]
+GO
+
+CREATE INDEX [UserName] ON [radcheck]([UserName]) ON [PRIMARY]
+GO
+
+
+--
+-- Table structure for table 'radacct'
+--
+
+CREATE TABLE [radgroupcheck] (
+	[id] [int] IDENTITY (1, 1) NOT NULL ,
+	[GroupName] [varchar] (64) NOT NULL ,
+	[Attribute] [varchar] (32) NOT NULL ,
+	[Value] [varchar] (253) NOT NULL ,
+	[op] [char] (2) NULL
+) ON [PRIMARY]
 GO
 
 ALTER TABLE [radgroupcheck] WITH NOCHECK ADD
@@ -158,10 +169,28 @@ ALTER TABLE [radgroupcheck] WITH NOCHECK ADD
 	CONSTRAINT [DF_radgroupcheck_Attribute] DEFAULT ('') FOR [Attribute],
 	CONSTRAINT [DF_radgroupcheck_Value] DEFAULT ('') FOR [Value],
 	CONSTRAINT [DF_radgroupcheck_op] DEFAULT (null) FOR [op],
-	CONSTRAINT [PK_radgroupcheck] PRIMARY KEY  NONCLUSTERED
+	CONSTRAINT [PK_radgroupcheck] PRIMARY KEY NONCLUSTERED
 	(
 		[id]
-	)  ON [PRIMARY]
+	) ON [PRIMARY]
+GO
+
+CREATE INDEX [GroupName] ON [radgroupcheck]([GroupName]) ON [PRIMARY]
+GO
+
+
+--
+-- Table structure for table 'radacct'
+--
+
+CREATE TABLE [radgroupreply] (
+	[id] [int] IDENTITY (1, 1) NOT NULL ,
+	[GroupName] [varchar] (64) NOT NULL ,
+	[Attribute] [varchar] (32) NOT NULL ,
+	[Value] [varchar] (253) NOT NULL ,
+	[op] [char] (2) NULL ,
+	[prio] [int] NOT NULL
+) ON [PRIMARY]
 GO
 
 ALTER TABLE [radgroupreply] WITH NOCHECK ADD
@@ -170,10 +199,27 @@ ALTER TABLE [radgroupreply] WITH NOCHECK ADD
 	CONSTRAINT [DF_radgroupreply_Value] DEFAULT ('') FOR [Value],
 	CONSTRAINT [DF_radgroupreply_op] DEFAULT (null) FOR [op],
 	CONSTRAINT [DF_radgroupreply_prio] DEFAULT (0) FOR [prio],
-	CONSTRAINT [PK_radgroupreply] PRIMARY KEY  NONCLUSTERED
+	CONSTRAINT [PK_radgroupreply] PRIMARY KEY NONCLUSTERED
 	(
 		[id]
-	)  ON [PRIMARY]
+	) ON [PRIMARY]
+GO
+
+CREATE INDEX [GroupName] ON [radgroupreply]([GroupName]) ON [PRIMARY]
+GO
+
+
+--
+-- Table structure for table 'radacct'
+--
+
+CREATE TABLE [radreply] (
+	[id] [int] IDENTITY (1, 1) NOT NULL ,
+	[UserName] [varchar] (64) NOT NULL ,
+	[Attribute] [varchar] (32) NOT NULL ,
+	[Value] [varchar] (253) NOT NULL ,
+	[op] [char] (2) NULL
+) ON [PRIMARY]
 GO
 
 ALTER TABLE [radreply] WITH NOCHECK ADD
@@ -181,19 +227,52 @@ ALTER TABLE [radreply] WITH NOCHECK ADD
 	CONSTRAINT [DF_radreply_Attribute] DEFAULT ('') FOR [Attribute],
 	CONSTRAINT [DF_radreply_Value] DEFAULT ('') FOR [Value],
 	CONSTRAINT [DF_radreply_op] DEFAULT (null) FOR [op],
-	CONSTRAINT [PK_radreply] PRIMARY KEY  NONCLUSTERED
+	CONSTRAINT [PK_radreply] PRIMARY KEY NONCLUSTERED
 	(
 		[id]
-	)  ON [PRIMARY]
+	) ON [PRIMARY]
+GO
+
+CREATE INDEX [UserName] ON [radreply]([UserName]) ON [PRIMARY]
+GO
+
+
+--
+-- Table structure for table 'radacct'
+--
+
+CREATE TABLE [radusergroup] (
+	[id] [int] IDENTITY (1, 1) NOT NULL ,
+	[UserName] [varchar] (64) NOT NULL ,
+	[GroupName] [varchar] (64) NULL ,
+	[Priority] [int] NULL
+) ON [PRIMARY]
 GO
 
 ALTER TABLE [radusergroup] WITH NOCHECK ADD
 	CONSTRAINT [DF_radusergroup_UserName] DEFAULT ('') FOR [UserName],
 	CONSTRAINT [DF_radusergroup_GroupName] DEFAULT ('') FOR [GroupName],
-	CONSTRAINT [PK_radusergroup] PRIMARY KEY  NONCLUSTERED
+	CONSTRAINT [PK_radusergroup] PRIMARY KEY NONCLUSTERED
 	(
 		[id]
-	)  ON [PRIMARY]
+	) ON [PRIMARY]
+GO
+
+CREATE INDEX [UserName] ON [radusergroup]([UserName]) ON [PRIMARY]
+GO
+
+
+--
+-- Table structure for table 'radacct'
+--
+
+CREATE TABLE [radpostauth] (
+	[id] [int] IDENTITY (1, 1) NOT NULL ,
+	[userName] [varchar] (64) NOT NULL ,
+	[pass] [varchar] (64) NOT NULL ,
+	[reply] [varchar] (32) NOT NULL ,
+	[authdate] [datetime] NOT NULL
+)
 GO
 
 ALTER TABLE [radpostauth] WITH NOCHECK ADD
@@ -205,56 +284,4 @@ ALTER TABLE [radpostauth] WITH NOCHECK ADD
 	(
 		[id]
 	) ON [PRIMARY]
-GO
-
- CREATE  INDEX [UserName] ON [radacct]([UserName]) ON [PRIMARY]
-GO
-
- CREATE  INDEX [FramedIPAddress] ON [radacct]([FramedIPAddress]) ON [PRIMARY]
-GO
-
- CREATE  INDEX [FramedIPv6Address] ON [radacct]([FramedIPv6Address]) ON [PRIMARY]
-GO
-
- CREATE  INDEX [FramedIPv6Prefix] ON [radacct]([FramedIPv6Prefix]) ON [PRIMARY]
-GO
-
- CREATE  INDEX [FramedInterfaceId] ON [radacct]([FramedInterfaceId]) ON [PRIMARY]
-GO
-
- CREATE  INDEX [DelegatedIPv6Prefix] ON [radacct]([DelegatedIPv6Prefix]) ON [PRIMARY]
-GO
-
- CREATE  INDEX [AcctSessionId] ON [radacct]([AcctSessionId]) ON [PRIMARY]
-GO
-
- CREATE  UNIQUE INDEX [AcctUniqueId] ON [radacct]([AcctUniqueId]) ON [PRIMARY]
-GO
-
- CREATE  INDEX [AcctStartTime] ON [radacct]([AcctStartTime]) ON [PRIMARY]
-GO
-
- CREATE  INDEX [AcctStopTime] ON [radacct]([AcctStopTime]) ON [PRIMARY]
-GO
-
- CREATE  INDEX [NASIPAddress] ON [radacct]([NASIPAddress]) ON [PRIMARY]
-GO
-
- /* For use by onoff */
- CREATE  INDEX [RadacctBulkClose] ON [radacct]([NASIPAddress],[AcctStartTime]) WHERE [AcctStopTime] IS NULL ON [PRIMARY]
-GO
-
- CREATE  INDEX [UserName] ON [radcheck]([UserName]) ON [PRIMARY]
-GO
-
- CREATE  INDEX [GroupName] ON [radgroupcheck]([GroupName]) ON [PRIMARY]
-GO
-
- CREATE  INDEX [GroupName] ON [radgroupreply]([GroupName]) ON [PRIMARY]
-GO
-
- CREATE  INDEX [UserName] ON [radreply]([UserName]) ON [PRIMARY]
-GO
-
- CREATE  INDEX [UserName] ON [radusergroup]([UserName]) ON [PRIMARY]
 GO


### PR DESCRIPTION
Tested using the FreeTDS driver against SQL Server 2017 on Linux Docker, mostly
focusing on the stored procedure which gives 350 allocs/sec; 425 reallocs/sec
(with no specific database server optimisation).

The queries are more complicated than with most other dialects since MS SQL
lacks a "SELECT FOR UPDATE" statement, and its table hints do not provide a
direct means to implement the row-level read lock needed to guarentee that
concurrent queries do not select the same Framed-IP-Address for allocation to
distinct users.
