### PR TITLE
Add capability to verify undocumented 'FR_CONF.*' in src/*

### DIFF
--- a/scripts/build/missing-raddb-mod-conf.sh
+++ b/scripts/build/missing-raddb-mod-conf.sh
@@ -3,10 +3,18 @@
 # mods src/modules/rlm_$mod
 ignored_mods="rlm_(test|example|sql)"
 
+# directories to be ignored
+ignored_dirs="src/(include|freeradius-devel|modules)"
+
+# ignored config options
+ignored_keys="(local_state_dir|sbin_dir)"
+
 # main()
 dir_modules="src/modules"
 
-# Only "rlm_*"
+#
+# Look up for FR_CONF in src/modules/rlm_${mod} and cross with raddb/mods-available/${mod}
+#
 for _mod in $(ls $dir_modules | grep "^rlm_" | grep -vE "${ignored_mods}"); do
 	mod_name="${_mod/rlm_/}"
 	mod_dir="${dir_modules}/${_mod}"
@@ -29,5 +37,19 @@ for _mod in $(ls $dir_modules | grep "^rlm_" | grep -vE "${ignored_mods}"); do
 			fi
 		done
 done
+
+#
+# Look up for FR_CONF in src/*
+#
+grep -l --include="*.c" -r FR_CONF_ src | egrep -v "${ignored_dirs}" | sort -n | uniq | \
+while read fr_conf_file; do
+	grep "FR_CONF_" $fr_conf_file | sed '/_DEPRECATED/d; /_SUBSECTION/d; s/^.*{ FR_CONF_.*("//g; s/".*$//g' | \
+	sort | uniq | egrep -v "${ignored_keys}" | \
+	while read fr_conf; do
+		if ! grep -q "${fr_conf}.*=" -r raddb/; then
+			echo "WARNING: ${fr_conf_file}: '${fr_conf}' has no reference in raddb/*"
+		fi
+	done
+done | sort -n
 
 exit 0

--- a/scripts/build/missing-raddb-mod-conf.txt
+++ b/scripts/build/missing-raddb-mod-conf.txt
@@ -10,3 +10,10 @@ WARNING: raddb/mods-available/rest has no reference for: fail_body_decode
 WARNING: raddb/mods-available/rest has no reference for: fail_header_decode
 WARNING: Module src/modules/rlm_securid has no raddb/mods-available/securid
 WARNING: Module src/modules/rlm_sigtran has no raddb/mods-available/sigtran
+WARNING: src/lib/io/schedule.c: 'stats_interval' has no reference in raddb/*
+WARNING: src/lib/server/trunk.c: 'close_delay' has no reference in raddb/*
+WARNING: src/lib/server/trunk.c: 'free_delay' has no reference in raddb/*
+WARNING: src/lib/server/trunk.c: 'manage_interval' has no reference in raddb/*
+WARNING: src/lib/server/trunk.c: 'open_delay' has no reference in raddb/*
+WARNING: src/lib/server/trunk.c: 'per_connection_max' has no reference in raddb/*
+WARNING: src/lib/server/trunk.c: 'per_connection_target' has no reference in raddb/*


### PR DESCRIPTION
We are currently crossing all 'FR_CONF.*' in src/modules/rlm_${mod} vs raddb/${mod} and now
also 'FR_CONF.*' in src/*