### PR TITLE
Add fr_dbuff_rewind() function and tests for it

### DIFF
--- a/src/lib/util/dbuff.h
+++ b/src/lib/util/dbuff.h
@@ -276,6 +276,36 @@ static inline ssize_t fr_dbuff_advance(fr_dbuff_t *dbuff, size_t inlen)
 }
 #define FR_DBUFF_ADVANCE_RETURN(_dbuff, _inlen) FR_DBUFF_RETURN(fr_dbuff_advance, _dbuff, _inlen)
 
+/** Move back position in dbuff by N bytes without sanity checks
+ *
+ * @note Do not call this function directly.
+ */
+static inline ssize_t _fr_dbuff_rewind(fr_dbuff_t *dbuff, size_t inlen)
+{
+	dbuff->p -= inlen;
+
+	return dbuff->parent ? _fr_dbuff_rewind(dbuff->parent, inlen) : (ssize_t)inlen;
+}
+
+/** Move back position in dbuff by N bytes
+ *
+ * @param[in] dbuff	to move back.
+ * @param[in] inlen	How much to move dbuff back by.
+ * @return
+ *	- 0	not moved back.
+ *	- >0	the number of bytes the dbuff was moved back by.
+ *	- <0	the amount by which inlen exceeded the bytes used in dbuff.
+ */
+static inline ssize_t fr_dbuff_rewind(fr_dbuff_t *dbuff, size_t inlen)
+{
+	size_t usedspace = fr_dbuff_used(dbuff);
+
+	if (inlen > usedspace) return -(inlen - usedspace);
+
+	return _fr_dbuff_rewind(dbuff, inlen);
+}
+#define FR_DBUFF_REWIND_RETURN(_dbuff, _inlen) FR_DBUFF_RETURN(fr_dbuff_rewind, _dbuff, _inlen)
+
 /** Copy n bytes into dbuff
  *
  * @param[in] dbuff	to copy data to.

--- a/src/lib/util/dbuff_tests.c
+++ b/src/lib/util/dbuff_tests.c
@@ -1,6 +1,7 @@
 #include <freeradius-devel/util/acutest.h>
 
 #include "dbuff.h"
+#include <string.h>
 
 
 //#include <gperftools/profiler.h>
@@ -219,6 +220,26 @@ static void test_dbuff_net_encode(void)
 	TEST_CHECK(fr_dbuff_in(&dbuff, u64val) == -(ssize_t)(sizeof(uint64_t) - sizeof(uint32_t)));
 }
 
+static void test_dbuff_rewind(void)
+{
+	uint8_t		buff[8];
+	uint8_t		expected[] = {0, 1, 2, 0, 1, 2, 3, 4};
+	fr_dbuff_t	dbuff;
+
+	TEST_CASE("Check valid uses");
+	fr_dbuff_init(&dbuff, buff, sizeof(buff));
+	fr_dbuff_bytes_in(&dbuff, 0, 1, 2, 3, 4, 5);
+	TEST_CHECK(fr_dbuff_rewind(&dbuff, 3) == 3);
+	fr_dbuff_bytes_in(&dbuff, 0, 1, 2, 3, 4);
+	TEST_CHECK(memcmp(buff, expected, sizeof(expected)) == 0);
+
+
+	TEST_CASE("Confirm rewind error checking");
+	fr_dbuff_init(&dbuff, buff, sizeof(buff));
+	TEST_CHECK(fr_dbuff_rewind(&dbuff, 4) == -4);
+	fr_dbuff_bytes_in(&dbuff, 0, 1, 2, 3);
+	TEST_CHECK(fr_dbuff_rewind(&dbuff, 5) == -1);
+}
 
 TEST_LIST = {
 	/*
@@ -228,6 +249,7 @@ TEST_LIST = {
 	{ "fr_dbuff_init_no_parent",			test_dbuff_init_no_parent },
 	{ "fr_dbuff_max",				test_dbuff_max },
 	{ "fr_dbuff_in",			test_dbuff_net_encode },
+	{ "fr_dbuff_rewind",			test_dbuff_rewind },
 
 	{ NULL }
 };


### PR DESCRIPTION
It is added to let encoding functions back out of writes that prove unnecessary, e.g.
a header for which no data will fit in the buffer.