### PR TITLE
Add deb-build-deps target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,14 +313,12 @@ dist-tag: freeradius-server-$(RADIUSD_VERSION_STRING).tar.gz freeradius-server-$
 #	Build a debian package
 #
 debian/control: debian/rules
-	debian/rules $?
+	debian/rules $@
 
-freeradius-build-deps_$(RADIUSD_VERSION_STRING)_all.deb: debian/control
-	mk-build-deps $?
-
+# freeradius-build-deps_$(RADIUSD_VERSION_STRING)_all.deb: debian/control
 .PHONY: deb-build-deps
-deb-build-deps: freeradius-build-deps_$(RADIUSD_VERSION_STRING)_all.deb
-	apt-get install -y ./$?
+deb-build-deps: debian/control
+	mk-build-deps -t 'apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y' -ir $?
 
 .PHONY: deb
 deb:

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,12 @@ endif
 #
 ifneq "$(MAKECMDGOALS)" "deb"
 ifneq "$(MAKECMDGOALS)" "rpm"
+ifneq "$(MAKECMDGOALS)" "deb-build-deps"
 ifeq "$(findstring crossbuild,$(MAKECMDGOALS))" ""
 $(if $(wildcard Make.inc),,$(error Missing 'Make.inc' Run './configure [options]' and retry))
 
 include Make.inc
+endif
 endif
 endif
 endif
@@ -310,6 +312,16 @@ dist-tag: freeradius-server-$(RADIUSD_VERSION_STRING).tar.gz freeradius-server-$
 #
 #	Build a debian package
 #
+debian/control: debian/rules
+	debian/rules $?
+
+freeradius-build-deps_$(RADIUSD_VERSION_STRING)_all.deb: debian/control
+	mk-build-deps $?
+
+.PHONY: deb-build-deps
+deb-build-deps: freeradius-build-deps_$(RADIUSD_VERSION_STRING)_all.deb
+	apt-get install -y ./$?
+
 .PHONY: deb
 deb:
 	@if ! which fakeroot; then \


### PR DESCRIPTION
This target will use `mk-build-deps` to create a dependencies package for the freeradius-server build dependencies and uses apt to install all of the build dependencies.