### PR TITLE
redis_ippool: Use client "uid" (Option 61) as device key when this is provided

### DIFF
--- a/raddb/mods-available/redis_ippool
+++ b/raddb/mods-available/redis_ippool
@@ -66,14 +66,38 @@ redis_ippool {
 #	gateway = &NAS-Identifier
 
 	#
-	#  device:: The device identifier.
+	#  device:: The unique device identifier to which an IP is assigned.
 	#
-	#  This is usually the MAC address.  It could be a combination
-	#  of attributes, a `User-Name` or a certificate serial number
-	#  (if the number of sessions were limited to one per
-	#  user/serial).
+	#  This is used as the lookup key to determine the IP address that has
+	#  been allocated to a device. It MUST therefore be something unique to
+	#  each "device" to which an IP address may be assigned.
+	#
+	#  For DHCP it is often simply the MAC address of the device.
 	#
 	device = &DHCP-Client-Hardware-Address
+
+	#
+	#  RFC 2132 specifies that the DHCP client may supply a unique
+	#  identifier ("uid") using Option 61 (DHCP-Client-Identifier) in which
+	#  case it must be used as the lookup key for configuration data.
+	#  Otherwise the client hardware address must be used. To comply with
+	#  this requirement use the following:
+	#
+#	device = "%{%{DHCP-Client-Identifier}:-%{DHCP-Client-Hardware-Address}}"
+
+	#
+	#  For purposes such as IP assignment using a RADIUS Framed-IP-Address
+	#  attribute the "device" identifier could be a `User-Name` or a
+	#  certificate serial number provided that the number of sessions is
+	#  limited to one per user/serial.
+	#
+	#  On a hostile network it SHOULD include a component that you trust,
+	#  arranged such that the overall key cannot be spoofed by manipulation
+	#  of the user-controlled data. For example you might determine that
+	#  ADSL-Agent-Circuit-Id is trusted but that Calling-Station-Id is
+	#  formatted as a user-controlled MAC address:
+	#
+#	device = "%{ADSL-Agent-Circuit-Id} %{Calling-Station-Id}"
 
 	#
 	#  requested_address:: The IP address being renewed or released.


### PR DESCRIPTION
As per RFC 2132.

Also add more clarity and examples to the description of the module configuration item.