### PR TITLE
Make the actual fr_value_box_to_network_dbuff() visible

### DIFF
--- a/src/lib/util/value.c
+++ b/src/lib/util/value.c
@@ -94,7 +94,6 @@ static_assert(SIZEOF_MEMBER(fr_value_box_t, vb_float32) == 4,
 static_assert(SIZEOF_MEMBER(fr_value_box_t, vb_float64) == 8,
 	      "vb_float64 has unexpected length");
 
-static ssize_t fr_value_box_to_network_dbuff(size_t *need, fr_dbuff_t *dbuff, fr_value_box_t const *value);
 
 /** Map data types to names representing those types
  */
@@ -1042,7 +1041,7 @@ ssize_t fr_value_box_to_network(size_t *need, uint8_t *dst, size_t dst_len, fr_v
 	return fr_value_box_to_network_dbuff(need, &FR_DBUFF_TMP(dst, dst_len), value);
 }
 
-static ssize_t fr_value_box_to_network_dbuff(size_t *need, fr_dbuff_t *dbuff, fr_value_box_t const *value)
+ssize_t fr_value_box_to_network_dbuff(size_t *need, fr_dbuff_t *dbuff, fr_value_box_t const *value)
 {
 	size_t min, max;
 

--- a/src/lib/util/value.h
+++ b/src/lib/util/value.h
@@ -37,6 +37,7 @@ typedef struct value_box fr_value_box_t;
 
 #include <freeradius-devel/build.h>
 #include <freeradius-devel/missing.h>
+#include <freeradius-devel/util/dbuff.h>
 #include <freeradius-devel/util/debug.h>
 #include <freeradius-devel/util/dict.h>
 #include <freeradius-devel/util/inet.h>
@@ -541,6 +542,8 @@ int		fr_value_box_hton(fr_value_box_t *dst, fr_value_box_t const *src);
 size_t		fr_value_box_network_length(fr_value_box_t *value);
 
 ssize_t		fr_value_box_to_network(size_t *need, uint8_t *out, size_t outlen, fr_value_box_t const *value);
+
+ssize_t		fr_value_box_to_network_dbuff(size_t *need, fr_dbuff_t *dbuff, fr_value_box_t const *value);
 
 /** Special value to indicate fr_value_box_from_network experienced a general error
  */

--- a/src/protocols/internal/encode.c
+++ b/src/protocols/internal/encode.c
@@ -36,7 +36,6 @@
 
 #include <talloc.h>
 
-static ssize_t fr_value_box_to_network_dbuff(size_t *need, fr_dbuff_t *dbuff, fr_value_box_t const *value);
 static ssize_t fr_internal_encode_pair_dbuff(fr_dbuff_t *dbuff, fr_cursor_t *cursor, void *encoder_ctx);
 
 /** We use the same header for all types
@@ -272,21 +271,6 @@ static ssize_t internal_encode(fr_dbuff_t *dbuff,
 	FR_PROTO_HEX_DUMP(enc_field, (value_field + (flen - 1)) - enc_field, "header");
 
 	return value_end - enc_field;
-}
-
-/** Encode a single value box, serializing its contents in generic network format
- *
- * @note this is a dbuff-oriented layer around fr_value_box_to_network(); once
- * dbuffs become the convention, this layer should no longer be necessary.
- */
-static ssize_t fr_value_box_to_network_dbuff(size_t *need, fr_dbuff_t *dbuff, fr_value_box_t const *value)
-{
-	ssize_t	result;
-
-	result = fr_value_box_to_network(need, dbuff->p, fr_dbuff_remaining(dbuff), value);
-	if (result < 0) return result;
-	fr_dbuff_advance(dbuff, result);
-	return result;
 }
 
 /** Encode a data structure into an internal attribute


### PR DESCRIPTION
We also get rid of the internal protocol's dbuff wrapper around
fr_value_box_to_network(); we leave fr_value_box_to_network()
(itself now a wrapper around the dbuff version) in place so we can
move other protocols to dbuff one at a time.