### PR TITLE
rlm_smtp with unit test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ addons:
     - dovecot-dev
     - dovecot-imapd
     - doxygen
+    - exim4
     - fakeroot
     - firebird-dev
     - freetds-dev
@@ -102,6 +103,7 @@ addons:
     - libykclient-dev
     - libyubikey-dev
     - lintian
+    - openssl
     # Needed for llvm-symbolizer
     - llvm-10
     - luajit

--- a/raddb/mods-available/smtp
+++ b/raddb/mods-available/smtp
@@ -1,0 +1,276 @@
+#  -*- text -*-
+#
+#
+#  $Id$
+
+#######################################################################
+#
+#  = SMTP Module
+#
+#  The `smtp` module validates a users name and password against an SMTP server.
+#  It should be called from an `authenticate` section.
+#
+#  The module can optionally perform a tls handshake, enabled with require_cert
+#
+
+smtp {
+	#
+	#  tls { ... }:: Configure the tls related items which control
+	#  how FreeRADIUS connects to an SMTP server.
+	#
+	tls {
+		#
+		#  .Certificate validation options
+		#
+		#  Specifies how the certificate(s) presented by the
+		#  SMTP server are validated, and which certificates
+		#  (if any) to send to that SMTP server.
+		#
+		#  The options here behave the same as the options in
+		#  other `tls` sections in the server.
+		#
+
+		#
+		#  certificate_file:: PEM formatted file containing the certificate we present to the SMTP server
+		#
+		#  Specifies a certificate and any intermediary CAs we should send to the SMTP server.
+		#
+		#  This file should usually contain the client certificate file first, then any
+		#  intermediary signing CAs, shallowest (direct signee of the certificate_file)
+		#  to deepest (signed directly by the root CA).
+		#
+#		certificate_file     = /path/to/radius.pem
+
+		#
+		#  ca_file:: PEM formatted file containing the chain
+		#  to validate the SMTP server's certificate.
+		#
+		#  Any certificate chain MUST be in order from server
+		#  certificate (first in the file) to intermediary CAs (second) to
+		#  Root CA (last in the file) as per RFC 4346 Section 7.4.2 (see certificate_list)
+		#
+		#  Providing a complete certificate chain here is the
+		#  most common way of validating the certificate
+		#  presented by an SMTP server.
+		#
+#		ca_file	             = "${certdir}/cacert.pem"
+
+		#
+		#  ca_issuer_file:: PEM formatted file containing the
+		#  CA that signed the SMTP server's certificate.
+		#
+		#  Specifies the certificate which directly signed
+		#  the certificate presented by the SMTPs server.
+		#
+		#  This configuration option can be used to prevent
+		#  certificates passing validation which were signed
+		#  by other intermediary CAs, or root CAs, in the
+		#  trusted certificate chain.
+		#
+#		ca_issuer_file     = "${certdir}/caissuer.pem"
+
+		#
+		#  ca_path:: A directory containing multiple root CA certs named by their hash.
+		#
+		#  See the OpenSSL documentation for more details:
+		#  - https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_set_default_verify_paths.html
+		#  - https://www.openssl.org/docs/man1.1.1/man1/c_rehash.html
+		#
+		#  This configuration option should only be used when the SMTP server being contacted
+		#  is not known ahead of time (using a URL from an external source), and/or the CA used
+		#  to sign the SMTP server certificate is unknown.
+		#
+#		ca_path	             = "${certdir}"
+
+		#
+		#  private_key_file:: PEM formatted file containing the private key for the specified `certificate_file`
+		#
+		#  This item must be specified if `certificate_file` is being used.
+		#
+#		private_key_file     = /path/to/radius.key
+
+		#
+		#  private_key_password:: Password used to decrypt the `private_key_file`.
+		#
+#		private_key_password = "supersecret"
+
+		#
+		#  random_file:: Source of random data used for various cryptographic functions.
+		#
+#		random_file          = /dev/urandom
+
+		#
+		#  check_cert:: Server certificate verification requirements.
+		#
+		#  May be one of:
+		#
+		#  [options="header,autowidth"]
+		#  |===
+		#  | Option | Description
+		#  | `no`   | Server certificate can be signed by any CA or be self-signed.
+		#  | `yes`  | Server certificate must be issued by one of the trusted CAs.
+		#  |===
+		#
+		#  Default is `yes`
+		#
+#		check_cert = no
+
+		#
+		#  request_cert:: Options for controlling how the
+		#  module requests TLS to the SMTP server.
+		#
+		#  May be one of:
+		#
+		#  [options="header,autowidth"]
+		#  |===
+		#  | Option | Description
+		#  | `demand`   | Require ssl validation to accept login
+		#  | `never`  | Do not try to establish ssl connection
+		#  | `allow`  | Try to establish ssl connection, continue even if it cannot
+		#  |===
+		#
+		#  default is 'allow'
+		#
+#		require_cert = allow
+
+		#
+		#  check_cert_cn:: Server certificate CN verification requirements.
+		#
+		#  May be one of:
+		#
+		#  [options="header,autowidth"]
+		#  |===
+		#  | Option | Description
+		#  | `no`   | Server certificate CN can be any value.
+		#  | `yes`  | Server certificate CN matches the host in the URI.
+		#  |===
+		#
+		#  Default is `yes`
+		#
+#		check_cert_cn = no
+
+		#
+		#  extract_cert_attrs:: Extract OIDs from presented certificates as OIDs.
+		#
+		#  Default is `no`
+		#
+#		extract_cert_attrs = no
+	}
+
+	#
+	#  uri:: URI which will be used for connecting to the SMTP server.
+	#
+	#  The `smtp` module uses Curl (https://curl.haxx.se/libcurl/) to implement
+	#  the underlying mail protocols.  The URI should be in the form of:
+	#
+	#  `SCHEME://IP:PORT/`
+	#
+
+	#	`SCHEME` can be one of the protocols supported by Curl.
+	#	i.e. ftp, ftps, gopher, http, https, imap, imaps, ldap, ldaps,
+	#	     pop3, pop3s, rtsp, scp, sftp, smb, smbs, smtp, smtps.
+	#	If no `SCHEME` is given, it defaults to `smtp`.
+	#
+	#	`IP` is the IP address of the server.  It can be an IPv4 address,
+	#	IPv6 address, hostname, etc.
+	#
+	#	`PORT` is optional, and will normally be chosen to be correct
+	#	for the given `SCHEME`.
+	#
+	#  For more information, see the CURL documentation at
+	#
+	#	https://ec.haxx.se/cmdline/cmdline-urls
+	#
+	uri = "smtp://192.0.20.1/"
+
+	#
+	#  timeout:: How long the module will wait before giving up on the response
+	#  from the SMTP server.
+	#
+	timeout = 5s
+
+	#
+	#  template_directory:: The source directory where all file attachments are pulled from
+	#  All file attachments should be their relative path from this location, without a leading /
+	#
+	template_directory = raddb/mods_config/smtp
+
+	#
+	#  Attachments:: attachments with their relative path from template_directory
+	#  There can be no leading / or ..
+	#
+	attachments = &SMTP-Attachments[*]
+
+	#
+	#  envelope_address:: This is the address used to send the mail,
+	#  Sent to the receiving server as MAIL FROM:<envelope_address>
+	#  sender_address will be defaulted to if this is not set
+	#
+	envelope_address = "postmaster@localhost"
+
+	#
+	#  sender_address:: This are the addresses displayed in the FROM: element of the header
+	#  This can be different than the provided envelope_address,
+	#  If envelope_address is set, this can be formatted however you want it to appear to the receiver
+	#  If envelope_address is not set, the first element in sender_address will be used as the envelope address
+	#
+	sender_address = &SMTP-Sender-Address[*]
+
+	#
+	#  recipients:: Email addresses to be set as recipients for the email
+	#  If recipients is set bcc, cc, and to will not be automatically added to the email
+	#  And so they must be included here.
+	#
+#	recipients = &SMTP-Recipients[*]
+#	recipients = &SMTP-TO[*]
+#	recipients = &SMTP-CC[*]
+#	recipients = &SMTP-BCC[*]
+
+	#
+	#  to:: Email addresses to be set in the TO: header
+	#  These addresses will be added as envelope recipients only if recipients is not set
+	#
+#	to = &SMTP-TO[*]
+	#
+	#  cc:: Email addresses to be set in the CC: header
+	#  These addresses will be added as envelope recipients only if recipients is not set
+	#
+#	cc = &SMTP-CC[*]
+
+	#
+	#  bcc:: Comma separated list of emails.
+	#  the local part may contain commas, the domain may not (RFC 2821)
+	#  Therefore, first comma after the @ represents a new address
+	#  not listed in the header of the email
+	#  if recipients is not set, these emails will be added to the envelope recipients
+	#
+#	bcc = &SMTP-BCC[*]
+
+	#
+	#  set_date:: Adds a Date: to the header, set to the time the request is received
+	#  Formatted as "Fri, 07 Aug 2020 00:57:37 -0400, (EDT)"
+	#  May be one of:
+	#
+	#  [options="header,autowidth"]
+	#  |===
+	#  | Option | Description
+	#  | `no`   | A Date: should be specified in the header, or left to the receiving mta
+	#  | `yes`  | A Date is formatted and added (recommended)
+	#  |===
+	#
+	#  Default is `yes`
+	#
+#	set_date = yes
+
+	#
+	#  header:: This is where any other headers can be added to the email
+	#  FROM, TO, and CC, should not be added here if their respective elements were set in the config
+	#  If no DATE header is provided, one will be added showing time that the request was received(recommended)
+	#  Non-standard mail headers may be set. Adhere to your MTA's documentation
+	#
+	header {
+		subject = "email subject"
+		Message-ID = "950124.162336@example.com"
+#		X-Originating-IP = "192.0.20.1"
+	}
+}

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -67,6 +67,7 @@ echo "Setting up fixtures"
 for i in \
     postgresql-setup.sh \
     imap-setup.sh \
+    exim-setup.sh \
     mysql-setup.sh \
     ldap-setup.sh \
     redis-setup.sh; do

--- a/scripts/travis/exim-setup.sh
+++ b/scripts/travis/exim-setup.sh
@@ -1,0 +1,133 @@
+#!/bin/sh -e
+#
+# ### This is a script to setup an exim smtp server for testing rlm_smtp
+#
+
+#
+# Declare the important path variables
+#
+
+# Base Directories
+BASEDIR=$(git rev-parse --show-toplevel)
+BUILDDIR="${BASEDIR}/build/ci/exim4"
+
+# Directories for exim processes
+RUNDIR="${BUILDDIR}/run"
+MAILDIR="${BUILDDIR}/mail"
+MAILDELIVERYDIR="${BUILDDIR}/mail_delivery_test"
+LOGDIR="${BUILDDIR}/eximlog"
+SPOOLDIR="${BUILDDIR}/spool"
+CERTDIR="${BUILDDIR}/certs"
+CERTSRCDIR="${BASEDIR}/raddb/certs"
+PASSWORD="whatever"
+
+# Important files for running dovecot
+CONF="${BUILDDIR}/exim.conf"
+
+# Used for supporting files
+TRAVISDIR="${BASEDIR}/scripts/travis"
+
+#
+# Prepare the directories and files needed for running exim
+#
+
+# Stop any currently running exim instance
+echo "Checking for a running exim instance"
+if [ -e "${RUNDIR}/exim.pid" ]
+then
+	echo "Stopping the current exim instance"
+	kill "$(cat ${RUNDIR}/exim.pid)"
+	rm -r "${BUILDDIR}"
+fi
+
+# Create the directories
+mkdir -p "${BUILDDIR}" "${RUNDIR}" "${MAILDELIVERYDIR}" "${MAILDIR}" "${LOGDIR}" "${SPOOLDIR}" "${CERTDIR}"
+
+# Create the certificate
+echo "Generating the certificates"
+openssl pkcs8 -in ${CERTSRCDIR}/rsa/server.key -passin pass:${PASSWORD} -out ${CERTDIR}/server.key
+cp ${CERTSRCDIR}/rsa/server.pem ${CERTDIR}/server.pem
+cp ${CERTSRCDIR}/rsa/ca.pem ${CERTDIR}/ca.pem
+
+# Create exim.conf file
+echo "Generating the exim configuration file"
+touch "${CONF}"
+
+# Build exim.conf
+echo "
+#
+# Set the user to run as - use -DEXIMUSER=user -DEXIMGROUP=group
+# rather than defining them here.
+#
+#EXIMUSER = username
+#EXIMGROUP = groupname
+LISTEN=127.0.0.1
+#
+#
+#  Where all the config files, logs, etc are. See also the
+#  "keep_environment" setting below.
+#
+MAIL_DIR = ${MAILDIR}
+pid_file_path = ${RUNDIR}/exim.pid
+log_file_path = ${LOGDIR}/%s
+spool_directory = ${SPOOLDIR}
+exim_user = EXIMUSER
+exim_group = EXIMGROUP
+daemon_smtp_ports = 2525 : 2465
+local_interfaces = LISTEN
+deliver_drop_privilege
+keep_environment = ${BASEDIR}
+tls_advertise_hosts = *
+tls_certificate = ${CERTDIR}/server.pem
+tls_privatekey = ${CERTDIR}/server.key
+tls_verify_certificates = ${CERTDIR}/ca.pem
+#tls_dhparam = ${CERTDIR}/dh
+tls_on_connect_ports = 2465
+tls_verify_hosts = *
+tls_require_ciphers = \${if =={\$received_port}{2525}\
+                           {NORMAL:%COMPAT}\
+                           {SECURE128}}
+received_header_text =
+acl_smtp_rcpt = accept
+begin acl
+begin routers
+#
+#  Only one router - we'll send everything to the \"local_delivery\"
+#  transport.
+#
+local_delivery:
+  driver = accept
+  transport = local_delivery
+  no_more
+begin transports
+#
+# Transport to write a file - this will write mail to an mbox.
+#
+local_delivery:
+  driver = appendfile
+  create_directory
+  directory_mode = 0750
+  mode = 0600
+#
+#  File to write to. Really dangerous in a normal config as it'll
+#  accept anything, including ../whatever, but we're writing our
+#  own headers so it doesn't matter so much here.
+#
+  file = \${if eq {\$h_x-testname:}{} {MAIL_DIR/\$local_part}{MAIL_DIR/\$h_x-testname:}}
+begin rewrite
+begin retry
+*                *                F,1s,1m
+begin authenticators
+
+" >"${CONF}"
+
+echo "Generating the file attachment"
+# Generate a file for test email attachments
+dd if=/dev/urandom bs=200 count=1 2>/dev/null | base64 | tr -d '\n'> ${BUILDDIR}/testfile
+
+#
+# Run the exim instance
+#
+echo "Starting exim"
+exim -C ${CONF} -bd -DEXIMUSER=$(id -u) -DEXIMGROUP=$(id -g)
+echo "Running exim on port 2525, accepting all local connections"

--- a/share/dictionary/freeradius/dictionary.freeradius.internal
+++ b/share/dictionary/freeradius/dictionary.freeradius.internal
@@ -235,6 +235,15 @@ ATTRIBUTE	Cache-Allow-Insert			1177	bool
 
 # 1178 unused
 
+ATTRIBUTE	SMTP-Mail-Header			1179	string
+ATTRIBUTE 	SMTP-Mail-Body				1180	string
+ATTRIBUTE 	SMTP-Sender-Address 			1181	string
+ATTRIBUTE 	SMTP-Recipients 			1182	string
+ATTRIBUTE 	SMTP-TO 				1183	string
+ATTRIBUTE 	SMTP-CC 				1184	string
+ATTRIBUTE 	SMTP-BCC				1185	string
+ATTRIBUTE 	SMTP-Attachments			1186	string
+
 ATTRIBUTE	Session-State-User-Name			1189	string
 
 ATTRIBUTE	Exec-Export				1190	string

--- a/src/modules/rlm_smtp/README.md
+++ b/src/modules/rlm_smtp/README.md
@@ -1,0 +1,21 @@
+# rlm_smtp
+## Metadata
+<dl>
+  <dt>category</dt><dd>authorization</dd>
+</dl>
+
+## Summary
+Allows users to submit smtp formatted, mime-encoded emails to a server
+Supports User-Name User-Password authentication
+Supports file attachments, size limited by the MDA
+
+Required request elements:
+SMTP-Sender-Email
+SMTP-Recipients
+SMTP-Mail-Header
+SMTP-Mail-Body
+
+Optional request elements:
+SMTP-Attachments
+User-Name
+User-Password

--- a/src/modules/rlm_smtp/README.md
+++ b/src/modules/rlm_smtp/README.md
@@ -7,15 +7,4 @@
 ## Summary
 Allows users to submit smtp formatted, mime-encoded emails to a server
 Supports User-Name User-Password authentication
-Supports file attachments, size limited by the MDA
-
-Required request elements:
-SMTP-Sender-Email
-SMTP-Recipients
-SMTP-Mail-Header
-SMTP-Mail-Body
-
-Optional request elements:
-SMTP-Attachments
-User-Name
-User-Password
+Supports file attachments, size limited by the MTA.

--- a/src/modules/rlm_smtp/all.mk
+++ b/src/modules/rlm_smtp/all.mk
@@ -1,0 +1,12 @@
+#  Check to see if we libfreeradius-curl, as that's a hard dependency
+#  which in turn depends on json-c.
+TARGETNAME	:=
+-include $(top_builddir)/src/lib/curl/all.mk
+TARGET		:=
+
+ifneq "$(TARGETNAME)" ""
+TARGET		:= rlm_smtp.a
+TGT_PREREQS	+= libfreeradius-curl.a
+endif
+
+SOURCES		:= rlm_smtp.c

--- a/src/modules/rlm_smtp/rlm_smtp.c
+++ b/src/modules/rlm_smtp/rlm_smtp.c
@@ -1,0 +1,1064 @@
+/*
+ *   This program is is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation; either version 2 of the License, or (at
+ *   your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program; if not, write to the Free Software
+ *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/**
+ * $Id$
+ * @file rlm_smtp.c
+ * @brief smtp server authentication.
+ *
+ * @copyright 2020 The FreeRADIUS server project
+ * @copyright 2020 Network RADIUS SARL <legal@networkradius.com>
+ */
+RCSID("$Id$")
+
+#include <freeradius-devel/server/base.h>
+#include <freeradius-devel/server/module.h>
+#include <freeradius-devel/curl/base.h>
+#include <freeradius-devel/util/talloc.h>
+#include <freeradius-devel/server/cf_priv.h>
+
+static fr_dict_t const 	*dict_radius; /*dictionary for radius protocol*/
+static fr_dict_t const 	*dict_freeradius;
+
+#define MAX_ATTRMAP	128
+
+extern fr_dict_autoload_t rlm_smtp_dict[];
+fr_dict_autoload_t rlm_smtp_dict[] = {
+	{ .out = &dict_radius, .proto = "radius" },
+	{ .out = &dict_freeradius, .proto = "freeradius"},
+	{ NULL }
+};
+
+static fr_dict_attr_t const 	*attr_auth_type;
+static fr_dict_attr_t const 	*attr_user_password;
+static fr_dict_attr_t const 	*attr_user_name;
+static fr_dict_attr_t const 	*attr_smtp_header;
+static fr_dict_attr_t const 	*attr_smtp_body;
+
+extern fr_dict_attr_autoload_t rlm_smtp_dict_attr[];
+fr_dict_attr_autoload_t rlm_smtp_dict_attr[] = {
+	{ .out = &attr_auth_type, .name = "Auth-Type", .type = FR_TYPE_UINT32, .dict = &dict_freeradius },
+	{ .out = &attr_user_name, .name = "User-Name", .type = FR_TYPE_STRING, .dict = &dict_radius },
+	{ .out = &attr_user_password, .name = "User-Password", .type = FR_TYPE_STRING, .dict = &dict_radius },
+	{ .out = &attr_smtp_header, .name = "SMTP-Mail-Header", .type = FR_TYPE_STRING, .dict = &dict_freeradius },
+	{ .out = &attr_smtp_body, .name = "SMTP-Mail-Body", .type = FR_TYPE_STRING, .dict = &dict_freeradius },
+	{ NULL },
+};
+
+typedef struct {
+	char const		*uri;			//!< URI of smtp server
+	char const		*template_dir;		//!< The directory that contains all email attachments
+	char const		*envelope_address;	//!< The address used to send the message
+	tmpl_t 			**sender_address;	//!< The address used to generate the FROM: header
+	tmpl_t 			**attachments;		//!< The attachments to be set
+	tmpl_t 			**recipient_addrs;	//!< Comma separated list of emails. Overrides elements in to, cc, bcc
+	tmpl_t 			**to_addrs;		//!< Comma separated list of emails to be listed in TO:
+	tmpl_t 			**cc_addrs;		//!< Comma separated list of emails to be listed in CC:
+	tmpl_t 			**bcc_addrs;		//!< Comma separated list of emails not to be listed
+	fr_time_delta_t 	timeout;		//!< Timeout for connection and server response
+	fr_curl_tls_t		tls;			//!< Used for handled all tls specific curl components
+	char const		*name;			//!< Auth-Type value for this module instance.
+	fr_dict_enum_t		*auth_type;
+	vp_map_t		*header_maps;		//!< Attribute map used to process header elements
+	CONF_SECTION		*cs;
+	bool 			set_date;
+} rlm_smtp_t;
+
+typedef struct {
+	rlm_smtp_t const    	*inst;		//!< Instance of rlm_smtp.
+	fr_curl_handle_t    	*mhandle;	//!< Thread specific multi handle.  Serves as the dispatch and coralling structure for smtp requests
+} rlm_smtp_thread_t;
+
+/*
+ *	Holds the context for parsing the email elements
+ */
+typedef struct {
+	REQUEST			*request;
+	fr_curl_io_request_t	*randle;
+	fr_cursor_t		cursor;
+	fr_cursor_t		body_cursor;
+	fr_dbuff_t		vp_in;
+	struct curl_slist	*recipients;
+	struct curl_slist	*header;
+	struct curl_slist 	*body_header;
+	fr_time_t 		time;
+	char 			time_str[60];
+	curl_mime		*mime;
+} fr_mail_ctx;
+
+/*
+ * 	Used to ensure that only strings are being set to the tmpl_t ** output
+ */
+static int cf_table_parse_tmpl(UNUSED TALLOC_CTX *ctx, void *out, UNUSED void *parent,
+			  CONF_ITEM *ci, CONF_PARSER const *rule)
+{
+	int 				rcode = 0;
+	ssize_t				slen;
+	int				type = rule->type;
+	bool 				tmpl = (type & FR_TYPE_TMPL);
+	CONF_PAIR			*cp = cf_item_to_pair(ci);
+	tmpl_t				*vpt;
+
+	static tmpl_rules_t	rules = {
+					.allow_unknown = true,
+					.allow_unresolved = true,
+					.allow_foreign = true
+				};
+
+	if (!tmpl) {
+		cf_log_err(cp, "Failed parsing attribute reference");
+		rcode = -1;
+		goto finish;
+	}
+
+	slen = tmpl_afrom_substr(cp, &vpt, &FR_SBUFF_IN(cf_pair_value(cp), strlen(cf_pair_value(cp))),
+				 cf_pair_value_quote(cp),
+				 tmpl_parse_rules_unquoted[cf_pair_value_quote(cp)],
+				 &rules);
+
+	/* There was an error */
+	if (slen < 0) {
+		char *spaces, *text;
+
+		fr_canonicalize_error(ctx, &spaces, &text, slen, cp->value);
+
+		cf_log_err(cp, "Failed parsing attribute reference:");
+		cf_log_err(cp, "%s", text);
+		cf_log_perr(cp, "%s^", spaces);
+
+		talloc_free(spaces);
+		talloc_free(text);
+		/* Return error */
+		rcode = -1;
+		goto finish;
+	}
+
+	if(tmpl_is_list(vpt)) {
+		rcode = -1;
+		goto finish;
+	}
+
+	/* Only string values should be used for SMTP components */
+	if(tmpl_expanded_type(vpt) != FR_TYPE_STRING) {
+		cf_log_err(cp, "Attribute reference must be a string");
+		rcode = -1;
+		goto finish;
+	}
+
+	*(tmpl_t **)out = vpt;
+
+	cp->parsed = true;
+
+finish:
+	return rcode;
+}
+
+/*
+ *	A mapping of configuration file names to internal variables.
+ */
+static const CONF_PARSER module_config[] = {
+	{ FR_CONF_OFFSET("uri", FR_TYPE_STRING, rlm_smtp_t, uri) },
+	{ FR_CONF_OFFSET("template_directory", FR_TYPE_STRING, rlm_smtp_t, template_dir) },
+	{ FR_CONF_OFFSET("attachments", FR_TYPE_TMPL | FR_TYPE_MULTI, rlm_smtp_t, attachments),
+		.func = cf_table_parse_tmpl, .dflt = "&SMTP-Attachments[*]", .quote = T_BARE_WORD},
+	{ FR_CONF_OFFSET("sender_address", FR_TYPE_TMPL | FR_TYPE_MULTI, rlm_smtp_t, sender_address),
+		.func = cf_table_parse_tmpl},
+	{ FR_CONF_OFFSET("envelope_address", FR_TYPE_STRING, rlm_smtp_t, envelope_address) },
+	{ FR_CONF_OFFSET("recipients", FR_TYPE_TMPL | FR_TYPE_MULTI, rlm_smtp_t, recipient_addrs),
+		.func = cf_table_parse_tmpl, .dflt = "&SMTP-Recipients[*]", .quote = T_BARE_WORD},
+	{ FR_CONF_OFFSET("TO", FR_TYPE_TMPL | FR_TYPE_MULTI, rlm_smtp_t, to_addrs), .func = cf_table_parse_tmpl,
+		.dflt = "&SMTP-TO[*]", .quote = T_BARE_WORD},
+	{ FR_CONF_OFFSET("CC", FR_TYPE_TMPL | FR_TYPE_MULTI, rlm_smtp_t, cc_addrs),
+		.func = cf_table_parse_tmpl, .dflt = "&SMTP-CC[*]", .quote = T_BARE_WORD},
+	{ FR_CONF_OFFSET("BCC", FR_TYPE_TMPL | FR_TYPE_MULTI, rlm_smtp_t, bcc_addrs),
+		.func = cf_table_parse_tmpl, .dflt = "&SMTP-BCC[*]", .quote = T_BARE_WORD },
+	{ FR_CONF_OFFSET("timeout", FR_TYPE_TIME_DELTA, rlm_smtp_t, timeout) },
+	{ FR_CONF_OFFSET("set_date", FR_TYPE_BOOL, rlm_smtp_t, set_date), .dflt = "yes" },
+	{ FR_CONF_OFFSET("tls", FR_TYPE_SUBSECTION, rlm_smtp_t, tls), .subcs = (void const *) fr_curl_tls_config },//!<loading the tls values
+	CONF_PARSER_TERMINATOR
+};
+
+/*
+ * 	Adds every element associated with a dict_attr to a curl_slist
+ */
+static int da_to_slist(fr_mail_ctx *uctx, struct curl_slist **out, const fr_dict_attr_t *dict_attr)
+{
+	REQUEST 			*request = ((fr_mail_ctx *)uctx)->request;
+	VALUE_PAIR			*vp;
+	int 				elems_added = 0;
+
+	/* Iterate over the VP and add the string value to the curl_slist */
+	vp = fr_cursor_iter_by_da_init(&uctx->cursor, &uctx->request->packet->vps, dict_attr);
+	while (vp) {
+		*out = curl_slist_append(*out, vp->vp_strvalue);
+		elems_added++;
+		vp = fr_cursor_next(&uctx->cursor);
+	}
+	/* Check that the elements were found */
+	if (elems_added == 0) {
+		RDEBUG3("There were no %s elements found", dict_attr->name);
+	}
+	return elems_added;
+}
+
+/*
+ * 	Takes a TMPL_TYPE_ATTR and adds it to an slist
+ */
+static int tmpl_attr_to_slist(fr_mail_ctx *uctx, struct curl_slist **out, tmpl_t * const tmpl)
+{
+	REQUEST 			*request = ((fr_mail_ctx *)uctx)->request;
+	VALUE_PAIR			*vp;
+	tmpl_cursor_ctx_t       	cc;
+	int 				count = 0;
+
+	/* Iterate over the VP and add the string value to the curl_slist */
+	vp = tmpl_cursor_init(NULL, NULL, &cc, &uctx->cursor, request, tmpl);
+	while (vp) {
+		count += 1;
+		*out = curl_slist_append(*out, vp->vp_strvalue);
+		vp = fr_cursor_next(&uctx->cursor);
+	}
+	/* Return the number of elements that were found */
+	tmpl_cursor_clear(&cc);
+	return count;
+}
+
+/*
+ * 	Parse through an array of tmpl * elements and add them to an slist
+ */
+static int tmpl_arr_to_slist (rlm_smtp_thread_t *t, fr_mail_ctx *uctx, struct curl_slist **out, tmpl_t ** const tmpl)
+{
+	REQUEST 	*request = uctx->request;
+	int 		count = 0;
+	char 		*expanded_str;
+
+	talloc_foreach(tmpl, current) {
+		if (current->type == TMPL_TYPE_ATTR) {
+			/* If the element contains a reference to an attribute, parse every value it references */
+			count += tmpl_attr_to_slist(uctx, out, current);
+		} else {
+			/* If the element is just a normal string, add it's name to the slist*/
+			if( tmpl_aexpand(t, &expanded_str, request, current, NULL, NULL) < 0) {
+				RDEBUG2("Could not expand the element %s", current->name);
+				break;
+			}
+			*out = curl_slist_append(*out, expanded_str);
+			count += 1;
+		}
+	}
+
+	return count;
+}
+
+/*
+ * 	Adds every element associated with a tmpl_attr to an sbuff
+ */
+static ssize_t tmpl_attr_to_sbuff (fr_mail_ctx *uctx, fr_sbuff_t *out, tmpl_t const *vpt, char const *delimeter)
+{
+	VALUE_PAIR		*vp;
+	tmpl_cursor_ctx_t       cc;
+
+	ssize_t			copied = 0;
+
+	/* Loop through the elements to be added to the sbuff */
+	vp = tmpl_cursor_init(NULL, NULL, &cc, &uctx->cursor, uctx->request, vpt);
+	while (vp) {
+		copied += fr_sbuff_in_bstrncpy(out, vp->vp_strvalue, vp->vp_length);
+		vp = fr_cursor_next(&uctx->cursor);
+		/* If there will be more values, add a comma and whitespace */
+		if (vp) {
+			copied += fr_sbuff_in_strcpy(out, delimeter);
+		}
+	}
+	tmpl_cursor_clear(&cc);
+	return copied;
+}
+
+/*
+ * 	Adds every value in a dict_attr to a curl_slist as a comma separated list with a preposition
+ */
+static int tmpl_arr_to_header (rlm_smtp_thread_t *t, fr_mail_ctx *uctx, struct curl_slist **out, tmpl_t ** const tmpl,
+		const char *preposition)
+{
+	REQUEST			*request = uctx->request;
+	fr_sbuff_t 		sbuff;
+	fr_sbuff_uctx_talloc_t 	sbuff_ctx;
+	ssize_t 		out_len = 0;
+	char 			*expanded_str;
+
+	/* Initialize the buffer for the recipients. Used for TO */
+	fr_sbuff_init_talloc(uctx, &sbuff, &sbuff_ctx, 256, SIZE_MAX);
+	/* Add the preposition for the header element */
+	fr_sbuff_in_strcpy(&sbuff, preposition);
+
+	talloc_foreach(tmpl, vpt) {
+		/* If there have already been elements added, keep them comma separated */
+		if (out_len > 0) {
+			out_len += fr_sbuff_in_strcpy(&sbuff, ", ");
+		}
+		/* Add the tmpl to the header sbuff */
+		if (vpt->type == TMPL_TYPE_ATTR) {
+			/* If the element contains a reference to an attribute, parse every value it references */
+			out_len += tmpl_attr_to_sbuff(uctx, &sbuff, vpt, ", ");
+		} else {
+			/* If the element is just a normal string, add it's name to the slist*/
+			if( tmpl_aexpand(t, &expanded_str, request, vpt, NULL, NULL) < 0) {
+				RDEBUG2("Could not expand the element %s", vpt->name);
+				break;
+			}
+			out_len += fr_sbuff_in_bstrncpy(&sbuff, expanded_str, vpt->len);
+		}
+	}
+
+	/* Add the generated buffer the the curl_slist if elements were added */
+	if (out_len > 0) {
+		*out = curl_slist_append(*out, sbuff.buff);
+		talloc_free(sbuff.buff);
+		/* one element was successfully added */
+		return 1;
+	}
+	talloc_free(sbuff.buff);
+	/* The element failed to be added */
+	RDEBUG2("Failed to add the element to the header");
+	return 0;
+}
+
+/*
+ * 	Takes a string value and adds it as a file path to upload as an attachment
+ */
+static int str_to_attachments (fr_mail_ctx *uctx, curl_mime *mime, char const * str, size_t len,
+		fr_sbuff_t *path_buffer, fr_sbuff_marker_t *m)
+{
+	int 			attachments_set = 0;
+	REQUEST			*request = uctx->request;
+	curl_mimepart		*part;
+
+	/* Move to the end of the template directory filepath */
+	fr_sbuff_set(path_buffer, m);
+
+	/* Check to see if the file attachment is valid, skip it if not */
+	RDEBUG2("Trying to set attachment: %s", str);
+
+	if(strncmp(str, "/", 1) == 0) {
+		RDEBUG2("File attachments cannot be an absolute path");
+		return 0;
+	}
+	if(strncmp(str, "..", 2) == 0) {
+		RDEBUG2("Cannot access values outside of template_directory");
+		return 0;
+	}
+
+	/* Copy the filename into the buffer */
+	fr_sbuff_in_bstrncpy(path_buffer, str, len);
+	/* Add the file attachment as a mime encoded part */
+	attachments_set++;
+	part = curl_mime_addpart(mime);
+	curl_mime_encoder(part, "base64");
+	curl_mime_filedata(part, path_buffer->buff);
+	return 1;
+}
+
+/*
+ * 	Parse a tmpl attr into a file attachment path and add it as a mime part
+ */
+static int tmpl_attr_to_attachment (fr_mail_ctx *uctx, curl_mime *mime, const tmpl_t * tmpl,
+		fr_sbuff_t *path_buffer, fr_sbuff_marker_t *m)
+{
+	VALUE_PAIR 		*vp;
+	REQUEST			*request = uctx->request;
+	tmpl_cursor_ctx_t       cc;
+	int 			attachments_set = 0;
+
+	/* Check for any file attachments */
+	for( vp = tmpl_cursor_init(NULL, NULL, &cc, &uctx->cursor, request, tmpl);
+	vp;
+       	vp = fr_cursor_next(&uctx->cursor)){
+		if(vp->vp_tainted) {
+			RDEBUG2("Skipping a tainted attachment");
+			continue;
+		}
+		attachments_set += str_to_attachments(uctx, mime, vp->vp_strvalue, vp->vp_length, path_buffer, m);
+	}
+	tmpl_cursor_clear(&cc);
+	return attachments_set;
+}
+
+/*
+ * 	Adds every element in a tmpl** to an attachment path, then adds it to the email
+ */
+static int tmpl_arr_to_attachments (rlm_smtp_thread_t *t, fr_mail_ctx *uctx, curl_mime *mime, tmpl_t ** const tmpl,
+		fr_sbuff_t *path_buffer, fr_sbuff_marker_t *m)
+{
+	REQUEST		*request = uctx->request;
+	ssize_t 	count = 0;
+	ssize_t 	expanded_str_len;
+	char 		*expanded_str;
+
+	talloc_foreach(tmpl, current) {
+		/* write the elements to the sbuff as a comma separated list */
+		if(current->type == TMPL_TYPE_ATTR) {
+			count += tmpl_attr_to_attachment(uctx, mime, current, path_buffer, m);
+		} else {
+			expanded_str_len = tmpl_aexpand(t, &expanded_str, request, current, NULL, NULL);
+			if(expanded_str_len < 0) {
+				RDEBUG2("Could not expand the element %s", current->name);
+				continue;
+			}
+			count += str_to_attachments(uctx, mime, expanded_str, expanded_str_len, path_buffer, m);
+		}
+	}
+
+	return count;
+}
+
+/*
+ * 	Returns the proper envolope address
+ */
+static const char * get_envelope_address(rlm_smtp_t const *inst)
+{
+	/* If the envelope address is set in the config, use that to send the email */
+	if(inst->envelope_address) return inst->envelope_address;
+
+	/* If the envelope address is not set, use the first sender address if any are set */
+	if(inst->sender_address) return inst->sender_address[0]->name;
+
+	/* There was no available envelope address */
+	return NULL;
+}
+
+/*
+ * 	Generate the FROM: header
+ */
+static int generate_from_header (rlm_smtp_thread_t *t, fr_mail_ctx *uctx, struct curl_slist **out, rlm_smtp_t const *inst)
+{
+	char const 			*from = "FROM: ";
+	fr_sbuff_t 			sbuff;
+	fr_sbuff_uctx_talloc_t 		sbuff_ctx;
+
+	/* If sender_address is set, then generate FROM: with those attributes */
+	if (inst->sender_address) {
+		tmpl_arr_to_header(t, uctx, &uctx->header, inst->sender_address, from);
+		return 0;
+	}
+	/* Initialize the buffer for the recipients. Used for TO */
+	fr_sbuff_init_talloc(uctx, &sbuff, &sbuff_ctx, 256, SIZE_MAX);
+	/* Add the preposition for the header element */
+	fr_sbuff_in_strcpy(&sbuff, from);
+
+	/* Copy the envelope address as the FROM: source */
+	fr_sbuff_in_bstrncpy(&sbuff, inst->envelope_address, strlen(inst->envelope_address));
+	*out = curl_slist_append(*out, sbuff.buff);
+
+	/* Free the buffer used to generate the FROM header */
+	talloc_free(sbuff.buff);
+	return 0;
+}
+
+/*
+ *	Generates a curl_slist of recipients
+ */
+static int recipients_source(rlm_smtp_thread_t *t, fr_mail_ctx *uctx, rlm_smtp_t const *inst)
+{
+	REQUEST			*request = uctx->request;
+	int 			recipients_set = 0;
+
+	/* Try to load the recipients into the envelope recipients if they are set */
+	if(inst->recipient_addrs) recipients_set += tmpl_arr_to_slist(t, uctx, &uctx->recipients, inst->recipient_addrs);
+
+	/* If any recipients were found, ignore to cc and bcc, return the amount added. */
+	if(recipients_set > 0) {
+		RDEBUG2("Recipients were generated from \"SMTP-Recipients\" and/or recipients in the config");
+		return recipients_set;
+	}
+	RDEBUG2("No addresses were found in SMTP-Recipient");
+
+	/* Try to load the to: addresses into the envelope recipients if they are set */
+	if(inst->to_addrs) recipients_set += tmpl_arr_to_slist(t, uctx, &uctx->recipients, inst->to_addrs);
+
+	/* Try to load the cc: addresses into the envelope recipients if they are set */
+	if(inst->cc_addrs) recipients_set += tmpl_arr_to_slist(t, uctx, &uctx->recipients, inst->cc_addrs);
+
+	/* Try to load the cc: addresses into the envelope recipients if they are set */
+	if(inst->bcc_addrs) recipients_set += tmpl_arr_to_slist(t, uctx, &uctx->recipients, inst->bcc_addrs);
+
+	RDEBUG2("%d recipients set", recipients_set);
+	return recipients_set;
+}
+
+/*
+ *	Generates a curl_slist of header elements header elements
+ */
+static int header_source(rlm_smtp_thread_t *t, fr_mail_ctx *uctx, UNUSED rlm_smtp_t const *inst)
+{
+	fr_sbuff_t 			time_out;
+	char const 			*to = "TO: ";
+	char const 			*cc = "CC: ";
+	REQUEST				*request = uctx->request;
+	fr_sbuff_t 			conf_buffer;
+	fr_sbuff_uctx_talloc_t 		conf_ctx;
+	vp_map_t			*conf_map;
+
+	char 				*expanded_rhs;
+
+	/* Initialize the sbuff for writing the config elements as header attributes */
+	fr_sbuff_init_talloc(uctx, &conf_buffer, &conf_ctx, 256, SIZE_MAX);
+	conf_map = inst->header_maps;
+	/* Load in all of the header elements supplies in the config */
+	while (conf_map->rhs && conf_map->lhs) {
+		/* Do any string expansion required in the rhs */
+		if( tmpl_aexpand(t, &expanded_rhs, request, conf_map->rhs, NULL, NULL) < 0) {
+			RDEBUG2("Skipping: %s's could not parse: %s", conf_map->lhs->name, conf_map->rhs->name);
+			goto next;
+		}
+		/* Format the conf item to be a valid SMTP header */
+		fr_sbuff_in_bstrncpy(&conf_buffer, conf_map->lhs->name, conf_map->lhs->len);
+		fr_sbuff_in_strcpy(&conf_buffer, ": ");
+		fr_sbuff_in_bstrncpy(&conf_buffer, expanded_rhs, strlen(expanded_rhs));
+		/* Add the header to the curl slist */
+		uctx->header = curl_slist_append(uctx->header, conf_buffer.buff);
+		talloc_free(conf_buffer.buff);
+		/* Check if there are more values to parse */
+	next:
+		if (!conf_map->next) break;
+		/* reinitialize the buffer and move to the next value */
+		fr_sbuff_init_talloc(uctx, &conf_buffer, &conf_ctx, 256, SIZE_MAX);
+		conf_map = conf_map->next;
+	}
+	/* Add the FROM: line */
+	generate_from_header(t, uctx, &uctx->header, inst);
+
+	/* Add the TO: line if there is one provided in the request by SMTP-TO */
+	tmpl_arr_to_header(t, uctx, &uctx->header, inst->to_addrs, to);
+
+	/* Add the CC: line if there is one provided in the request by SMTP-CC */
+	tmpl_arr_to_header(t, uctx, &uctx->header, inst->cc_addrs, cc);
+
+	/* Add all the generic header elements in the request */
+	da_to_slist(uctx, &uctx->header, attr_smtp_header);
+
+	/* If no header elements could be found, there is an error */
+	if ( uctx->header == NULL) {
+		RDEBUG2("Header elements could not be added");
+ 		return -1;
+	}
+
+	/* Set the DATE: to the time that the request was received */
+	if (inst->set_date == true){
+		time_out = FR_SBUFF_OUT(uctx->time_str, sizeof(uctx->time_str));
+		fr_time_strftime_local(&time_out, fr_time(), "DATE: %a, %d %b %Y %T %z, (%Z) \r\n");
+		uctx->header = curl_slist_append(uctx->header, uctx->time_str);
+	}
+	RDEBUG2("Finished generating the curl_slist for the header elements");
+	return 0;
+}
+
+/*
+ * 	Add the Body elements to the email
+ */
+static size_t body_source(char *ptr, size_t size, size_t nmemb, void *mail_ctx)
+{
+	fr_mail_ctx 		*uctx = mail_ctx;
+	fr_dbuff_t		out;
+	REQUEST			*request = uctx->request;
+	VALUE_PAIR 		*vp;
+
+	fr_dbuff_init(&out, (uint8_t *)ptr, (size * nmemb));  /* Wrap the output buffer so we can track our position easily */
+
+	vp = fr_cursor_current(&uctx->body_cursor);
+	if (!vp) {
+		RDEBUG2("vp could not be found for the body element");
+		return 0;
+	}
+	/* Copy the vp into the email. If it cannot all be loaded, return the amount of memory that was loaded and get called again */
+	if (fr_dbuff_memcpy_in_partial(&out, &uctx->vp_in, SIZE_MAX) < fr_dbuff_remaining(&uctx->vp_in)) {
+		RDEBUG2("%zu bytes used (partial copy)", fr_dbuff_used(&out));
+		return fr_dbuff_used(&out);
+	}
+	/* Once this value pair is fully copied, prepare for the next element */
+	vp = fr_cursor_next(&uctx->body_cursor);
+	if (vp) {
+		fr_dbuff_init(&uctx->vp_in, (uint8_t const *)vp->vp_strvalue, vp->vp_length);
+
+	}
+	RDEBUG2("%zu bytes used (full copy)", fr_dbuff_used(&out));
+	return fr_dbuff_used(&out);
+}
+
+/*
+ * 	Initialize all the body elements to be uploaded later
+ */
+static int body_init (fr_mail_ctx *uctx, curl_mime *mime)
+{
+	VALUE_PAIR 	*vp;
+	REQUEST		*request = uctx->request;
+
+	curl_mimepart	*part;
+	curl_mime	*mime_body;
+
+	int 		body_elements = 0;
+
+	/* Initialize a second mime to apply special conditions to the body elements */
+	mime_body = curl_mime_init(uctx->randle->candle);
+
+	/* initialize the cursor used by the body_source function*/
+	vp = fr_cursor_iter_by_da_init(&uctx->body_cursor, &uctx->request->packet->vps, attr_smtp_body);
+	fr_dbuff_init(&uctx->vp_in, (uint8_t const *)vp->vp_strvalue, vp->vp_length);
+
+	/* Add a mime part to mime_body for every body element */
+	while(vp){
+		body_elements++;
+		part = curl_mime_addpart(mime_body);
+		curl_mime_encoder(part, "8bit");
+		curl_mime_data_cb(part, vp->vp_length, body_source, NULL, NULL, uctx);
+		vp = fr_cursor_next(&uctx->body_cursor);
+	}
+	RDEBUG2("initialized %d body element part(s)", body_elements);
+
+	/* Re-initialize the cursor for use when uploading the data to curl */
+	fr_cursor_iter_by_da_init(&uctx->body_cursor, &uctx->request->packet->vps, attr_smtp_body);
+
+	/* Add body_mime as a subpart of the mime request with a local content-disposition*/
+	part = curl_mime_addpart(mime);
+	curl_mime_subparts(part, mime_body);
+	curl_mime_type(part, "multipart/mixed" );
+	uctx->body_header = curl_slist_append(NULL, "Content-Disposition: inline"); /* Initialize the body_header curl_slist */
+	curl_mime_headers(part, uctx->body_header, 1);
+
+	return body_elements;
+}
+
+/*
+ * 	Adds every SMTP_Attachments file to the email as a MIME part
+ */
+static int attachments_source(rlm_smtp_thread_t *t, fr_mail_ctx *uctx, curl_mime *mime, rlm_smtp_t const *inst)
+{
+	REQUEST			*request = uctx->request;
+	int 			attachments_set = 0;
+	fr_sbuff_uctx_talloc_t 	sbuff_ctx;
+	fr_sbuff_t 		path_buffer;
+	fr_sbuff_marker_t 	m;
+
+	/* Make sure that a template directory is provided */
+	if (!inst->template_dir) return 0;
+
+	/* Initialize the buffer to write the file path */
+	fr_sbuff_init_talloc(uctx, &path_buffer, &sbuff_ctx, talloc_array_length(inst->template_dir) + 128, SIZE_MAX);
+
+	/* Write the initial path to the buffer */
+	fr_sbuff_in_bstrcpy_buffer(&path_buffer, inst->template_dir);
+	/* Make sure the template_directory path ends in a "/" */
+	if (inst->template_dir[talloc_array_length(inst->template_dir)-2] != '/'){
+		RDEBUG2("Adding / to end of template_dir");
+		fr_sbuff_in_char(&path_buffer, '/');
+	}
+
+	/* Mark the buffer so we only re-write after the template_dir component */
+	fr_sbuff_marker(&m, &path_buffer);
+
+	/* Add the attachments to the email */
+	attachments_set += tmpl_arr_to_attachments(t, uctx, mime, inst->attachments, &path_buffer, &m);
+
+	/* Check for any file attachments */
+	talloc_free(path_buffer.buff);
+	return attachments_set;
+}
+
+/*
+ * 	Free the curl slists
+ */
+static int _free_mail_ctx(fr_mail_ctx *uctx)
+{
+	curl_mime_free(uctx->mime);
+	curl_slist_free_all(uctx->header);
+	curl_slist_free_all(uctx->recipients);
+	return 0;
+}
+
+/*
+ * 	Check if the email was successfully sent, and if the certificate information was extracted
+ */
+static rlm_rcode_t mod_authorize_result(module_ctx_t const *mctx, REQUEST *request, void *rctx)
+{
+	fr_mail_ctx 			*mail_ctx = rctx;
+	rlm_smtp_t const		*inst = talloc_get_type_abort_const(mctx->instance, rlm_smtp_t);
+	fr_curl_io_request_t     	*randle = mail_ctx->randle;
+	fr_curl_tls_t const		*tls;
+	long 				curl_out;
+	long				curl_out_valid;
+	tls = &inst->tls;
+
+	curl_out_valid = curl_easy_getinfo(randle->candle, CURLINFO_SSL_VERIFYRESULT, &curl_out);
+	if (curl_out_valid == CURLE_OK){
+		RDEBUG2("server certificate %s verified", curl_out ? "was" : "not");
+	} else {
+		RDEBUG2("server certificate result not found");
+	}
+
+	if (randle->result != CURLE_OK) {
+		talloc_free(randle);
+		return RLM_MODULE_REJECT;
+	}
+
+	if (tls->extract_cert_attrs) fr_curl_response_certinfo(request, randle);
+	talloc_free(randle);
+
+	return RLM_MODULE_OK;
+}
+
+/*
+ *	Checks that there is a User-Name and User-Password field in the request
+ *	As well as all of the required SMTP elements
+ *	Sets the: username, password
+ *		website URI
+ *		timeout information
+ *		TLS information
+ *		Sender and recipient information
+ *		Email header and body
+ *		File attachments
+ *
+ *	Then it queues the request and yeilds until a response is given
+ *	When it responds, mod_authorize_resume is called.
+ */
+static rlm_rcode_t CC_HINT(nonnull) mod_authorize(module_ctx_t const *mctx, REQUEST *request)
+{
+	rlm_smtp_t const		*inst = talloc_get_type_abort_const(mctx->instance, rlm_smtp_t);
+	rlm_smtp_thread_t       	*t = talloc_get_type_abort(mctx->thread, rlm_smtp_thread_t);
+	fr_curl_io_request_t     	*randle;
+	fr_mail_ctx			*mail_ctx;
+	const char 			*envelope_address;
+
+	VALUE_PAIR const 		*smtp_body, *username, *password;
+
+	if (fr_pair_find_by_da(request->control, attr_auth_type) != NULL) {
+		RDEBUG3("Auth-Type is already set.  Not setting 'Auth-Type := %s'", inst->name);
+		return RLM_MODULE_NOOP;
+	}
+
+	/* Elements provided by the request */
+	username = fr_pair_find_by_da(request->packet->vps, attr_user_name);
+	password = fr_pair_find_by_da(request->packet->vps, attr_user_password);
+	smtp_body = fr_pair_find_by_da(request->packet->vps, attr_smtp_body);
+
+	/* Make sure all of the essential email components are present and possible*/
+	if(!smtp_body) {
+		RDEBUG2("Attribute \"smtp-body\" is required for smtp");
+		return RLM_MODULE_INVALID;
+	}
+	if (!inst->sender_address && !inst->envelope_address) {
+		RDEBUG2("At least one of \"sender_address\" or \"envelope_address\" in the config, or \"SMTP-Sender-Address\" in the request is needed");
+		return RLM_MODULE_INVALID;
+	}
+
+	/* allocate the handle and set the curl options */
+	randle = fr_curl_io_request_alloc(request);
+	if (!randle){
+		RDEBUG2("A handle could not be allocated for the request");
+		return RLM_MODULE_FAIL;
+	}
+
+	/* Initialize the uctx to perform the email */
+	mail_ctx = talloc_zero(randle, fr_mail_ctx);
+	*mail_ctx = (fr_mail_ctx) {
+		.request 	= request,
+		.randle 	= randle,
+		.mime 		= curl_mime_init(randle->candle),
+		.time 		= fr_time() /* time the request was received. Used to set DATE: */
+	};
+
+	/* Set the destructor function to free all of the curl_slist elements */
+	talloc_set_destructor(mail_ctx, _free_mail_ctx);
+
+	/* Set the generic curl request conditions */
+	FR_CURL_REQUEST_SET_OPTION(CURLOPT_URL, inst->uri);
+	FR_CURL_REQUEST_SET_OPTION(CURLOPT_DEFAULT_PROTOCOL, "smtp");
+	FR_CURL_REQUEST_SET_OPTION(CURLOPT_CONNECTTIMEOUT_MS, fr_time_delta_to_msec(inst->timeout));
+	FR_CURL_REQUEST_SET_OPTION(CURLOPT_TIMEOUT_MS, fr_time_delta_to_msec(inst->timeout));
+	if(RDEBUG_ENABLED3) {
+		FR_CURL_REQUEST_SET_OPTION(CURLOPT_VERBOSE, 1L);
+	}
+	FR_CURL_REQUEST_SET_OPTION(CURLOPT_UPLOAD, 1L);
+
+	/* Set the username and pasword if they have been provided */
+	if (username && username->vp_length != 0 && password) {
+		FR_CURL_REQUEST_SET_OPTION(CURLOPT_USERNAME, username->vp_strvalue);
+		FR_CURL_REQUEST_SET_OPTION(CURLOPT_PASSWORD, password->vp_strvalue);
+		RDEBUG2("Username and password set");
+	}
+
+	/* Send the envelope address */
+	envelope_address = get_envelope_address(inst);
+	if(envelope_address == NULL) {
+		RDEBUG2("The envelope address must be set");
+		goto error;
+	}
+	FR_CURL_REQUEST_SET_OPTION(CURLOPT_MAIL_FROM, get_envelope_address(inst));
+
+	/* Set the recipients */
+	mail_ctx->recipients = NULL; /* Prepare the recipients curl_slist to be initialized */
+       	if(recipients_source(t, mail_ctx, inst) <= 0) {
+		RDEBUG2("At least one recipient is required to send an email");
+		goto error;
+	}
+	FR_CURL_REQUEST_SET_OPTION(CURLOPT_MAIL_RCPT, mail_ctx->recipients);
+
+	/* Set the header elements */
+	mail_ctx->header = NULL; /* Prepare the header curl_slist to be initialized */
+       	if(header_source(t, mail_ctx, inst) != 0) {
+		RDEBUG2("The header slist could not be generated");
+		goto error;
+	}
+	/* CURLOPT_HTTPHEADER is the option that they use for the header in the curl example
+	 * https://curl.haxx.se/libcurl/c/smtp-mime.html */
+	FR_CURL_REQUEST_SET_OPTION(CURLOPT_HTTPHEADER, mail_ctx->header);
+
+	/* Initialize the body elements to be uploaded */
+	if (body_init(mail_ctx, mail_ctx->mime) == 0) {
+		RDEBUG2("The body could not be generated");
+		goto error;
+	}
+
+	/* Initialize the attachments if there are any*/
+	if(attachments_source(t, mail_ctx, mail_ctx->mime, inst) == 0){
+		RDEBUG2("No files were attached to the email");
+	}
+
+	/* Add the mime endoced elements to the curl request */
+	FR_CURL_REQUEST_SET_OPTION(CURLOPT_MIMEPOST, mail_ctx->mime);
+
+	/* Initialize tls if it has been set up */
+	if (fr_curl_easy_tls_init(randle, &inst->tls) != 0) return RLM_MODULE_INVALID;
+
+	if (fr_curl_io_request_enqueue(t->mhandle, request, randle)) return RLM_MODULE_INVALID;
+
+	return unlang_module_yield(request, mod_authorize_result, NULL, mail_ctx);
+error:
+	return RLM_MODULE_INVALID;
+}
+
+/*
+ * 	Called when the smtp server responds
+ * 	It checks if the response was CURLE_OK
+ * 	If it was, it tries to extract the certificate attributes
+ * 	If the response was not OK, we REJECT the request
+ * 	This does not confirm an email may be sent, only that the provided login credentials are valid for the server
+ */
+static rlm_rcode_t CC_HINT(nonnull) mod_authenticate_resume(module_ctx_t const *mctx, REQUEST *request, void *rctx)
+{
+	rlm_smtp_t const		*inst = talloc_get_type_abort_const(mctx->instance, rlm_smtp_t);
+	fr_curl_io_request_t     	*randle = rctx;
+	fr_curl_tls_t const		*tls;
+	long 				curl_out;
+	long				curl_out_valid;
+
+	tls = &inst->tls;
+
+	curl_out_valid = curl_easy_getinfo(randle->candle, CURLINFO_SSL_VERIFYRESULT, &curl_out);
+	if (curl_out_valid == CURLE_OK){
+		RDEBUG2("server certificate %s verified", curl_out ? "was" : "not");
+	} else {
+		RDEBUG2("server certificate result not found");
+	}
+
+	if (randle->result != CURLE_OK) {
+		talloc_free(randle);
+		return RLM_MODULE_REJECT;
+	}
+
+	if (tls->extract_cert_attrs) fr_curl_response_certinfo(request, randle);
+
+	talloc_free(randle);
+	return RLM_MODULE_OK;
+}
+
+/*
+ *	Checks that there is a User-Name and User-Password field in the request
+ *	Checks that User-Password is not Blank
+ *	Sets the: username, password
+ *		website URI
+ *		timeout information
+ *		and TLS information
+ *
+ *	Then it queues the request and yeilds until a response is given
+ *	When it responds, mod_authenticate_resume is called.
+ */
+static rlm_rcode_t CC_HINT(nonnull(1,2)) mod_authenticate(module_ctx_t const *mctx, REQUEST *request)
+{
+	rlm_smtp_t const	*inst = talloc_get_type_abort_const(mctx->instance, rlm_smtp_t);
+	rlm_smtp_thread_t       *t = talloc_get_type_abort(mctx->thread, rlm_smtp_thread_t);
+	VALUE_PAIR const 	*username, *password;
+	fr_curl_io_request_t    *randle;
+
+	randle = fr_curl_io_request_alloc(request);
+	if (!randle){
+	error:
+		return RLM_MODULE_FAIL;
+	}
+
+	username = fr_pair_find_by_da(request->packet->vps, attr_user_name);
+	password = fr_pair_find_by_da(request->packet->vps, attr_user_password);
+
+	/* Make sure we have a user-name and user-password, and that they are possible */
+	if (!username) {
+		REDEBUG("Attribute \"User-Name\" is required for authentication");
+		return RLM_MODULE_INVALID;
+	}
+	if (username->vp_length == 0) {
+		RDEBUG2("\"User-Password\" must not be empty");
+		return RLM_MODULE_INVALID;
+	}
+	if (!password) {
+		RDEBUG2("Attribute \"User-Password\" is required for authentication");
+		return RLM_MODULE_INVALID;
+	}
+
+	FR_CURL_REQUEST_SET_OPTION(CURLOPT_DEFAULT_PROTOCOL, "smtp");
+	FR_CURL_REQUEST_SET_OPTION(CURLOPT_URL, inst->uri);
+	FR_CURL_REQUEST_SET_OPTION(CURLOPT_CONNECTTIMEOUT_MS, fr_time_delta_to_msec(inst->timeout));
+	FR_CURL_REQUEST_SET_OPTION(CURLOPT_TIMEOUT_MS, fr_time_delta_to_msec(inst->timeout));
+
+	FR_CURL_REQUEST_SET_OPTION(CURLOPT_VERBOSE, 1L);
+
+	if (fr_curl_easy_tls_init(randle, &inst->tls) != 0) return RLM_MODULE_INVALID;
+
+	if (fr_curl_io_request_enqueue(t->mhandle, request, randle)) return RLM_MODULE_INVALID;
+
+	return unlang_module_yield(request, mod_authenticate_resume, NULL, randle);
+}
+
+/*
+ *	Initialize global curl instance
+ */
+static int mod_load(void)
+{
+	if (fr_curl_init() < 0) return -1;
+	return 0;
+}
+
+/*
+ *	Close global curl instance
+ */
+static void mod_unload(void)
+{
+	fr_curl_free();
+}
+
+/** Verify that a map in the header section makes sense
+ *
+ */
+static int smtp_verify(vp_map_t *map, void *ctx)
+{
+	if (unlang_fixup_update(map, ctx) < 0) return -1;
+
+	return 0;
+}
+
+static int mod_bootstrap(void *instance, UNUSED CONF_SECTION *conf)
+{
+	rlm_smtp_t 	*inst = instance;
+
+	talloc_foreach(inst->recipient_addrs, vpt) INFO("NAME: %s", vpt->name);
+
+	return 0;
+}
+
+
+static int mod_instantiate(void *instance, CONF_SECTION *conf)
+{
+	rlm_smtp_t	*inst = instance;
+	CONF_SECTION	*header;
+
+	inst->cs = conf;
+
+	header = cf_section_find(inst->cs, "header", NULL);
+	if (!header) {
+		return 0;
+	}
+
+	/*
+	 *	Make sure the users don't screw up too badly.
+	 */
+	{
+		tmpl_rules_t	parse_rules = {
+			.allow_foreign = true,	/* Because we don't know where we'll be called */
+			.allow_unknown = true,
+			.allow_unresolved = true,
+			.prefix = TMPL_ATTR_REF_PREFIX_AUTO,
+		};
+		if (map_afrom_cs(inst, &inst->header_maps, header,
+				 &parse_rules, &parse_rules, smtp_verify, NULL, MAX_ATTRMAP) < 0) {
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+/*
+ *	Initialize a new thread with a curl instance
+ */
+static int mod_thread_instantiate(UNUSED CONF_SECTION const *conf, void *instance, fr_event_list_t *el, void *thread)
+{
+	rlm_smtp_thread_t    		*t = thread;
+	fr_curl_handle_t    		*mhandle;
+
+	t->inst = instance;
+
+	mhandle = fr_curl_io_init(t, el, false);
+	if (!mhandle) return -1;
+
+	t->mhandle = mhandle;
+	return 0;
+}
+
+/*
+ *	Close the thread and free the memory
+ */
+static int mod_thread_detach(UNUSED fr_event_list_t *el, void *thread)
+{
+	rlm_smtp_thread_t    *t = thread;
+	talloc_free(t->mhandle);
+	return 0;
+}
+
+/*
+ *	The module name should be the only globally exported symbol.
+ *	That is, everything else should be 'static'.
+ *
+ *	If the module needs to temporarily modify it's instantiation
+ *	data, the type should be changed to RLM_TYPE_THREAD_UNSAFE.
+ *	The server will then take care of ensuring that the module
+ *	is single-threaded.
+ */
+extern module_t rlm_smtp;
+module_t rlm_smtp = {
+	.magic		        = RLM_MODULE_INIT,
+	.name		        = "smtp",
+	.type		        = RLM_TYPE_THREAD_SAFE,
+	.inst_size	        = sizeof(rlm_smtp_t),
+	.thread_inst_size   	= sizeof(rlm_smtp_thread_t),
+	.config		        = module_config,
+	.bootstrap 		= mod_bootstrap,
+	.instantiate		= mod_instantiate,
+	.onload            	= mod_load,
+	.unload             	= mod_unload,
+	.thread_instantiate 	= mod_thread_instantiate,
+	.thread_detach      	= mod_thread_detach,
+
+	.methods = {
+		[MOD_AUTHENTICATE]	= mod_authenticate,
+		[MOD_AUTHORIZE]         = mod_authorize,
+	},
+};

--- a/src/tests/modules/imap/imap_tls/auth_tls.unlang
+++ b/src/tests/modules/imap/imap_tls/auth_tls.unlang
@@ -1,13 +1,5 @@
 imap_tls.authenticate
 
-# if (&request.cert-attrs.Issuer) {
-#        test_fail
-#}
-# else {
-#        test_pass
-#}
-
-
 if (ok) {
     update control {
         &Auth-Type := Accept

--- a/src/tests/modules/smtp/all.mk
+++ b/src/tests/modules/smtp/all.mk
@@ -1,0 +1,3 @@
+#
+# Test the "smtp" module
+#

--- a/src/tests/modules/smtp/module.conf
+++ b/src/tests/modules/smtp/module.conf
@@ -1,0 +1,49 @@
+#smtp unit test config
+smtp {
+	tls {
+		ca_file	= "$ENV{top_srcdir}raddb/certs/rsa/ca.pem"
+
+		certificate_file = "$ENV{top_srcdir}raddb/certs/rsa/client.pem"
+
+		private_key_file = "$ENV{top_srcdir}raddb/certs/rsa/client.key"
+
+		private_key_password = "whatever"
+
+		random_file = /dev/urandom
+
+		check_cert_cn = no
+
+		require_cert = demand
+
+		extract_cert_attrs = yes
+
+        }
+
+	header {
+		subject = "Send to %{User-Name}"
+		message_id = "123456789@example.com"
+	}
+
+	uri = "127.0.0.1:2525"
+	timeout = 200s
+	template_directory = "$ENV{top_srcdir}build/ci/exim4"
+
+	envelope_address = "postmaster@localhost"
+	attachments = &SMTP-Attachments[*]
+
+	recipients = "conf_recipient_1@localhost"
+	recipients = "conf_recipient_2@localhost"
+	recipients = &SMTP-Recipients[*]
+	recipients = &SMTP-TO[*]
+	recipients = &SMTP-CC[*]
+
+	TO = "conf_to@localhost"
+	TO = &SMTP-TO[*]
+
+	CC = &SMTP-CC[*]
+
+	set_date = no
+}
+
+exec {
+}

--- a/src/tests/modules/smtp/smtp_attachment/module.conf
+++ b/src/tests/modules/smtp/smtp_attachment/module.conf
@@ -1,0 +1,47 @@
+#smtp_attachment unit test config
+smtp {
+	tls {
+		ca_file	= "$ENV{top_srcdir}raddb/certs/rsa/ca.pem"
+
+		certificate_file = "$ENV{top_srcdir}raddb/certs/rsa/client.pem"
+
+		private_key_file = "$ENV{top_srcdir}raddb/certs/rsa/client.key"
+
+		private_key_password = "whatever"
+
+		random_file = /dev/urandom
+
+		check_cert_cn = no
+
+		require_cert = demand
+
+		extract_cert_attrs = yes
+
+        }
+
+	header {
+		subject = "Send to %{User-Name}"
+		message_id = "123456789@example.com"
+	}
+
+	uri = "127.0.0.1:2525"
+	timeout = 5s
+	template_directory = "$ENV{top_srcdir}build/ci/exim4"
+
+	sender_address = "sender_email@localhost"
+	envelope_address = "postmaster@localhost"
+
+	recipients = "conf_recipient_1@localhost"
+	recipients = "conf_recipient_2@localhost"
+	recipients = &SMTP-Recipients[*]
+
+	TO = "conf_to@localhost"
+	TO = &SMTP-TO[*]
+
+	CC = &SMTP-CC[*]
+
+	set_date = no
+}
+
+exec {
+}

--- a/src/tests/modules/smtp/smtp_attachment/tls_attachment.attrs
+++ b/src/tests/modules/smtp/smtp_attachment/tls_attachment.attrs
@@ -1,0 +1,11 @@
+#
+#  Input packet
+#
+User-Name = 'Bob'
+User-Password = 'Saget'
+
+#
+#  Expected answer
+#
+Packet-Type == Access-Accept
+

--- a/src/tests/modules/smtp/smtp_attachment/tls_attachment.unlang
+++ b/src/tests/modules/smtp/smtp_attachment/tls_attachment.unlang
@@ -1,0 +1,47 @@
+
+
+update request {
+	&SMTP-Mail-Header += "x-test-Subject: smtp test"
+	&SMTP-Mail-Body += "sent from the smtp test module\r\n"
+
+	&SMTP-Recipients += "smtp_attachment_receiver@localhost"
+
+	&SMTP-TO += "smtp_to_1@localhost"
+	&SMTP-TO += "smtp_to_2@localhost"
+
+	&SMTP-CC += "smtp_cc_1@localhost"
+	&SMTP-CC += "smtp_cc_2@localhost"
+
+	&SMTP-Attachments += "testfile"
+}
+smtp.authorize
+
+#
+# Wait up to a tenth second for exim to deliver the email
+# Then confirm it was delivered
+#
+if (`/bin/sh -c "for i in 1 2 3 4 5 ; \
+do if [ -e build/ci/exim4/mail/smtp_attachment_receiver ] ;\
+then break; \
+fi; sleep .02;\
+done ; \
+test -f build/ci/exim4/mail/smtp_attachment_receiver ;\
+echo $?"` == "1") {
+	reject
+}
+
+#
+# Extract the full contents of the email
+# Pull out the base64 encoded test, decode it, trim line endings
+# Compare the result with the expected output
+#
+if (`/bin/sh -c "cat build/ci/exim4/mail/smtp_attachment_receiver | \
+grep -E '^[A-Za-z0-9+/]{4}*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$' | base64 -d | tr -d '\r\n' | \
+grep -f build/ci/exim4/testfile"`){
+	update control {
+		&Auth-Type := Accept
+	}
+}
+else {
+	reject
+}

--- a/src/tests/modules/smtp/smtp_authenticate/all.mk
+++ b/src/tests/modules/smtp/smtp_authenticate/all.mk
@@ -1,0 +1,3 @@
+#
+# Test the "smtp" module
+#

--- a/src/tests/modules/smtp/smtp_authenticate/module.conf
+++ b/src/tests/modules/smtp/smtp_authenticate/module.conf
@@ -1,0 +1,28 @@
+#smtp_authenticate unit test config
+
+smtp {
+	uri = "127.0.0.1:2525"
+	timeout = 5s
+	template_directory = "$ENV{top_srcdir}build/ci/exim4/"
+
+	tls {
+		ca_file	= "$ENV{top_srcdir}raddb/certs/rsa/ca.pem"
+
+		certificate_file = "$ENV{top_srcdir}raddb/certs/rsa/client.pem"
+
+		private_key_file = "$ENV{top_srcdir}raddb/certs/rsa/client.key"
+
+		private_key_password = "whatever"
+
+		random_file = /dev/urandom
+
+		check_cert_cn = no
+
+		require_cert = demand
+
+		extract_cert_attrs = yes
+        }
+}
+
+exec {
+}

--- a/src/tests/modules/smtp/smtp_authenticate/tls_authenticate.attrs
+++ b/src/tests/modules/smtp/smtp_authenticate/tls_authenticate.attrs
@@ -1,0 +1,11 @@
+#
+#  Input packet
+#
+User-Name = 'Bob'
+User-Password = 'Saget'
+
+#
+#  Expected answer
+#
+Packet-Type == Access-Accept
+

--- a/src/tests/modules/smtp/smtp_authenticate/tls_authenticate.unlang
+++ b/src/tests/modules/smtp/smtp_authenticate/tls_authenticate.unlang
@@ -1,0 +1,25 @@
+update request {
+	&SMTP-Mail-Header += "Subject: smtp test"
+	&SMTP-Mail-Header += "FROM: smtp_sender@gmail.com"
+	&SMTP-Mail-Header += "TO: smtp_receiver@localhost"
+	&SMTP-Mail-Body += "sent from the smtp test module\r\n"
+	&SMTP-Sender-Address += "smtp_sender@localhost"
+	&SMTP-Recipients += "smtp_receiver@localhost"
+	&SMTP-Attachments += "testfile"
+}
+smtp.authenticate
+
+if(ok) {
+	update control {
+		&Auth-Type := Accept
+	}
+}
+else {
+	reject
+}
+
+if (&request:TLS-Cert-Issuer =~ /@example\.org/) {
+        test_pass
+} else {
+	test_fail
+}

--- a/src/tests/modules/smtp/smtp_crln/all.mk
+++ b/src/tests/modules/smtp/smtp_crln/all.mk
@@ -1,0 +1,3 @@
+#
+# Test the "smtp" module
+#

--- a/src/tests/modules/smtp/smtp_crln/module.conf
+++ b/src/tests/modules/smtp/smtp_crln/module.conf
@@ -1,0 +1,38 @@
+#smtp_crln unit test config
+
+smtp {
+	tls {
+		ca_file	= "$ENV{top_srcdir}raddb/certs/rsa/ca.pem"
+
+		certificate_file = "$ENV{top_srcdir}raddb/certs/rsa/client.pem"
+
+		private_key_file = "$ENV{top_srcdir}raddb/certs/rsa/client.key"
+
+		private_key_password = "whatever"
+
+		random_file = /dev/urandom
+
+		check_cert_cn = no
+
+		require_cert = demand
+
+		extract_cert_attrs = yes
+        }
+	header {
+		subject = "Send to %{User-Name}"
+		message_id = "123456789@example.com"
+	}
+
+	uri = "127.0.0.1:2525"
+	timeout = 5s
+	template_directory = "$ENV{top_srcdir}build/ci/exim4"
+	sender_address = "sender_email@localhost"
+	sender_address = "sender_email2@localhost"
+	envelope_address = "postmaster@localhost"
+	recipients = "crln_test_receiver@localhost"
+	recipients = &SMTP-Recipients[*]
+	set_date = no
+}
+
+exec {
+}

--- a/src/tests/modules/smtp/smtp_crln/tls_crln.attrs
+++ b/src/tests/modules/smtp/smtp_crln/tls_crln.attrs
@@ -1,0 +1,11 @@
+#
+#  Input packet
+#
+User-Name = 'Bob'
+User-Password = 'Saget'
+
+#
+#  Expected answer
+#
+Packet-Type == Access-Accept
+

--- a/src/tests/modules/smtp/smtp_crln/tls_crln.unlang
+++ b/src/tests/modules/smtp/smtp_crln/tls_crln.unlang
@@ -1,0 +1,43 @@
+update request {
+	&SMTP-Mail-Body += "sent from the smtp test module\r\n"
+	&SMTP-Mail-Body += "\r\n"
+	&SMTP-Mail-Body += "Some Body\r\n"
+	&SMTP-Mail-Body += ".\r\n"
+	&SMTP-Mail-Body += "More Body\r\n"
+	&SMTP-Mail-Body += "."
+	&SMTP-Mail-Body += "Most Body\r\n"
+
+	&SMTP-Recipients += "crln_test_receiver@localhost"
+	&SMTP-Sender-Address += "smtp_sender@localhost"
+}
+smtp.authorize
+
+#
+# Wait up to a tenth second for exim to deliver the email
+# Then confirm it was delivered
+#
+if (`/bin/sh -c "for i in 1 2 3 4 5 ; \
+do if [ -e build/ci/exim4/mail/crln_test_receiver ] ;\
+then break; \
+fi; sleep .02;\
+done ; \
+test -f build/ci/exim4/mail/crln_test_receiver ;\
+echo $?"` == "1") {
+	reject
+}
+
+if (`/bin/sh -c "cat build/ci/exim4/mail/crln_test_receiver | \
+grep -E 'Most Body'"`) {
+	update control {
+		&Auth-Type := Accept
+	}
+}
+else {
+	reject
+}
+
+if (&request:TLS-Cert-Issuer =~ /@example\.org/) {
+        test_pass
+} else {
+	test_fail
+}

--- a/src/tests/modules/smtp/smtp_stringparse/all.mk
+++ b/src/tests/modules/smtp/smtp_stringparse/all.mk
@@ -1,0 +1,3 @@
+#
+# Test the "smtp" module
+#

--- a/src/tests/modules/smtp/smtp_stringparse/module.conf
+++ b/src/tests/modules/smtp/smtp_stringparse/module.conf
@@ -1,0 +1,37 @@
+#smtp_stringparse unit test config
+
+smtp {
+	tls {
+		ca_file	= "$ENV{top_srcdir}raddb/certs/rsa/ca.pem"
+
+		certificate_file = "$ENV{top_srcdir}raddb/certs/rsa/client.pem"
+
+		private_key_file = "$ENV{top_srcdir}raddb/certs/rsa/client.key"
+
+		private_key_password = "whatever"
+
+		random_file = /dev/urandom
+
+		check_cert_cn = no
+
+		require_cert = demand
+
+		extract_cert_attrs = yes
+        }
+	header {
+		Subject = "for %{User-Name}"
+		message_id = "123456789@example.com"
+	}
+
+	uri = "127.0.0.1:2525"
+	timeout = 5s
+	template_directory = "$ENV{top_srcdir}build/ci/exim4"
+	sender_address = &SMTP-Sender-Address[*]
+	envelope_address = "postmaster@localhost"
+	recipients = "conf-stringparse-recipient@localhost"
+	recipients = &SMTP-Recipients[*]
+	set_date = no
+}
+
+exec {
+}

--- a/src/tests/modules/smtp/smtp_stringparse/tls_stringparse.attrs
+++ b/src/tests/modules/smtp/smtp_stringparse/tls_stringparse.attrs
@@ -1,0 +1,11 @@
+#
+#  Input packet
+#
+User-Name = 'Bob'
+User-Password = 'BobsPass'
+
+#
+#  Expected answer
+#
+Packet-Type == Access-Accept
+

--- a/src/tests/modules/smtp/smtp_stringparse/tls_stringparse.unlang
+++ b/src/tests/modules/smtp/smtp_stringparse/tls_stringparse.unlang
@@ -1,0 +1,40 @@
+update request {
+	&SMTP-Mail-Body += "sent from the smtp test module\r\n"
+
+	&SMTP-Recipients += "stringparse_test_receiver@localhost"
+
+	&SMTP-Sender-Address += "smtp_sender@localhost"
+	&SMTP-Sender-Address += "smtp_sender_2@localhost"
+	&SMTP-Sender-Address += "smtp_sender_3@localhost"
+}
+smtp.authorize
+
+#
+# Wait up to a tenth second for exim to deliver the email
+# Then confirm it was delivered
+#
+if (`/bin/sh -c "for i in 1 2 3 4 5 ; \
+do if [ -e build/ci/exim4/mail/stringparse_test_receiver ] ;\
+then break; \
+fi; sleep .02;\
+done ; \
+test -f build/ci/exim4/mail/stringparse_test_receiver ;\
+echo $?"` == "1") {
+	reject
+}
+
+if (`/bin/sh -c "cat build/ci/exim4/mail/stringparse_test_receiver | \
+grep -E 'Subject: for Bob'"`) {
+	update control {
+		&Auth-Type := Accept
+	}
+}
+else {
+	reject
+}
+
+if (&request:TLS-Cert-Issuer =~ /@example\.org/) {
+        test_pass
+} else {
+	test_fail
+}

--- a/src/tests/modules/smtp/tls_delivery.attrs
+++ b/src/tests/modules/smtp/tls_delivery.attrs
@@ -1,0 +1,11 @@
+#
+#  Input packet
+#
+User-Name = 'Bob'
+User-Password = 'Saget'
+
+#
+#  Expected answer
+#
+Packet-Type == Access-Accept
+

--- a/src/tests/modules/smtp/tls_delivery.unlang
+++ b/src/tests/modules/smtp/tls_delivery.unlang
@@ -1,0 +1,65 @@
+update request {
+	&SMTP-Mail-Header += "x-test-Subject: smtp test"
+	&SMTP-Mail-Body += "sent from the smtp test module\r\n"
+
+	&SMTP-Recipients += "smtp_delivery_receiver@localhost"
+	&SMTP-Recipients += "smtp_recipient_request@localhost"
+
+	&SMTP-TO += "smtp_to_request_1@localhost"
+	&SMTP-TO += "smtp_to_request_2@localhost"
+
+	&SMTP-CC += "smtp_cc_request_1@localhost"
+	&SMTP-CC += "smtp_cc_request_2@localhost"
+
+	&SMTP-Attachments += "testfile"
+}
+smtp.authorize
+
+#
+# Wait up to a tenth second for exim to deliver the email
+# Then confirm it was delivered
+#
+if (`/bin/sh -c "for i in 1 2 3 4 5 ; \
+do if [ -e build/ci/exim4/mail/smtp_delivery_receiver ] ;\
+then break; \
+fi; sleep .02;\
+done ; \
+test -f build/ci/exim4/mail/smtp_delivery_receiver ;\
+echo $?"` == "1") {
+	reject
+}
+
+#
+# Check for the delivery of the remaining emails
+#
+if (!(`/bin/sh -c "for i in 1 2 3 ; \
+do if [ -e build/ci/exim4/mail/smtp_cc_request_1 ] \
+&& [ -e build/ci/exim4/mail/smtp_cc_request_2 ] \
+&& [ -e build/ci/exim4/mail/smtp_to_request_1 ] \
+&& [ -e build/ci/exim4/mail/smtp_to_request_2 ] \
+&& [ -e build/ci/exim4/mail/smtp_recipient_request ] \
+&& [ -e build/ci/exim4/mail/conf_recipient_1 ] \
+&& [ -e build/ci/exim4/mail/conf_recipient_2 ] ;\
+then \
+echo 'found' ;\
+break; \
+fi; sleep .02;\
+done ;"` == "found")) {
+	reject
+}
+
+#
+# Extract the full contents of the email
+# Pull out the base64 encoded test, decode it, trim line endings
+# Compare the result with the expected output
+#
+if (`/bin/sh -c "cat build/ci/exim4/mail/smtp_delivery_receiver | \
+grep -E '^[A-Za-z0-9+/]{4}*([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$' | base64 -d | tr -d '\r\n' | \
+grep -f build/ci/exim4/testfile"`){
+	update control {
+		&Auth-Type := Accept
+	}
+}
+else {
+	reject
+}


### PR DESCRIPTION
mod_authorize sends emails
It requires the request attributes:
SMTP-Sender-Email, SMTP-Recipients, SMTP-Mail-Header, SMTP-Mail-Body
It optionally accepts:
SMTP-Attachments, User-Name, User-Password

mod_authenticate confirms an email can be sent
It requires the request attributes:
User-Name, User-Password