### PR TITLE
rlm_icmp: Fix icmp6 support

### DIFF
--- a/raddb/mods-available/icmp
+++ b/raddb/mods-available/icmp
@@ -42,7 +42,7 @@ icmp {
 	#
 	#  src_ipaddr: Source address for ICMP messages.
 	#
-#	src_ipaddr = 192.0.2.128
+#	src_ipaddr = *
 
 	#
 	#  timeout:: How long to wait for the reply.
@@ -67,12 +67,13 @@ icmp {
 #
 icmp ping {
 	timeout = 1s
+	src_ipaddr = *
 }
 
 #
 # ## A version for ICMPv6
 #
-icmp icmp6 {
+icmp ping6 {
 	timeout = 1s
-	src_ipaddr = 2001:DB8::
+	src_ipaddr = ::
 }

--- a/src/modules/rlm_icmp/rlm_icmp.c
+++ b/src/modules/rlm_icmp/rlm_icmp.c
@@ -369,7 +369,7 @@ static void mod_icmp_read(UNUSED fr_event_list_t *el, UNUSED int sockfd, UNUSED 
 	if (len <= 0) return;
 
 	DEBUG4("GOT %zd bytes", len);
-
+	HEXDUMP4((uint8_t const *)buffer, len, "received packet[length %ld]", len);
 	/*
 	 *	Ignore packets if we haven't sent any requests.
 	 */


### PR DESCRIPTION
The documentation says that sockets() created with IPPROTO_ICMPV6 will receive packets
without the IPv6 header nor IPv6 extension headers.

In this case, we don't have a way to extract the source address. That is the reason for
we are using the ICMP requests 'ident' field instead of the IP address.