### PR TITLE
Make ethernet.h the sole definer of ethernet_header_t

### DIFF
--- a/src/lib/util/net.h
+++ b/src/lib/util/net.h
@@ -33,6 +33,7 @@ extern "C" {
 #endif
 
 #include <freeradius-devel/build.h>
+#include <freeradius-devel/ethernet/ethernet.h>
 #include <freeradius-devel/missing.h>
 #include <freeradius-devel/util/hash.h>
 #include <freeradius-devel/util/misc.h>
@@ -96,15 +97,6 @@ typedef enum {
 #define	I_DF		0x4000		//!< Dont fragment flag.
 #define IP_MF		0x2000		//!< More fragments flag.
 #define IP_OFFMASK	0x1fff		//!< Mask for fragmenting bits.
-
-/*
- *	Structure of a DEC/Intel/Xerox or 802.3 Ethernet header.
- */
-typedef struct CC_HINT(__packed__) {
-	uint8_t		ether_dst[ETHER_ADDR_LEN];
-	uint8_t		ether_src[ETHER_ADDR_LEN];
-	uint16_t	ether_type;
-} ethernet_header_t;
 
 /*
  *	Structure of an internet header, naked of options.

--- a/src/modules/proto_arp/proto_arp_ethernet.c
+++ b/src/modules/proto_arp/proto_arp_ethernet.c
@@ -145,8 +145,8 @@ static ssize_t mod_write(fr_listen_t *li, UNUSED void *packet_ctx, UNUSED fr_tim
 	 *	Set the destination MAC as the target address from
 	 *	ARP.
 	 */
-	memcpy(eth_hdr->ether_src, thread->pcap->ether_addr, ETHER_ADDR_LEN);
-	memcpy(eth_hdr->ether_dst, arp->tha, ETHER_ADDR_LEN);
+	memcpy(eth_hdr->src_addr, thread->pcap->ether_addr, ETHER_ADDR_LEN);
+	memcpy(eth_hdr->dst_addr, arp->tha, ETHER_ADDR_LEN);
 
 	/*
 	 *	If we fail injecting the reply, just ignore it.

--- a/src/protocols/dhcpv4/pcap.c
+++ b/src/protocols/dhcpv4/pcap.c
@@ -51,8 +51,8 @@ int fr_dhcpv4_pcap_send(fr_pcap_t *pcap, uint8_t *dst_ether_addr, RADIUS_PACKET 
 
 	/* fill in Ethernet layer (L2) */
 	eth_hdr = (ethernet_header_t *)dhcp_packet;
-	memcpy(eth_hdr->ether_dst, dst_ether_addr, ETH_ADDR_LEN);
-	memcpy(eth_hdr->ether_src, pcap->ether_addr, ETH_ADDR_LEN);
+	memcpy(eth_hdr->src_addr, dst_ether_addr, ETH_ADDR_LEN);
+	memcpy(eth_hdr->dst_addr, pcap->ether_addr, ETH_ADDR_LEN);
 	eth_hdr->ether_type = htons(ETH_TYPE_IP);
 	end += ETH_ADDR_LEN + ETH_ADDR_LEN + sizeof(eth_hdr->ether_type);
 

--- a/src/protocols/dhcpv4/raw.c
+++ b/src/protocols/dhcpv4/raw.c
@@ -122,8 +122,8 @@ int fr_dhcpv4_raw_packet_send(int sockfd, struct sockaddr_ll *link_layer, RADIUS
 	}
 
 	/* fill in Ethernet layer (L2) */
-	memcpy(eth_hdr->ether_dst, eth_bcast, ETH_ADDR_LEN);
-	memcpy(eth_hdr->ether_src, dhmac, ETH_ADDR_LEN);
+	memcpy(eth_hdr->dst_addr, eth_bcast, ETH_ADDR_LEN);
+	memcpy(eth_hdr->src_addr, dhmac, ETH_ADDR_LEN);
 	eth_hdr->ether_type = htons(ETH_TYPE_IP);
 
 	/* fill in IP layer (L3) */
@@ -225,13 +225,13 @@ RADIUS_PACKET *fr_dhcv4_raw_packet_recv(int sockfd, struct sockaddr_ll *link_lay
 	 *	If Ethernet destination is not broadcast (ff:ff:ff:ff:ff:ff)
 	 *	Check if it matches the source HW address used (DHCP-Client-Hardware-Address = 267)
 	 */
-	if ((memcmp(&eth_bcast, &eth_hdr->ether_dst, ETH_ADDR_LEN) != 0) &&
+	if ((memcmp(&eth_bcast, &eth_hdr->dst_addr, ETH_ADDR_LEN) != 0) &&
 	    (vp = fr_pair_find_by_da(request->vps, attr_dhcp_client_hardware_address, TAG_ANY)) &&
-	    ((vp->vp_type == FR_TYPE_ETHERNET) && (memcmp(vp->vp_ether, &eth_hdr->ether_dst, ETH_ADDR_LEN) != 0))) {
+	    ((vp->vp_type == FR_TYPE_ETHERNET) && (memcmp(vp->vp_ether, &eth_hdr->dst_addr, ETH_ADDR_LEN) != 0))) {
 
 		/* No match. */
 		DISCARD_RP("Ethernet destination (%pV) is not broadcast and doesn't match request source (%pV)",
-			   fr_box_ether(eth_hdr->ether_dst), &vp->data);
+			   fr_box_ether(eth_hdr->dst_addr), &vp->data);
 	}
 
 	/*


### PR DESCRIPTION
Member name references are now consistent with the now-sole definition.