### PR TITLE
Fix OpenSSL 1.1.0 builds

### DIFF
--- a/src/main/cb.c
+++ b/src/main/cb.c
@@ -124,7 +124,7 @@ void cbtls_msg(int write_p, int msg_version, int content_type,
 		state->info.alert_level = 0x00;
 		state->info.alert_description = 0x00;
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
 	} else if (content_type == SSL3_RT_INNER_CONTENT_TYPE && buf[0] == SSL3_RT_APPLICATION_DATA) {
 		/* let tls_ack_handler set application_data */
 		state->info.content_type = SSL3_RT_HANDSHAKE;

--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -3314,9 +3314,8 @@ post_ca:
 	 *	to the same server recently. This doesn't work for EAP, so we
 	 *	disable early data.
 	 *
-	 *	OpenSSL 1.1.1 and later set this as the default
 	 */
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && OPENSSL_VERSION_NUMBER < 0x10101000L
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
 	SSL_CTX_set_max_early_data(ctx, 0);
 #endif
 


### PR DESCRIPTION
https://github.com/FreeRADIUS/freeradius-server/pull/3516 mistakenly used constants and function calls only present in OpenSSL 1.1.1 or later when the guard used was set to 1.1.0 or later.

This notably broke the Debian 9 build.