### PR TITLE
Fix '-fsanitize=' handle

### DIFF
--- a/configure
+++ b/configure
@@ -13440,17 +13440,17 @@ done
 
     devldflags="$devldflags"
 
-    fsanitizeflags="$fsanitizeflags,address"
+    fsanitizeflags="address,$fsanitizeflags"
   fi
 
         if test "x$llvm_leak_sanitizer" = "xyes" && test "x$ax_cv_cc_clang" = "xyes"; then
-                fsanitizeflags="$fsanitizeflags,leak"
+                fsanitizeflags="leak,$fsanitizeflags"
   fi
 
         if test "x$llvm_undefined_behaviour_sanitizer" = "xyes" && test "x$ax_cv_cc_clang" = "xyes"; then
                     devcflags="$devcflags -fno-sanitize-recover=undefined -fno-omit-frame-pointer"
     devldflags="$devldflags -fno-sanitize-recover=undefined"
-    fsanitizeflags="$fsanitizeflags,undefined"
+    fsanitizeflags="undefined,$fsanitizeflags"
   fi
 
   if test "x$fsanitizeflags" != "xyes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -1777,7 +1777,7 @@ if test "x$developer" = "xyes"; then
 
     devldflags="$devldflags"
 
-    fsanitizeflags="$fsanitizeflags,address"
+    fsanitizeflags="address,$fsanitizeflags"
   fi
 
   dnl #
@@ -1787,7 +1787,7 @@ if test "x$developer" = "xyes"; then
     dnl #
     dnl #  -fsanitize=leak	- Build with lsan support
     dnl #
-    fsanitizeflags="$fsanitizeflags,leak"
+    fsanitizeflags="leak,$fsanitizeflags"
   fi
 
   dnl #
@@ -1800,7 +1800,7 @@ if test "x$developer" = "xyes"; then
     dnl #
     devcflags="$devcflags -fno-sanitize-recover=undefined -fno-omit-frame-pointer"
     devldflags="$devldflags -fno-sanitize-recover=undefined"
-    fsanitizeflags="$fsanitizeflags,undefined"
+    fsanitizeflags="undefined,$fsanitizeflags"
   fi
 
   if test "x$fsanitizeflags" != "xyes"; then


### PR DESCRIPTION
It will avoid having ' -fsanitize=,whatever' instead of '-fsanitize=whatever' or '-fsanitize=whatever,'