### PR TITLE
Add missing backslash that precluded server from starting

### DIFF
--- a/raddb/mods-config/sql/main/postgresql/queries.conf
+++ b/raddb/mods-config/sql/main/postgresql/queries.conf
@@ -502,7 +502,7 @@ accounting {
 					FramedInterfaceId = NULLIF('%{Framed-Interface-Id}', ''), \
 					DelegatedIPv6Prefix = NULLIF('%{Delegated-IPv6-Prefix}', '')::inet, \
 					AcctUpdateTime = ${....event_timestamp}, \
-					AcctSessionTime = COALESCE(%{%{Acct-Session-Time}:-NULL},
+					AcctSessionTime = COALESCE(%{%{Acct-Session-Time}:-NULL}, \
 						(${....event_timestamp_epoch} - EXTRACT(EPOCH FROM(AcctStartTime)))), \
 					AcctInputOctets = (('%{%{Acct-Input-Gigawords}:-0}'::bigint << 32) + \
 						'%{%{Acct-Input-Octets}:-0}'::bigint), \


### PR DESCRIPTION

Server did not start, because it found an unterminated string. Adding the previous-existing backslash fixed it.
```
including configuration file /etc/raddb/mods-config/sql/main/postgresql/queries.conf
/etc/raddb/mods-config/sql/main/postgresql/queries.conf[505]: Parse error: Unterminated string
Errors reading or parsing /etc/raddb/radiusd.conf
```