### PR TITLE
Ignore user-provided dhparams in FIPS mode

### DIFF
--- a/src/lib/tls/ctx.c
+++ b/src/lib/tls/ctx.c
@@ -83,6 +83,23 @@ static int ctx_dh_params_load(SSL_CTX *ctx, char *file)
 
 	if (!file) return 0;
 
+	/*
+	 * Prior to trying to load the file, check what OpenSSL will do with it.
+	 *
+	 * Certain downstreams (such as RHEL) will ignore user-provided dhparams
+	 * in FIPS mode, unless the specified parameters are FIPS-approved.
+	 * However, since OpenSSL >= 1.1.1 will automatically select parameters
+	 * anyways, there's no point in attempting to load them.
+	 *
+	 * Change suggested by @t8m
+	 */
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+	if (FIPS_mode() > 0) {
+		WARN(LOG_PREFIX ": Ignoring user-selected DH parameters in FIPS mode. Using defaults.");
+		return 0;
+	}
+#endif
+
 	if ((bio = BIO_new_file(file, "r")) == NULL) {
 		ERROR("Unable to open DH file - %s", file);
 		return -1;


### PR DESCRIPTION
OpenSSL in RHEL 8.3 introduces a breaking change in FIPS mode:
user-provided dhparams will be ignored (and dhparam generation
may fail as well), unless they are on the FIPS approved list of
parameters. However, OpenSSL since v1.1.1 will automatically select
an appropriate DH parameter set anyways, if the user did not provide
any. These will be FIPS approved.

`Signed-off-by: Alexander Scheel <ascheel@redhat.com>`

----

Same as #3554 but for master. Fixes return statement. 