### PR TITLE
v3.0.x: Refresh dhcp-ippool queries and stored procedures

### DIFF
--- a/raddb/mods-config/sql/ippool-dhcp/mssql/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/procedure.sql
@@ -1,0 +1,139 @@
+--
+-- A stored procedure to reallocate a user's previous address, otherwise
+-- provide a free address.
+--
+-- Using this SP reduces the usual set dialogue of queries to a single
+-- query:
+--
+--   BEGIN TRAN; "SELECT FOR UPDATE"; UPDATE; COMMIT TRAN;  ->  EXEC sp
+--
+-- The stored procedure is executed on an database instance within a single
+-- round trip which often leads to reduced deadlocking and significant
+-- performance improvements especially on multi-master clusters, perhaps even
+-- by an order of magnitude or more.
+--
+-- To use this stored procedure the corresponding queries.conf statements must
+-- be configured as follows:
+--
+-- allocate_begin = ""
+-- allocate_find = "\
+--      EXEC fr_allocate_previous_or_new_framedipaddress \
+--              @v_pool_name = '%{control:${pool_name}}', \
+--              @v_username = '%{User-Name}', \
+--              @v_callingstationid = '%{Calling-Station-Id}', \
+--              @v_nasipaddress = '%{NAS-IP-Address}', \
+--              @v_pool_key = '${pool_key}', \
+--              @v_lease_duration = ${lease_duration} \
+--      "
+-- allocate_update = ""
+-- allocate_commit = ""
+--
+
+CREATE INDEX UserName_CallingStationId ON radippool(pool_name,UserName,CallingStationId)
+GO
+
+CREATE OR ALTER PROCEDURE fr_allocate_previous_or_new_framedipaddress
+	@v_pool_name VARCHAR(64),
+	@v_username VARCHAR(64),
+	@v_callingstationid VARCHAR(64),
+	@v_nasipaddress VARCHAR(15),
+	@v_pool_key VARCHAR(64),
+	@v_lease_duration INT
+AS
+	BEGIN
+
+		-- MS SQL lacks a "SELECT FOR UPDATE" statement, and its table
+		-- hints do not provide a direct means to implement the row-level
+		-- read lock needed to guarentee that concurrent queries do not
+		-- select the same Framed-IP-Address for allocation to distinct
+		-- users.
+		--
+		-- The "WITH cte AS ( SELECT ... ) UPDATE cte ... OUTPUT INTO"
+		-- patterns in this procedure body compensate by wrapping
+		-- the SELECT in a synthetic UPDATE which locks the row.
+
+		DECLARE @r_address_tab TABLE(id VARCHAR(15));
+		DECLARE @r_address VARCHAR(15);
+
+		BEGIN TRAN;
+
+		-- Reissue an existing IP address lease when re-authenticating a session
+		--
+		WITH cte AS (
+			SELECT TOP(1) FramedIPAddress
+			FROM radippool
+			WHERE pool_name = @v_pool_name
+				AND expiry_time > CURRENT_TIMESTAMP
+				AND UserName = @v_username
+				AND CallingStationId = @v_callingstationid
+		)
+		UPDATE cte WITH (rowlock, readpast)
+		SET FramedIPAddress = FramedIPAddress
+		OUTPUT INSERTED.FramedIPAddress INTO @r_address_tab;
+		SELECT @r_address = id FROM @r_address_tab;
+
+		-- Reissue an user's previous IP address, provided that the lease is
+		-- available (i.e. enable sticky IPs)
+		--
+		-- When using this SELECT you should delete the one above. You must also
+		-- set allocate_clear = "" in queries.conf to persist the associations
+		-- for expired leases.
+		--
+		-- WITH cte AS (
+		-- 	SELECT TOP(1) FramedIPAddress
+		-- 	FROM radippool
+		-- 	WHERE pool_name = @v_pool_name
+		-- 		AND UserName = @v_username
+		-- 		AND CallingStationId = @v_callingstationid
+		-- )
+		-- UPDATE cte WITH (rowlock, readpast)
+		-- SET FramedIPAddress = FramedIPAddress
+		-- OUTPUT INSERTED.FramedIPAddress INTO @r_address_tab;
+		-- SELECT @r_address = id FROM @r_address_tab;
+
+		-- If we didn't reallocate a previous address then pick the least
+		-- recently used address from the pool which maximises the likelihood
+		-- of re-assigning the other addresses to their recent user
+		--
+		IF @r_address IS NULL
+		BEGIN
+			WITH cte AS (
+				SELECT TOP(1) FramedIPAddress
+				FROM radippool
+				WHERE pool_name = @v_pool_name
+					AND ( expiry_time < CURRENT_TIMESTAMP OR expiry_time IS NULL )
+				ORDER BY
+					expiry_time
+			)
+			UPDATE cte WITH (rowlock, readpast)
+			SET FramedIPAddress = FramedIPAddress
+			OUTPUT INSERTED.FramedIPAddress INTO @r_address_tab;
+			SELECT @r_address = id FROM @r_address_tab;
+		END
+
+		-- Return nothing if we failed to allocated an address
+		--
+		IF @r_address IS NULL
+		BEGIN
+			COMMIT TRAN;
+			RETURN;
+		END
+
+		-- Update the pool having allocated an IP address
+		--
+		UPDATE radippool
+		SET
+			NASIPAddress = @v_nasipaddress,
+			pool_key = @v_pool_key,
+			CallingStationId = @v_callingstationid,
+			UserName = @v_username,
+			expiry_time = DATEADD(SECOND,@v_lease_duration,CURRENT_TIMESTAMP)
+		WHERE framedipaddress = @r_address;
+
+		COMMIT TRAN;
+
+		-- Return the address that we allocated
+		SELECT @r_address;
+
+	END
+GO

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -1,0 +1,173 @@
+# -*- text -*-
+#
+#  ippool-dhcp/mssql/queries.conf -- MSSQL queries for rlm_sqlippool
+#
+#  $Id$
+
+# MSSQL-specific syntax
+allocate_begin = "BEGIN TRAN"
+allocate_commit = "COMMIT TRAN"
+
+#
+#  This series of queries allocates an IP address
+#
+#allocate_clear = "\
+#	UPDATE ${ippool_table} \
+#	SET \
+#		NASIPAddress = '', \
+#		pool_key = 0, \
+#		expiry_time = CURRENT_TIMESTAMP \
+#	WHERE pool_key = '${pool_key}'"
+
+#
+#  (Note: If your pool_key is set to Calling-Station-Id and not NAS-Port
+#  then you may wish to delete the "AND nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'
+#  from the WHERE clause)
+#
+allocate_clear = "\
+	UPDATE ${ippool_table} \
+	SET \
+		NASIPAddress = '', \
+		pool_key = 0, \
+		expiry_time = CURRENT_TIMESTAMP \
+	WHERE expiry_time <= DATEADD(SECOND,-1,CURRENT_TIMESTAMP) \
+	AND NASIPAddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"
+
+#
+#  The ORDER BY clause of this query tries to allocate the same IP-address
+#  which user had last session...
+#
+allocate_find = "\
+	WITH cte AS ( \
+		SELECT TOP(1) FramedIPAddress FROM ${ippool_table} \
+		WHERE pool_name = '%{control:${pool_name}}' \
+		AND ( expiry_time < CURRENT_TIMESTAMP OR expiry_time IS NULL ) \
+		OR ( NASIPAddress = '%{NAS-IP-Address}' AND pool_key = '${pool_key}' ) \
+		ORDER BY \
+			CASE WHEN UserName = '%{User-Name}' THEN 0 ELSE 1 END, \
+			CASE WHEN CallingStationId = '%{Calling-Station-Id}' THEN 0 ELSE 1 END, \
+			expiry_time \
+	) \
+	UPDATE cte WITH (rowlock, readpast) \
+	SET FramedIPAddress = FramedIPAddress \
+	OUTPUT INSERTED.FramedIPAddress"
+
+#
+#  If you prefer to allocate a random IP address every time, use this query instead.
+#  Note: This is very slow if you have a lot of free IPs.
+#
+#allocate_find = "\
+#	WITH cte AS ( \
+#		SELECT TOP(1) FramedIPAddress FROM ${ippool_table} \
+#		WHERE pool_name = '%{control:${pool_name}}' \
+#		AND ( \
+#			expiry_time < CURRENT_TIMESTAMP OR expiry_time IS NULL \
+#		) \
+#		ORDER BY \
+#			newid() \
+#	) \
+#	UPDATE cte WITH (rowlock, readpast) \
+#	SET FramedIPAddress = FramedIPAddress \
+#	OUTPUT INSERTED.FramedIPAddress"
+
+#
+#  If an IP could not be allocated, check to see if the pool exists or not
+#  This allows the module to differentiate between a full pool and no pool
+#  Note: If you are not running redundant pool modules this query may be
+#  commented out to save running this query every time an ip is not allocated.
+#
+pool_check = "\
+	SELECT TOP(1) id \
+	FROM ${ippool_table} \
+	WHERE pool_name='%{control:${pool_name}}'"
+
+#
+#  This is the final IP Allocation query, which saves the allocated ip details.
+#
+allocate_update = "\
+	UPDATE ${ippool_table} \
+	SET \
+		NASIPAddress = '%{NAS-IP-Address}', pool_key = '${pool_key}', \
+		CallingStationId = '%{Calling-Station-Id}', \
+		UserName = '%{User-Name}', expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
+	WHERE FramedIPAddress = '%I'"
+
+#
+#  Use a stored procedure to find AND allocate the address. Read and customise
+#  `procedure.sql` in this directory to determine the optimal configuration.
+#
+#allocate_begin = ""
+#allocate_find = "\
+#	EXEC fr_allocate_previous_or_new_framedipaddress \
+#		@v_pool_name = '%{control:${pool_name}}', \
+#		@v_username = '%{User-Name}', \
+#		@v_callingstationid = '%{Calling-Station-Id}', \
+#		@v_nasipaddress = '%{NAS-IP-Address}', \
+#		@v_pool_key = '${pool_key}', \
+#		@v_lease_duration = ${lease_duration} \
+#	"
+#allocate_update = ""
+#allocate_commit = ""
+
+#
+#  This series of queries frees an IP number when an accounting START record arrives.
+#
+start_update = "\
+	UPDATE ${ippool_table} \
+	SET \
+		expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
+	WHERE NASIPAddress = '%{NAS-IP-Address}' \
+	AND pool_key = '${pool_key}' \
+	AND UserName = '%{User-Name}' \
+	AND CallingStationId = '%{Calling-Station-Id}' \
+	AND FramedIPAddress = '%{${attribute_name}}'"
+
+#
+#  Free an IP when an accounting STOP record arrives
+#
+stop_clear = "\
+	UPDATE ${ippool_table} \
+	SET \
+		NASIPAddress = '', \
+		pool_key = 0, \
+		expiry_time = CURRENT_TIMESTAMP \
+	WHERE NASIPAddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}' \
+	AND pool_key = '${pool_key}' \
+	AND UserName = '%{User-Name}' \
+	AND CallingStationId = '%{Calling-Station-Id}' \
+	AND FramedIPAddress = '%{${attribute_name}}'"
+
+#
+#  Update the expiry time for an IP when an accounting ALIVE record arrives
+#
+alive_update = "\
+	UPDATE ${ippool_table} \
+	SET \
+		expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
+	WHERE NASIPAddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}' \
+	AND pool_key = '${pool_key}' \
+	AND UserName = '%{User-Name}' \
+	AND CallingStationId = '%{Calling-Station-Id}' \
+	AND FramedIPAddress = '%{${attribute_name}}'"
+
+#
+#  Frees all IPs allocated to a NAS when an accounting ON record arrives
+#
+on_clear = "\
+	UPDATE ${ippool_table} \
+	SET \
+		NASIPAddress = '', \
+		pool_key = 0, \
+		expiry_time = CURRENT_TIMESTAMP \
+	WHERE NASIPAddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"
+
+#
+#  Frees all IPs allocated to a NAS when an accounting OFF record arrives
+#
+off_clear = "\
+	UPDATE ${ippool_table} \
+	SET \
+		NASIPAddress = '', \
+		pool_key = 0, \
+		expiry_time = CURRENT_TIMESTAMP \
+	WHERE NASIPAddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/schema.sql
@@ -1,0 +1,25 @@
+--
+-- Table structure for table 'radippool'
+--
+CREATE TABLE radippool (
+  id                    int IDENTITY (1,1) NOT NULL,
+  pool_name             varchar(30) NOT NULL,
+  FramedIPAddress       varchar(15) NOT NULL default '',
+  NASIPAddress          varchar(15) NOT NULL default '',
+  CalledStationId       VARCHAR(32) NOT NULL,
+  CallingStationId      VARCHAR(30) NOT NULL,
+  expiry_time           DATETIME NULL default NULL,
+  UserName              varchar(64) NOT NULL default '',
+  pool_key              varchar(30) NOT NULL default '',
+  PRIMARY KEY (id)
+)
+GO
+
+CREATE INDEX poolname_expire ON radippool(pool_name, expiry_time)
+GO
+
+CREATE INDEX FramedIPAddress ON radippool(FramedIPAddress)
+GO
+
+CREATE INDEX NASIPAddress_poolkey_FramedIPAddress ON radippool(NASIPAddress, pool_key, FramedIPAddress)
+GO

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/procedure-no-skip-locked.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/procedure-no-skip-locked.sql
@@ -1,0 +1,148 @@
+--
+-- A stored procedure to reallocate a user's previous address, otherwise
+-- provide a free address.
+--
+-- NOTE: This version of the SP is intended for MySQL variants that do not
+--       support the SKIP LOCKED pragma, i.e. MariaDB and versions of MySQL
+--       prior to 8.0. It should be a lot faster than using the default SP
+--       without the SKIP LOCKED pragma under highly concurrent workloads
+--       and not result in thread starvation.
+--
+--       It is however a *useful hack* which should not be used if SKIP
+--       LOCKED is available.
+--
+-- WARNING: This query uses server-local, "user locks" (GET_LOCK and
+--          RELEASE_LOCK), without the need for a transaction, to emulate
+--          row locking with locked-row skipping. User locks are not
+--          supported on clusters such as Galera and MaxScale.
+--
+-- Using this SP reduces the usual set dialogue of queries to a single
+-- query:
+--
+--   START TRANSACTION; SELECT FOR UPDATE; UPDATE; COMMIT;  ->  CALL sp()
+--
+-- The stored procedure is executed within a single round trip which often
+-- leads to reduced deadlocking and significant performance improvements.
+--
+-- To use this stored procedure the corresponding queries.conf statements must
+-- be configured as follows:
+--
+-- allocate_begin = ""
+-- allocate_find = "\
+-- 	CALL fr_allocate_previous_or_new_framedipaddress( \
+-- 		'%{control:${pool_name}}', \
+-- 		'%{User-Name}', \
+-- 		'%{Calling-Station-Id}', \
+-- 		'%{NAS-IP-Address}', \
+-- 		'${pool_key}', \
+-- 		${lease_duration} \
+-- 	)"
+-- allocate_update = ""
+-- allocate_commit = ""
+--
+
+CREATE INDEX poolname_username_callingstationid ON radippool(pool_name,username,callingstationid);
+
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS fr_allocate_previous_or_new_framedipaddress;
+CREATE PROCEDURE fr_allocate_previous_or_new_framedipaddress (
+        IN v_pool_name VARCHAR(64),
+        IN v_username VARCHAR(64),
+        IN v_callingstationid VARCHAR(64),
+        IN v_nasipaddress VARCHAR(15),
+        IN v_pool_key VARCHAR(64),
+        IN v_lease_duration INT
+)
+proc:BEGIN
+        DECLARE r_address VARCHAR(15);
+
+        -- Reissue an existing IP address lease when re-authenticating a session
+        --
+        SELECT framedipaddress INTO r_address
+        FROM radippool
+        WHERE pool_name = v_pool_name
+                AND expiry_time > NOW()
+                AND username = v_username
+                AND callingstationid = v_callingstationid
+        LIMIT 1;
+
+        -- Reissue an user's previous IP address, provided that the lease is
+        -- available (i.e. enable sticky IPs)
+        --
+        -- When using this SELECT you should delete the one above. You must also
+        -- set allocate_clear = "" in queries.conf to persist the associations
+        -- for expired leases.
+        --
+        -- SELECT framedipaddress INTO r_address
+        -- FROM radippool
+        -- WHERE pool_name = v_pool_name
+        --         AND username = v_username
+        --         AND callingstationid = v_callingstationid
+        -- LIMIT 1;
+
+        IF r_address IS NOT NULL THEN
+                UPDATE radippool
+                SET
+                        nasipaddress = v_nasipaddress,
+                        pool_key = v_pool_key,
+                        callingstationid = v_callingstationid,
+                        username = v_username,
+                        expiry_time = NOW() + INTERVAL v_lease_duration SECOND
+                WHERE
+                        framedipaddress = r_address;
+                SELECT r_address;
+                LEAVE proc;
+        END IF;
+
+        REPEAT
+
+                -- If we didn't reallocate a previous address then pick the least
+                -- recently used address from the pool which maximises the likelihood
+                -- of re-assigning the other addresses to their recent user
+                --
+                SELECT framedipaddress INTO r_address
+                FROM radippool
+                WHERE pool_name = v_pool_name
+                        AND ( expiry_time < NOW() OR expiry_time IS NULL )
+                --
+                -- WHERE ... GET_LOCK(...,0) = 1 is a poor man's SKIP LOCKED that simulates
+                -- a row-level lock using a "user lock" that allows the locked "rows" to be
+                -- skipped. After the user lock is acquired and the SELECT retired it does
+                -- not mean that the entirety of the WHERE clause is still true: Another
+                -- thread may have updated the expiry time and released the lock after we
+                -- checked the expiry_time but before we acquired the lock since SQL is free
+                -- to reorder the WHERE condition. Therefore we must recheck the condition
+                -- in the UPDATE statement below to detect this race.
+                --
+                        AND GET_LOCK(CONCAT('radippool_', framedipaddress), 0) = 1
+                LIMIT 1;
+
+                IF r_address IS NULL THEN
+                        DO RELEASE_LOCK(CONCAT('radippool_', r_address));
+                        LEAVE proc;
+                END IF;
+
+                UPDATE radippool
+                SET
+                        nasipaddress = v_nasipaddress,
+                        pool_key = v_pool_key,
+                        callingstationid = v_callingstationid,
+                        username = v_username,
+                        expiry_time = NOW() + INTERVAL v_lease_duration SECOND
+                WHERE
+                        framedipaddress = r_address
+                --
+                -- Here we re-evaluate the original condition for selecting the address
+                -- to detect a race, in which case we try again...
+                --
+                        AND (expiry_time<NOW() OR expiry_time IS NULL);
+
+        UNTIL ROW_COUNT() <> 0 END REPEAT;
+
+        DO RELEASE_LOCK(CONCAT('radippool_', r_address));
+        SELECT r_address;
+
+END$$
+
+DELIMITER ;

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/procedure.sql
@@ -1,0 +1,129 @@
+--
+-- A stored procedure to reallocate a user's previous address, otherwise
+-- provide a free address.
+--
+-- Using this SP reduces the usual set dialogue of queries to a single
+-- query:
+--
+--   START TRANSACTION; SELECT FOR UPDATE; UPDATE; COMMIT;  ->  CALL sp()
+--
+-- The stored procedure is executed on an database instance within a single
+-- round trip which often leads to reduced deadlocking and significant
+-- performance improvements especially on multi-master clusters, perhaps even
+-- by an order of magnitude or more.
+--
+-- To use this stored procedure the corresponding queries.conf statements must
+-- be configured as follows:
+--
+-- allocate_begin = ""
+-- allocate_find = "\
+-- 	CALL fr_allocate_previous_or_new_framedipaddress( \
+-- 		'%{control:${pool_name}}', \
+-- 		'%{User-Name}', \
+-- 		'%{Calling-Station-Id}', \
+-- 		'%{NAS-IP-Address}', \
+-- 		'${pool_key}', \
+-- 		${lease_duration} \
+-- 	)"
+-- allocate_update = ""
+-- allocate_commit = ""
+--
+
+CREATE INDEX poolname_username_callingstationid ON radippool(pool_name,username,callingstationid);
+
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS fr_allocate_previous_or_new_framedipaddress;
+CREATE PROCEDURE fr_allocate_previous_or_new_framedipaddress (
+        IN v_pool_name VARCHAR(64),
+        IN v_username VARCHAR(64),
+        IN v_callingstationid VARCHAR(64),
+        IN v_nasipaddress VARCHAR(15),
+        IN v_pool_key VARCHAR(64),
+        IN v_lease_duration INT
+)
+proc:BEGIN
+        DECLARE r_address VARCHAR(15);
+
+        SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+
+        START TRANSACTION;
+
+        -- Reissue an existing IP address lease when re-authenticating a session
+        --
+        SELECT framedipaddress INTO r_address
+        FROM radippool
+        WHERE pool_name = v_pool_name
+                AND expiry_time > NOW()
+                AND username = v_username
+                AND callingstationid = v_callingstationid
+        LIMIT 1
+        FOR UPDATE;
+--      FOR UPDATE SKIP LOCKED;  -- Better performance, but limited support
+
+        -- NOTE: You should enable SKIP LOCKED here (as well as any other
+        --       instances) if your database server supports it. If it is not
+        --       supported and you are not running a multi-master cluster (e.g.
+        --       Galera or MaxScale) then you should instead consider using the
+        --       SP in procedure-no-skip-locked.sql which will be faster and
+        --       less likely to result in thread starvation under highly
+        --       concurrent load.
+
+        -- Reissue an user's previous IP address, provided that the lease is
+        -- available (i.e. enable sticky IPs)
+        --
+        -- When using this SELECT you should delete the one above. You must also
+        -- set allocate_clear = "" in queries.conf to persist the associations
+        -- for expired leases.
+        --
+        -- SELECT framedipaddress INTO r_address
+        -- FROM radippool
+        -- WHERE pool_name = v_pool_name
+        --         AND username = v_username
+        --         AND callingstationid = v_callingstationid
+        -- LIMIT 1
+        -- FOR UPDATE;
+        -- -- FOR UPDATE SKIP LOCKED;  -- Better performance, but limited support
+
+        -- If we didn't reallocate a previous address then pick the least
+        -- recently used address from the pool which maximises the likelihood
+        -- of re-assigning the other addresses to their recent user
+        --
+        IF r_address IS NULL THEN
+                SELECT framedipaddress INTO r_address
+                FROM radippool
+                WHERE pool_name = v_pool_name
+                        AND ( expiry_time < NOW() OR expiry_time IS NULL )
+                ORDER BY
+                        expiry_time
+                LIMIT 1
+                FOR UPDATE;
+--              FOR UPDATE SKIP LOCKED;  -- Better performance, but limited support
+        END IF;
+
+        -- Return nothing if we failed to allocated an address
+        --
+        IF r_address IS NULL THEN
+                COMMIT;
+                LEAVE proc;
+        END IF;
+
+        -- Update the pool having allocated an IP address
+        --
+        UPDATE radippool
+        SET
+                nasipaddress = v_nasipaddress,
+                pool_key = v_pool_key,
+                callingstationid = v_callingstationid,
+                username = v_username,
+                expiry_time = NOW() + INTERVAL v_lease_duration SECOND
+        WHERE framedipaddress = r_address;
+
+        COMMIT;
+
+        -- Return the address that we allocated
+        SELECT r_address;
+
+END$$
+
+DELIMITER ;

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -5,22 +5,20 @@
 #  $Id$
 
 #
-# This series of queries allocates an IP address
+#  This series of queries allocates an IP address
 #
 #allocate_clear = "\
 #	UPDATE ${ippool_table} \
 #	SET \
 #		nasipaddress = '', \
 #		pool_key = 0, \
-#		callingstationid = '', \
-#		username = '', \
 #		expiry_time = NOW() \
 #	WHERE pool_key = '${pool_key}'"
 
 #
 #  This series of queries allocates an IP address
 #  (Note: If your pool_key is set to Calling-Station-Id and not NAS-Port
-#  then you may wish to delete the "AND nasipaddress = '%{Nas-IP-Address}'
+#  then you may wish to delete the "AND nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'
 #  from the WHERE clause)
 #
 allocate_clear = "\
@@ -28,47 +26,68 @@ allocate_clear = "\
 	SET \
 		nasipaddress = '', \
 		pool_key = 0, \
-		callingstationid = '', \
-		username = '', \
 		expiry_time = NOW() \
 	WHERE expiry_time <= NOW() - INTERVAL 1 SECOND \
-	AND nasipaddress = '%{Nas-IP-Address}'"
+	AND nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"
 
 #
-#  Search for the SAME Calling-Station-ID as last time, OR an entry
-#  where there is no Calling-Station-Id.
-#
-#  If the lease was expired, the allocate_clear above will reset the
-#  Calling-Station-Id to ''.
-#
-#  If the lease wasn't expired, we want to give the user the same IP
-#  as last time.
-#
-#  Then, we order by expiry_time, so that when there is no existing
-#  entry for the Calling-Station-Id, it picks the OLDEST expired IP.
+#  The ORDER BY clause of this query tries to allocate the same IP-address
+#  which user had last session...
 #
 allocate_find = "\
-	SELECT framedipaddress \
-	FROM ${ippool_table} \
+	SELECT framedipaddress FROM ${ippool_table} \
 	WHERE pool_name = '%{control:${pool_name}}' \
-	AND (callingstationid = '%{Calling-Station-Id}' or callingstationid = '') \
+	AND ( \
+		expiry_time < NOW() OR expiry_time IS NULL OR expiry_time = 0 \
+		OR ( nasipaddress = '%{NAS-IP-Address}' AND pool_key = '${pool_key}' ) \
+	) \
 	ORDER BY \
+		(username <> '%{User-Name}'), \
 		(callingstationid <> '%{Calling-Station-Id}'), \
 		expiry_time \
 	LIMIT 1 \
 	FOR UPDATE"
 
 #
-#  If you prefer to allocate a random IP address every time, use this query instead
+#  The above query again, but with SKIP LOCKED. This requires MySQL >= 8.0.1,
+#  and InnoDB.
 #
 #allocate_find = "\
-#	SELECT framedipaddress \
-#	FROM ${ippool_table} \
+#	SELECT framedipaddress FROM ${ippool_table} \
 #	WHERE pool_name = '%{control:${pool_name}}' \
-#	AND expiry_time < NOW() \
-#	ORDER BY RAND() \
+#	AND (expiry_time < NOW() OR expiry_time IS NULL) \
+#	ORDER BY \
+#		(username <> '%{User-Name}'), \
+#		(callingstationid <> '%{Calling-Station-Id}'), \
+#		expiry_time \
+#	LIMIT 1 \
+#	FOR UPDATE SKIP LOCKED"
+
+#
+#  If you prefer to allocate a random IP address every time, use this query instead.
+#  Note: This is very slow if you have a lot of free IPs.
+#
+#allocate_find = "\
+#	SELECT framedipaddress FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' \
+#	AND expiry_time IS NULL \
+#	ORDER BY \
+#		RAND() \
 #	LIMIT 1 \
 #	FOR UPDATE"
+
+#
+#  The above query again, but with SKIP LOCKED. This requires MySQL >= 8.0.1,
+#  and InnoDB.
+#
+#allocate_find = "\
+#	SELECT framedipaddress FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' \
+#	AND expiry_time IS NULL \
+#	ORDER BY \
+#		RAND() \
+#	LIMIT 1 \
+#	FOR UPDATE SKIP LOCKED"
 
 #
 #  If an IP could not be allocated, check to see if the pool exists or not
@@ -83,21 +102,35 @@ pool_check = "\
 	LIMIT 1"
 
 #
-#  This is the final IP Allocation query, which saves the allocated ip details
+#  This is the final IP Allocation query, which saves the allocated ip details.
 #
 allocate_update = "\
 	UPDATE ${ippool_table} \
 	SET \
-		nasipaddress = '%{NAS-IP-Address}', \
-		pool_key = '${pool_key}', \
+		nasipaddress = '%{NAS-IP-Address}', pool_key = '${pool_key}', \
 		callingstationid = '%{Calling-Station-Id}', \
-		username = '%{User-Name}', \
-		expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
+		username = '%{User-Name}', expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
 	WHERE framedipaddress = '%I'"
 
 #
-#  This series of queries frees an IP number when an accounting
-#  START record arrives
+#  Use a stored procedure to find AND allocate the address. Read and customise
+#  `procedure.sql` in this directory to determine the optimal configuration.
+#
+#allocate_begin = ""
+#allocate_find = "\
+#	CALL fr_allocate_previous_or_new_framedipaddress( \
+#		'%{control:${pool_name}}', \
+#		'%{User-Name}', \
+#		'%{Calling-Station-Id}', \
+#		'%{NAS-IP-Address}', \
+#		'${pool_key}', \
+#		${lease_duration} \
+#	)"
+#allocate_update = ""
+#allocate_commit = ""
+
+#
+#  This series of queries frees an IP number when an accounting START record arrives.
 #
 start_update = "\
 	UPDATE ${ippool_table} \
@@ -107,38 +140,35 @@ start_update = "\
 	AND pool_key = '${pool_key}' \
 	AND username = '%{User-Name}' \
 	AND callingstationid = '%{Calling-Station-Id}' \
-	AND framedipaddress = '%{Framed-IP-Address}'"
+	AND framedipaddress = '%{${attribute_name}}'"
 
 #
-#  This series of queries frees an IP number when an accounting
-#  STOP record arrives
+#  This series of queries frees an IP number when an accounting STOP record arrives.
 #
-stop_clear = "UPDATE ${ippool_table} \
+stop_clear = "\
+	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '', \
 		pool_key = 0, \
-		callingstationid = '', \
-		username = '', \
 		expiry_time = NOW() \
-	WHERE nasipaddress = '%{Nas-IP-Address}' \
+	WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}' \
 	AND pool_key = '${pool_key}' \
 	AND username = '%{User-Name}' \
 	AND callingstationid = '%{Calling-Station-Id}' \
-	AND framedipaddress = '%{Framed-IP-Address}'"
+	AND framedipaddress = '%{${attribute_name}}'"
 
 #
-#  This series of queries frees an IP number when an accounting
-#  ALIVE record arrives
+#  This series of queries frees an IP number when an accounting ALIVE record arrives.
 #
 alive_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
-	WHERE nasipaddress = '%{Nas-IP-Address}' \
+	WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}' \
 	AND pool_key = '${pool_key}' \
 	AND username = '%{User-Name}' \
 	AND callingstationid = '%{Calling-Station-Id}' \
-	AND framedipaddress = '%{Framed-IP-Address}'"
+	AND framedipaddress = '%{${attribute_name}}'"
 
 #
 #  This series of queries frees the IP numbers allocate to a
@@ -149,10 +179,8 @@ on_clear = "\
 	SET \
 		nasipaddress = '', \
 		pool_key = 0, \
-		callingstationid = '', \
-		username = '', \
 		expiry_time = NOW() \
-	WHERE nasipaddress = '%{Nas-IP-Address}'"
+	WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"
 
 #
 #  This series of queries frees the IP numbers allocate to a
@@ -163,7 +191,5 @@ off_clear = "\
 	SET \
 		nasipaddress = '', \
 		pool_key = 0, \
-		callingstationid = '', \
-		username = '', \
 		expiry_time = NOW() \
-	WHERE nasipaddress = '%{Nas-IP-Address}'"
+	WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/schema.sql
@@ -13,7 +13,6 @@ CREATE TABLE radippool (
   pool_key              varchar(30) NOT NULL default '',
   PRIMARY KEY (id),
   KEY radippool_poolname_expire (pool_name, expiry_time),
-  KEY callingstationid (callingstationid),
   KEY framedipaddress (framedipaddress),
   KEY radippool_nasip_poolkey_ipaddress (nasipaddress, pool_key, framedipaddress)
 ) ENGINE=InnoDB;

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/procedure.sql
@@ -1,0 +1,129 @@
+--
+-- A stored procedure to reallocate a user's previous address, otherwise
+-- provide a free address.
+--
+-- Using this SP reduces the usual set dialogue of queries to a single
+-- query:
+--
+--   BEGIN; SELECT FOR UPDATE; UPDATE; COMMIT;  ->  SELECT sp() FROM dual
+--
+-- The stored procedure is executed on an database instance within a single
+-- round trip which often leads to reduced deadlocking and significant
+-- performance improvements especially on multi-master clusters, perhaps even
+-- by an order of magnitude or more.
+--
+-- To use this stored procedure the corresponding queries.conf statements must
+-- be configured as follows:
+--
+-- allocate_begin = ""
+-- allocate_find = "\
+--         SELECT fr_allocate_previous_or_new_framedipaddress( \
+--                 '%{control:${pool_name}}', \
+--                 '%{User-Name}', \
+--                 '%{%{Calling-Station-Id}:-0}', \
+--                 '%{NAS-IP-Address}', \
+--                 '${pool_key}', \
+--                 ${lease_duration} \
+--         ) FROM dual"
+-- allocate_update = ""
+-- allocate_commit = ""
+--
+
+CREATE OR REPLACE FUNCTION fr_allocate_previous_or_new_framedipaddress (
+        v_pool_name IN VARCHAR2,
+        v_username IN VARCHAR2,
+        v_callingstationid IN VARCHAR2,
+        v_nasipaddress IN VARCHAR2,
+        v_pool_key IN VARCHAR2,
+        v_lease_duration IN INTEGER
+)
+RETURN varchar2 IS
+        PRAGMA AUTONOMOUS_TRANSACTION;
+        r_address varchar2(15);
+BEGIN
+
+        -- Reissue an existing IP address lease when re-authenticating a session
+        --
+          BEGIN
+                SELECT framedipaddress INTO r_address FROM radippool WHERE id IN (
+                        SELECT id FROM (
+                                SELECT *
+                                FROM radippool
+                                WHERE pool_name = v_pool_name
+                                        AND expiry_time > current_timestamp
+                                        AND username = v_username
+                                        AND callingstationid = v_callingstationid
+                        ) WHERE ROWNUM <= 1
+                ) FOR UPDATE SKIP LOCKED;
+          EXCEPTION
+                    WHEN NO_DATA_FOUND THEN
+                        r_address := NULL;
+          END;
+
+        -- Reissue an user's previous IP address, provided that the lease is
+        -- available (i.e. enable sticky IPs)
+        --
+        -- When using this SELECT you should delete the one above. You must also
+        -- set allocate_clear = "" in queries.conf to persist the associations
+        -- for expired leases.
+        --
+        -- BEGIN
+        --         SELECT framedipaddress INTO r_address FROM radippool WHERE id IN (
+        --                 SELECT id FROM (
+        --                         SELECT *
+        --                         FROM radippool
+        --                         WHERE pool_name = v_pool_name
+        --                                 AND username = v_username
+        --                                 AND callingstationid = v_callingstationid
+        --                 ) WHERE ROWNUM <= 1
+        --         ) FOR UPDATE SKIP LOCKED;
+        -- EXCEPTION
+        --         WHEN NO_DATA_FOUND THEN
+        --              r_address := NULL;
+        -- END;
+
+        -- If we didn't reallocate a previous address then pick the least
+        -- recently used address from the pool which maximises the likelihood
+        -- of re-assigning the other addresses to their recent user
+        --
+        IF r_address IS NULL THEN
+                BEGIN
+                        SELECT framedipaddress INTO r_address FROM radippool WHERE id IN (
+                                SELECT id FROM (
+                                        SELECT *
+                                        FROM radippool
+                                        WHERE pool_name = v_pool_name
+                                        AND expiry_time < CURRENT_TIMESTAMP
+                                        ORDER BY expiry_time
+                                       ) WHERE ROWNUM <= 1
+                        ) FOR UPDATE SKIP LOCKED;
+                EXCEPTION
+                        WHEN NO_DATA_FOUND THEN
+                                r_address := NULL;
+                END;
+        END IF;
+
+        -- Return nothing if we failed to allocated an address
+        --
+        IF r_address IS NULL THEN
+                COMMIT;
+                RETURN r_address;
+        END IF;
+
+        -- Update the pool having allocated an IP address
+        --
+        UPDATE radippool
+        SET
+                nasipaddress = v_nasipaddress,
+                pool_key = v_pool_key,
+                callingstationid = v_callingstationid,
+                username = v_username,
+                expiry_time = CURRENT_TIMESTAMP + v_lease_duration * INTERVAL '1' SECOND(1)
+        WHERE framedipaddress = r_address;
+
+        -- Return the address that we allocated
+        COMMIT;
+        RETURN r_address;
+
+END;
+/

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/schema.sql
@@ -1,19 +1,18 @@
 CREATE TABLE radippool (
 	id                      INT PRIMARY KEY,
 	pool_name               VARCHAR(30) NOT NULL,
-	framedipaddress         VARCHAR(30) NOT NULL,
-	nasipaddress            VARCHAR(30) NOT NULL,
-	pool_key                VARCHAR(64) NOT NULL,
-	calledstationid         VARCHAR(64),
-	callingstationid        VARCHAR(64) NOT NULL,
-	expiry_time             TIMESTAMP(0) NOT NULL,
-	username                VARCHAR(100)
+	framedipaddress         VARCHAR(15) NOT NULL,
+	nasipaddress            VARCHAR(15) NOT NULL,
+	pool_key                VARCHAR(30) NOT NULL,
+	CalledStationId         VARCHAR(64) NOT NULL,
+	CallingStationId        VARCHAR(64) NOT NULL,
+	expiry_time             timestamp(0) NOT NULL,
+	username                VARCHAR(64)
 );
 
-CREATE INDEX radippool_poolname_ipaddr ON radippool (pool_name, framedipaddress);
 CREATE INDEX radippool_poolname_expire ON radippool (pool_name, expiry_time);
-CREATE INDEX radippool_nasipaddr_key ON radippool (nasipaddress, pool_key);
-CREATE INDEX radippool_nasipaddr_calling ON radippool (nasipaddress, callingstationid);
+CREATE INDEX radippool_framedipaddress ON radippool (framedipaddress);
+CREATE INDEX radippool_nasip_poolkey_ipaddress ON radippool (nasipaddress, pool_key, framedipaddress);
 
 CREATE SEQUENCE radippool_seq START WITH 1 INCREMENT BY 1;
 
@@ -21,8 +20,8 @@ CREATE OR REPLACE TRIGGER radippool_serialnumber
 	BEFORE INSERT OR UPDATE OF id ON radippool
 	FOR EACH ROW
 	BEGIN
-		IF ( :NEW.id = 0 OR :NEW.id IS NULL ) THEN
-			SELECT radippool_seq.NEXTVAL INTO :NEW.id FROM dual;
-		END IF;
+		if ( :new.id = 0 or :new.id is null ) then
+			SELECT radippool_seq.nextval into :new.id from dual;
+		end if;
 	END;
 /

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/procedure.sql
@@ -1,0 +1,111 @@
+--
+-- A stored procedure to reallocate a user's previous address, otherwise
+-- provide a free address.
+--
+-- Using this SP reduces the usual set dialogue of queries to a single
+-- query:
+--
+--   START TRANSACTION; SELECT FOR UPDATE; UPDATE; COMMIT;  ->  SELECT sp()
+--
+-- The stored procedure is executed on an database instance within a single
+-- round trip which often leads to reduced deadlocking and significant
+-- performance improvements especially on multi-master clusters, perhaps even
+-- by an order of magnitude or more.
+--
+-- To use this stored procedure the corresponding queries.conf statements must
+-- be configured as follows:
+--
+-- allocate_begin = ""
+-- allocate_find = "\
+--	SELECT fr_allocate_previous_or_new_framedipaddress( \
+--		'%{control:${pool_name}}', \
+--		'%{User-Name}', \
+--		'%{Calling-Station-Id}', \
+--		'%{NAS-IP-Address}', \
+--		'${pool_key}', \
+--		${lease_duration} \
+--	)"
+-- allocate_update = ""
+-- allocate_commit = ""
+--
+
+CREATE INDEX radippool_poolname_username_callingstationid ON radippool(pool_name,username,callingstationid);
+
+CREATE OR REPLACE FUNCTION fr_allocate_previous_or_new_framedipaddress (
+	v_pool_name VARCHAR(64),
+	v_username VARCHAR(64),
+	v_callingstationid VARCHAR(64),
+	v_nasipaddress VARCHAR(16),
+	v_pool_key VARCHAR(64),
+	v_lease_duration INT
+)
+RETURNS inet
+LANGUAGE plpgsql
+AS $$
+DECLARE
+	r_address inet;
+BEGIN
+
+	-- Reissue an existing IP address lease when re-authenticating a session
+	--
+	SELECT framedipaddress INTO r_address
+	FROM radippool
+	WHERE pool_name = v_pool_name
+		AND expiry_time > NOW()
+		AND username = v_username
+		AND callingstationid = v_callingstationid
+	LIMIT 1
+	FOR UPDATE SKIP LOCKED;
+
+	-- Reissue an user's previous IP address, provided that the lease is
+	-- available (i.e. enable sticky IPs)
+	--
+	-- When using this SELECT you should delete the one above. You must also
+	-- set allocate_clear = "" in queries.conf to persist the associations
+	-- for expired leases.
+	--
+	-- SELECT framedipaddress INTO r_address
+	-- FROM radippool
+	-- WHERE pool_name = v_pool_name
+	--	 AND username = v_username
+	--	 AND callingstationid = v_callingstationid
+	-- LIMIT 1
+	-- FOR UPDATE SKIP LOCKED;
+
+	-- If we didn't reallocate a previous address then pick the least
+	-- recently used address from the pool which maximises the likelihood
+	-- of re-assigning the other addresses to their recent user
+	--
+	IF r_address IS NULL THEN
+		SELECT framedipaddress INTO r_address
+		FROM radippool
+		WHERE pool_name = v_pool_name
+		AND expiry_time < NOW()
+		ORDER BY
+		    expiry_time
+		LIMIT 1
+		FOR UPDATE SKIP LOCKED;
+	END IF;
+
+	-- Return nothing if we failed to allocated an address
+	--
+	IF r_address IS NULL THEN
+		RETURN r_address;
+	END IF;
+
+	-- Update the pool having allocated an IP address
+	--
+	UPDATE radippool
+	SET
+		nasipaddress = v_nasipaddress,
+		pool_key = v_pool_key,
+		callingstationid = v_callingstationid,
+		username = v_username,
+		expiry_time = NOW() + v_lease_duration * interval '1 sec'
+	WHERE framedipaddress = r_address;
+
+	-- Return the address that we allocated
+	RETURN r_address;
+
+END
+$$;

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -1,15 +1,8 @@
 # -*- text -*-
 #
-#  ippool-dhcp/oracle/queries.conf -- Oracle queries for rlm_sqlippool
+#  ippool-dhcp/postgresql/queries.conf -- PostgreSQL queries for rlm_sqlippool
 #
 #  $Id$
-
-allocate_begin = "commit"
-start_begin = "commit"
-alive_begin = "commit"
-stop_begin = "commit"
-on_begin = "commit"
-off_begin = "commit"
 
 #
 #  This query allocates an IP address from the Pool
@@ -17,72 +10,55 @@ off_begin = "commit"
 #  to the user that they had last session...
 #
 allocate_find = "\
-	SELECT framedipaddress FROM ${ippool_table} WHERE id IN ( \
-		SELECT id FROM ( \
-			SELECT * \
-			FROM ${ippool_table} \
-			WHERE pool_name = '%{control:${pool_name}}' \
-			AND ( \
-				expiry_time < current_timestamp \
-				OR ( nasipaddress = '%{NAS-IP-Address}' AND pool_key = '${pool_key}' ) \
-			) \
-			ORDER BY \
-				DECODE(username,'%{SQL-User-Name}',2,1), \
-				DECODE(callingstationid,'%{%{Calling-Station-Id}:-0}',2,1), \
-				expiry_time \
-		) WHERE ROWNUM <= 1 \
-	) FOR UPDATE"
+	SELECT framedipaddress \
+	FROM ${ippool_table} \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND ( \
+		expiry_time < 'now'::timestamp(0) \
+		OR ( nasipaddress = '%{NAS-IP-Address}' AND pool_key = '${pool_key}' ) \
+	) \
+	ORDER BY \
+		(username <> '%{SQL-User-Name}'), \
+		(callingstationid <> '%{Calling-Station-Id}'), \
+		expiry_time \
+	LIMIT 1 \
+	FOR UPDATE"
 
 #
-#  The above query again, but with SKIP LOCKED. This requires Oracle > 11g.
-#  It may work in 9i and 10g, but is not documented, so YMMV.
+#  The above query again, but with SKIP LOCKED. This requires PostgreSQL >= 9.5.
 #
 #allocate_find = "\
-#	SELECT framedipaddress FROM ${ippool_table} WHERE id IN ( \
-#		SELECT id FROM ( \
-#			SELECT * \
-#			FROM ${ippool_table} \
-#			WHERE pool_name = '%{control:${pool_name}}' \
-#			AND ( \
-#				expiry_time < current_timestamp \
-#				OR ( nasipaddress = '%{NAS-IP-Address}' AND pool_key = '${pool_key}' ) \
-#			) \
-#			ORDER BY \
-#				DECODE(username,'%{SQL-User-Name}',2,1), \
-#				DECODE(callingstationid,'%{%{Calling-Station-Id}:-0}',2,1), \
-#				expiry_time \
-#		) WHERE ROWNUM <= 1 \
-#	) FOR UPDATE SKIP LOCKED"
+#	SELECT framedipaddress \
+#	FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' \
+#	AND expiry_time < 'now'::timestamp(0) \
+#	ORDER BY \
+#		(username <> '%{SQL-User-Name}'), \
+#		(callingstationid <> '%{Calling-Station-Id}'), \
+#		expiry_time \
+#	LIMIT 1 \
+#	FOR UPDATE SKIP LOCKED"
 
 #
 #  If you prefer to allocate a random IP address every time, use this query instead
 #  Note: This is very slow if you have a lot of free IPs.
 #
 #allocate_find = "\
-#	SELECT framedipaddress FROM ${ippool_table} WHERE id IN ( \
-#		SELECT id FROM ( \
-#			SELECT * \
-#			FROM ${ippool_table} \
-#			WHERE pool_name = '%{control:${pool_name}}' \
-#			AND expiry_time < current_timestamp \
-#			ORDER BY DBMS_RANDOM.VALUE \
-#		) WHERE ROWNUM <= 1 \
-#	) FOR UPDATE"
+#	SELECT framedipaddress FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' AND expiry_time < 'now'::timestamp(0) \
+#	ORDER BY RANDOM() \
+#	LIMIT 1 \
+#	FOR UPDATE"
 
 #
-#  The above query again, but with SKIP LOCKED. This requires Oracle > 11g.
-#  It may work in 9i and 10g, but is not documented, so YMMV.
+#  The above query again, but with SKIP LOCKED. This requires PostgreSQL >= 9.5.
 #
 #allocate_find = "\
-#	SELECT framedipaddress FROM ${ippool_table} WHERE id IN ( \
-#		SELECT id FROM (\
-#			SELECT * \
-#			FROM ${ippool_table} \
-#			WHERE pool_name = '%{control:${pool_name}}' \
-#			AND expiry_time < current_timestamp \
-#			ORDER BY DBMS_RANDOM.VALUE \
-#		) WHERE ROWNUM <= 1 \
-#	) FOR UPDATE SKIP LOCKED"
+#	SELECT framedipaddress FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' AND expiry_time < 'now'::timestamp(0) \
+#	ORDER BY RANDOM() \
+#	LIMIT 1 \
+#	FOR UPDATE SKIP LOCKED"
 
 #
 #  If an IP could not be allocated, check to see whether the pool exists or not
@@ -92,12 +68,9 @@ allocate_find = "\
 #
 pool_check = "\
 	SELECT id \
-	FROM (\
-		SELECT id \
-		FROM ${ippool_table} \
-		WHERE pool_name='%{control:${pool_name}}'\
-	) \
-	WHERE ROWNUM = 1"
+	FROM ${ippool_table} \
+	WHERE pool_name='%{control:${pool_name}}' \
+	LIMIT 1"
 
 #
 #  This query marks the IP address handed out by "allocate-find" as used
@@ -108,9 +81,9 @@ allocate_update = "\
 	SET \
 		nasipaddress = '%{NAS-IP-Address}', \
 		pool_key = '${pool_key}', \
-		callingstationid = '%{%{Calling-Station-Id}:-0}', \
+		callingstationid = '%{Calling-Station-Id}', \
 		username = '%{SQL-User-Name}', \
-		expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
+		expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval \
 	WHERE framedipaddress = '%I'"
 
 #
@@ -126,23 +99,31 @@ allocate_update = "\
 allocate_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
-		nasipaddress = '0', \
-		pool_key = '0', \
-		expiry_time = current_timestamp - INTERVAL '1' second(1) \
+		nasipaddress = '', \
+		pool_key = 0, \
+		expiry_time = 'now'::timestamp(0) - '1 second'::interval \
 	WHERE nasipaddress = '%{NAS-IP-Address}' \
 	AND pool_key = '${pool_key}'"
-
 
 #
 #  Use a stored procedure to find AND allocate the address. Read and customise
 #  `procedure.sql` in this directory to determine the optimal configuration.
 #
+#  This requires PostgreSQL >= 9.5 as SKIP LOCKED is used.
+#
+#  The "NO LOAD BALANCE" comment is included here to indicate to a PgPool
+#  system that this needs to be a write transaction. PgPool itself cannot
+#  detect this from the statement alone. If you are using PgPool and do not
+#  have this comment, the query may go to a read only server, and will fail.
+#  This has no negative effect if you are not using PgPool.
+#
 #allocate_begin = ""
 #allocate_find = "\
+#	/*NO LOAD BALANCE*/ \
 #	SELECT fr_allocate_previous_or_new_framedipaddress( \
 #		'%{control:${pool_name}}', \
 #		'%{SQL-User-Name}', \
-#		'%{%{Calling-Station-Id}:-0}', \
+#		'%{Calling-Station-Id}', \
 #		'%{NAS-IP-Address}', \
 #		'${pool_key}', \
 #		'${lease_duration}' \
@@ -157,23 +138,24 @@ allocate_clear = "\
 start_update = "\
 	UPDATE ${ippool_table} \
 	SET \
-		expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
+		expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval \
 	WHERE nasipaddress = '%{NAS-IP-Address}' \
 	AND pool_key = '${pool_key}'"
 
 #
-#  This query frees an IP address when an accounting STOP record arrives
+#  This query frees an IP address when an accounting
+#  STOP record arrives
 #
 stop_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
-		nasipaddress = '0', \
-		pool_key = '0', \
-		expiry_time = current_timestamp - INTERVAL '1' second(1) \
+		nasipaddress = '', \
+		pool_key = 0, \
+		expiry_time = 'now'::timestamp(0) - '1 second'::interval \
 	WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}' \
 	AND pool_key = '${pool_key}' \
 	AND username = '%{SQL-User-Name}' \
-	AND callingstationid = '%{%{Calling-Station-Id}:-0}' \
+	AND callingstationid = '%{Calling-Station-Id}' \
 	AND framedipaddress = '%{${attribute_name}}'"
 
 #
@@ -183,12 +165,12 @@ stop_clear = "\
 alive_update = "\
 	UPDATE ${ippool_table} \
 	SET \
-		expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
+		expiry_time = 'now'::timestamp(0) + '${lease_duration} seconds'::interval \
 	WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{${attribute_name}}' \
 	AND username = '%{SQL-User-Name}' \
-	AND callingstationid = '%{%{Calling-Station-Id}:-0}'"
+	AND callingstationid = '%{Calling-Station-Id}'"
 
 #
 #  This query frees all IP addresses allocated to a NAS when an
@@ -197,9 +179,9 @@ alive_update = "\
 on_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
-		nasipaddress = '0', \
-		pool_key = '0', \
-		expiry_time = current_timestamp - INTERVAL '1' second(1) \
+		nasipaddress = '', \
+		pool_key = 0, \
+		expiry_time = 'now'::timestamp(0) - '1 second'::interval \
 	WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"
 
 #
@@ -209,7 +191,7 @@ on_clear = "\
 off_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
-		nasipaddress = '0', \
-		pool_key = '0', \
-		expiry_time = current_timestamp - INTERVAL '1' second(1) \
+		nasipaddress = '', \
+		pool_key = 0, \
+		expiry_time = 'now'::timestamp(0) - '1 second'::interval \
 	WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/schema.sql
@@ -1,0 +1,22 @@
+--
+-- Table structure for table 'radippool'
+--
+-- See also "procedure.sql" in this directory for additional
+-- indices and a stored procedure that is much faster.
+--
+
+CREATE TABLE radippool (
+	id			BIGSERIAL PRIMARY KEY,
+	pool_name		varchar(64) NOT NULL,
+	FramedIPAddress		INET NOT NULL,
+	NASIPAddress		VARCHAR(16) NOT NULL default '',
+	pool_key		VARCHAR(64) NOT NULL default 0,
+	CalledStationId		VARCHAR(64),
+	CallingStationId	text NOT NULL default ''::text,
+	expiry_time		TIMESTAMP(0) without time zone NOT NULL default 'now'::timestamp(0),
+	username		text DEFAULT ''::text
+);
+
+CREATE INDEX radippool_poolname_expire ON radippool USING btree (pool_name, expiry_time);
+CREATE INDEX radippool_framedipaddress ON radippool USING btree (framedipaddress);
+CREATE INDEX radippool_nasip_poolkey_ipaddress ON radippool USING btree (nasipaddress, pool_key, framedipaddress);

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -5,22 +5,37 @@
 #  $Id$
 
 #
+#  SQLite does not implement SELECT FOR UPDATE which is normally used to place
+#  an exclusive lock over rows to prevent the same address from being
+#  concurrently selected for allocation to multiple users.
+#
+#  The most granular read-blocking lock that SQLite has is an exclusive lock
+#  over the database, so that's what we use. All locking in SQLite is performed
+#  over the entire database and we perform a row update for any IP that we
+#  allocate, requiring an exclusive lock. Taking the exclusive lock from the
+#  start of the transaction (even if it were not required to guard the SELECT)
+#  is actually quicker than if we deferred it causing SQLite to "upgrade" the
+#  automatic shared lock for the transaction to an exclusive lock for the
+#  subsequent UPDATE.
+#
+allocate_begin = "BEGIN EXCLUSIVE"
+allocate_commit = "COMMIT"
+
+#
 #  This series of queries allocates an IP address
 #
 #allocate_clear = "\
 #	UPDATE ${ippool_table} \
 #	SET \
-#		nasipaddress = '', \
+#		nasipaddress = '',
 #		pool_key = 0, \
-#		callingstationid = '', \
-#		username = '', \
-#		expiry_time = NULL \
+#		expiry_time = datetime('now') \
 #	WHERE pool_key = '${pool_key}'"
 
 #
 #  This series of queries allocates an IP address
 #  (Note: If your pool_key is set to Calling-Station-Id and not NAS-Port
-#  then you may wish to delete the "AND nasipaddress = '%{Nas-IP-Address}'
+#  then you may wish to delete the "AND nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'
 #  from the WHERE clause)
 #
 allocate_clear = "\
@@ -28,11 +43,9 @@ allocate_clear = "\
 	SET \
 		nasipaddress = '', \
 		pool_key = 0, \
-		callingstationid = '', \
-		username = '', \
-		expiry_time = NULL \
+		expiry_time = datetime('now') \
 	WHERE expiry_time <= datetime(strftime('%%s', 'now') - 1, 'unixepoch') \
-	AND nasipaddress = '%{Nas-IP-Address}'"
+	AND nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"
 
 #
 #  The ORDER BY clause of this query tries to allocate the same IP-address
@@ -42,26 +55,29 @@ allocate_find = "\
 	SELECT framedipaddress \
 	FROM ${ippool_table} \
 	WHERE pool_name = '%{control:${pool_name}}' \
-	AND (\
-		((expiry_time < datetime('now')) OR expiry_time IS NULL) \
-		OR (callingstationid = '%{Calling-Station-Id}') \
-		AND expiry_time > datetime('now')\
+	AND ( \
+		( expiry_time < datetime('now') OR expiry_time IS NULL ) \
+		OR ( nasipaddress = '%{NAS-IP-Address}' AND pool_key = '${pool_key}' ) \
 	) \
 	ORDER BY \
+		(username <> '%{User-Name}'), \
 		(callingstationid <> '%{Calling-Station-Id}'), \
 		expiry_time \
 	LIMIT 1"
 
 #
-# If you prefer to allocate a random IP address every time, use this query instead
+#   If you prefer to allocate a random IP address every time, i
+#   use this query instead
+#   Note: This is very slow if you have a lot of free IPs.
 #
+
 #allocate_find = "\
-#	SELECT framedipaddress FROM ${ippool_table} \
-#	WHERE pool_name = '%{control:${pool_name}}' \
+#	SELECT framedipaddress \
+#	FROM ${ippool_table} \
+# 	WHERE pool_name = '%{control:${pool_name}}' \
 #	AND expiry_time IS NULL \
 #	ORDER BY RAND() \
-#	LIMIT 1 \
-#	FOR UPDATE"
+# 	LIMIT 1"
 
 #
 #  If an IP could not be allocated, check to see if the pool exists or not
@@ -86,15 +102,10 @@ allocate_update = "\
 		callingstationid = '%{Calling-Station-Id}', \
 		username = '%{User-Name}', \
 		expiry_time = datetime(strftime('%%s', 'now') + ${lease_duration}, 'unixepoch') \
-	WHERE framedipaddress = '%I' \
-	AND expiry_time IS NULL"
+	WHERE framedipaddress = '%I'"
 
 #
-#  The following queries are not used for DHCP IP assignment.
-#
-
-#
-#  This series of queries frees an IP number when an accounting START record arrives
+#  Free an IP when an accounting START record arrives
 #
 start_update = "\
 	UPDATE ${ippool_table} \
@@ -104,62 +115,55 @@ start_update = "\
 	AND pool_key = '${pool_key}' \
 	AND username = '%{User-Name}' \
 	AND callingstationid = '%{Calling-Station-Id}' \
-	AND framedipaddress = '%{Framed-IP-Address}'"
+	AND framedipaddress = '%{${attribute_name}}'"
 
 #
-#  This series of queries frees an IP number when an accounting STOP record arrives
+#  Free an IP when an accounting STOP record arrives
 #
 stop_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '', \
 		pool_key = 0, \
-		callingstationid = '', \
-		username = '', \
-		expiry_time = NULL \
-	WHERE nasipaddress = '%{Nas-IP-Address}' \
+		expiry_time = datetime('now') \
+	WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}' \
 	AND pool_key = '${pool_key}' \
 	AND username = '%{User-Name}' \
 	AND callingstationid = '%{Calling-Station-Id}' \
-	AND framedipaddress = '%{Framed-IP-Address}'"
+	AND framedipaddress = '%{${attribute_name}}'"
 
 #
-#  This series of queries frees an IP number when an accounting ALIVE record arrives
+#  Update the expiry time for an IP when an accounting ALIVE record arrives
 #
 alive_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		expiry_time = datetime(strftime('%%s', 'now') + ${lease_duration}, 'unixepoch') \
-	WHERE nasipaddress = '%{Nas-IP-Address}' \
+	WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}' \
 	AND pool_key = '${pool_key}' \
 	AND username = '%{User-Name}' \
 	AND callingstationid = '%{Calling-Station-Id}' \
-	AND framedipaddress = '%{Framed-IP-Address}'"
+	AND framedipaddress = '%{${attribute_name}}'"
 
 #
-#  This series of queries frees the IP numbers allocate to a
-#  NAS when an accounting ON record arrives
+#  Frees all IPs allocated to a NAS when an accounting ON record arrives
 #
 on_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '', \
 		pool_key = 0, \
-		callingstationid = '', \
-		username = '', \
-		expiry_time = NULL \
-	WHERE nasipaddress = '%{Nas-IP-Address}'"
+		expiry_time = datetime('now') \
+	WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"
 
 #
-#  This series of queries frees the IP numbers allocate to a
-#  NAS when an accounting OFF record arrives
+#  Frees all IPs allocated to a NAS when an accounting OFF record arrives
 #
 off_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '', \
 		pool_key = 0, \
-		callingstationid = '', \
-		username = '', \
-		expiry_time = NULL \
-	WHERE nasipaddress = '%{Nas-IP-Address}'"
+		expiry_time = datetime('now') \
+	WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"
+

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
@@ -1,18 +1,18 @@
+--
+-- Table structure for table 'radippool'
+--
 CREATE TABLE radippool (
-	id                      int PRIMARY KEY,
-	pool_name               varchar(30) NOT NULL,
-	framedipaddress         varchar(30) NOT NULL,
-	nasipaddress            varchar(30) NOT NULL DEFAULT '',
-	pool_key                varchar(64) NOT NULL DEFAULT '',
-	calledstationid         varchar(64),
-	callingstationid        varchar(64) NOT NULL DEFAULT '',
-	expiry_time             timestamp DEFAULT NULL,
-	username                varchar(100)
+  id                    int(11) PRIMARY KEY,
+  pool_name             varchar(30) NOT NULL,
+  framedipaddress       varchar(15) NOT NULL default '',
+  nasipaddress          varchar(15) NOT NULL default '',
+  calledstationid       VARCHAR(30) NOT NULL,
+  callingstationid      VARCHAR(30) NOT NULL,
+  expiry_time           DATETIME NULL default NULL,
+  username              varchar(64) NOT NULL default '',
+  pool_key              varchar(30) NOT NULL
 );
- 
--- Example of how to put IPs in the pool
--- INSERT INTO radippool (id, pool_name, framedipaddress) VALUES (1, 'local', '192.168.5.10');
--- INSERT INTO radippool (id, pool_name, framedipaddress) VALUES (2, 'local', '192.168.5.11');
--- INSERT INTO radippool (id, pool_name, framedipaddress) VALUES (3, 'local', '192.168.5.12');
--- INSERT INTO radippool (id, pool_name, framedipaddress) VALUES (4, 'local', '192.168.5.13');
 
+CREATE INDEX radippool_poolname_expire ON radippool(pool_name, expiry_time);
+CREATE INDEX radippool_framedipaddress ON radippool(framedipaddress);
+CREATE INDEX radippool_nasip_poolkey_ipaddress ON radippool(nasipaddress, pool_key, framedipaddress);


### PR DESCRIPTION
Almost identical to the RADIUS ippool queries but worth maintaining differentiation since in future the queries may honour a Requested-IP-Address.

Some differences with respect to remembering username, calling station and freed-time when clearing leases that will be ported to the RADIUS queries in future. (To permit IP stickiness and reduce the likelihood of immediate lease reuse.)

The new PostgreSQL queries have been tested. Others follow the same pattern of changes.