### PR TITLE
Revise the no-advance dbuff macros so they initially have start == p

### DIFF
--- a/src/lib/util/dbuff.h
+++ b/src/lib/util/dbuff.h
@@ -69,7 +69,7 @@ struct fr_dbuff_s {
  */
 #define FR_DBUFF_NO_ADVANCE(_dbuff) (fr_dbuff_t) \
 { \
-	.start	= (_dbuff)->start, \
+	.start	= (_dbuff)->p, \
 	.end	= (_dbuff)->end, \
 	.p	= (_dbuff)->p, \
 	.is_const = (_dbuff)->is_const, \
@@ -79,11 +79,15 @@ struct fr_dbuff_s {
 
 #define _FR_DBUFF_RESERVE(_dbuff, _reserve, _adv_parent) \
 (fr_dbuff_t){ \
-	.start	= (_dbuff)->start, \
-	.end	= ((size_t)(_dbuff) > (_reserve)) && ((_dbuff)->end - (_reserve)) >= ((_dbuff)->start) ? \
+	.start	= (_adv_parent) ? \
+			(_dbuff)->start : \
+			(((_dbuff)->end - (_reserve)) >= ((_dbuff)->p) ?  \
+				(_dbuff)->p : \
+				(_dbuff)->end - (_reserve)), \
+	.end	= ((_dbuff)->end - (_reserve)) >= ((_dbuff)->start) ? \
 			(_dbuff)->end - (_reserve) : \
 			(_dbuff)->start, \
-	.p	= ((size_t)(_dbuff) > (_reserve)) && ((_dbuff)->end - (_reserve)) >= ((_dbuff)->p) ? \
+	.p	= ((_dbuff)->end - (_reserve)) >= ((_dbuff)->p) ? \
 			(_dbuff)->p : \
 			(_dbuff)->end - (_reserve), \
 	.is_const = (_dbuff)->is_const, \


### PR DESCRIPTION
This means that fr_dbuff_used() for a no-advance dbuff is equal to the number
of bytes written to it, not including bytes written to its parent.