### PR TITLE
:gear: Fix 'make test.modules' verbosity

### DIFF
--- a/src/tests/modules/json/all.mk
+++ b/src/tests/modules/json/all.mk
@@ -1,7 +1,3 @@
 #
 #  Test the "json" module
 #
-
-#  MODULE.test is the main target for this module.
-json.test:
-	${Q}echo OK: json.test

--- a/src/tests/modules/linelog/all.mk
+++ b/src/tests/modules/linelog/all.mk
@@ -1,7 +1,3 @@
 #
 #  Test the "files" module
 #
-
-#  MODULE.test is the main target for this module.
-linelog.test:
-	${Q}echo OK: linelog.test


### PR DESCRIPTION
Lets keep the same behavior for all tests/modules/$name targets
whitout that 'OK' message.