### PR TITLE
fix HUP rate limit for large deltas in system time

### DIFF
--- a/src/lib/server/main_loop.c
+++ b/src/lib/server/main_loop.c
@@ -95,7 +95,7 @@ static void handle_signal_self(int flag)
 		static time_t last_hup = 0;
 
 		when = time(NULL);
-		if ((int) (when - last_hup) < 5) {
+		if (when - last_hup < (time_t) 5) {
 			INFO("Ignoring HUP (less than 5s since last one)");
 			return;
 		}


### PR DESCRIPTION
The subtraction of the last HUP's time_t from the current time_t is cast into an int.
Depending on what int defaults to this may overflow and make HUPs impossible.
e.g. for a 32 bit signed int, after 69 years, HUPs will be rejected