### PR TITLE
trigger: Fix wrong return

### DIFF
--- a/src/lib/server/trigger.c
+++ b/src/lib/server/trigger.c
@@ -420,7 +420,7 @@ int trigger_exec(REQUEST *request, CONF_SECTION const *cs, char const *name, boo
 		talloc_free(fake);
 		talloc_free(spaces);
 		talloc_free(text);
-		return false;
+		return -1;
 	}
 
 	/*


### PR DESCRIPTION
`trigger_exec()` is supposed to return `-1` on failure and `0` on success.