### PR TITLE
Fix and improve cui/postgresql

### DIFF
--- a/raddb/mods-config/sql/cui/postgresql/queries.conf
+++ b/raddb/mods-config/sql/cui/postgresql/queries.conf
@@ -14,7 +14,7 @@ post-auth {
 		VALUES \
 			('%{%{Packet-Src-IPv6-Address}:-%{Packet-Src-IP-Address}}', '%{Calling-Station-Id}', \
 			'%{User-Name}', '%{reply:Chargeable-User-Identity}') \
-		ON CONFLICT (clientipaddress, callingstationid, username) \
+		ON CONFLICT ON CONSTRAINT ${..cui_table}_pkey \
 		DO UPDATE SET cui = EXCLUDED.cui, lastaccounting = '-infinity'::timestamp"
 
 }

--- a/raddb/mods-config/sql/cui/postgresql/queries.conf
+++ b/raddb/mods-config/sql/cui/postgresql/queries.conf
@@ -5,12 +5,17 @@
 #  $Id$
 
 post-auth {
+	#  Note: Clause ON CONFLICT (aka upsert) was added in PostgreSQL 9.5.
+	#  If you're using an older version, you should upgrade, or use queries.conf
+	#  and schema.sql from FreeRADIUS 3.0.20 or older.
 	query = "\
 		INSERT INTO ${..cui_table} \
 			(clientipaddress, callingstationid, username, cui) \
 		VALUES \
 			('%{%{Packet-Src-IPv6-Address}:-%{Packet-Src-IP-Address}}', '%{Calling-Station-Id}', \
-			'%{User-Name}', '%{reply:Chargeable-User-Identity}')"
+			'%{User-Name}', '%{reply:Chargeable-User-Identity}') \
+		ON CONFLICT (clientipaddress, callingstationid, username) \
+		DO UPDATE SET cui = EXCLUDED.cui, lastaccounting = '-infinity'::timestamp"
 
 }
 

--- a/raddb/mods-config/sql/cui/postgresql/schema.sql
+++ b/raddb/mods-config/sql/cui/postgresql/schema.sql
@@ -1,3 +1,5 @@
+-- Table for Chargeable-User-Identity.
+-- Note: If you change name of the table, change name of cui_pkey as well.
 CREATE TABLE cui (
 	clientipaddress inet NOT NULL DEFAULT '0.0.0.0',
 	callingstationid text NOT NULL DEFAULT '',
@@ -5,7 +7,7 @@ CREATE TABLE cui (
 	cui text NOT NULL DEFAULT '',
 	creationdate timestamp with time zone NOT NULL DEFAULT now(),
 	lastaccounting timestamp with time zone NOT NULL DEFAULT '-infinity'::timestamp,
-	PRIMARY KEY (username, clientipaddress, callingstationid)
+	CONSTRAINT cui_pkey PRIMARY KEY (username, clientipaddress, callingstationid)
 );
 
 /* This is an old workaround for upsert which was needed prior PostgreSQL 9.5.

--- a/raddb/mods-config/sql/cui/postgresql/schema.sql
+++ b/raddb/mods-config/sql/cui/postgresql/schema.sql
@@ -1,9 +1,9 @@
 CREATE TABLE cui (
 	clientipaddress inet NOT NULL DEFAULT '0.0.0.0',
-	callingstationid varchar(50) NOT NULL DEFAULT '',
-	username varchar(64) NOT NULL DEFAULT '',
-	cui varchar(128) NOT NULL DEFAULT '',
-	creationdate timestamp with time zone NOT NULL DEFAULT 'now()',
+	callingstationid text NOT NULL DEFAULT '',
+	username text NOT NULL DEFAULT '',
+	cui text NOT NULL DEFAULT '',
+	creationdate timestamp with time zone NOT NULL DEFAULT now(),
 	lastaccounting timestamp with time zone NOT NULL DEFAULT '-infinity'::timestamp,
 	PRIMARY KEY (username, clientipaddress, callingstationid)
 );

--- a/raddb/mods-config/sql/cui/postgresql/schema.sql
+++ b/raddb/mods-config/sql/cui/postgresql/schema.sql
@@ -1,11 +1,11 @@
 CREATE TABLE cui (
-  clientipaddress INET NOT NULL DEFAULT '0.0.0.0',
-  callingstationid varchar(50) NOT NULL DEFAULT '',
-  username varchar(64) NOT NULL DEFAULT '',
-  cui varchar(128) NOT NULL DEFAULT '',
-  creationdate TIMESTAMP with time zone NOT NULL default 'now()',
-  lastaccounting TIMESTAMP with time zone NOT NULL default '-infinity'::timestamp,
-  PRIMARY KEY  (username, clientipaddress, callingstationid)
+	clientipaddress inet NOT NULL DEFAULT '0.0.0.0',
+	callingstationid varchar(50) NOT NULL DEFAULT '',
+	username varchar(64) NOT NULL DEFAULT '',
+	cui varchar(128) NOT NULL DEFAULT '',
+	creationdate timestamp with time zone NOT NULL DEFAULT 'now()',
+	lastaccounting timestamp with time zone NOT NULL DEFAULT '-infinity'::timestamp,
+	PRIMARY KEY (username, clientipaddress, callingstationid)
 );
 
 CREATE RULE postauth_query AS ON INSERT TO cui

--- a/raddb/mods-config/sql/cui/postgresql/schema.sql
+++ b/raddb/mods-config/sql/cui/postgresql/schema.sql
@@ -8,7 +8,12 @@ CREATE TABLE cui (
 	PRIMARY KEY (username, clientipaddress, callingstationid)
 );
 
+/* This is an old workaround for upsert which was needed prior PostgreSQL 9.5.
+ * It's incompatible with the currently used method (ON CONFLICT clause), so if
+ * you're updating an old database, you have to remove it:
+ * DROP RULE postauth_query ON cui;
+
 CREATE RULE postauth_query AS ON INSERT TO cui
 	WHERE EXISTS(SELECT 1 FROM cui WHERE (username, clientipaddress, callingstationid)=(NEW.username, NEW.clientipaddress, NEW.callingstationid))
 	DO INSTEAD UPDATE cui SET lastaccounting ='-infinity'::timestamp with time zone, cui=NEW.cui WHERE (username, clientipaddress, callingstationid)=(NEW.username, NEW.clientipaddress, NEW.callingstationid);
-
+*/


### PR DESCRIPTION
### fix postgresql schema for cui
I'm getting the following error with the current schema:

    rlm_sql_postgresql: 22001: STRING DATA RIGHT TRUNCATION

Moreover, in PostgreSQL the text type is highly preferred above varchar. Schema for radacct already uses it, so it seems that schema for cui is just outdated.

I also fixed formatting.

### use real upsert (ON CONFLICT) instead of workaround in postgresql cui 

Clause ON CONFLICT performs better than the RULE workaround and it's guaranted to be atomic (the workaround is not).

It requires PostgreSQL 9.5 or newer; this version was released in 2016 and the previous versions are already unsupported, so it shouldn't be a problem for anyone using latest FreeRADIUS versions.

**There's a problem with backward compatibility because ON CONFLICT doesn't work when there's a RULE ON INSERT defined on the table.** It results in the following error in radius.log:

    Error: rlm_sql_postgresql: 0A000: FEATURE NOT SUPPORTED