### PR TITLE
Sqlite memleak

### DIFF
--- a/src/modules/rlm_sql/drivers/rlm_sql_sqlite/rlm_sql_sqlite.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_sqlite/rlm_sql_sqlite.c
@@ -94,6 +94,7 @@ static sql_rcode_t sql_error_to_rcode(int status)
 	case SQLITE_ERROR:	/* SQL error or missing database */
 	case SQLITE_FULL:
 	case SQLITE_MISMATCH:
+	case SQLITE_BUSY:       /* Database file busy - can be caused by locking */
 		return RLM_SQL_ERROR;
 
 	/*


### PR DESCRIPTION
Fix to handle memory leak observed when DHCP used SQLite as the back end and the server was subjected to a heavy load.
SQLITE_BUSY responses were being treated by reconnecting - without clearing resources for former connections.