### PR TITLE
Not found regexes should return -1

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -47,6 +47,7 @@ FreeRADIUS 3.0.21 Thu 14 Nov 2019 12:00:00 EDT urgency=low
 	* Reference sqlippool by it's correct name.  Fixes #3272
 	* Revert 3.0.20 patch which caused crashes on duplicate clients.
 	* Update WiMAX-MSK attribute.  Fixes #3280.
+	* Fix unexpected regex like %{regex:}
 
 FreeRADIUS 3.0.20 Thu 14 Nov 2019 12:00:00 EDT urgency=medium
 	Feature improvements

--- a/src/main/regex.c
+++ b/src/main/regex.c
@@ -124,7 +124,7 @@ int regex_request_to_sub(TALLOC_CTX *ctx, char **out, REQUEST *request, uint32_t
 	if (!cap) {
 		RDEBUG4("No subcapture data found");
 		*out = NULL;
-		return 1;
+		return -1;
 	}
 
 	ret = pcre_get_substring(cap->value, (int *)cap->rxmatch, (int)cap->nmatch, num, &p);
@@ -182,7 +182,7 @@ int regex_request_to_sub_named(TALLOC_CTX *ctx, char **out, REQUEST *request, ch
 	if (!cap) {
 		RDEBUG4("No subcapture data found");
 		*out = NULL;
-		return 1;
+		return -1;
 	}
 
 	ret = pcre_get_named_substring(cap->preg->compiled, cap->value,


### PR DESCRIPTION
It fixes calls like `"%{regex:}"`