### PR TITLE
Handle SQLITE_BUSY as an error

### DIFF
--- a/src/modules/rlm_sql/drivers/rlm_sql_sqlite/rlm_sql_sqlite.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_sqlite/rlm_sql_sqlite.c
@@ -95,6 +95,7 @@ static sql_rcode_t sql_error_to_rcode(int status)
 	case SQLITE_ERROR:	/* SQL error or missing database */
 	case SQLITE_FULL:
 	case SQLITE_MISMATCH:
+	case SQLITE_BUSY:	/* Can be caused by database locking */
 		return RLM_SQL_ERROR;
 
 	/*


### PR DESCRIPTION
Exclusive locks can cause SQLite to return an SQLITE_BUSY error.
Treating this as an error causes processing of the current packet to be
abandoned complete with clearing up of the query.  Previously it was
being treated as a need for a reconnect which was causing a memory leak
as the existing connection was not cleared before reconnecting.