### PR TITLE
radmin: Add capability to show more about the home servers

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -11,6 +11,8 @@ FreeRADIUS 3.0.22 Tue 24 Mar 2020 12:00:00 EDT urgency=low
 	* Allow delta CRLs.  Fixes #3393.
 	* Limited support for dynamic home servers.  See proxy.conf
 	  and doc/configuration/dynamic_home_servers.md
+	* Update radmin to show more information about the home servers
+	  using "show home_server list all".
 
 	Bug fixes
 	* Respect the "log_reject" configuration item in more places.

--- a/src/main/command.c
+++ b/src/main/command.c
@@ -1138,7 +1138,7 @@ static int command_show_modules(rad_listen_t *listener, UNUSED int argc, UNUSED 
 }
 
 #ifdef WITH_PROXY
-static int command_show_home_servers(rad_listen_t *listener, UNUSED int argc, UNUSED char *argv[])
+static int command_show_home_servers(rad_listen_t *listener, int argc, char *argv[])
 {
 	int i;
 	home_server_t *home;
@@ -1212,10 +1212,19 @@ static int command_show_home_servers(rad_listen_t *listener, UNUSED int argc, UN
 
 		} else continue;
 
-		cprintf(listener, "%s\t%d\t%s\t%s\t%s\t%d\n",
-			ip_ntoh(&home->ipaddr, buffer, sizeof(buffer)),
-			home->port, proto, type, state,
-			home->currently_outstanding);
+		if (argc > 0 && !strcmp(argv[0], "all")) {
+			char const *dynamic = home->dynamic ? "yes" : "no";
+
+			cprintf(listener, "%s\t%d\t%s\t%s\t%s\t%d\t(name=%s, dynamic=%s)\n",
+				ip_ntoh(&home->ipaddr, buffer, sizeof(buffer)),
+				home->port, proto, type, state,
+				home->currently_outstanding, home->name, dynamic);
+		} else {
+			cprintf(listener, "%s\t%d\t%s\t%s\t%s\t%d\n",
+				ip_ntoh(&home->ipaddr, buffer, sizeof(buffer)),
+				home->port, proto, type, state,
+				home->currently_outstanding);
+		}
 	}
 
 	return CMD_OK;
@@ -2056,7 +2065,7 @@ static fr_command_table_t command_table_show_client[] = {
 #ifdef WITH_PROXY
 static fr_command_table_t command_table_show_home[] = {
 	{ "list", FR_READ,
-	  "show home_server list - shows list of home servers",
+	  "show home_server list [all] - shows list of home servers",
 	  command_show_home_servers, NULL },
 	{ "state", FR_READ,
 	  "show home_server state <ipaddr> <port> [udp|tcp] [src <ipaddr>] - shows state of given home server",


### PR DESCRIPTION
Now we can know the home server name and if is dynamic or no.

e.g:

```
radmin> show home_server list all
127.0.0.1	1812	udp	auth	unknown	0	(name=localhost, dynamic=no)
192.168.1.253	1812	udp	auth	unknown	0	(name=capacete.lan, dynamic=yes)
radmin>
``` 