### PR TITLE
ippool - mysql: simplified allocate_find query.

### DIFF
--- a/raddb/mods-config/sql/ippool/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mysql/queries.conf
@@ -90,7 +90,7 @@ allocate_find = "\
 	SELECT framedipaddress FROM ${ippool_table} \
 	WHERE pool_name = '%{control:Pool-Name}' \
 	AND ( \
-		expiry_time < NOW() OR expiry_time IS NULL OR expiry_time = 0 \
+		expiry_time < NOW() OR expiry_time IS NULL \
 		OR ( nasipaddress = '%{NAS-IP-Address}' AND pool_key = '${pool_key}' ) \
 	) \
 	ORDER BY \


### PR DESCRIPTION
The special case "expiry_time = 0" is redundant, because of "expiry_time < NOW()".
NOW() is always greater than 0.