### PR TITLE
v3.0.x: MySQL setup: Use correct syntax for creating the radius user

### DIFF
--- a/raddb/mods-config/sql/main/mysql/setup.sql
+++ b/raddb/mods-config/sql/main/mysql/setup.sql
@@ -11,8 +11,7 @@
 #
 #  Create default administrator for RADIUS
 #
-CREATE USER 'radius'@'localhost';
-SET PASSWORD FOR 'radius'@'localhost' = PASSWORD('radpass');
+CREATE USER 'radius'@'localhost' IDENTIFIED BY 'radpass';
 
 # The server can read any table in SQL
 GRANT SELECT ON radius.* TO 'radius'@'localhost';


### PR DESCRIPTION
This syntax works from at least MySQL 5.7 to MySQL 8 and corresponding MariaDB
versions.