### PR TITLE
ippool - mysql: Fix and comment SKIP LOCKED usage

### DIFF
--- a/raddb/mods-config/sql/ippool/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mysql/queries.conf
@@ -33,6 +33,16 @@
 #  Using SKIP LOCKED speed up the allocate_find query by 10
 #  times. However, it requires MySQL >= 8.0.1, and InnoDB.
 #
+#  If SKIP LOCKED is used, all UPDATE queries like
+#  allocate_clear, on_clear and off_clear should update and lock
+#  as few rows as possible. Rows are locked if they will be updated
+#  or if they are traversed due to searching for rows that need to be updated.
+#  Traversed and locked rows can be reduced by using proper indices, avoiding
+#  full table scans and by specifying a precise update condition.
+#  Many locked rows are a problem because an allocate_find query, which runs at the
+#  same time, would skip these rows. The pool could wrongly appear as full
+#  and the allocation of an IP would fail.
+#
 #  Uncomment the next line to automatically use SKIP LOCKED
 #skip_locked = "SKIP LOCKED"
 
@@ -62,6 +72,10 @@
 #  then you may wish to delete the "AND nasipaddress = '%{Nas-IP-Address}'
 #  from the WHERE clause)
 #
+#  With "expiry_time > 0" we only update recently expired rows. If we would also
+#  update already freed rows, we would lock all free rows at the same time.
+#  This would be bad for allocate_find, see skip_locked option above.
+#
 allocate_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
@@ -70,7 +84,7 @@ allocate_clear = "\
 		callingstationid = '', \
 		username = '', \
 		expiry_time = 0 \
-	WHERE expiry_time <= NOW() - INTERVAL 1 SECOND \
+	WHERE expiry_time <= NOW() - INTERVAL 1 SECOND AND expiry_time > 0 \
 	AND nasipaddress = '%{Nas-IP-Address}'"
 
 #

--- a/raddb/mods-config/sql/ippool/mysql/schema.sql
+++ b/raddb/mods-config/sql/ippool/mysql/schema.sql
@@ -14,5 +14,7 @@ CREATE TABLE radippool (
   PRIMARY KEY (id),
   KEY radippool_poolname_expire (pool_name, expiry_time),
   KEY framedipaddress (framedipaddress),
-  KEY radippool_nasip_poolkey_ipaddress (nasipaddress, pool_key, framedipaddress)
+  KEY radippool_nasip_poolkey_ipaddress (nasipaddress, pool_key, framedipaddress),
+  KEY poolkey (pool_key),
+  KEY nasipaddress_expiry (nasipaddress, expiry_time)
 ) ENGINE=InnoDB;


### PR DESCRIPTION
Due to SKIP LOCKED is it possible that a pool can be wrongly appear as full, if to many rows are locked by other queries.
This is not a theoretical issue, I saw many failed IP allocation because of this.

This pull request fixes SKIP LOCKED configuration problems in the default config.
A more detailed description of the issue is described as comment in the config.