### PR TITLE
RPM spec dependencies for RHEL8

### DIFF
--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -264,8 +264,10 @@ This plugin provides Perl support for the FreeRADIUS server project.
 Summary: Python support for FreeRADIUS
 Group: System Environment/Daemons
 Requires: %{name}%{?_isa} = %{version}-%{release}
-Requires: python
-BuildRequires: python-devel
+%{!?el8:Requires: python}
+%{?el8:Requires: python2}
+%{!?el8:BuildRequires: python-devel}
+%{?el8:BuildRequires: python2-devel}
 
 %description python
 This plugin provides Python support for the FreeRADIUS server project.


### PR DESCRIPTION
Forward port patch from v3 required to satisfy deps on RHEL/CentOS 8.