### PR TITLE
Convert internal protocol encode to use dbuff

### DIFF
--- a/src/protocols/internal/encode.c
+++ b/src/protocols/internal/encode.c
@@ -269,7 +269,7 @@ static ssize_t internal_encode(fr_dbuff_t *dbuff,
 		enc_field[0] |= ((flen - 1) << 2);
 	}
 
-	FR_PROTO_HEX_DUMP(enc_field, value_field + flen - 1 - enc_field, "header");
+	FR_PROTO_HEX_DUMP(enc_field, (value_field + (flen - 1)) - enc_field, "header");
 
 	return value_end - enc_field;
 }

--- a/src/protocols/internal/encode.c
+++ b/src/protocols/internal/encode.c
@@ -32,30 +32,49 @@
 #include <freeradius-devel/util/net.h>
 #include <freeradius-devel/util/pair.h>
 #include <freeradius-devel/util/proto.h>
+#include <freeradius-devel/util/dbuff.h>
 
 #include <talloc.h>
+
+static ssize_t fr_value_box_to_network_dbuff(size_t *need, fr_dbuff_t *dbuff, fr_value_box_t const *value);
+static ssize_t fr_internal_encode_pair_dbuff(fr_dbuff_t *dbuff, fr_cursor_t *cursor, void *encoder_ctx);
 
 /** We use the same header for all types
  *
  */
-static ssize_t internal_encode(uint8_t *out, size_t outlen,
+
+/** Encode the value of the value pair the cursor currently points at.
+ *
+ * @param dbuff		data buffer to place the encoded data in
+ * @param da_stack	da stack corresponding to the value pair
+ * @param depth		in da_stack
+ * @param cursor	cursor whose current value is the one to be encoded
+ * @param encoder_ctx	encoder context
+ *
+ * @return	either a negative number, indicating an error
+ * 		or the number of bytes used to encode the value
+ */
+static ssize_t internal_encode(fr_dbuff_t *dbuff,
 			       fr_da_stack_t *da_stack, unsigned int depth,
 			       fr_cursor_t *cursor, void *encoder_ctx)
 {
-	uint8_t				*p = out, *enc_field = p, *len_field, *value_field;
-	uint8_t				*end = out + outlen;
+	uint8_t				*enc_field, *len_field, *value_field, *value_end;
 	fr_dict_attr_t const		*da = da_stack->da[depth];
 	VALUE_PAIR			*vp = fr_cursor_current(cursor);
 
 	uint8_t				flen;
 	ssize_t				slen = 0;
 
+	uint8_t				buff[sizeof(uint64_t)];
+
 	FR_PROTO_STACK_PRINT(da_stack, depth);
 
+	enc_field = dbuff->p;
+
 	/*
-	 *	Zero out 'enc_field'
+	 *	Zero out first encoding byte
 	 */
-	*(p++) = 0x00;
+	fr_dbuff_memset(dbuff, 0, 1);
 
 	/*
 	 *	Ensure we have at least enough space
@@ -63,7 +82,7 @@ static ssize_t internal_encode(uint8_t *out, size_t outlen,
 	 *	type and length fields, and one byte
 	 *	of data.
 	 */
-	FR_PAIR_ENCODE_HAVE_SPACE(p, end, (sizeof(uint64_t) * 2) + 2);
+	FR_DBUFF_CHECK_FREESPACE_RETURN(dbuff, (sizeof(uint64_t) * 2) + 2);
 
 	switch (da->type) {
 	/*
@@ -81,8 +100,8 @@ static ssize_t internal_encode(uint8_t *out, size_t outlen,
 	 *	Need to use the second encoding byte
 	 */
 	if (da->flags.is_unknown) {
-		*(p++) = 0x00;
-		FR_PAIR_ENCODE_HAVE_SPACE(p, end, (sizeof(uint64_t) * 2) + 2);	/* Check we still have room */
+		fr_dbuff_memset(dbuff, 0, 1);
+		FR_DBUFF_CHECK_FREESPACE_RETURN(dbuff, (sizeof(uint64_t) * 2) + 2);	/* Check we still have room */
 
 		enc_field[0] |= FR_INTERNAL_FLAG_EXTENDED;
 		enc_field[1] |= FR_INTERNAL_FLAG_INTERNAL;
@@ -92,9 +111,10 @@ static ssize_t internal_encode(uint8_t *out, size_t outlen,
 	 *	Encode the type and write the width of the
 	 *	integer to the encoding byte.
 	 */
-	flen = fr_net_from_uint64v(p, da->attr);
-	p += flen;
+	flen = fr_net_from_uint64v(buff, da->attr);
 	enc_field[0] |= ((flen - 1) << 5);
+
+	fr_dbuff_memcpy_in(dbuff, buff, flen);
 
 	/*
 	 *	Mark where the length field will be, and
@@ -107,33 +127,24 @@ static ssize_t internal_encode(uint8_t *out, size_t outlen,
 	 *	We've already done the checks for encoding
 	 *	two fields of the maximum size above.
 	 */
-	len_field = p;
-	p++;
-	value_field = p;
-
-	/*
-	 *	Ensures that any encoding functions leave
-	 *	at least 5 bytes in the buffer, so we
-	 *	can deal with the case where the length
-	 *	is > 255, gracefully.
-	 */
-#define LEAVE_ROOM_FOR_LEN(_end, _p) ((_end) - (_p)) - (sizeof(uint64_t) - 1)
+	len_field = dbuff->p;
+	fr_dbuff_advance(dbuff, 1);
+	value_field = dbuff->p;
 
 	switch (da->type) {
 	case FR_TYPE_VALUES:
 	{
 		size_t need = 0;
 
-		slen = fr_value_box_to_network(&need, p, LEAVE_ROOM_FOR_LEN(end, p), &vp->data);
+		slen = fr_value_box_to_network_dbuff(&need, FR_DBUFF_RESERVE(dbuff, sizeof(uint64_t) - 1), &vp->data);
 		if (slen < 0) switch (slen) {
 		case FR_VALUE_BOX_NET_ERROR:
 		default:
 			return PAIR_ENCODE_FATAL_ERROR;
 
 		case FR_VALUE_BOX_NET_OOM:
-			return (out - p) - need;
+			return (enc_field - dbuff->p) - need;
 		}
-		p += slen;
 		FR_PROTO_HEX_DUMP(value_field, slen, "value %s",
 				  fr_table_str_by_value(fr_value_box_type_table, vp->vp_type, "<UNKNOWN>"));
 		fr_cursor_next(cursor);
@@ -156,9 +167,9 @@ static ssize_t internal_encode(uint8_t *out, size_t outlen,
 	 */
 	case FR_TYPE_VSA:
 	case FR_TYPE_VENDOR:
-		slen = internal_encode(p, LEAVE_ROOM_FOR_LEN(end, p), da_stack, depth + 1, cursor, encoder_ctx);
+		slen = internal_encode(FR_DBUFF_RESERVE(dbuff, sizeof(uint64_t) - 1), da_stack, depth + 1,
+				       cursor, encoder_ctx);
 		if (slen < 0) return slen;
-		p += slen;
 		break;
 
 	/*
@@ -185,10 +196,9 @@ static ssize_t internal_encode(uint8_t *out, size_t outlen,
 				fr_proto_da_stack_partial_build(da_stack, da_stack->da[depth], child->da);
 				FR_PROTO_STACK_PRINT(da_stack, depth);
 
-				slen = internal_encode(p, LEAVE_ROOM_FOR_LEN(end, p),
+				slen = internal_encode(FR_DBUFF_RESERVE(dbuff, sizeof(uint64_t) - 1),
 						       da_stack, depth + 1, &children, encoder_ctx);
 				if (slen < 0) return slen;
-				p += slen;
 			}
 			fr_cursor_next(cursor);
 			break;
@@ -197,9 +207,9 @@ static ssize_t internal_encode(uint8_t *out, size_t outlen,
 		/*
 		 *	Still encoding intermediary TLVs...
 		 */
-		slen = internal_encode(p, LEAVE_ROOM_FOR_LEN(end, p), da_stack, depth + 1, cursor, encoder_ctx);
+		slen = internal_encode(FR_DBUFF_RESERVE(dbuff, sizeof(uint64_t) - 1), da_stack, depth + 1,
+				       cursor, encoder_ctx);
 		if (slen < 0) return slen;
-		p += slen;
 		break;
 
 	/*
@@ -219,9 +229,9 @@ static ssize_t internal_encode(uint8_t *out, size_t outlen,
 		     vp = fr_cursor_current(&children)) {
 		     	FR_PROTO_TRACE("encode ctx changed %s -> %s", da->name, vp->da->name);
 
-			slen = fr_internal_encode_pair(p, LEAVE_ROOM_FOR_LEN(end, p), &children, encoder_ctx);
+			slen = fr_internal_encode_pair_dbuff(FR_DBUFF_RESERVE(dbuff, sizeof(uint64_t) - 1),
+							     &children, encoder_ctx);
 			if (slen < 0) return slen;
-			p += slen;
 		}
 		fr_cursor_next(cursor);
 	}
@@ -241,9 +251,8 @@ static ssize_t internal_encode(uint8_t *out, size_t outlen,
 	 *	the function.
 	 */
 	{
-		uint8_t	buff[sizeof(uint64_t)];
-
-		flen = fr_net_from_uint64v(buff, p - value_field);
+		value_end = dbuff->p;
+		flen = fr_net_from_uint64v(buff, value_end - value_field);
 
 		/*
 		 *	Ugh, it's a long one, need to memmove the
@@ -252,24 +261,57 @@ static ssize_t internal_encode(uint8_t *out, size_t outlen,
 		 *	buffer space.
 		 */
 		if (flen > 1) {
-			size_t	value_len = p - value_field;
-			uint8_t *to = len_field + flen;
-
-			memmove(to, value_field, value_len);
-
-			p = to + value_len;
+			fr_dbuff_advance(dbuff, flen - 1);
+			memmove(len_field + flen, value_field, value_end - value_field);
+			value_end += flen - 1;
 		}
 		memcpy(len_field, buff, flen);
 		enc_field[0] |= ((flen - 1) << 2);
 	}
 
-	/*
-	 *	value_field needs to be adjusted for
-	 *	actual length field size.
-	 */
-	FR_PROTO_HEX_DUMP(out, (value_field + (flen - 1)) - out, "header");
+	FR_PROTO_HEX_DUMP(enc_field, value_field + flen - 1 - enc_field, "header");
 
-	return p - out;
+	return value_end - enc_field;
+}
+
+/** Encode a single value box, serializing its contents in generic network format
+ *
+ * @note this is a dbuff-oriented layer around fr_value_box_to_network(); once
+ * dbuffs become the convention, this layer should no longer be necessary.
+ */
+static ssize_t fr_value_box_to_network_dbuff(size_t *need, fr_dbuff_t *dbuff, fr_value_box_t const *value)
+{
+	ssize_t	result;
+
+	result = fr_value_box_to_network(need, dbuff->p, fr_dbuff_freespace(dbuff), value);
+	if (result < 0) return result;
+	fr_dbuff_advance(dbuff, result);
+	return result;
+}
+
+/** Encode a data structure into an internal attribute
+ *
+ * This will become the main entry point when we switch fully to dbuff.
+ *
+ * @param[in,out] dbuff		Where to write encoded data and how much one can write.
+ * @param[in] cursor		Specifying attribute to encode.
+ * @param[in] encoder_ctx	Additional data such as the shared secret to use.
+ * @return
+ *	- >0 The number of bytes written to out.
+ *	- 0 Nothing to encode (or attribute skipped).
+ *	- <0 an error occurred.
+ */
+static ssize_t fr_internal_encode_pair_dbuff(fr_dbuff_t *dbuff, fr_cursor_t *cursor, void *encoder_ctx)
+{
+	VALUE_PAIR		*vp;
+	fr_da_stack_t		da_stack;
+
+	vp = fr_cursor_current(cursor);
+	if (!vp) return 0;
+
+	fr_proto_da_stack_build(&da_stack, vp->da);
+
+	return internal_encode(dbuff, &da_stack, 0, cursor, encoder_ctx);
 }
 
 /** Encode a data structure into an internal attribute
@@ -287,15 +329,7 @@ static ssize_t internal_encode(uint8_t *out, size_t outlen,
  */
 ssize_t fr_internal_encode_pair(uint8_t *out, size_t outlen, fr_cursor_t *cursor, void *encoder_ctx)
 {
-	VALUE_PAIR		*vp;
-	fr_da_stack_t		da_stack;
-
-	vp = fr_cursor_current(cursor);
-	if (!vp) return 0;
-
-	fr_proto_da_stack_build(&da_stack, vp->da);
-
-	return internal_encode(out, outlen, &da_stack, 0, cursor, encoder_ctx);
+	return fr_internal_encode_pair_dbuff(FR_DBUFF_TMP(out, outlen), cursor, encoder_ctx);
 }
 
 /*


### PR DESCRIPTION
Ultimately, we will switch generally from passing around ptr/length
to using dbuffs. Doing it in stages means the following:

- the outside interface (and inside via test points) will only
  change once, at the end
- because of that, and because of common functions called by
  various protocols' code (e.g. fr_value_box_to_network()),
  there will be wrappers that ultimately go away or become the
  official versions (e.g. fr_value_box_to_network_dbuff() and
  fr_internal_encode_pair_dbuff())

The layout and time's arrow combine to give internal_encode()
two alternatives:

- copying data only when it's known, at a cost in time and memory
  for copying some data twice
- modifying and/or moving already-written data (e.g filling in
  fields in the first encoding byte when they're known, or moving
  encoded data when it turns out to be longer than 255 bytes so
  that the length can be stored)

internal_encode() has done the latter in the past, and this version
sticks with it by noting dbuff->p's value before fr_dbuff_mem*()ing
in things it may want to overwrite or move.