### PR TITLE
v3.0.x certs: Don't drop extensions when creating server certificates; doc and Makefile tidy

### DIFF
--- a/raddb/certs/Makefile
+++ b/raddb/certs/Makefile
@@ -28,7 +28,7 @@ include passwords.mk
 #
 ######################################################################
 .PHONY: all
-all: index.txt serial dh server ca client
+all: index.txt serial dh ca server client
 
 .PHONY: client
 client: client.pem
@@ -91,7 +91,7 @@ server.csr server.key: server.cnf
 	$(OPENSSL) req -new  -out server.csr -keyout server.key -config ./server.cnf
 	chmod g+r server.key
 
-server.crt: server.csr ca.key ca.pem
+server.crt: ca.key ca.pem server.csr
 	$(OPENSSL) ca -batch -keyfile ca.key -cert ca.pem -in server.csr  -key $(PASSWORD_CA) -out server.crt -extensions xpserver_ext -extfile xpextensions -config ./server.cnf
 
 server.p12: server.crt
@@ -116,7 +116,7 @@ client.csr client.key: client.cnf
 	$(OPENSSL) req -new  -out client.csr -keyout client.key -config ./client.cnf
 	chmod g+r client.key
 
-client.crt: client.csr ca.pem ca.key
+client.crt: ca.key ca.pem client.csr
 	$(OPENSSL) ca -batch -keyfile ca.key -cert ca.pem -in client.csr  -key $(PASSWORD_CA) -out client.crt -extensions xpclient_ext -extfile xpextensions -config ./client.cnf
 
 client.p12: client.crt
@@ -142,7 +142,7 @@ inner-server.csr inner-server.key: inner-server.cnf
 	$(OPENSSL) req -new  -out inner-server.csr -keyout inner-server.key -config ./inner-server.cnf
 	chmod g+r inner-server.key
 
-inner-server.crt: inner-server.csr ca.key ca.pem
+inner-server.crt: ca.key ca.pem inner-server.csr
 	$(OPENSSL) ca -batch -keyfile ca.key -cert ca.pem -in inner-server.csr  -key $(PASSWORD_CA) -out inner-server.crt -extensions xpserver_ext -extfile xpextensions -config ./inner-server.cnf
 
 inner-server.p12: inner-server.crt

--- a/raddb/certs/README
+++ b/raddb/certs/README
@@ -57,7 +57,7 @@ user authentication.  See the instructions below for how to create the
 various certificates.  The old test certificates can be deleted by
 running the following command:
 
-$ rm -f *.pem *.der *.csr *.crt *.key *.p12 serial* index.txt*
+$ make destroycerts
 
   Then, follow the instructions below for creating real certificates.
 
@@ -108,9 +108,9 @@ $ vi server.cnf
   country, state, etc.  Be sure that the commonName field here is
   different from the commonName for the CA certificate.
 
-$ make server.pem
+$ make server
 
-  This step creates the server certificate.
+  This step creates and verifies the server certificate.
 
   If you have an existing certificate authority, and wish to create a
   certificate signing request for the server certificate, edit
@@ -128,9 +128,9 @@ $ make server.csr
 
   Client certificates are used by EAP-TLS, and optionally by EAP-TTLS
 and PEAP.  The following steps outline how to create a client
-certificate that is signed by the server certificate created above.
-You will have to have the password for the server certificate in the
-"input_password" and "output_password" fields of the server.cnf file.
+certificate that is signed by the CA certificate created above.  You
+will have to have the password for the CA certificate in the
+"input_password" and "output_password" fields of the ca.cnf file.
 
 
 $ vi client.cnf
@@ -143,7 +143,7 @@ $ vi client.cnf
   country, state, etc.  Be sure that the commonName field here is
   the User-Name that will be used for logins!
 
-$ make client.pem
+$ make client
 
   The users certificate will be in "emailAddress.pem",
   i.e. "user@example.com.pem".
@@ -187,7 +187,7 @@ with ALL operating systems.  Some common issues are:
     see them, it will stop doing EAP.  The most visible effect is
     that the client starts EAP, gets a few Access-Challenge packets,
     and then a little while later re-starts EAP.  If this happens, see
-    the FAQ, and the comments in "raddb/mods-available/eap" for how to 
+    the FAQ, and the comments in "raddb/mods-available/eap" for how to
     fix it.
 
   - Windows requires the root certificates to be on the client PC.

--- a/raddb/certs/inner-server.cnf
+++ b/raddb/certs/inner-server.cnf
@@ -19,6 +19,7 @@ default_crl_days	= 30
 default_md		= sha256
 preserve		= no
 policy			= policy_match
+copy_extensions		= copy
 
 [ policy_match ]
 countryName		= match

--- a/raddb/certs/server.cnf
+++ b/raddb/certs/server.cnf
@@ -19,6 +19,7 @@ default_crl_days	= 30
 default_md		= sha256
 preserve		= no
 policy			= policy_match
+copy_extensions		= copy
 
 [ policy_match ]
 countryName		= match


### PR DESCRIPTION
Main fix is to set "[ CA_default ] ... copy_extensions = copy" to ensure that the basic constrains, key usage and subject alternate name extensions set in the config file and included in the CSR are actually applied to the resulting certificate.

This doesn't apply to v4 which takes a different approach that has the opposite problem: The extensions are added by the CA step and are not present in the CSR, which means that the extensions are present in the FR CA-signed certificate but will be confusing for anyone generating a CSR with SANs for signing by an external CA.