### PR TITLE
radclient: The '-c' value should be >= 1

### DIFF
--- a/src/main/radclient.c
+++ b/src/main/radclient.c
@@ -1197,9 +1197,11 @@ int main(int argc, char **argv)
 			break;
 
 		case 'c':
-			if (!isdigit((int) *optarg))
-				usage();
+			if (!isdigit((int) *optarg)) usage();
+
 			resend_count = atoi(optarg);
+
+			if (resend_count < 1) usage();
 			break;
 
 		case 'D':


### PR DESCRIPTION
If we pass '-c 0' causes an infinity loop.