### PR TITLE
dhcpv4: Don't conflate src and dst MACs when sending

### DIFF
--- a/src/protocols/dhcpv4/pcap.c
+++ b/src/protocols/dhcpv4/pcap.c
@@ -51,8 +51,8 @@ int fr_dhcpv4_pcap_send(fr_pcap_t *pcap, uint8_t *dst_ether_addr, RADIUS_PACKET 
 
 	/* fill in Ethernet layer (L2) */
 	eth_hdr = (ethernet_header_t *)dhcp_packet;
-	memcpy(eth_hdr->src_addr, dst_ether_addr, ETH_ADDR_LEN);
-	memcpy(eth_hdr->dst_addr, pcap->ether_addr, ETH_ADDR_LEN);
+	memcpy(eth_hdr->src_addr, pcap->ether_addr, ETH_ADDR_LEN);
+	memcpy(eth_hdr->dst_addr, dst_ether_addr, ETH_ADDR_LEN);
 	eth_hdr->ether_type = htons(ETH_TYPE_IP);
 	end += ETH_ADDR_LEN + ETH_ADDR_LEN + sizeof(eth_hdr->ether_type);
 


### PR DESCRIPTION
Typo introduced by: c8f2a11ec30b568745e0f5722b2dbc8fc676ea18