### PR TITLE
rlm_postgresql: Bound the total query time on non-Linux systems too

### DIFF
--- a/src/include/radiusd.h
+++ b/src/include/radiusd.h
@@ -416,6 +416,7 @@ uint32_t	rad_pps(uint32_t *past, uint32_t *present, time_t *then, struct timeval
 int		rad_expand_xlat(REQUEST *request, char const *cmd,
 				int max_argc, char const *argv[], bool can_fail,
 				size_t argv_buflen, char *argv_buf);
+void		rad_tv_sub(struct timeval const *end, struct timeval const *start, struct timeval *elapsed);
 
 void		verify_request(char const *file, int line, REQUEST *request);	/* only for special debug builds */
 void		rad_mode_to_str(char out[10], mode_t mode);

--- a/src/main/exec.c
+++ b/src/main/exec.c
@@ -45,27 +45,6 @@ RCSID("$Id$")
 
 #define MAX_ARGV (256)
 
-#define USEC 1000000
-static void tv_sub(struct timeval *end, struct timeval *start,
-		   struct timeval *elapsed)
-{
-	elapsed->tv_sec = end->tv_sec - start->tv_sec;
-	if (elapsed->tv_sec > 0) {
-		elapsed->tv_sec--;
-		elapsed->tv_usec = USEC;
-	} else {
-		elapsed->tv_usec = 0;
-	}
-	elapsed->tv_usec += end->tv_usec;
-	elapsed->tv_usec -= start->tv_usec;
-
-	if (elapsed->tv_usec >= USEC) {
-		elapsed->tv_usec -= USEC;
-		elapsed->tv_sec++;
-	}
-}
-
-
 /** Start a process
  *
  * @param cmd Command to execute. This is parsed into argv[] parts,
@@ -427,12 +406,12 @@ int radius_readfrom_program(int fd, pid_t pid, int timeout,
 		FD_SET(fd, &fds);
 
 		gettimeofday(&when, NULL);
-		tv_sub(&when, &start, &elapsed);
+		rad_tv_sub(&when, &start, &elapsed);
 		if (elapsed.tv_sec >= timeout) goto too_long;
 
 		when.tv_sec = timeout;
 		when.tv_usec = 0;
-		tv_sub(&when, &elapsed, &wake);
+		rad_tv_sub(&when, &elapsed, &wake);
 
 		rcode = select(fd + 1, &fds, NULL, NULL, &wake);
 		if (rcode == 0) {

--- a/src/main/stats.c
+++ b/src/main/stats.c
@@ -58,25 +58,6 @@ fr_stats_t proxy_dsc_stats = FR_STATS_INIT;
 #endif
 #endif
 
-static void tv_sub(struct timeval *end, struct timeval *start,
-		   struct timeval *elapsed)
-{
-	elapsed->tv_sec = end->tv_sec - start->tv_sec;
-	if (elapsed->tv_sec > 0) {
-		elapsed->tv_sec--;
-		elapsed->tv_usec = USEC;
-	} else {
-		elapsed->tv_usec = 0;
-	}
-	elapsed->tv_usec += end->tv_usec;
-	elapsed->tv_usec -= start->tv_usec;
-
-	if (elapsed->tv_usec >= USEC) {
-		elapsed->tv_usec -= USEC;
-		elapsed->tv_sec++;
-	}
-}
-
 static void stats_time(fr_stats_t *stats, struct timeval *start,
 		       struct timeval *end)
 {
@@ -86,7 +67,7 @@ static void stats_time(fr_stats_t *stats, struct timeval *start,
 	if ((start->tv_sec == 0) || (end->tv_sec == 0) ||
 	    (end->tv_sec < start->tv_sec)) return;
 
-	tv_sub(end, start, &diff);
+	rad_tv_sub(end, start, &diff);
 
 	if (diff.tv_sec >= 10) {
 		stats->elapsed[7]++;

--- a/src/main/util.c
+++ b/src/main/util.c
@@ -1706,3 +1706,27 @@ int rad_segid(gid_t gid)
 	}
 	return 0;
 }
+
+/** Determine the elapsed time between two timevals
+  *
+  * @param end timeval nearest to the present
+  * @param start timeval furthest from the present
+  * @param elapsed Where to write the elapsed time
+  */
+void rad_tv_sub(struct timeval const *end, struct timeval const *start, struct timeval *elapsed)
+{
+	elapsed->tv_sec = end->tv_sec - start->tv_sec;
+	if (elapsed->tv_sec > 0) {
+		elapsed->tv_sec--;
+		elapsed->tv_usec = USEC;
+	} else {
+		elapsed->tv_usec = 0;
+	}
+	elapsed->tv_usec += end->tv_usec;
+	elapsed->tv_usec -= start->tv_usec;
+
+	if (elapsed->tv_usec >= USEC) {
+		elapsed->tv_usec -= USEC;
+		elapsed->tv_sec++;
+	}
+}

--- a/src/modules/rlm_sql/drivers/rlm_sql_postgresql/rlm_sql_postgresql.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_postgresql/rlm_sql_postgresql.c
@@ -74,26 +74,6 @@ static const CONF_PARSER driver_config[] = {
 	CONF_PARSER_TERMINATOR
 };
 
-#define USEC 1000000
-static void tv_sub(struct timeval *end, struct timeval *start,
-		struct timeval *elapsed)
-{
-	elapsed->tv_sec = end->tv_sec - start->tv_sec;
-	if (elapsed->tv_sec > 0) {
-		elapsed->tv_sec--;
-		elapsed->tv_usec = USEC;
-	} else {
-		elapsed->tv_usec = 0;
-	}
-	elapsed->tv_usec += end->tv_usec;
-	elapsed->tv_usec -= start->tv_usec;
-
-	if (elapsed->tv_usec >= USEC) {
-		elapsed->tv_usec -= USEC;
-		elapsed->tv_sec++;
-	}
-}
-
 static int mod_instantiate(CONF_SECTION *conf, rlm_sql_config_t *config)
 {
 #if defined(HAVE_OPENSSL_CRYPTO_H) && (defined(HAVE_PQINITOPENSSL) || defined(HAVE_PQINITSSL))
@@ -361,12 +341,12 @@ static CC_HINT(nonnull) sql_rcode_t sql_query(rlm_sql_handle_t *handle, UNUSED r
 
 		if (config->query_timeout) {
 			gettimeofday(&when, NULL);
-			tv_sub(&when, &start, &elapsed);
+			rad_tv_sub(&when, &start, &elapsed);
 			if (elapsed.tv_sec >= config->query_timeout) goto too_long;
 
 			when.tv_sec = config->query_timeout;
 			when.tv_usec = 0;
-			tv_sub(&when, &elapsed, &wake);
+			rad_tv_sub(&when, &elapsed, &wake);
 		}
 
 		r = select(sockfd + 1, &read_fd, NULL, NULL, config->query_timeout ? &wake : NULL);

--- a/src/modules/rlm_sql/drivers/rlm_sql_postgresql/rlm_sql_postgresql.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_postgresql/rlm_sql_postgresql.c
@@ -74,6 +74,26 @@ static const CONF_PARSER driver_config[] = {
 	CONF_PARSER_TERMINATOR
 };
 
+#define USEC 1000000
+static void tv_sub(struct timeval *end, struct timeval *start,
+		struct timeval *elapsed)
+{
+	elapsed->tv_sec = end->tv_sec - start->tv_sec;
+	if (elapsed->tv_sec > 0) {
+		elapsed->tv_sec--;
+		elapsed->tv_usec = USEC;
+	} else {
+		elapsed->tv_usec = 0;
+	}
+	elapsed->tv_usec += end->tv_usec;
+	elapsed->tv_usec -= start->tv_usec;
+
+	if (elapsed->tv_usec >= USEC) {
+		elapsed->tv_usec -= USEC;
+		elapsed->tv_sec++;
+	}
+}
+
 static int mod_instantiate(CONF_SECTION *conf, rlm_sql_config_t *config)
 {
 #if defined(HAVE_OPENSSL_CRYPTO_H) && (defined(HAVE_PQINITOPENSSL) || defined(HAVE_PQINITSSL))
@@ -304,9 +324,8 @@ static CC_HINT(nonnull) sql_rcode_t sql_query(rlm_sql_handle_t *handle, UNUSED r
 					      char const *query)
 {
 	rlm_sql_postgres_conn_t *conn = handle->conn;
-	struct timeval timeout = {config->query_timeout, 0};
-	int sockfd, r;
-	fd_set read_fd;
+	struct timeval start;
+	int sockfd;
 	ExecStatusType status;
 	int numfields = 0;
 	PGresult *tmp_result;
@@ -331,11 +350,28 @@ static CC_HINT(nonnull) sql_rcode_t sql_query(rlm_sql_handle_t *handle, UNUSED r
 	 * We try to avoid blocking by waiting until the driver indicates that
          * the result is ready or our timeout expires
 	 */
+	gettimeofday(&start, NULL);
 	while (PQisBusy(conn->db)) {
+		int r;
+		fd_set read_fd;
+		struct timeval when, elapsed, wake;
+
 		FD_ZERO(&read_fd);
 		FD_SET(sockfd, &read_fd);
-		r = select(sockfd + 1, &read_fd, NULL, NULL, config->query_timeout ? &timeout : NULL);
+
+		if (config->query_timeout) {
+			gettimeofday(&when, NULL);
+			tv_sub(&when, &start, &elapsed);
+			if (elapsed.tv_sec >= config->query_timeout) goto too_long;
+
+			when.tv_sec = config->query_timeout;
+			when.tv_usec = 0;
+			tv_sub(&when, &elapsed, &wake);
+		}
+
+		r = select(sockfd + 1, &read_fd, NULL, NULL, config->query_timeout ? &wake : NULL);
 		if (r == 0) {
+		too_long:
 			ERROR("rlm_sql_postgresql: Socket read timeout after %d seconds", config->query_timeout);
 			return RLM_SQL_RECONNECT;
 		}


### PR DESCRIPTION
Non-Linux systems do not decrease the timeval passed in the timeout parameter
to select, so we keep track of the elapsed time ourselves.