### PR TITLE
Convert fr_struct_to_network() to use dbuff

### DIFF
--- a/src/lib/util/dns.h
+++ b/src/lib/util/dns.h
@@ -27,7 +27,7 @@ RCSIDH(dns_h, "$Id$")
 extern "C" {
 #endif
 
-ssize_t		fr_dns_label_from_value_box(size_t *need, uint8_t *buf, size_t buflen, uint8_t *where, bool compression, fr_value_box_t const *value);
+ssize_t		fr_dns_label_from_value_box(fr_dbuff_t *dbuff, bool compression, fr_value_box_t const *value);
 
 ssize_t		fr_dns_label_length(uint8_t const *buf, size_t buf_len, uint8_t const **p_label);
 

--- a/src/lib/util/struct.h
+++ b/src/lib/util/struct.h
@@ -23,6 +23,7 @@
  */
 RCSIDH(struct_h, "$Id$")
 
+#include <freeradius-devel/util/dbuff.h>
 #include <freeradius-devel/util/value.h>
 #include <freeradius-devel/util/cursor.h>
 #include <freeradius-devel/util/pair.h>
@@ -41,12 +42,12 @@ ssize_t fr_struct_from_network(TALLOC_CTX *ctx, fr_cursor_t *cursor,
 			       fr_dict_attr_t const **child,
 			       fr_decode_value_t decode_value, void *decoder_ctx) CC_HINT(nonnull(2,3,4));
 
-typedef ssize_t (*fr_encode_value_t)(uint8_t *out, size_t outlen, fr_da_stack_t *da_stack, unsigned int depth,
+typedef ssize_t (*fr_encode_value_t)(fr_dbuff_t *dbuff, fr_da_stack_t *da_stack, unsigned int depth,
 				     fr_cursor_t *cursor, void *encoder_ctx);
 
-ssize_t fr_struct_to_network(uint8_t *out, size_t outlen, fr_da_stack_t *da_stack, unsigned int depth,
+ssize_t fr_struct_to_network(fr_dbuff_t *dbuff, fr_da_stack_t *da_stack, unsigned int depth,
 			     fr_cursor_t *cursor, void *encoder_ctx,
-			     fr_encode_value_t encode_value) CC_HINT(nonnull(1,3,5));
+			     fr_encode_value_t encode_value) CC_HINT(nonnull(1,2,4));
 
 VALUE_PAIR *fr_unknown_from_network(TALLOC_CTX *ctx, fr_dict_attr_t const *parent,
 				    uint8_t const *data, size_t data_len) CC_HINT(nonnull);

--- a/src/lib/util/value.h
+++ b/src/lib/util/value.h
@@ -573,9 +573,9 @@ int		fr_value_box_hton(fr_value_box_t *dst, fr_value_box_t const *src);
 
 size_t		fr_value_box_network_length(fr_value_box_t *value);
 
-ssize_t		fr_value_box_to_network(size_t *need, uint8_t *out, size_t outlen, fr_value_box_t const *value);
+ssize_t		fr_value_box_to_network(UNUSED size_t *need, uint8_t *out, size_t outlen, fr_value_box_t const *value);
 
-ssize_t		fr_value_box_to_network_dbuff(size_t *need, fr_dbuff_t *dbuff, fr_value_box_t const *value);
+ssize_t		fr_value_box_to_network_dbuff(fr_dbuff_t *dbuff, fr_value_box_t const *value);
 
 /** Special value to indicate fr_value_box_from_network experienced a general error
  */

--- a/src/protocols/arp/base.c
+++ b/src/protocols/arp/base.c
@@ -171,14 +171,14 @@ ssize_t fr_arp_encode(uint8_t *packet, size_t packet_len, uint8_t const *request
 		fr_strerror_printf("No ARP attributes in the attribute list");
 		return -1;
 	}
-	     
+
 	fr_proto_da_stack_build(&da_stack, attr_arp_packet);
 	FR_PROTO_STACK_PRINT(&da_stack, 0);
 
 	/*
 	 *	Call the struct encoder to do the actual work.
 	 */
-	slen = fr_struct_to_network(packet, packet_len, &da_stack, 0, &cursor, NULL, NULL);
+	slen = fr_struct_to_network(&FR_DBUFF_TMP(packet, packet_len), &da_stack, 0, &cursor, NULL, NULL);
 	if (slen <= 0) return slen;
 
 	if (slen != FR_ARP_PACKET_SIZE) return slen;

--- a/src/protocols/internal/encode.c
+++ b/src/protocols/internal/encode.c
@@ -57,38 +57,31 @@ static ssize_t internal_encode(fr_dbuff_t *dbuff,
 			       fr_da_stack_t *da_stack, unsigned int depth,
 			       fr_cursor_t *cursor, void *encoder_ctx)
 {
-	uint8_t				*enc_field, *len_field, *value_field, *value_end;
-	fr_dict_attr_t const		*da = da_stack->da[depth];
-	VALUE_PAIR			*vp = fr_cursor_current(cursor);
+	fr_dbuff_t		work_dbuff = FR_DBUFF_NO_ADVANCE(dbuff);
+	fr_dbuff_marker_t	enc_field, value_field, value_end;
+	fr_dict_attr_t const	*da = da_stack->da[depth];
+	VALUE_PAIR		*vp = fr_cursor_current(cursor);
 
-	uint8_t				flen;
-	ssize_t				slen = 0;
+	size_t			flen;
+	ssize_t			slen;
 
-	uint8_t				buff[sizeof(uint64_t)];
+	uint8_t			buff[sizeof(uint64_t)];
 
 	FR_PROTO_STACK_PRINT(da_stack, depth);
 
-	enc_field = dbuff->p;
+	fr_dbuff_marker(&enc_field, &work_dbuff);
 
 	/*
 	 *	Zero out first encoding byte
 	 */
-	fr_dbuff_memset(dbuff, 0, 1);
-
-	/*
-	 *	Ensure we have at least enough space
-	 *	for the encode byte, two full width
-	 *	type and length fields, and one byte
-	 *	of data.
-	 */
-	FR_DBUFF_CHECK_REMAINING_RETURN(dbuff, (sizeof(uint64_t) * 2) + 2);
+	FR_DBUFF_BYTES_IN_RETURN(&work_dbuff, 0);
 
 	switch (da->type) {
 	/*
 	 *	Only leaf attributes can be tainted
 	 */
 	case FR_TYPE_VALUE:
-		if (vp->vp_tainted) enc_field[0] |= FR_INTERNAL_FLAG_TAINTED;
+		if (vp->vp_tainted) fr_dbuff_marker_current(&enc_field)[0] |= FR_INTERNAL_FLAG_TAINTED;
 		break;
 
 	default:
@@ -99,55 +92,34 @@ static ssize_t internal_encode(fr_dbuff_t *dbuff,
 	 *	Need to use the second encoding byte
 	 */
 	if (da->flags.is_unknown) {
-		fr_dbuff_memset(dbuff, 0, 1);
-		FR_DBUFF_CHECK_REMAINING_RETURN(dbuff, (sizeof(uint64_t) * 2) + 2);	/* Check we still have room */
-
-		enc_field[0] |= FR_INTERNAL_FLAG_EXTENDED;
-		enc_field[1] |= FR_INTERNAL_FLAG_INTERNAL;
+		FR_DBUFF_BYTES_IN_RETURN(&work_dbuff, FR_INTERNAL_FLAG_INTERNAL);
+		fr_dbuff_marker_current(&enc_field)[0] |= FR_INTERNAL_FLAG_EXTENDED;
 	}
 
 	/*
 	 *	Encode the type and write the width of the
 	 *	integer to the encoding byte.
 	 */
-	flen = fr_dbuff_uint64v_in(dbuff, da->attr);
-	if (flen <= 0) return flen;
-	enc_field[0] |= ((flen - 1) << 5);
+	flen = fr_net_from_uint64v(buff, da->attr);
+	FR_DBUFF_MEMCPY_IN_RETURN(&work_dbuff, buff, flen);
+	fr_dbuff_marker_current(&enc_field)[0] |= ((flen - 1) << 5);
 
 	/*
-	 *	Mark where the length field will be, and
-	 *	advance the pointer by one.
-	 *
-	 *	We assume most lengths will fit in one
-	 *	byte, but we lie to functions deeper in the
-	 *	stack about how much space there is left.
-	 *
-	 *	We've already done the checks for encoding
-	 *	two fields of the maximum size above.
+	 *	Leave one byte in hopes that the length will fit
+	 *	and remember where the encoded data starts.
 	 */
-	len_field = dbuff->p;
-	fr_dbuff_advance(dbuff, 1);
-	value_field = dbuff->p;
+	FR_DBUFF_ADVANCE_RETURN(&work_dbuff, 1);
+	fr_dbuff_marker(&value_field, &work_dbuff);
 
 	switch (da->type) {
 	case FR_TYPE_VALUE:
-	{
-		size_t need = 0;
-
-		slen = fr_value_box_to_network_dbuff(&need, &FR_DBUFF_RESERVE(dbuff, sizeof(uint64_t) - 1), &vp->data);
-		if (slen < 0) switch (slen) {
-		case FR_VALUE_BOX_NET_ERROR:
-		default:
-			return PAIR_ENCODE_FATAL_ERROR;
-
-		case FR_VALUE_BOX_NET_OOM:
-			return (enc_field - dbuff->p) - need;
-		}
-		FR_PROTO_HEX_DUMP(value_field, slen, "value %s",
+		slen = fr_value_box_to_network_dbuff(&FR_DBUFF_RESERVE(&work_dbuff, sizeof(uint64_t) - 1), &vp->data);
+		fr_dbuff_marker(&value_end, &work_dbuff);
+		if (slen < 0) return PAIR_ENCODE_FATAL_ERROR;
+		FR_PROTO_HEX_DUMP(fr_dbuff_marker_current(&value_field), slen, "value %s",
 				  fr_table_str_by_value(fr_value_box_type_table, vp->vp_type, "<UNKNOWN>"));
 		fr_cursor_next(cursor);
 		break;
-	}
 
 	/*
 	 *	This is the vendor container.
@@ -165,8 +137,9 @@ static ssize_t internal_encode(fr_dbuff_t *dbuff,
 	 */
 	case FR_TYPE_VSA:
 	case FR_TYPE_VENDOR:
-		slen = internal_encode(&FR_DBUFF_RESERVE(dbuff, sizeof(uint64_t) - 1), da_stack, depth + 1,
+		slen = internal_encode(&FR_DBUFF_RESERVE(&work_dbuff, sizeof(uint64_t) - 1), da_stack, depth + 1,
 				       cursor, encoder_ctx);
+		fr_dbuff_marker(&value_end, &work_dbuff);
 		if (slen < 0) return slen;
 		break;
 
@@ -198,6 +171,7 @@ static ssize_t internal_encode(fr_dbuff_t *dbuff,
 						       da_stack, depth + 1, &children, encoder_ctx);
 				if (slen < 0) return slen;
 			}
+			fr_dbuff_marker(&value_end, &work_dbuff);
 			fr_cursor_next(cursor);
 			break;
 		}
@@ -205,8 +179,9 @@ static ssize_t internal_encode(fr_dbuff_t *dbuff,
 		/*
 		 *	Still encoding intermediary TLVs...
 		 */
-		slen = internal_encode(&FR_DBUFF_RESERVE(dbuff, sizeof(uint64_t) - 1), da_stack, depth + 1,
+		slen = internal_encode(&FR_DBUFF_RESERVE(&work_dbuff, sizeof(uint64_t) - 1), da_stack, depth + 1,
 				       cursor, encoder_ctx);
+		fr_dbuff_marker(&value_end, &work_dbuff);
 		if (slen < 0) return slen;
 		break;
 
@@ -220,18 +195,19 @@ static ssize_t internal_encode(fr_dbuff_t *dbuff,
 	 */
 	case FR_TYPE_GROUP:
 	{
-		fr_cursor_t children;
+		fr_cursor_t	children;
 
 		for (vp = fr_cursor_talloc_init(&children, &vp->children.slist, VALUE_PAIR);
 		     vp;
 		     vp = fr_cursor_current(&children)) {
 		     	FR_PROTO_TRACE("encode ctx changed %s -> %s", da->name, vp->da->name);
 
-			slen = fr_internal_encode_pair_dbuff(&FR_DBUFF_RESERVE(dbuff, sizeof(uint64_t) - 1),
+			slen = fr_internal_encode_pair_dbuff(&FR_DBUFF_RESERVE(&work_dbuff, sizeof(uint64_t) - 1),
 							     &children, encoder_ctx);
 			if (slen < 0) return slen;
 		}
 		fr_cursor_next(cursor);
+		fr_dbuff_marker(&value_end, &work_dbuff);
 	}
 		break;
 
@@ -244,32 +220,24 @@ static ssize_t internal_encode(fr_dbuff_t *dbuff,
 	/*
 	 *	Encode the total length, and write the width
 	 *	of the integer to the encoding byte.
-	 *
-	 *	Already did length checks at the start of
-	 *	the function.
 	 */
-	{
-		value_end = dbuff->p;
-		flen = fr_net_from_uint64v(buff, value_end - value_field);
+	slen = fr_dbuff_marker_current(&value_end) - fr_dbuff_marker_current(&value_field);
+	flen = fr_net_from_uint64v(buff, slen);
 
-		/*
-		 *	Ugh, it's a long one, need to memmove the
-		 *	data, good job we lied to all the encoding
-		 *      functions earlier, so we *must* have enough
-		 *	buffer space.
-		 */
-		if (flen > 1) {
-			fr_dbuff_advance(dbuff, flen - 1);
-			memmove(len_field + flen, value_field, value_end - value_field);
-			value_end += flen - 1;
-		}
-		memcpy(len_field, buff, flen);
-		enc_field[0] |= ((flen - 1) << 2);
+	/*
+	 *	Ugh, it's a long one, need to memmove the
+	 *	data.
+	 */
+	if (flen > 1) {
+		FR_DBUFF_ADVANCE_RETURN(&work_dbuff, flen - 1);
+		memmove(fr_dbuff_marker_current(&value_field) + flen - 1, fr_dbuff_marker_current(&value_field), slen);
 	}
+	memcpy(fr_dbuff_marker_current(&value_field) - 1, buff, flen);
+	fr_dbuff_marker_current(&enc_field)[0] |= ((flen - 1) << 2);
 
-	FR_PROTO_HEX_DUMP(enc_field, (value_field + (flen - 1)) - enc_field, "header");
+	FR_PROTO_HEX_DUMP(fr_dbuff_marker_current(&enc_field), fr_dbuff_used(&work_dbuff) - slen, "header");
 
-	return value_end - enc_field;
+	return fr_dbuff_set(dbuff, &work_dbuff);
 }
 
 /** Encode a data structure into an internal attribute

--- a/src/protocols/radius/base.c
+++ b/src/protocols/radius/base.c
@@ -240,33 +240,34 @@ size_t fr_radius_attr_len(VALUE_PAIR const *vp)
  * We put them into MD5 in the reverse order from that used when
  * encrypting passwords to RADIUS.
  */
-ssize_t fr_radius_ascend_secret(uint8_t *out, size_t outlen, uint8_t const *in, size_t inlen,
+ssize_t fr_radius_ascend_secret(fr_dbuff_t *dbuff, uint8_t const *in, size_t inlen,
 				char const *secret, uint8_t const *vector)
 {
 	fr_md5_ctx_t	*md5_ctx;
 	int		i;
 	uint8_t		buff[RADIUS_AUTH_VECTOR_LENGTH];
+	fr_dbuff_t		work_dbuff = FR_DBUFF_NO_ADVANCE(dbuff);
+	fr_dbuff_marker_t	start;
 
-	if (outlen < RADIUS_AUTH_VECTOR_LENGTH) return -(outlen - RADIUS_AUTH_VECTOR_LENGTH);
+	fr_dbuff_marker(&start, &work_dbuff);
 
-	/*
-	 *	Probably shouldn't happen, but deal with it gracefully if it does
-	 */
-	if (inlen < RADIUS_AUTH_VECTOR_LENGTH) {
-		memset(buff, 0, sizeof(buff));
-		memcpy(buff, in, inlen);
-		in = buff;
-	}
+	if (inlen > RADIUS_AUTH_VECTOR_LENGTH) inlen = RADIUS_AUTH_VECTOR_LENGTH;
+
+	FR_DBUFF_ADVANCE_RETURN(&work_dbuff, RADIUS_AUTH_VECTOR_LENGTH);
+
+	fr_dbuff_set_to_start(&work_dbuff);
+	fr_dbuff_memcpy_in(&work_dbuff, in, inlen);
+	if (inlen < RADIUS_AUTH_VECTOR_LENGTH) fr_dbuff_memset(&work_dbuff, 0, RADIUS_AUTH_VECTOR_LENGTH - inlen);
 
 	md5_ctx = fr_md5_ctx_alloc(true);
 	fr_md5_update(md5_ctx, vector, RADIUS_AUTH_VECTOR_LENGTH);
 	fr_md5_update(md5_ctx, (uint8_t const *) secret, talloc_array_length(secret) - 1);
-	fr_md5_final(out, md5_ctx);
+	fr_md5_final(buff, md5_ctx);
 	fr_md5_ctx_free(&md5_ctx);
 
-	for (i = 0; i < RADIUS_AUTH_VECTOR_LENGTH; i++ ) out[i] ^= in[i];
+	for (i = 0; i < RADIUS_AUTH_VECTOR_LENGTH; i++) fr_dbuff_marker_current(&start)[i] ^= buff[i];
 
-	return RADIUS_AUTH_VECTOR_LENGTH;
+	return fr_dbuff_set(dbuff, &work_dbuff);
 }
 
 /** Basic validation of RADIUS packet header

--- a/src/protocols/radius/decode.c
+++ b/src/protocols/radius/decode.c
@@ -1146,7 +1146,7 @@ ssize_t fr_radius_decode_pair_value(TALLOC_CTX *ctx, fr_cursor_t *cursor, fr_dic
 		 *	Ascend-Receive-Secret
 		 */
 		case FLAG_ENCRYPT_ASCEND_SECRET:
-			fr_radius_ascend_secret(buffer, sizeof(buffer), p, data_len,
+			fr_radius_ascend_secret(&FR_DBUFF_TMP(buffer, sizeof(buffer)), p, data_len,
 						packet_ctx->secret, packet_ctx->vector);
 			buffer[RADIUS_AUTH_VECTOR_LENGTH] = '\0';
 			data_len = strlen((char *) buffer);

--- a/src/protocols/radius/radius.h
+++ b/src/protocols/radius/radius.h
@@ -28,6 +28,7 @@
 #include <freeradius-devel/util/packet.h>
 #include <freeradius-devel/util/rand.h>
 #include <freeradius-devel/util/log.h>
+#include <freeradius-devel/util/dbuff.h>
 
 #define RADIUS_AUTH_VECTOR_OFFSET      		4
 #define RADIUS_HEADER_LENGTH			20
@@ -101,7 +102,7 @@ int		fr_radius_verify(uint8_t *packet, uint8_t const *original,
 bool		fr_radius_ok(uint8_t const *packet, size_t *packet_len_p,
 			     uint32_t max_attributes, bool require_ma, decode_fail_t *reason) CC_HINT(nonnull (1,2));
 
-ssize_t		fr_radius_ascend_secret(uint8_t *out, size_t outlen, uint8_t const *in, size_t inlen,
+ssize_t		fr_radius_ascend_secret(fr_dbuff_t *dbuff, uint8_t const *in, size_t inlen,
 					char const *secret, uint8_t const *vector);
 
 ssize_t		fr_radius_recv_header(int sockfd, fr_ipaddr_t *src_ipaddr, uint16_t *src_port, unsigned int *code);

--- a/src/tests/unit/protocols/radius/tunnel.txt
+++ b/src/tests/unit/protocols/radius/tunnel.txt
@@ -94,9 +94,9 @@ match Tunnel-Password = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 #  can represent this value.
 #
 encode-pair Tunnel-Password = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx123456789a"
-match Tunnel-Password too long
+match Attribute name is too long
 returned
-match -9223372036854775807
+match -1
 
 count
 match 63


### PR DESCRIPTION
Since this function can take a value encoder appropriate for the protocol using it,
this entails converting encode_value for DHCPv6 and RADIUS, the two protocols that
pass in their encode_value functions.