### PR TITLE
Fix the 'python_path' (rlm_python/Python2)

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -21,6 +21,9 @@ FreeRADIUS 3.0.21 Thu 14 Nov 2019 12:00:00 EDT urgency=low
 	  Patch from Terry Burton.
 	* rlm_sql_unixodbc fixes. Patches from Terry Burton. Fixes #2822
 	* Fixes when building with LibreSSL. Patch from Nathan Owens.
+	* The rlm_python should append the 'python_path' paths in 'sys.path',
+	  It fixes the expected behavior to use the existing Python modules.
+      Fixes #3180
 
 FreeRADIUS 3.0.20 Thu 14 Nov 2019 12:00:00 EDT urgency=medium
 	Feature improvements

--- a/raddb/mods-available/python
+++ b/raddb/mods-available/python
@@ -13,7 +13,7 @@ python {
 	#  item is GLOBAL TO THE SERVER.  That is, you cannot have two
 	#  instances of the python module, each with a different path.
 	#
-#        python_path="/path/to/python/files:/another_path/to/python_files/"
+#        python_path="${modconfdir}/${.:name}:/path/to/python/files:/another_path/to/python_files/"
 
 	module = example
 


### PR DESCRIPTION
The PySys_SetPath() reset the entire python path causing problems to use the existing libraries.

Therefore, we should split the 'python_path' paths and append into 'sys.path'. It is the correct way to keep the default paths allowing to use existing libraries