### PR TITLE
Refinement to DHCP de-dup

### DIFF
--- a/src/modules/proto_dhcp/dhcp.c
+++ b/src/modules/proto_dhcp/dhcp.c
@@ -349,9 +349,9 @@ RADIUS_PACKET *fr_dhcp_recv(int sockfd)
 	packet->code = code[2] | PW_DHCP_OFFSET;
 
 	/*
-	 *	Create a unique vector from the xid and the client
-	 *	hardware address.  This is a hack for the RADIUS
-	 *	infrastructure in the rest of the server.
+	 *	Create a unique vector from the message type, the
+	 * 	xid and the client hardware address.  This is a hack
+	 *	for the RADIUS infrastructure in the rest of the server.
 	 *	It is also used for de-duplicating DHCP packets
 	 *
 	 *	Note: packet->data[2] == 6, when the hardware address
@@ -359,10 +359,11 @@ RADIUS_PACKET *fr_dhcp_recv(int sockfd)
 	 *	but can be up to 16
 	 */
 	memset(packet->vector, 0, AUTH_VECTOR_LEN);
-	memcpy(packet->vector, packet->data + 4, 4); /* xid */
-	memcpy(packet->vector + 4, packet->data + 28,
-		(packet->data[2] + 4 > AUTH_VECTOR_LEN ?
-		AUTH_VECTOR_LEN - 4 - packet->data[2] : packet->data[2])); /* chaddr */
+	packet->vector[0] = packet->code & 0xff; /* DCHP message type */
+	memcpy(packet->vector + 1, packet->data + 4, 4); /* xid */
+	memcpy(packet->vector + 5, packet->data + 28,
+		(packet->data[2] + 5 > AUTH_VECTOR_LEN ?
+		AUTH_VECTOR_LEN - 5 - packet->data[2] : packet->data[2])); /* chaddr */
 
 	/*
 	 *	FIXME: for DISCOVER / REQUEST: src_port == dst_port + 1
@@ -2177,20 +2178,21 @@ RADIUS_PACKET *fr_dhcp_recv_raw_packet(int sockfd, struct sockaddr_ll *p_ll, RAD
 	packet->code = code[2] | PW_DHCP_OFFSET;
 
 	/*
-	 *	Create a unique vector from the xid and the client
-	 *	hardware address.  This is a hack for the RADIUS
-	 *	infrastructure in the rest of the server.
+	 *	Create a unique vector from the message type, the
+	 * 	xid and the client hardware address.  This is a hack
+	 *	for the RADIUS infrastructure in the rest of the server.
 	 *	It is also used for de-duplicating DHCP packets
 	 *
 	 *	Note: packet->data[2] == 6, when the hardware address
-	 *	is a MAC address which is smaller than AUTH_VECTOR_LEN - 4
-	 *	but can be up to 16.
+	 *	is a MAC address which is smaller than AUTH_VECTOR_LEN
+	 *	but can be up to 16
 	 */
 	memset(packet->vector, 0, AUTH_VECTOR_LEN);
-	memcpy(packet->vector, packet->data + 4, 4); /* xid */
-	memcpy(packet->vector + 4, packet->data + 28,
-		(packet->data[2] + 4 > AUTH_VECTOR_LEN ?
-		AUTH_VECTOR_LEN - 4 - packet->data[2] : packet->data[2])); /* chaddr */
+	packet->vector[0] = packet->code & 0xff; /* DCHP message type */
+	memcpy(packet->vector + 1, packet->data + 4, 4); /* xid */
+	memcpy(packet->vector + 5, packet->data + 28,
+		(packet->data[2] + 5 > AUTH_VECTOR_LEN ?
+		AUTH_VECTOR_LEN - 5 - packet->data[2] : packet->data[2])); /* chaddr */
 
 	packet->src_port = udp_src_port;
 	packet->dst_port = udp_dst_port;


### PR DESCRIPTION
Added in the message code.  Without this, certain clients request packet
would match their discover packet and so get treated as a duplicate.