### PR TITLE
test: lets test the 'radsniff -a'

### DIFF
--- a/src/tests/bin/radsniff
+++ b/src/tests/bin/radsniff
@@ -3,4 +3,7 @@
 . src/tests/bin/lib.sh
 
 do_test $TESTBIN/radsniff -h
-#do_test $TESTBIN/radsniff -a
+
+# list all interfaces
+do_test $TESTBIN/radsniff -a
+


### PR DESCRIPTION
It will prevent to detect issues with pcap.c API used to fetch and list
all network interfaces.