### PR TITLE
rlm_always: xlat for setting module status via unlang

### DIFF
--- a/raddb/mods-available/always
+++ b/raddb/mods-available/always
@@ -60,6 +60,31 @@
 #}
 
 #
+#  ## xlat for peeking and poking the status
+#
+#  An xlat based on the instance name can be called to change the status
+#  returned by the instance.
+#
+#  .Example
+#
+#  ```
+#  %{db_status:ok}
+#  %{db_status:fail}
+#  %{db_status:notfound}
+#  ...
+#  ```
+#
+#  The above xlats expand to the current status of the module. To fetch the
+#  current status without affecting it call the xlat with an empty argument:
+#
+#  .Example
+#
+#  ```
+#  %{db_status:}
+#  ```
+#
+
+#
 #  ## Configuration Settings
 #
 #  The following default instances allow the use of return codes like

--- a/raddb/sites-available/resource-check
+++ b/raddb/sites-available/resource-check
@@ -1,0 +1,140 @@
+# -*- text -*-
+######################################################################
+#
+#  This virtual server provides an example of how to dynamically amend the
+#  control flow within some virtual server's policy on the basis of the status
+#  of some resource, such as an external database.
+#
+#  This resource-check virtual server receives periodic dummy server-status
+#  requests that trigger an arbitrary set of checks. On the basis of those
+#  checks the status of an instance of the rlm_always module, that we refer to
+#  as the "control module", is updated to reflect the system status.
+#
+#  Elsewhere, some other virtual server (the "controlled virtual server") uses
+#  the control module to make decisions during the processing of incoming
+#  requests. By amending the status of the control module in response to the
+#  system status this virtual server is able to manipulate the outcome of the
+#  controlled virtual server.
+#
+#  Firstly, the authorize section of this virtual server will need to be
+#  amended to check the status of the external resources and to set the status
+#  of the control module appropriately, as described in the inline comments
+#  below...
+#
+#  In addition to configuring and activating this virtual server, a control
+#  module must be configured as an instance of rlm_always in mods-enabled, for
+#  example:
+#
+#    always db_online {
+#        # Default to online
+#        rcode = ok
+#    }
+#
+#  Now trigger the resource checks by sending a server-status request to this
+#  virtual server, as follows:
+#
+#    echo "Message-Authenticator = 0x00" | \
+#      radclient -r 1 -t 3 -q 127.0.0.1:18122 status testing123
+#
+#  The trigger could be invoked by a cron job or if more frequent checks than
+#  once per minute are required a systemd timer might be used.
+#
+#  The current status of the control module can be examined at any time using
+#  radmin:
+#
+#    radmin -e 'show module status db_online'
+#
+#  For radmin to work requires that the control-socket virtual server is
+#  configured and enabled.
+#
+#  The controlled virtual server will contain some control flow decision that
+#  uses the control module, for example:
+#
+#    server default {
+#
+#    ...
+#
+#    recv Access-Request {
+#
+#        #  If the database is not healthy then remain silent to trigger
+#        #  NAS failover
+#        #
+#        db_online {
+#            fail = 1
+#        }
+#        if (fail) {
+#             do_not_respond
+#        }
+#
+#        sql
+#
+#        pap
+#    }
+#
+#    ...
+#
+#
+#  The configuration for this virtual server follows and should be amended as
+#  required...
+#
+
+
+#
+#  Listen on a local port for Server-Status requests that trigger the resource
+#  checks.
+#
+#  This uses the normal set of clients, with the same secret as for
+#  authentication and accounting.
+#
+
+#
+#  Within this virual server we provide only an Autz-Type Status-Server section
+#  whose task is to perform the resource checks and sets the status of the
+#  "control module"
+#
+server resource-check {
+
+namespace = radius
+
+listen {
+	transport = udp
+	udp {
+		ipaddr = 127.0.0.1
+		port = 18122
+	}
+	type = Status-Server
+}
+
+recv Status-Server {
+
+	#
+	#  In this example we check whether a PostgreSQL database is in
+	#  recovery (or inaccessible) and when this is the case we fail the
+	#  db_online control module.
+	#
+	#  Other modules could be used here.
+	#
+	#  You can even invoke synchronous checks using the %{exec:...} xlat in
+	#  which case timeout should be set to less than the check trigger
+	#  interval to avoid buildup of checks when resources do not respond.
+	#  See rlm_exec for details.
+	#
+	if ("%{sql:SELECT pg_is_in_recovery()}" != "f") {
+
+		# Fail the db_online module, if it isn't already
+		if ("%{db_online:}" != "fail") {
+			%{db_online:fail}
+		}
+
+	} else {
+
+		# Set the db_online module status to alive, if it isn't already
+		if ("%{db_online:}" != "alive") {
+			%{db_online:alive}
+		}
+
+	}
+
+}
+
+}

--- a/src/tests/modules/always/module.conf
+++ b/src/tests/modules/always/module.conf
@@ -1,3 +1,7 @@
 always my_reject {
 	rcode = reject
 }
+
+always db_status {
+	rcode = ok
+}

--- a/src/tests/modules/always/set_rcode.attrs
+++ b/src/tests/modules/always/set_rcode.attrs
@@ -1,0 +1,11 @@
+#
+#  Input packet
+#
+User-Name = "bob"
+User-Password = "hello"
+
+#
+#  Expected answer
+#
+Packet-Type == Access-Accept
+Reply-Message == "success"

--- a/src/tests/modules/always/set_rcode.unlang
+++ b/src/tests/modules/always/set_rcode.unlang
@@ -1,0 +1,44 @@
+#
+#  Set status to "notfound". xlat should expand to previous status, "alive"
+#
+if ("%{db_status:notfound}" != "alive") {
+	update reply {
+		&Reply-Message += "failed"
+	}
+}
+
+
+#
+#  Verify that the status was changed
+#
+db_status
+if (!notfound) {
+	update reply {
+		&Reply-Message += "failed"
+	}
+}
+
+
+#
+#  Fetch status using xlat without setting the status
+#
+if ("%{db_status:}" != "notfound") {
+	update reply {
+		&Reply-Message += "failed"
+	}
+}
+
+
+#
+#  Verify that the status did not change
+#
+db_status
+if (notfound) {
+	update reply {
+		&Reply-Message += "success"
+	}
+}
+
+update control {
+	&Cleartext-Password := "hello"
+}

--- a/src/tests/modules/always/set_status_dead.attrs
+++ b/src/tests/modules/always/set_status_dead.attrs
@@ -1,0 +1,11 @@
+#
+#  Input packet
+#
+User-Name = "bob"
+User-Password = "hello"
+
+#
+#  Expected answer
+#
+Packet-Type == Access-Accept
+Reply-Message == "success"

--- a/src/tests/modules/always/set_status_dead.unlang
+++ b/src/tests/modules/always/set_status_dead.unlang
@@ -1,0 +1,18 @@
+#
+#  Set the module status to dead, call it and check that it fails
+#
+%{db_status:fail}
+
+db_status {
+	fail = 1
+}
+
+if (fail) {
+	update reply {
+		&Reply-Message := "success"
+	}
+}
+
+update control {
+	&Cleartext-Password := "hello"
+}

--- a/src/tests/modules/always/set_status_revive.attrs
+++ b/src/tests/modules/always/set_status_revive.attrs
@@ -1,0 +1,11 @@
+#
+#  Input packet
+#
+User-Name = "bob"
+User-Password = "hello"
+
+#
+#  Expected answer
+#
+Packet-Type == Access-Accept
+Reply-Message == "success"

--- a/src/tests/modules/always/set_status_revive.unlang
+++ b/src/tests/modules/always/set_status_revive.unlang
@@ -1,0 +1,28 @@
+#
+#  Fail a module...
+#
+%{db_status:fail}
+db_status {
+	fail = 1
+}
+if (!fail) {
+	update reply {
+		&Reply-Message += "failed"
+	}
+}
+
+
+#
+#  ... Now revive it
+#
+%{db_status:alive}
+db_status
+if (ok) {
+	update reply {
+		&Reply-Message += "success"
+	}
+}
+
+update control {
+	&Cleartext-Password := "hello"
+}


### PR DESCRIPTION
Parity with: radmin -e 'set module status db_status {alive,fail,notfound,...}'