### PR TITLE
rlm_python3: Fix build against Python 3.8.x

### DIFF
--- a/src/modules/rlm_python3/configure
+++ b/src/modules/rlm_python3/configure
@@ -3173,7 +3173,8 @@ $as_echo "$as_me: ${PYTHON3_CONFIG_BIN}'s cflags were \"${python3_cflags}\"" >&6
 			s/-Wp,-D_FORTIFY_SOURCE=[[:digit:]]//g;\
 			s/-g[^ ]*//g;\
 			s/-W[^ ]*//g;\
-			s/-DNDEBUG[[:blank:]]*//g;
+			s/-DNDEBUG[[:blank:]]*//g;\
+			s/-specs=[^ ]*//g
 			'`
 		{ $as_echo "$as_me:${as_lineno-$LINENO}: Sanitized cflags were \"${mod_cflags}\"" >&5
 $as_echo "$as_me: Sanitized cflags were \"${mod_cflags}\"" >&6;}

--- a/src/modules/rlm_python3/configure.ac
+++ b/src/modules/rlm_python3/configure.ac
@@ -48,6 +48,7 @@ if test x$with_[]modname != xno; then
 		dnl # Strip debug symbol flags (-g[0-9]?). We decide on debugging symbols, not python
 		dnl # Strip -W*, we decide what warnings are important
 		dnl # Strip -DNDEBUG
+		dnl # Strip -specs=/path/whatever.specs, We don't need the compiler .specs that comes from Python
 		mod_cflags=`echo $python3_cflags | sed -e '\
 			s/-I/-isystem/g;\
 			s/-isysroot[[ =]]\{0,1\}[[^-]]*//g;\
@@ -55,7 +56,8 @@ if test x$with_[]modname != xno; then
 			s/-Wp,-D_FORTIFY_SOURCE=[[[:digit:]]]//g;\
 			s/-g[[^ ]]*//g;\
 			s/-W[[^ ]]*//g;\
-			s/-DNDEBUG[[[:blank:]]]*//g;
+			s/-DNDEBUG[[[:blank:]]]*//g;\
+			s/-specs=[^ ]*//g;
 			'`
 		AC_MSG_NOTICE([Sanitized cflags were \"${mod_cflags}\"])
 


### PR DESCRIPTION
We don't need the -specs=/... that comes from Python