### PR TITLE
revised *_encodable() functions to be as consistent as possible

### DIFF
--- a/src/protocols/dhcpv4/encode.c
+++ b/src/protocols/dhcpv4/encode.c
@@ -56,7 +56,7 @@ static inline VALUE_PAIR *next_encodable(fr_cursor_t *cursor, void *encoder_ctx)
 	VALUE_PAIR	*vp;
 	fr_dhcpv4_ctx_t	*packet_ctx = encoder_ctx;
 
-	while ((vp = fr_cursor_next(cursor))) if (is_encodable(packet_ctx->root, vp)) break;
+	do { vp = fr_cursor_next(cursor); } while (vp && !is_encodable(packet_ctx->root, vp));
 	return fr_cursor_current(cursor);
 }
 

--- a/src/protocols/dhcpv6/encode.c
+++ b/src/protocols/dhcpv6/encode.c
@@ -77,7 +77,7 @@ static inline VALUE_PAIR *next_encodable(fr_cursor_t *cursor, void *encoder_ctx)
 	VALUE_PAIR		*vp;
 	fr_dhcpv6_encode_ctx_t	*packet_ctx = encoder_ctx;
 
-	while ((vp = fr_cursor_next(cursor))) if (is_encodable(packet_ctx->root, vp)) break;
+	do { vp = fr_cursor_next(cursor); } while (vp && !is_encodable(packet_ctx->root, vp));
 	return fr_cursor_current(cursor);
 }
 


### PR DESCRIPTION
src/protocols/{dhcpv*,radius}/encode.c have functions for iterating over encodable attributes. Here we rewrite them to simplify them and make them as alike as possible (dhcpv6 only encodes boolean attributes if they're true, and radius doesn't check ancestry).

