### PR TITLE
v4: unixodbc fixes for resultsets containing fixed-length data

### DIFF
--- a/src/modules/rlm_sql/drivers/rlm_sql_unixodbc/rlm_sql_unixodbc.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_unixodbc/rlm_sql_unixodbc.c
@@ -169,7 +169,7 @@ static sql_rcode_t sql_select_query(rlm_sql_handle_t *handle, rlm_sql_config_t *
 
 	for (i = 1; i <= colcount; i++) {
 		len = 0;
-		SQLColAttributes(conn->stmt, ((SQLUSMALLINT) i), SQL_COLUMN_LENGTH, NULL, 0, NULL, &len);
+		SQLColAttributes(conn->stmt, ((SQLUSMALLINT) i), SQL_DESC_LENGTH, NULL, 0, NULL, &len);
 		conn->row[i - 1] = talloc_array(conn->row, char, ++len);
 		SQLBindCol(conn->stmt, i, SQL_C_CHAR, (SQLCHAR *)conn->row[i - 1], len, NULL);
 	}

--- a/src/modules/rlm_sql/drivers/rlm_sql_unixodbc/rlm_sql_unixodbc.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_unixodbc/rlm_sql_unixodbc.c
@@ -168,6 +168,7 @@ static sql_rcode_t sql_select_query(rlm_sql_handle_t *handle, rlm_sql_config_t *
 	conn->row = talloc_zero_array(conn, char *, colcount + 1); /* Space for pointers */
 
 	for (i = 1; i <= colcount; i++) {
+		len = 0;
 		SQLColAttributes(conn->stmt, ((SQLUSMALLINT) i), SQL_COLUMN_LENGTH, NULL, 0, NULL, &len);
 		conn->row[i - 1] = talloc_array(conn->row, char, ++len);
 		SQLBindCol(conn->stmt, i, SQL_C_CHAR, (SQLCHAR *)conn->row[i - 1], len, NULL);


### PR DESCRIPTION
`SQL_COLUMN_LENGTH` is the length of the data at source.
`SQL_DESC_OCTET_LENGTH` is the length of the data on the wire.
`SQL_DESC_LENGTH` is the display length of the data in the resultset.

Appears as though the latter is needed.

Tested with unixODBC -> MS ODBC driver 17 -> MS SQL 2017.