### PR TITLE
radsniff: The test need files from LFS

### DIFF
--- a/src/tests/all.mk
+++ b/src/tests/all.mk
@@ -6,6 +6,11 @@ PORT := 12340
 SECRET := testing123
 
 #
+#	We need the 'git-lfs' installed to fetch some binary files.
+#
+GIT_HAS_LFS = $(shell git lfs 1> /dev/null 2>&1 && echo yes || echo no)
+
+#
 #  To work around OpenSSL issues with travis.
 #
 raddb/test.conf:
@@ -51,6 +56,7 @@ test: \
 		test.modules	\
 		test.radiusd-c	\
 		test.radclient	\
+		test.radsniff	\
 		test.auth	\
 		test.digest	\
 		test.radmin	\

--- a/src/tests/radsniff/all.mk
+++ b/src/tests/radsniff/all.mk
@@ -3,12 +3,6 @@
 #
 
 #
-#	Test name
-#
-TEST  := test.radsniff
-FILES := $(subst $(DIR)/,,$(wildcard $(DIR)/*.txt))
-
-#
 #	.pcap file to be injested.
 #
 #	It was generated with:
@@ -16,12 +10,27 @@ FILES := $(subst $(DIR)/,,$(wildcard $(DIR)/*.txt))
 #
 #	TZ=UTC tcpdump -i lo0 -c100 -w radius-auth+acct+coa-100pkts.pcap "port 1812 or port 1813 or port 3799"
 #
+#	NOTE: The src/tests/radsniff/radius-auth+acct+coa-100pkts.pcap.gz will be fetched during "git pull"
+#	if the system has the "git lfs" installed properly. if not, it will be ignored.
+#
 PCAP_IN := $(BUILD_DIR)/tests/radsniff/radius-auth+acct+coa-100pkts.pcap
+
+ifeq "$(GIT_HAS_LFS)" "no"
+test.radsniff:
+	$(Q)echo "WARNING: Can't execute 'test.radsniff' without 'git lfs' installed. ignoring."
+else
+
+#
+#	Test name
+#
+TEST  := test.radsniff
+FILES := $(subst $(DIR)/,,$(wildcard $(DIR)/*.txt))
 
 $(eval $(call TEST_BOOTSTRAP))
 
 #
 #	Uncompress the input .pcap file
+#
 #
 .PRECIOUS: $(OUTPUT)/%.pcap
 $(OUTPUT)/%.pcap: $(DIR)/%.pcap.gz
@@ -72,4 +81,4 @@ $(OUTPUT)/%.txt: $(DIR)/%.txt $(TEST_BIN_DIR)/radsniff $(PCAP_IN)
 		exit 1;                                                                                       \
 	fi
 	$(Q)touch $@
-
+endif


### PR DESCRIPTION
The radsniff test needs some files on LFS. therefore, if the system
doesn't have the 'git lfs' installed properly. just skip it and keep
going. # Scald :battery: