### PR TITLE
Fix memory leak in radsniff

### DIFF
--- a/src/bin/radsniff.c
+++ b/src/bin/radsniff.c
@@ -2289,6 +2289,7 @@ int main(int argc, char *argv[])
 				INFO("%i.%s", i++, dev_p->name);
 			}
 			ret = 0;
+			pcap_freealldevs(all_devices);
 			goto finish;
 		}
 


### PR DESCRIPTION
We should call pcap_freealldevs() always after pcap_findalldevs()