### PR TITLE
Adjust value_field in internal_encode() if flen > 1

### DIFF
--- a/src/protocols/internal/encode.c
+++ b/src/protocols/internal/encode.c
@@ -258,6 +258,7 @@ static ssize_t internal_encode(uint8_t *out, size_t outlen,
 			memmove(to, value_field, value_len);
 
 			p = to + value_len;
+			value_field += flen - 1;
 		}
 		memcpy(len_field, buff, flen);
 		enc_field[0] |= ((flen - 1) << 2);


### PR DESCRIPTION
When internal_encode() loses its bet that there will be less than
256 bytes of encoded data, the header must grow to hold the length
and the data moved to make room. When that happens, value_field
has to be adjusted to match--otherwise, the FR_PROTO_HEX_DUMP() of
the header won't show the entire header.

The existing long name internal encode test exercises this if the debug level is set at or above 4. A diff of the outputs (with time/date stamp removed):

99c99
< Debug : hex: 0000: 06 01 01 
---
> Debug : hex: 0000: 06 01 01 2c

The dump of the long name shows that it is indeed 0x12c bytes long:

Debug : hex: -- value string --
Debug : hex: 0000: 30 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 
Debug : hex: 0010: 36 37 38 39 30 31 32 33 34 35 36 37 38 39 30 31 
Debug : hex: 0020: 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 37 
Debug : hex: 0030: 38 39 30 31 32 33 34 35 36 37 38 39 30 31 32 33 
Debug : hex: 0040: 34 35 36 37 38 39 30 31 32 33 34 35 36 37 38 39 
Debug : hex: 0050: 30 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 
Debug : hex: 0060: 36 37 38 39 30 31 32 33 34 35 36 37 38 39 30 31 
Debug : hex: 0070: 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 37 
Debug : hex: 0080: 38 39 30 31 32 33 34 35 36 37 38 39 30 31 32 33 
Debug : hex: 0090: 34 35 36 37 38 39 30 31 32 33 34 35 36 37 38 39 
Debug : hex: 00a0: 30 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 
Debug : hex: 00b0: 36 37 38 39 30 31 32 33 34 35 36 37 38 39 30 31 
Debug : hex: 00c0: 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 37 
Debug : hex: 00d0: 38 39 30 31 32 33 34 35 36 37 38 39 30 31 32 33 
Debug : hex: 00e0: 34 35 36 37 38 39 30 31 32 33 34 35 36 37 38 39 
Debug : hex: 00f0: 30 31 32 33 34 35 36 37 38 39 30 31 32 33 34 35 
Debug : hex: 0100: 36 37 38 39 30 31 32 33 34 35 36 37 38 39 30 31 
Debug : hex: 0110: 32 33 34 35 36 37 38 39 30 31 32 33 34 35 36 37 
Debug : hex: 0120: 38 39 30 31 32 33 34 35 36 37 38 39