### PR TITLE
4.0.x - explain DHCP destination port when sending to a giaddr

### DIFF
--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -56,6 +56,7 @@ listen {
 		#  it to 67 on a production network unless you really know
 		#  what you're doing. Even if nothing is configured below, the
 		#  server may still NAK legitimate responses from clients.
+		#  This is also the destination port when sending to a giaddr.
 		port = 6700
 
 		#  Interface name we are listening on. See comments above.


### PR DESCRIPTION
Helps understanding #3221