### PR TITLE
Fix invalid openssl_free() call

### DIFF
--- a/src/lib/tls/base.c
+++ b/src/lib/tls/base.c
@@ -459,7 +459,7 @@ static void openssl_free(void *to_free)
  */
 void tls_free(void)
 {
-	if (--instance_count > 0) return;
+	if (instance_count-- > 0) return;
 
 	FR_TLS_REMOVE_THREAD_STATE();
 	ENGINE_cleanup();


### PR DESCRIPTION
Due to wrong 'instance_count' decrement