### PR TITLE
Add the ability to move signed/unsigned integers into dbuffs.

### DIFF
--- a/src/lib/util/dbuff.h
+++ b/src/lib/util/dbuff.h
@@ -29,6 +29,7 @@ RCSIDH(dbuff_h, "$Id$")
 extern "C" {
 #  endif
 
+#include <freeradius-devel/missing.h>
 #include <freeradius-devel/util/debug.h>
 #include <freeradius-devel/util/net.h>
 #include <stdbool.h>
@@ -347,7 +348,7 @@ static inline ssize_t fr_dbuff_memset(fr_dbuff_t *dbuff, uint8_t c, size_t inlen
  * 	>0	(2, actually) the number of bytes set in the dbuff
  * 	<0	the number of bytes required
  */
-static inline ssize_t fr_dbuff_net_from_uint16(fr_dbuff_t *dbuff, uint16_t num)
+static inline ssize_t fr_dbuff_net_encode_uint16(fr_dbuff_t *dbuff, uint16_t num)
 {
 	size_t	freespace = fr_dbuff_remaining(dbuff);
 
@@ -371,7 +372,7 @@ static inline ssize_t fr_dbuff_net_from_uint16(fr_dbuff_t *dbuff, uint16_t num)
  * 	>0	(4, actually) the number of bytes set in the dbuff
  * 	<0	the number of bytes required
  */
-static inline ssize_t fr_dbuff_net_from_uint32(fr_dbuff_t *dbuff, uint32_t num)
+static inline ssize_t fr_dbuff_net_encode_uint32(fr_dbuff_t *dbuff, uint32_t num)
 {
 	size_t freespace = fr_dbuff_remaining(dbuff);
 
@@ -395,7 +396,7 @@ static inline ssize_t fr_dbuff_net_from_uint32(fr_dbuff_t *dbuff, uint32_t num)
  * 	>0	(8, actually) the number of bytes set in the dbuff
  * 	<0	the number of bytes required
  */
-static inline ssize_t fr_dbuff_net_from_uint64(fr_dbuff_t *dbuff, uint64_t num)
+static inline ssize_t fr_dbuff_net_encode_uint64(fr_dbuff_t *dbuff, uint64_t num)
 {
 	size_t freespace = fr_dbuff_remaining(dbuff);
 
@@ -410,6 +411,68 @@ static inline ssize_t fr_dbuff_net_from_uint64(fr_dbuff_t *dbuff, uint64_t num)
 }
 #define FR_DBUFF_NET_FROM_UINT64_RETURN(_dbuff, _num) FR_DBUFF_RETURN(fr_dbuff_net_from_uint64, _dbuff, _num)
 
+/** Copy a signed 16-bit integer into a buffer in wire format (big endian)
+ *
+ * @param[in] dbuff	to copy data to
+ * @param[in] num	value to copy
+ * @return
+ * 	0	no data set
+ * 	>0	(2, actually) the number of bytes set in the dbuff
+ * 	<0	the number of bytes required
+ */
+static inline ssize_t fr_dbuff_net_encode_int16(fr_dbuff_t *dbuff, int16_t num)
+{
+	return fr_dbuff_net_encode_uint16(dbuff, (uint16_t) num);
+}
+#define FR_DBUFF_NET_FROM_INT16_RETURN(_dbuff, _num) FR_DBUFF_RETURN(fr_dbuff_net_from_int16, _dbuff, _num)
+
+/** Copy a signed 32-bit integer into a buffer in wire format (big endian)
+ *
+ * @param[in] dbuff	to copy data to
+ * @param[in] num	value to copy
+ * @return
+ * 	0	no data set
+ * 	>0	(4, actually) the number of bytes set in the dbuff
+ * 	<0	the number of bytes required
+ */
+static inline ssize_t fr_dbuff_net_encode_int32(fr_dbuff_t *dbuff, int32_t num)
+{
+	return fr_dbuff_net_encode_uint32(dbuff, (uint32_t) num);
+}
+#define FR_DBUFF_NET_FROM_INT32_RETURN(_dbuff, _num) FR_DBUFF_RETURN(fr_dbuff_net_from_int32, _dbuff, _num)
+
+/** Copy a signed 64-bit integer into a buffer in wire format (big endian)
+ *
+ * @param[in] dbuff	to copy data to
+ * @param[in] num	value to copy
+ * @return
+ * 	0	no data set
+ * 	>0	(8, actually) the number of bytes set in the dbuff
+ * 	<0	the number of bytes required
+ */
+static inline ssize_t fr_dbuff_net_encode_int64(fr_dbuff_t *dbuff, int64_t num)
+{
+	return fr_dbuff_net_encode_uint64(dbuff, (uint64_t) num);
+}
+#define FR_DBUFF_NET_FROM_UINT64_RETURN(_dbuff, _num) FR_DBUFF_RETURN(fr_dbuff_net_from_uint64, _dbuff, _num)
+
+#define fr_dbuff_net_encode(dbuff, value) \
+	_Generic((value), \
+		int16_t		: fr_dbuff_net_encode_int16(dbuff, (int16_t) value), \
+		int32_t		: fr_dbuff_net_encode_int32(dbuff, (int32_t) value), \
+		int64_t		: fr_dbuff_net_encode_int64(dbuff, (int64_t) value), \
+		uint16_t	: fr_dbuff_net_encode_uint16(dbuff, (uint16_t) value), \
+		uint32_t	: fr_dbuff_net_encode_uint32(dbuff, (uint32_t) value), \
+		uint64_t	: fr_dbuff_net_encode_uint64(dbuff, (uint64_t) value) \
+	)
+
+static inline ssize_t fr_dbuff_net_encode_uint64v(fr_dbuff_t *dbuff, uint64_t num)
+{
+	size_t	num_bytes = ROUND_UP_DIV((size_t)fr_high_bit_pos(num), 8);
+
+	num = ntohll(num);
+	return fr_dbuff_memcpy_in(dbuff, ((uint8_t *)&num) + (sizeof(uint64_t) - num_bytes), num_bytes);
+}
 /** @} */
 
 #ifdef __cplusplus

--- a/src/lib/util/dbuff_tests.c
+++ b/src/lib/util/dbuff_tests.c
@@ -42,34 +42,151 @@ static void test_dbuff_init_no_parent(void)
 	TEST_CHECK(dbuff.parent == NULL);
 }
 
-static void test_dbuff_net_from(void)
+/** Test the various dbuff_net_encode() functions and macros
+ *
+ * @note Passing constants to fr_dbuff_net_encode() as it is written results in
+ * 	 warnings about narrowing casts on the constants--but those casts are in
+ * 	 the underlying inlined fr_net_from*() functions. They have to be there;
+ * 	 that's how those functions work. (The tests worked despite the warnings.)
+ * 	 Using variables avoids the warnings, at least with the compile options
+ *	 the build system uses by default.
+ */
+static void test_dbuff_net_encode(void)
 {
 	uint8_t		buff[sizeof(uint64_t)];
 	fr_dbuff_t	dbuff;
+	uint16_t	u16val = 0x1234;
+	uint32_t	u32val = 0x12345678;
+	uint64_t	u64val = 0x123456789abcdef0;
+	int16_t		i16val = 0x1234;
+	int32_t		i32val = 0xd34d;
+	int64_t		i64val = 0x123456789abcdef0;
 
-	TEST_CASE("Generate wire format 16-bit value");
+	TEST_CASE("Generate wire format unsigned 16-bit value");
 	memset(buff, 0, sizeof(buff));
 	fr_dbuff_init(&dbuff, buff, sizeof(buff));
 
-	TEST_CHECK(fr_dbuff_net_from_uint16(&dbuff, 0x1234) == sizeof(uint16_t));
+	TEST_CHECK(fr_dbuff_net_encode(&dbuff, u16val) == sizeof(uint16_t));
 	TEST_CHECK(buff[0] == 0x12);
 	TEST_CHECK(buff[1] == 0x34);
 
-	TEST_CASE("Generate wire format 32-bit value");
+	TEST_CASE("Generate wire format unsigned 32-bit value");
 	memset(buff, 0, sizeof(buff));
 	fr_dbuff_init(&dbuff, buff, sizeof(buff));
 
-	TEST_CHECK(fr_dbuff_net_from_uint32(&dbuff, 0x12345678) == sizeof(uint32_t));
+	TEST_CHECK(fr_dbuff_net_encode(&dbuff, u32val) == sizeof(uint32_t));
 	TEST_CHECK(buff[0] == 0x12);
 	TEST_CHECK(buff[1] == 0x34);
 	TEST_CHECK(buff[2] == 0x56);
 	TEST_CHECK(buff[3] == 0x78);
 
-	TEST_CASE("Generate wire format 64-bit value");
+	TEST_CASE("Generate wire format unsigned 64-bit value");
 	memset(buff, 0, sizeof(buff));
 	fr_dbuff_init(&dbuff, buff, sizeof(buff));
 
-	TEST_CHECK(fr_dbuff_net_from_uint64(&dbuff, 0x123456789abcdef0) == sizeof(uint64_t));
+	TEST_CHECK(fr_dbuff_net_encode(&dbuff, u64val) == sizeof(uint64_t));
+	TEST_CHECK(buff[0] == 0x12);
+	TEST_CHECK(buff[1] == 0x34);
+	TEST_CHECK(buff[2] == 0x56);
+	TEST_CHECK(buff[3] == 0x78);
+	TEST_CHECK(buff[4] == 0x9a);
+	TEST_CHECK(buff[5] == 0xbc);
+	TEST_CHECK(buff[6] == 0xde);
+	TEST_CHECK(buff[7] == 0xf0);
+
+	TEST_CASE("Generate wire format signed 16-bit value");
+	memset(buff, 0, sizeof(buff));
+	fr_dbuff_init(&dbuff, buff, sizeof(buff));
+
+	TEST_CHECK(fr_dbuff_net_encode(&dbuff, i16val) == sizeof(int16_t));
+	TEST_CHECK(buff[0] == 0x12);
+	TEST_CHECK(buff[1] == 0x34);
+
+	TEST_CASE("Generate wire format signed 32-bit value");
+	memset(buff, 0, sizeof(buff));
+	fr_dbuff_init(&dbuff, buff, sizeof(buff));
+
+	TEST_CHECK(fr_dbuff_net_encode(&dbuff, i32val) == sizeof(int32_t));
+	TEST_CHECK(buff[0] == 0x00);
+	TEST_CHECK(buff[1] == 0x00);
+	TEST_CHECK(buff[2] == 0xd3);
+	TEST_CHECK(buff[3] == 0x4d);
+
+
+	TEST_CASE("Generate wire format signed 64-bit value");
+	memset(buff, 0, sizeof(buff));
+	fr_dbuff_init(&dbuff, buff, sizeof(buff));
+
+	TEST_CHECK(fr_dbuff_net_encode(&dbuff, i64val) == sizeof(int64_t));
+	TEST_CHECK(buff[0] == 0x12);
+	TEST_CHECK(buff[1] == 0x34);
+	TEST_CHECK(buff[2] == 0x56);
+	TEST_CHECK(buff[3] == 0x78);
+	TEST_CHECK(buff[4] == 0x9a);
+	TEST_CHECK(buff[5] == 0xbc);
+	TEST_CHECK(buff[6] == 0xde);
+	TEST_CHECK(buff[7] == 0xf0);
+
+	TEST_CASE("Generate wire format variable-width");
+	memset(buff, 0, sizeof(buff));
+	fr_dbuff_init(&dbuff, buff, sizeof(buff));
+	TEST_CHECK(fr_dbuff_net_encode_uint64v(&dbuff, 0x12) == 1);
+	TEST_CHECK(buff[0] == 0x12);
+
+	memset(buff, 0, sizeof(buff));
+	fr_dbuff_init(&dbuff, buff, sizeof(buff));
+	TEST_CHECK(fr_dbuff_net_encode_uint64v(&dbuff, 0x1234) == 2);
+	TEST_CHECK(buff[0] == 0x12);
+	TEST_CHECK(buff[1] == 0x34);
+
+	memset(buff, 0, sizeof(buff));
+	fr_dbuff_init(&dbuff, buff, sizeof(buff));
+	TEST_CHECK(fr_dbuff_net_encode_uint64v(&dbuff, 0x123456) == 3);
+	TEST_CHECK(buff[0] == 0x12);
+	TEST_CHECK(buff[1] == 0x34);
+	TEST_CHECK(buff[2] == 0x56);
+
+	memset(buff, 0, sizeof(buff));
+	fr_dbuff_init(&dbuff, buff, sizeof(buff));
+	TEST_CHECK(fr_dbuff_net_encode_uint64v(&dbuff, 0x12345678) == 4);
+	TEST_CHECK(buff[0] == 0x12);
+	TEST_CHECK(buff[1] == 0x34);
+	TEST_CHECK(buff[2] == 0x56);
+	TEST_CHECK(buff[3] == 0x78);
+
+	memset(buff, 0, sizeof(buff));
+	fr_dbuff_init(&dbuff, buff, sizeof(buff));
+	TEST_CHECK(fr_dbuff_net_encode_uint64v(&dbuff, 0x123456789a) == 5);
+	TEST_CHECK(buff[0] == 0x12);
+	TEST_CHECK(buff[1] == 0x34);
+	TEST_CHECK(buff[2] == 0x56);
+	TEST_CHECK(buff[3] == 0x78);
+	TEST_CHECK(buff[4] == 0x9a);
+
+	memset(buff, 0, sizeof(buff));
+	fr_dbuff_init(&dbuff, buff, sizeof(buff));
+	TEST_CHECK(fr_dbuff_net_encode_uint64v(&dbuff, 0x123456789abc) == 6);
+	TEST_CHECK(buff[0] == 0x12);
+	TEST_CHECK(buff[1] == 0x34);
+	TEST_CHECK(buff[2] == 0x56);
+	TEST_CHECK(buff[3] == 0x78);
+	TEST_CHECK(buff[4] == 0x9a);
+	TEST_CHECK(buff[5] == 0xbc);
+
+	memset(buff, 0, sizeof(buff));
+	fr_dbuff_init(&dbuff, buff, sizeof(buff));
+	TEST_CHECK(fr_dbuff_net_encode_uint64v(&dbuff, 0x123456789abcde) == 7);
+	TEST_CHECK(buff[0] == 0x12);
+	TEST_CHECK(buff[1] == 0x34);
+	TEST_CHECK(buff[2] == 0x56);
+	TEST_CHECK(buff[3] == 0x78);
+	TEST_CHECK(buff[4] == 0x9a);
+	TEST_CHECK(buff[5] == 0xbc);
+	TEST_CHECK(buff[6] == 0xde);
+
+	memset(buff, 0, sizeof(buff));
+	fr_dbuff_init(&dbuff, buff, sizeof(buff));
+	TEST_CHECK(fr_dbuff_net_encode_uint64v(&dbuff, 0x123456789abcdef0) == 8);
 	TEST_CHECK(buff[0] == 0x12);
 	TEST_CHECK(buff[1] == 0x34);
 	TEST_CHECK(buff[2] == 0x56);
@@ -82,8 +199,7 @@ static void test_dbuff_net_from(void)
 	TEST_CASE("Refuse to write to too-small space");
 	fr_dbuff_init(&dbuff, buff, sizeof(uint32_t));
 
-	TEST_CHECK(fr_dbuff_net_from_uint64(&dbuff,
-					    0x123456789abcdef0) == -(ssize_t)(sizeof(uint64_t) - sizeof(uint32_t)));
+	TEST_CHECK(fr_dbuff_net_encode(&dbuff, u64val) == -(ssize_t)(sizeof(uint64_t) - sizeof(uint32_t)));
 }
 
 
@@ -93,7 +209,7 @@ TEST_LIST = {
 	 */
 	{ "fr_dbuff_init",				test_dbuff_init },
 	{ "fr_dbuff_init_no_parent",			test_dbuff_init_no_parent },
-	{ "fr_dbuff_net_from",				test_dbuff_net_from },
+	{ "fr_dbuff_net_encode",			test_dbuff_net_encode },
 
 	{ NULL }
 };

--- a/src/lib/util/value.c
+++ b/src/lib/util/value.c
@@ -1207,17 +1207,17 @@ ssize_t fr_value_box_to_network_dbuff(size_t *need, fr_dbuff_t *dbuff, fr_value_
 		} else switch (value->enumv->flags.length) {
 		case 2:
 			if (date > UINT16_MAX) date = UINT16_MAX;
-			fr_dbuff_net_from_uint16(dbuff, date);
+			fr_dbuff_net_encode(dbuff, (int16_t) date);
 			break;
 
 		date_size4:
 		case 4:
 			if (date > UINT32_MAX) date = UINT32_MAX;
-			fr_dbuff_net_from_uint32(dbuff, date);
+			fr_dbuff_net_encode(dbuff, (int32_t) date);
 			break;
 
 		case 8:
-			fr_dbuff_net_from_uint64(dbuff, date);
+			fr_dbuff_net_encode(dbuff, date);
 			break;
 
 		default:
@@ -1266,7 +1266,7 @@ ssize_t fr_value_box_to_network_dbuff(size_t *need, fr_dbuff_t *dbuff, fr_value_
 			} else if (date > INT16_MAX) {
 				date = INT16_MAX;
 			}
-			fr_dbuff_net_from_uint16(dbuff, (uint16_t)date);
+			fr_dbuff_net_encode(dbuff, (int16_t)date);
 			break;
 
 		delta_size4:
@@ -1276,11 +1276,11 @@ ssize_t fr_value_box_to_network_dbuff(size_t *need, fr_dbuff_t *dbuff, fr_value_
 			} else if (date > INT32_MAX) {
 				date = INT32_MAX;
 			}
-			fr_dbuff_net_from_uint32(dbuff, (uint32_t)date);
+			fr_dbuff_net_encode(dbuff, (int32_t)date);
 			break;
 
 		case 8:
-			fr_dbuff_net_from_uint64(dbuff, (uint64_t)date);
+			fr_dbuff_net_encode(dbuff, (int64_t)date);
 			break;
 
 		default:

--- a/src/protocols/internal/encode.c
+++ b/src/protocols/internal/encode.c
@@ -110,10 +110,8 @@ static ssize_t internal_encode(fr_dbuff_t *dbuff,
 	 *	Encode the type and write the width of the
 	 *	integer to the encoding byte.
 	 */
-	flen = fr_net_from_uint64v(buff, da->attr);
+	flen = fr_dbuff_net_encode_uint64v(dbuff, da->attr);
 	enc_field[0] |= ((flen - 1) << 5);
-
-	fr_dbuff_memcpy_in(dbuff, buff, flen);
 
 	/*
 	 *	Mark where the length field will be, and


### PR DESCRIPTION
We provide for either wire format or the format of the computer
running the code, and add generic macros that will provide the
appropriate size based on the type of the argument. The names
are now fr_dbuff_encode* and fr_dbuff_net_encode*.