### PR TITLE
rlm_radius_udp: The recv_buff should be > 0

### DIFF
--- a/src/modules/rlm_radius/rlm_radius_udp.c
+++ b/src/modules/rlm_radius/rlm_radius_udp.c
@@ -745,7 +745,11 @@ static fr_connection_state_t conn_init(void **h_out, fr_connection_t *conn, void
 	talloc_set_destructor(h, _udp_handle_free);
 
 #ifdef SO_RCVBUF
+#  ifdef __APPLE__
+	if (h->inst->recv_buff_is_set && h->inst->recv_buff > 0) {
+#  else
 	if (h->inst->recv_buff_is_set) {
+#  endif
 		int opt;
 
 		opt = h->inst->recv_buff;


### PR DESCRIPTION
It will avoid to pass invalid parameters for setsockopt() like:

"radius - Failed setting 'recv_buf': EINVAL: Invalid argument"