### PR TITLE
Align V3 dhcp_sqlippool config with V4

### DIFF
--- a/raddb/mods-available/dhcp_sqlippool
+++ b/raddb/mods-available/dhcp_sqlippool
@@ -41,6 +41,9 @@ sqlippool dhcp_sqlippool {
 	#
 	allocate_clear_timeout = 1
 
+	#  The attribute in which the IP address is returned in the reply
+	attribute_name = "DHCP-Your-IP-Address"
+
 	#  Assign the IP address, even if the Framed-IP-Address attribute
 	#  already exists in the reply.
 	#

--- a/raddb/policy.d/dhcp
+++ b/raddb/policy.d/dhcp
@@ -32,13 +32,6 @@ dhcp_sqlippool.post-auth {
 	#  Call the actual module
 	dhcp_sqlippool
 
-	#  Convert Framed-IP-Address to DHCP, but only if we
-	#  actually allocated an address.
-	if (ok) {
-		update reply {
-			&DHCP-Your-IP-Address = "%{reply:Framed-IP-Address}"
-		}
-	}
 }
 
 


### PR DESCRIPTION
Rather than putting returned addresses into Framed-IP-Address and then
copying into DHCP-Your-IP-Address, place the IP address directly into
the correct attribute.