### PR TITLE
Generalize/replace the "hack" in dhcpv4_encode_xlat() with a new

### DIFF
--- a/src/lib/util/cursor.h
+++ b/src/lib/util/cursor.h
@@ -30,6 +30,7 @@ extern "C" {
 #include <freeradius-devel/missing.h>
 
 #include <stddef.h>
+#include <stdbool.h>
 #include <talloc.h>
 
 /** Callback for implementing custom iterators
@@ -46,6 +47,16 @@ extern "C" {
  *	- NULL if no more matching attributes were found.
  */
 typedef void *(*fr_cursor_iter_t)(void **prev, void *to_eval, void *uctx);
+
+/** Type of evaluation functions to pass to the fr_cursor_filter_*() functions.
+ *
+ * @param[in] item	the item to be evaluated
+ * @param[in] uctx	context that may assist with evaluation
+ * @return
+ * 	- true if the evaluation function is satisfied.
+ * 	- false if the evaluation function is not satisfied.
+ */
+typedef bool (*fr_cursor_eval_t)(void *item, void *uctx);
 
 typedef struct {
 	void			**head;		//!< First item in the list.
@@ -82,6 +93,12 @@ void fr_cursor_append(fr_cursor_t *cursor, void *v) CC_HINT(nonnull);
 void fr_cursor_insert(fr_cursor_t *cursor, void *v) CC_HINT(nonnull);
 
 void fr_cursor_merge(fr_cursor_t *cursor, fr_cursor_t *to_append) CC_HINT(nonnull);
+
+void *fr_cursor_filter_head(fr_cursor_t *cursor, fr_cursor_eval_t eval, void *uctx);
+
+void *fr_cursor_filter_next(fr_cursor_t *cursor, fr_cursor_eval_t eval, void *uctx);
+
+void *fr_cursor_filter_current(fr_cursor_t *cursor, fr_cursor_eval_t eval, void *uctx);
 
 void *fr_cursor_intersect_head(fr_cursor_t *a, fr_cursor_t *b) CC_HINT(nonnull);
 

--- a/src/modules/rlm_dhcpv4/rlm_dhcpv4.c
+++ b/src/modules/rlm_dhcpv4/rlm_dhcpv4.c
@@ -165,12 +165,7 @@ static xlat_action_t dhcpv4_encode_xlat(TALLOC_CTX *ctx, fr_cursor_t *out,
 
 	if (!fr_cursor_head(cursor)) return XLAT_ACTION_DONE;	/* Nothing to encode */
 
-	while ((vp = fr_cursor_current(cursor))) {
-		if ((vp->da->flags.internal) || (vp->da->dict != dict_dhcpv4)) {
-			fr_cursor_next(cursor);
-			continue;
-		}
-
+	while ((vp = fr_cursor_filter_current(cursor, is_dhcpv4_encodable, NULL))) {
 		len = fr_dhcpv4_encode_option(p, end - p, cursor,
 					      &(fr_dhcpv4_ctx_t){ .root = fr_dict_root(dict_dhcpv4) });
 		if (len < 0) {

--- a/src/protocols/dhcpv4/base.c
+++ b/src/protocols/dhcpv4/base.c
@@ -268,6 +268,21 @@ bool fr_dhcpv4_ok(uint8_t const *data, ssize_t data_len, uint8_t *message_type, 
 	return true;
 }
 
+/** Evaluation function for DCHPV4-encodability
+ *
+ * @param item	pointer to a VALUE_PAIR
+ * @param uctx	context
+ *
+ * @return true if the underlying VALUE_PAIR is DHCPv4 encodable, false otherwise
+ */
+bool is_dhcpv4_encodable(void *item, UNUSED void * uctx)
+{
+	VALUE_PAIR *vp = item;
+
+	VP_VERIFY(vp);
+	return (vp->da->dict == dict_dhcpv4) && (!vp->da->flags.internal);
+}
+
 ssize_t fr_dhcpv4_encode(uint8_t *buffer, size_t buflen, dhcp_packet_t *original, int code, uint32_t xid, VALUE_PAIR *vps)
 {
 	uint8_t		*p;

--- a/src/protocols/dhcpv4/dhcpv4.h
+++ b/src/protocols/dhcpv4/dhcpv4.h
@@ -149,6 +149,7 @@ int8_t		fr_dhcpv4_attr_cmp(void const *a, void const *b);
 
 bool		fr_dhcpv4_ok(uint8_t const *data, ssize_t data_len, uint8_t *message_type, uint32_t *xid);
 RADIUS_PACKET	*fr_dhcpv4_packet_alloc(uint8_t const *data, ssize_t data_len);
+bool 		is_dhcpv4_encodable(void *item, UNUSED void *uctx);
 ssize_t		fr_dhcpv4_encode(uint8_t *buffer, size_t buflen, dhcp_packet_t *original, int code, uint32_t xid, VALUE_PAIR *vps);
 int		fr_dhcpv4_global_init(void);
 void		fr_dhcpv4_global_free(void);


### PR DESCRIPTION
function, fr_cursor_filter_current() (the name in initial discussion
was fr_cursor_intersect_current(), but it's unrelated to the intersect
functions). It takes two parameters, a cursor and an "evaluation
function", and looks at successive items, starting at the current
cursor position, until either it runs out or finds one that the
evaluation function approves of. If it runs out, it returns NULL;
otherwise, it returns a pointer to the approved item.