### PR TITLE
v3.0.x: Reference the sqlippool module by its name in the default site

### DIFF
--- a/raddb/sites-available/default
+++ b/raddb/sites-available/default
@@ -638,7 +638,7 @@ accounting {
 #	sradutmp
 
 	#  Return an address to the IP Pool when we see a stop record.
-#	main_pool
+#	sqlippool
 
 	#
 	#  Log traffic to an SQL database.
@@ -727,8 +727,9 @@ post-auth {
 		&reply: += &session-state:
 	}
 
-	#  Get an address from the IP Pool.
-#	main_pool
+	#  Refresh leases when we see a start or alive. Return an address to
+	#  the IP Pool when we see a stop record.
+#	sqlippool
 
 
 	#  Create the CUI value and add the attribute to Access-Accept.


### PR DESCRIPTION
The default configuraton for the sqlippool module creates the module
directly rather using a named instance so the main_pool name does not
resolve to a module.

Pools are usually differentiated using the Pool-Name control attribute
such that only a single instance is normally required. Multiple
instances are only required where multiple pool have different backend
databases or IP allocation policies (queries, etc.)