### PR TITLE
rlm_always: xlat for setting module status and rcode via unlang

### DIFF
--- a/raddb/mods-available/always
+++ b/raddb/mods-available/always
@@ -32,6 +32,26 @@
 #
 #  mpp = <integer>
 #
+#  An xlat based on the instance name can be called to change the status
+#  returned by the instance.
+#
+#  Force the module status to be alive or dead:
+#
+#  %{db_status:alive}
+#  %{db_status:dead}
+#
+#  Update the rcode returned by an alive module (a dead module returns fail):
+#
+#  %{db_status:ok}
+#  %{db_status:fail}
+#  %{db_status:notfound}
+#  ...
+#
+#  The above xlats expand to the current status of the module. To fetch the
+#  current status without affecting it call the xlat with an empty argument:
+#
+#  %{db_status:}
+#
 always reject {
 	rcode = reject
 }

--- a/src/tests/modules/always/module.conf
+++ b/src/tests/modules/always/module.conf
@@ -1,3 +1,7 @@
 always my_reject {
 	rcode = reject
 }
+
+always db_status {
+	rcode = ok
+}

--- a/src/tests/modules/always/set_rcode.unlang
+++ b/src/tests/modules/always/set_rcode.unlang
@@ -1,0 +1,44 @@
+#
+#  Set status to "notfound". xlat should expand to previous status, "alive"
+#
+if ("%{db_status:notfound}" != "alive") {
+	update reply {
+		Filter-Id += "failed"
+	}
+}
+
+
+#
+#  Verify that the status was changed
+#
+db_status
+if (!notfound) {
+	update reply {
+		Filter-Id += "failed"
+	}
+}
+
+
+#
+#  Fetch status using xlat without setting the status
+#
+if ("%{db_status:}" != "notfound") {
+	update reply {
+		Filter-Id += "failed"
+	}
+}
+
+
+#
+#  Verify that the status did not change
+#
+db_status
+if (notfound) {
+	update reply {
+		Filter-Id += "success"
+	}
+}
+
+update control {
+	Cleartext-Password := "hello"
+}

--- a/src/tests/modules/always/set_status_dead.unlang
+++ b/src/tests/modules/always/set_status_dead.unlang
@@ -1,0 +1,18 @@
+#
+#  Set the module status to dead, call it and check that it fails
+#
+%{db_status:dead}
+
+db_status {
+	fail = 1
+}
+
+if (fail) {
+	update reply {
+		Filter-Id := "success"
+	}
+}
+
+update control {
+	Cleartext-Password := "hello"
+}

--- a/src/tests/modules/always/set_status_revive.unlang
+++ b/src/tests/modules/always/set_status_revive.unlang
@@ -1,0 +1,28 @@
+#
+#  Fail a module...
+#
+%{db_status:dead}
+db_status {
+	fail = 1
+}
+if (!fail) {
+	update reply {
+		Filter-Id += "failed"
+	}
+}
+
+
+#
+#  ... Now revive it
+#
+%{db_status:alive}
+db_status
+if (ok) {
+	update reply {
+		Filter-Id += "success"
+	}
+}
+
+update control {
+	Cleartext-Password := "hello"
+}


### PR DESCRIPTION
Parity with: radmin -e 'set module status db_status {alive,dead,notfound,...}'

Introduces a module option `register_xlat` so that existing rlm_always modules do not register xlats with names that potentially conflict with xlats registered by other modules.

If this is along the right lines then I'll work up the same for v4.