### PR TITLE
arp: Check that filter is not truncated when reformatting

### DIFF
--- a/src/modules/proto_arp/proto_arp_ethernet.c
+++ b/src/modules/proto_arp/proto_arp_ethernet.c
@@ -198,7 +198,10 @@ static int mod_open(fr_listen_t *li)
 		filter = "arp";
 	} else {
 		filter = buffer;
-		snprintf(buffer, sizeof(buffer), "arp and %s", filter);
+		if (snprintf(buffer, sizeof(buffer), "arp and %s", filter) >= (int)sizeof(buffer) ) {
+			PERROR("Filter length exceeds buffer");
+			return -1;
+		};
 	}
 
 	if (fr_pcap_apply_filter(thread->pcap, filter) < 0) {


### PR DESCRIPTION
Silences a warning from gcc > 7.1.