### PR TITLE
Add a status to IP pool table

### DIFF
--- a/raddb/mods-available/dhcp_sqlippool
+++ b/raddb/mods-available/dhcp_sqlippool
@@ -30,7 +30,7 @@ sqlippool dhcp_sqlippool {
 	pool_name = "Pool-Name"
 
 	# SQL table to use for ippool range and lease info
-	ippool_table = "radippool"
+	ippool_table = "dhcpippool"
 
 	# IP lease duration. (Leases expire even if no DHCP-Release packet is received)
 	lease_duration = 7200

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/procedure.sql
@@ -55,9 +55,12 @@ AS
 		WITH cte AS (
 			SELECT TOP(1) FramedIPAddress
 			FROM dhcpippool
+			JOIN dhcpstatus
+			ON dhcpstatus.status_id = dhcpippool.status_id
 			WHERE pool_name = @v_pool_name
 				AND expiry_time > CURRENT_TIMESTAMP
 				AND pool_key = @v_pool_key
+				AND dhcpstatus.status IN ('dynamic', 'static')
 		)
 		UPDATE cte WITH (rowlock, readpast)
 		SET FramedIPAddress = FramedIPAddress
@@ -74,8 +77,11 @@ AS
 		-- WITH cte AS (
 		-- 	SELECT TOP(1) FramedIPAddress
 		-- 	FROM dhcpippool
+		--	JOIN dhcpstatus
+		--	ON dhcpstatus.status_id = dhcpippool.status_id
 		-- 	WHERE pool_name = @v_pool_name
 		-- 		AND pool_key = @v_pool_key
+		--		AND dhcpstatus.status IN ('dynamic', 'static')
 		-- )
 		-- UPDATE cte WITH (rowlock, readpast)
 		-- SET FramedIPAddress = FramedIPAddress
@@ -91,8 +97,11 @@ AS
 			WITH cte AS (
 				SELECT TOP(1) FramedIPAddress
 				FROM dhcpippool
+				JOIN dhcpstatus
+				ON dhcpstatus.status_id = dhcpippool.status_id
 				WHERE pool_name = @v_pool_name
 					AND expiry_time < CURRENT_TIMESTAMP
+					AND dhcpstatus.status = 'dynamic'
 				ORDER BY
 					expiry_time
 			)

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -27,12 +27,16 @@ allocate_find = "\
 	WHERE ${ippool_table}.id IN ( \
 		SELECT TOP (1) id FROM ${ippool_table} WHERE id IN ( \
 			(SELECT TOP(1) id FROM ${ippool_table} WITH (xlock rowlock readpast) \
+			JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
 			WHERE pool_name = '%{control:${pool_name}}' \
-			AND pool_key = '${pool_key}' ) \
+			AND pool_key = '${pool_key}' \
+			AND dhcpstatus.status IN ('dynamic', 'static')) \
 			UNION \
 			(SELECT TOP(1) id FROM ${ippool_table} WITH (xlock rowlock readpast) \
+			JOIN dhcpstatus IN ${ippool_table}.status_id = dhcpstatus.status_id \
 			WHERE pool_name = '%{control:${pool_name}}' \
-			AND expiry_time < CURRENT_TIMESTAMP) \
+			AND expiry_time < CURRENT_TIMESTAMP \
+			AND dhcpstatus.status = 'dynamic') \
 		) \
 		ORDER BY CASE WHEN pool_key = '${pool_key}' THEN 0 ELSE 1 END, expiry_time \
 	)"
@@ -44,8 +48,10 @@ allocate_find = "\
 #allocate_find = "\
 #	WITH cte AS ( \
 #		SELECT TOP(1) FramedIPAddress FROM ${ippool_table} \
+#		JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
 #		WHERE pool_name = '%{control:${pool_name}}' \
 #		AND expiry_time < CURRENT_TIMESTAMP \
+#		AND dhcpstatus.status = 'dynamic' \
 #		ORDER BY \
 #			newid() \
 #	) \

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -21,7 +21,7 @@ allocate_find = "\
 	SET FramedIPAddress = FramedIPAddress, \
 	pool_key = '${pool_key}', \
 	expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP), \
-	NASIPAddress = '%{DHCP-Gateway-IP-Address}' \
+	GatewayIPAddress = '%{DHCP-Gateway-IP-Address}' \
 	OUTPUT INSERTED.FramedIPAddress \
 	FROM ${ippool_table} \
 	WHERE ${ippool_table}.id IN ( \
@@ -71,7 +71,7 @@ pool_check = "\
 #allocate_update = "\
 #	UPDATE ${ippool_table} \
 #	SET \
-#		NASIPAddress = '%{DHCP-Gateway-IP-Address}', pool_key = '${pool_key}', \
+#		GatewayIPAddress = '%{DHCP-Gateway-IP-Address}', pool_key = '${pool_key}', \
 #		expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
 #	WHERE FramedIPAddress = '%I'"
 
@@ -81,11 +81,9 @@ pool_check = "\
 #
 #allocate_begin = ""
 #allocate_find = "\
-#	EXEC fr_allocate_previous_or_new_framedipaddress \
+#	EXEC fr_dhcp_allocate_previous_or_new_framedipaddress \
 #		@v_pool_name = '%{control:${pool_name}}', \
-#		@v_username = '', \
-#		@v_callingstationid = '', \
-#		@v_nasipaddress = '%{DHCP-Gateway-IP-Address}', \
+#		@v_gatewayipaddress = '%{DHCP-Gateway-IP-Address}', \
 #		@v_pool_key = '${pool_key}', \
 #		@v_lease_duration = ${lease_duration} \
 #	"
@@ -105,7 +103,7 @@ start_update = ""
 stop_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
-		NASIPAddress = '', \
+		GatewayIPAddress = '', \
 		pool_key = '0', \
 		expiry_time = CURRENT_TIMESTAMP \
 	WHERE pool_name = '%{control:${pool_name}}' \

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/schema.sql
@@ -1,25 +1,26 @@
 --
--- Table structure for table 'radippool'
+-- Table structure for table 'dhcpippool'
 --
-CREATE TABLE radippool (
+-- See also "procedure.sql" in this directory for
+-- a stored procedure that gives much faster response.
+--
+
+CREATE TABLE dhcpippool (
   id                    int IDENTITY (1,1) NOT NULL,
   pool_name             varchar(30) NOT NULL,
   FramedIPAddress       varchar(15) NOT NULL default '',
-  NASIPAddress          varchar(15) NOT NULL default '',
-  CalledStationId       VARCHAR(32) NOT NULL default '',
-  CallingStationId      VARCHAR(30) NOT NULL default '',
-  expiry_time           DATETIME NOT NULL default CURRENT_TIMESTAMP,
-  UserName              varchar(64) NOT NULL default '',
   pool_key              varchar(30) NOT NULL default '',
+  GatewayIPAddress      varchar(15) NOT NULL default '',
+  expiry_time           DATETIME NOT NULL default CURRENT_TIMESTAMP,
   PRIMARY KEY (id)
 )
 GO
 
-CREATE INDEX poolname_expire ON radippool(pool_name, expiry_time)
+CREATE INDEX dhcp_poolname_expire ON dhcpippool(pool_name, expiry_time)
 GO
 
-CREATE INDEX FramedIPAddress ON radippool(FramedIPAddress)
+CREATE INDEX dhcp_FramedIPAddress ON dhcpippool(FramedIPAddress)
 GO
 
-CREATE INDEX poolname_poolkey_FramedIPAddress ON radippool(pool_name, pool_key, FramedIPAddress)
+CREATE INDEX dhcp_poolname_poolkey_FramedIPAddress ON dhcpippool(pool_name, pool_key, FramedIPAddress)
 GO

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/schema.sql
@@ -5,6 +5,16 @@
 -- a stored procedure that gives much faster response.
 --
 
+CREATE TABLE dhcpstatus (
+  status_id             int NOT NULL,
+  status		varchar(10) NOT NULL,
+  PRIMARY KEY (status_id)
+)
+GO
+
+INSERT INTO dhcpstatus (status_id, status) VALUES (1, 'dynamic'), (2, 'static'), (3, 'declined'), (4, 'disabled')
+GO
+
 CREATE TABLE dhcpippool (
   id                    int IDENTITY (1,1) NOT NULL,
   pool_name             varchar(30) NOT NULL,
@@ -12,6 +22,8 @@ CREATE TABLE dhcpippool (
   pool_key              varchar(30) NOT NULL default '',
   GatewayIPAddress      varchar(15) NOT NULL default '',
   expiry_time           DATETIME NOT NULL default CURRENT_TIMESTAMP,
+  status_id		int NOT NULL default 1,
+  CONSTRAINT fk_status_id FOREIGN KEY (status_id) REFERENCES dhcpstatus (status_id),
   PRIMARY KEY (id)
 )
 GO
@@ -24,3 +36,4 @@ GO
 
 CREATE INDEX dhcp_poolname_poolkey_FramedIPAddress ON dhcpippool(pool_name, pool_key, FramedIPAddress)
 GO
+

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/procedure-no-skip-locked.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/procedure-no-skip-locked.sql
@@ -12,9 +12,9 @@
 --       LOCKED is available.
 --
 -- WARNING: This query uses server-local, "user locks" (GET_LOCK and
---          RELEASE_LOCK), without the need for a transaction, to emulate
---          row locking with locked-row skipping. User locks are not
---          supported on clusters such as Galera and MaxScale.
+--	  RELEASE_LOCK), without the need for a transaction, to emulate
+--	  row locking with locked-row skipping. User locks are not
+--	  supported on clusters such as Galera and MaxScale.
 --
 -- Using this SP reduces the usual set dialogue of queries to a single
 -- query:
@@ -43,93 +43,96 @@ DELIMITER $$
 
 DROP PROCEDURE IF EXISTS fr_dhcp_allocate_previous_or_new_framedipaddress;
 CREATE PROCEDURE fr_allocate_previous_or_new_framedipaddress (
-        IN v_pool_name VARCHAR(64),
-        IN v_gatewayipaddress VARCHAR(15),
-        IN v_pool_key VARCHAR(64),
-        IN v_lease_duration INT
+	IN v_pool_name VARCHAR(64),
+	IN v_gatewayipaddress VARCHAR(15),
+	IN v_pool_key VARCHAR(64),
+	IN v_lease_duration INT
 )
 proc:BEGIN
-        DECLARE r_address VARCHAR(15);
+	DECLARE r_address VARCHAR(15);
 
-        -- Reissue an existing IP address lease when re-authenticating a session
-        --
-        SELECT framedipaddress INTO r_address
-        FROM dhcpippool
-        WHERE pool_name = v_pool_name
-                AND expiry_time > NOW()
-                AND pool_key = v_pool_key
-        LIMIT 1;
+	-- Reissue an existing IP address lease when re-authenticating a session
+	--
+	SELECT framedipaddress INTO r_address
+	FROM dhcpippool
+	WHERE pool_name = v_pool_name
+		AND expiry_time > NOW()
+		AND pool_key = v_pool_key
+		AND `status` IN ('dynamic', 'static')
+	LIMIT 1;
 
-        -- Reissue an user's previous IP address, provided that the lease is
-        -- available (i.e. enable sticky IPs)
-        --
-        -- When using this SELECT you should delete the one above. You must also
-        -- set allocate_clear = "" in queries.conf to persist the associations
-        -- for expired leases.
-        --
-        -- SELECT framedipaddress INTO r_address
-        -- FROM dhcpippool
-        -- WHERE pool_name = v_pool_name
-        --         AND pool_key = v_pool_key
-        -- LIMIT 1;
+	-- Reissue an user's previous IP address, provided that the lease is
+	-- available (i.e. enable sticky IPs)
+	--
+	-- When using this SELECT you should delete the one above. You must also
+	-- set allocate_clear = "" in queries.conf to persist the associations
+	-- for expired leases.
+	--
+	-- SELECT framedipaddress INTO r_address
+	-- FROM dhcpippool
+	-- WHERE pool_name = v_pool_name
+	--	AND pool_key = v_pool_key
+	--	AND `status` IN ('dynamic', 'static')
+	-- LIMIT 1;
 
-        IF r_address IS NOT NULL THEN
-                UPDATE dhcpippool
-                SET
-                        gatewayipaddress = v_gatewayipaddress,
-                        pool_key = v_pool_key,
-                        expiry_time = NOW() + INTERVAL v_lease_duration SECOND
-                WHERE
-                        framedipaddress = r_address;
-                SELECT r_address;
-                LEAVE proc;
-        END IF;
+	IF r_address IS NOT NULL THEN
+		UPDATE dhcpippool
+		SET
+			gatewayipaddress = v_gatewayipaddress,
+			pool_key = v_pool_key,
+			expiry_time = NOW() + INTERVAL v_lease_duration SECOND
+		WHERE
+			framedipaddress = r_address;
+		SELECT r_address;
+		LEAVE proc;
+	END IF;
 
-        REPEAT
+	REPEAT
 
-                -- If we didn't reallocate a previous address then pick the least
-                -- recently used address from the pool which maximises the likelihood
-                -- of re-assigning the other addresses to their recent user
-                --
-                SELECT framedipaddress INTO r_address
-                FROM dhcpippool
-                WHERE pool_name = v_pool_name
-                        AND expiry_time < NOW()
-                --
-                -- WHERE ... GET_LOCK(...,0) = 1 is a poor man's SKIP LOCKED that simulates
-                -- a row-level lock using a "user lock" that allows the locked "rows" to be
-                -- skipped. After the user lock is acquired and the SELECT retired it does
-                -- not mean that the entirety of the WHERE clause is still true: Another
-                -- thread may have updated the expiry time and released the lock after we
-                -- checked the expiry_time but before we acquired the lock since SQL is free
-                -- to reorder the WHERE condition. Therefore we must recheck the condition
-                -- in the UPDATE statement below to detect this race.
-                --
-                        AND GET_LOCK(CONCAT('dhcpippool_', framedipaddress), 0) = 1
-                LIMIT 1;
+		-- If we didn't reallocate a previous address then pick the least
+		-- recently used address from the pool which maximises the likelihood
+		-- of re-assigning the other addresses to their recent user
+		--
+		SELECT framedipaddress INTO r_address
+		FROM dhcpippool
+		WHERE pool_name = v_pool_name
+			AND expiry_time < NOW()
+			AND `status` = 'dynamic'
+		--
+		-- WHERE ... GET_LOCK(...,0) = 1 is a poor man's SKIP LOCKED that simulates
+		-- a row-level lock using a "user lock" that allows the locked "rows" to be
+		-- skipped. After the user lock is acquired and the SELECT retired it does
+		-- not mean that the entirety of the WHERE clause is still true: Another
+		-- thread may have updated the expiry time and released the lock after we
+		-- checked the expiry_time but before we acquired the lock since SQL is free
+		-- to reorder the WHERE condition. Therefore we must recheck the condition
+		-- in the UPDATE statement below to detect this race.
+		--
+			AND GET_LOCK(CONCAT('dhcpippool_', framedipaddress), 0) = 1
+		LIMIT 1;
 
-                IF r_address IS NULL THEN
-                        DO RELEASE_LOCK(CONCAT('dhcpippool_', r_address));
-                        LEAVE proc;
-                END IF;
+		IF r_address IS NULL THEN
+			DO RELEASE_LOCK(CONCAT('dhcpippool_', r_address));
+			LEAVE proc;
+		END IF;
 
-                UPDATE dhcpippool
-                SET
-                        gatewayipaddress = v_gatewayipaddress,
-                        pool_key = v_pool_key,
-                        expiry_time = NOW() + INTERVAL v_lease_duration SECOND
-                WHERE
-                        framedipaddress = r_address
-                --
-                -- Here we re-evaluate the original condition for selecting the address
-                -- to detect a race, in which case we try again...
-                --
-                        AND expiry_time<NOW();
+		UPDATE dhcpippool
+		SET
+			gatewayipaddress = v_gatewayipaddress,
+			pool_key = v_pool_key,
+			expiry_time = NOW() + INTERVAL v_lease_duration SECOND
+		WHERE
+			framedipaddress = r_address
+		--
+		-- Here we re-evaluate the original condition for selecting the address
+		-- to detect a race, in which case we try again...
+		--
+			AND expiry_time<NOW();
 
-        UNTIL ROW_COUNT() <> 0 END REPEAT;
+	UNTIL ROW_COUNT() <> 0 END REPEAT;
 
-        DO RELEASE_LOCK(CONCAT('dhcpippool_', r_address));
-        SELECT r_address;
+	DO RELEASE_LOCK(CONCAT('dhcpippool_', r_address));
+	SELECT r_address;
 
 END$$
 

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/procedure.sql
@@ -31,88 +31,91 @@ DELIMITER $$
 
 DROP PROCEDURE IF EXISTS fr_dhcp_allocate_previous_or_new_framedipaddress;
 CREATE PROCEDURE fr_dhcp_allocate_previous_or_new_framedipaddress (
-        IN v_pool_name VARCHAR(30),
-        IN v_gatewayipaddress VARCHAR(15),
-        IN v_pool_key VARCHAR(30),
-        IN v_lease_duration INT
+	IN v_pool_name VARCHAR(30),
+	IN v_gatewayipaddress VARCHAR(15),
+	IN v_pool_key VARCHAR(30),
+	IN v_lease_duration INT
 )
 proc:BEGIN
-        DECLARE r_address VARCHAR(15);
+	DECLARE r_address VARCHAR(15);
 
-        SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+	SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
 
-        START TRANSACTION;
+	START TRANSACTION;
 
-        -- Reissue an existing IP address lease when re-authenticating a session
-        --
-        SELECT framedipaddress INTO r_address
-        FROM dhcpippool
-        WHERE pool_name = v_pool_name
-                AND expiry_time > NOW()
-                AND pool_key = v_pool_key
-        LIMIT 1
-        FOR UPDATE;
+	-- Reissue an existing IP address lease when re-authenticating a session
+	--
+	SELECT framedipaddress INTO r_address
+	FROM dhcpippool
+	WHERE pool_name = v_pool_name
+		AND expiry_time > NOW()
+		AND pool_key = v_pool_key
+		AND `status` IN ('dynamic', 'static')
+	LIMIT 1
+	FOR UPDATE;
 --      FOR UPDATE SKIP LOCKED;  -- Better performance, but limited support
 
-        -- NOTE: You should enable SKIP LOCKED here (as well as any other
-        --       instances) if your database server supports it. If it is not
-        --       supported and you are not running a multi-master cluster (e.g.
-        --       Galera or MaxScale) then you should instead consider using the
-        --       SP in procedure-no-skip-locked.sql which will be faster and
-        --       less likely to result in thread starvation under highly
-        --       concurrent load.
+	-- NOTE: You should enable SKIP LOCKED here (as well as any other
+	--       instances) if your database server supports it. If it is not
+	--       supported and you are not running a multi-master cluster (e.g.
+	--       Galera or MaxScale) then you should instead consider using the
+	--       SP in procedure-no-skip-locked.sql which will be faster and
+	--       less likely to result in thread starvation under highly
+	--       concurrent load.
 
-        -- Reissue an user's previous IP address, provided that the lease is
-        -- available (i.e. enable sticky IPs)
-        --
-        -- When using this SELECT you should delete the one above. You must also
-        -- set allocate_clear = "" in queries.conf to persist the associations
-        -- for expired leases.
-        --
-        -- SELECT framedipaddress INTO r_address
-        -- FROM dhcpippool
-        -- WHERE pool_name = v_pool_name
-        --         AND pool_key = v_pool_key
-        -- LIMIT 1
-        -- FOR UPDATE;
-        -- -- FOR UPDATE SKIP LOCKED;  -- Better performance, but limited support
+	-- Reissue an user's previous IP address, provided that the lease is
+	-- available (i.e. enable sticky IPs)
+	--
+	-- When using this SELECT you should delete the one above. You must also
+	-- set allocate_clear = "" in queries.conf to persist the associations
+	-- for expired leases.
+	--
+	-- SELECT framedipaddress INTO r_address
+	-- FROM dhcpippool
+	-- WHERE pool_name = v_pool_name
+	--	AND pool_key = v_pool_key
+	--	AND `status` IN ('dynamic', 'static')
+	-- LIMIT 1
+	-- FOR UPDATE;
+	-- -- FOR UPDATE SKIP LOCKED;  -- Better performance, but limited support
 
-        -- If we didn't reallocate a previous address then pick the least
-        -- recently used address from the pool which maximises the likelihood
-        -- of re-assigning the other addresses to their recent user
-        --
-        IF r_address IS NULL THEN
-                SELECT framedipaddress INTO r_address
-                FROM dhcpippool
-                WHERE pool_name = v_pool_name
-                        AND expiry_time < NOW()
-                ORDER BY
-                        expiry_time
-                LIMIT 1
-                FOR UPDATE;
---              FOR UPDATE SKIP LOCKED;  -- Better performance, but limited support
-        END IF;
+	-- If we didn't reallocate a previous address then pick the least
+	-- recently used address from the pool which maximises the likelihood
+	-- of re-assigning the other addresses to their recent user
+	--
+	IF r_address IS NULL THEN
+		SELECT framedipaddress INTO r_address
+		FROM dhcpippool
+		WHERE pool_name = v_pool_name
+			AND expiry_time < NOW()
+			AND `status` = 'dynamic'
+		ORDER BY
+			expiry_time
+		LIMIT 1
+		FOR UPDATE;
+--	      FOR UPDATE SKIP LOCKED;  -- Better performance, but limited support
+	END IF;
 
-        -- Return nothing if we failed to allocated an address
-        --
-        IF r_address IS NULL THEN
-                COMMIT;
-                LEAVE proc;
-        END IF;
+	-- Return nothing if we failed to allocated an address
+	--
+	IF r_address IS NULL THEN
+		COMMIT;
+		LEAVE proc;
+	END IF;
 
-        -- Update the pool having allocated an IP address
-        --
-        UPDATE dhcpippool
-        SET
-                gatewayipaddress = v_gatewayipaddress,
-                pool_key = v_pool_key,
-                expiry_time = NOW() + INTERVAL v_lease_duration SECOND
-        WHERE framedipaddress = r_address;
+	-- Update the pool having allocated an IP address
+	--
+	UPDATE dhcpippool
+	SET
+		gatewayipaddress = v_gatewayipaddress,
+		pool_key = v_pool_key,
+		expiry_time = NOW() + INTERVAL v_lease_duration SECOND
+	WHERE framedipaddress = r_address;
 
-        COMMIT;
+	COMMIT;
 
-        -- Return the address that we allocated
-        SELECT r_address;
+	-- Return the address that we allocated
+	SELECT r_address;
 
 END$$
 

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -14,12 +14,12 @@
 #  If using MySQL < 8.0.1 then remove SKIP LOCKED
 
 allocate_find = "\
-	(SELECT framedipaddress, pool_key, expiry_time FROM radippool \
+	(SELECT framedipaddress, pool_key, expiry_time FROM ${ippool_table} \
 		WHERE pool_name = '%{control:${pool_name}}' \
 		AND pool_key = '${pool_key}' \
 		ORDER BY expiry_time DESC LIMIT 1 FOR UPDATE SKIP LOCKED \
 	) UNION ( \
-	SELECT framedipaddress, pool_key, expiry_time FROM radippool \
+	SELECT framedipaddress, pool_key, expiry_time FROM ${ippool_table} \
 		WHERE pool_name = '%{control:${pool_name}}' \
 		AND expiry_time < NOW() \
 		ORDER BY expiry_time LIMIT 1 FOR UPDATE SKIP LOCKED \
@@ -70,7 +70,7 @@ pool_check = "\
 allocate_update = "\
 	UPDATE ${ippool_table} \
 	SET \
-		nasipaddress = '%{DHCP-Gateway-IP-Address}', pool_key = '${pool_key}', \
+		gatewayipaddress = '%{DHCP-Gateway-IP-Address}', pool_key = '${pool_key}', \
 		expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
 	WHERE framedipaddress = '%I'"
 
@@ -80,10 +80,8 @@ allocate_update = "\
 #
 #allocate_begin = ""
 #allocate_find = "\
-#	CALL fr_allocate_previous_or_new_framedipaddress( \
+#	CALL fr_dhcp_allocate_previous_or_new_framedipaddress( \
 #		'%{control:${pool_name}}', \
-#		'', \
-#		'', \
 #		'%{DHCP-Gateway-IP-Address}', \
 #		'${pool_key}', \
 #		${lease_duration} \
@@ -104,7 +102,7 @@ start_update = ""
 stop_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
-		nasipaddress = '', \
+		gatewayipaddress = '', \
 		pool_key = '0', \
 		expiry_time = NOW() \
 	WHERE pool_name = '%{control:${pool_name}}' \

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -17,11 +17,13 @@ allocate_find = "\
 	(SELECT framedipaddress, pool_key, expiry_time FROM ${ippool_table} \
 		WHERE pool_name = '%{control:${pool_name}}' \
 		AND pool_key = '${pool_key}' \
+		AND `status` IN ('dynamic', 'static') \
 		ORDER BY expiry_time DESC LIMIT 1 FOR UPDATE SKIP LOCKED \
 	) UNION ( \
 	SELECT framedipaddress, pool_key, expiry_time FROM ${ippool_table} \
 		WHERE pool_name = '%{control:${pool_name}}' \
 		AND expiry_time < NOW() \
+		AND `status` = 'dynamic' \
 		ORDER BY expiry_time LIMIT 1 FOR UPDATE SKIP LOCKED \
 	) ORDER BY (pool_key <> '${pool_key}'), expiry_time \
 	LIMIT 1"
@@ -34,6 +36,7 @@ allocate_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} \
 #	WHERE pool_name = '%{control:${pool_name}}' \
 #	AND expiry_time < NOW() \
+#	AND `status` = 'dynamic' \
 #	ORDER BY \
 #		RAND() \
 #	LIMIT 1 \
@@ -47,6 +50,7 @@ allocate_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} \
 #	WHERE pool_name = '%{control:${pool_name}}' \
 #	AND expiry_time < NOW() \
+#	AND `status` = 'dynamic' \
 #	ORDER BY \
 #		RAND() \
 #	LIMIT 1 \

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/schema.sql
@@ -5,13 +5,14 @@
 -- that is much faster.
 --
 
-CREATE TABLE radippool (
-  id                    int(11) unsigned NOT NULL auto_increment,
+CREATE TABLE dhcpippool (
+  id                    int unsigned NOT NULL auto_increment,
   pool_name             varchar(30) NOT NULL,
   framedipaddress       varchar(15) NOT NULL default '',
   pool_key              varchar(30) NOT NULL default '',
   gatewayipaddress      varchar(15) NOT NULL default '',
   expiry_time           DATETIME NOT NULL default NOW(),
+  `status`		ENUM('dynamic', 'static', 'declined', 'disabled') DEFAULT 'dynamic',
   PRIMARY KEY (id),
   KEY dhcpippool_poolname_expire (pool_name, expiry_time),
   KEY framedipaddress (framedipaddress),

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/schema.sql
@@ -1,5 +1,5 @@
 --
--- Table structure for table 'radippool'
+-- Table structure for table 'dhcpippool'
 --
 -- See also "procedure.sql" in this directory for a stored procedure
 -- that is much faster.
@@ -9,14 +9,11 @@ CREATE TABLE radippool (
   id                    int(11) unsigned NOT NULL auto_increment,
   pool_name             varchar(30) NOT NULL,
   framedipaddress       varchar(15) NOT NULL default '',
-  nasipaddress          varchar(15) NOT NULL default '',
-  calledstationid       VARCHAR(30) NOT NULL default '',
-  callingstationid      VARCHAR(30) NOT NULL default '',
-  expiry_time           DATETIME NOT NULL default NOW(),
-  username              varchar(64) NOT NULL default '',
   pool_key              varchar(30) NOT NULL default '',
+  gatewayipaddress      varchar(15) NOT NULL default '',
+  expiry_time           DATETIME NOT NULL default NOW(),
   PRIMARY KEY (id),
-  KEY radippool_poolname_expire (pool_name, expiry_time),
+  KEY dhcpippool_poolname_expire (pool_name, expiry_time),
   KEY framedipaddress (framedipaddress),
-  KEY radippool_poolname_poolkey_ipaddress (pool_name, pool_key, framedipaddress)
+  KEY dhcpippool_poolname_poolkey_ipaddress (pool_name, pool_key, framedipaddress)
 ) ENGINE=InnoDB;

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/procedure.sql
@@ -17,98 +17,110 @@
 --
 -- allocate_begin = ""
 -- allocate_find = "\
---         SELECT fr_dhcp_allocate_previous_or_new_framedipaddress( \
---                 '%{control:${pool_name}}', \
---                 '%{DHCP-Gateway-IP-Address}', \
---                 '${pool_key}', \
---                 ${lease_duration} \
---         ) FROM dual"
+--	SELECT fr_dhcp_allocate_previous_or_new_framedipaddress( \
+--		'%{control:${pool_name}}', \
+--		'%{DHCP-Gateway-IP-Address}', \
+--		'${pool_key}', \
+--		${lease_duration} \
+--	) FROM dual"
 -- allocate_update = ""
 -- allocate_commit = ""
 --
 
 CREATE OR REPLACE FUNCTION fr_dhcp_allocate_previous_or_new_framedipaddress (
-        v_pool_name IN VARCHAR2,
-        v_gatewayipaddress IN VARCHAR2,
-        v_pool_key IN VARCHAR2,
-        v_lease_duration IN INTEGER
+	v_pool_name IN VARCHAR2,
+	v_gatewayipaddress IN VARCHAR2,
+	v_pool_key IN VARCHAR2,
+	v_lease_duration IN INTEGER
 )
 RETURN varchar2 IS
-        PRAGMA AUTONOMOUS_TRANSACTION;
-        r_address varchar2(15);
+	PRAGMA AUTONOMOUS_TRANSACTION;
+	r_address varchar2(15);
 BEGIN
 
-        -- Reissue an existing IP address lease when re-authenticating a session
-        --
-          BEGIN
-                SELECT framedipaddress INTO r_address FROM dhcpippool WHERE id IN (
-                        SELECT id FROM (
-                                SELECT *
-                                FROM dhcpippool
-                                WHERE pool_name = v_pool_name
-                                        AND expiry_time > current_timestamp
-                                        AND pool_key = v_pool_key
-                        ) WHERE ROWNUM <= 1
-                ) FOR UPDATE SKIP LOCKED;
-          EXCEPTION
-                    WHEN NO_DATA_FOUND THEN
-                        r_address := NULL;
-          END;
+	-- Reissue an existing IP address lease when re-authenticating a session
+	--
+	BEGIN
+		SELECT framedipaddress INTO r_address FROM dhcpippool WHERE id IN (
+			SELECT id FROM (
+				SELECT *
+				FROM dhcpippool
+				JOIN dhcpstatus
+				ON dhcpstatus.status_id = dhcpippool.status_id
+				WHERE pool_name = v_pool_name
+					AND expiry_time > current_timestamp
+					AND pool_key = v_pool_key
+					AND dhcpstatus.status IN ('dynamic', 'static')
+			) WHERE ROWNUM <= 1
+		) FOR UPDATE SKIP LOCKED;
+	EXCEPTION
+		WHEN NO_DATA_FOUND THEN
+			r_address := NULL;
+	END;
 
-        -- Oracle >= 12c version of the above query
-        --
-        -- BEGIN
-        --       SELECT framedipaddress INTO r_address FROM dhcpippool WHERE id IN (
-        --               SELECT id FROM dhcpippool
-        --               WHERE pool_name = v_pool_name
-        --                       AND expiry_time > current_timestamp
-        --                       AND pool_key = v_pool_key
-        --               FETCH FIRST 1 ROWS ONLY
-        --       ) FOR UPDATE SKIP LOCKED;
-        -- EXCEPTION
-        --           WHEN NO_DATA_FOUND THEN
-        --               r_address := NULL;
-        -- END;
+	-- Oracle >= 12c version of the above query
+	--
+	-- BEGIN
+	--	SELECT framedipaddress INTO r_address FROM dhcpippool WHERE id IN (
+	--		SELECT id FROM dhcpippool
+	--		JOIN dhcpstatus
+	--		ON dhcpstatus.status_id = dhcpippool.status_id
+	--		WHERE pool_name = v_pool_name
+	--			AND expiry_time > current_timestamp
+	--			AND pool_key = v_pool_key
+	--			AND dhcpstatus.status IN ('dynamic', 'static')
+	--		FETCH FIRST 1 ROWS ONLY
+	--	) FOR UPDATE SKIP LOCKED;
+	-- EXCEPTION
+	--	WHEN NO_DATA_FOUND THEN
+	--		r_address := NULL;
+	-- END;
 
-        -- Reissue an user's previous IP address, provided that the lease is
-        -- available (i.e. enable sticky IPs)
-        --
-        -- When using this SELECT you should delete the one above. You must also
-        -- set allocate_clear = "" in queries.conf to persist the associations
-        -- for expired leases.
-        --
-        -- BEGIN
-        --         SELECT framedipaddress INTO r_address FROM dhcpippool WHERE id IN (
-        --                 SELECT id FROM (
-        --                         SELECT *
-        --                         FROM dhcpippool
-        --                         WHERE pool_name = v_pool_name
-        --                                 AND pool_key = v_pool_key
-        --                 ) WHERE ROWNUM <= 1
-        --         ) FOR UPDATE SKIP LOCKED;
-        -- EXCEPTION
-        --         WHEN NO_DATA_FOUND THEN
-        --              r_address := NULL;
-        -- END;
+	-- Reissue an user's previous IP address, provided that the lease is
+	-- available (i.e. enable sticky IPs)
+	--
+	-- When using this SELECT you should delete the one above. You must also
+	-- set allocate_clear = "" in queries.conf to persist the associations
+	-- for expired leases.
+	--
+	-- BEGIN
+	--	SELECT framedipaddress INTO r_address FROM dhcpippool WHERE id IN (
+	--		SELECT id FROM (
+	--			SELECT *
+	--			FROM dhcpippool
+	--			JOIN dhcpstatus
+	--			ON dhcpstatus.status_id = dhcpippool.status_id
+	--			WHERE pool_name = v_pool_name
+	--				AND pool_key = v_pool_key
+	--				AND dhcpstatus.status IN ('dynamic', 'static')
+	--			) WHERE ROWNUM <= 1
+	--	) FOR UPDATE SKIP LOCKED;
+	-- EXCEPTION
+	--	WHEN NO_DATA_FOUND THEN
+	--		r_address := NULL;
+	-- END;
 
-        -- Oracle >= 12c version of the above query
-        --
-        -- BEGIN
-        --       SELECT framedipaddress INTO r_address FROM dhcpippool WHERE id IN (
-        --               SELECT id FROM dhcpippool
-        --               WHERE pool_name = v_pool_name
-        --                       AND pool_key = v_pool_key
-        --               FETCH FIRST 1 ROWS ONLY
-        --       ) FOR UPDATE SKIP LOCKED;
-        -- EXCEPTION
-        --           WHEN NO_DATA_FOUND THEN
-        --               r_address := NULL;
-        -- END;
+	-- Oracle >= 12c version of the above query
+	--
+	-- BEGIN
+	--	SELECT framedipaddress INTO r_address FROM dhcpippool WHERE id IN (
+	--		SELECT id FROM dhcpippool
+	--		JOIN dhcpstatus
+	--		ON dhcpstatus.status_id = dhcpippool.status_id
+	--		WHERE pool_name = v_pool_name
+	--			AND pool_key = v_pool_key
+	--			AND dhcpstatus.status IN ('dynamic', 'static')
+	--	       FETCH FIRST 1 ROWS ONLY
+	--       ) FOR UPDATE SKIP LOCKED;
+	-- EXCEPTION
+	--	   WHEN NO_DATA_FOUND THEN
+	--	       r_address := NULL;
+	-- END;
 
-        -- If we didn't reallocate a previous address then pick the least
-        -- recently used address from the pool which maximises the likelihood
-        -- of re-assigning the other addresses to their recent user
-        --
+	-- If we didn't reallocate a previous address then pick the least
+	-- recently used address from the pool which maximises the likelihood
+	-- of re-assigning the other addresses to their recent user
+	--
 
 	IF r_address IS NULL THEN
 		DECLARE
@@ -117,8 +129,11 @@ BEGIN
 			OPEN l_cursor FOR
 				SELECT framedipaddress
 				FROM dhcpippool
+				JOIN dhcpstatus
+				ON dhcpstatus.status_id = dhcpippool.status_id
 				WHERE pool_name = v_pool_name
 				AND expiry_time < CURRENT_TIMESTAMP
+				AND dhcpstatus.status = 'dynamic'
 				ORDER BY expiry_time
 				FOR UPDATE SKIP LOCKED;
 			FETCH l_cursor INTO r_address;
@@ -130,25 +145,25 @@ BEGIN
 	END IF;
 	
 
-        -- Return nothing if we failed to allocated an address
-        --
-        IF r_address IS NULL THEN
-                COMMIT;
-                RETURN r_address;
-        END IF;
+	-- Return nothing if we failed to allocated an address
+	--
+	IF r_address IS NULL THEN
+		COMMIT;
+		RETURN r_address;
+	END IF;
 
-        -- Update the pool having allocated an IP address
-        --
-        UPDATE dhcpippool
-        SET
-                gatewayipaddress = v_gatewayipaddress,
-                pool_key = v_pool_key,
-                expiry_time = CURRENT_TIMESTAMP + v_lease_duration * INTERVAL '1' SECOND(1)
-        WHERE framedipaddress = r_address;
+	-- Update the pool having allocated an IP address
+	--
+	UPDATE dhcpippool
+	SET
+		gatewayipaddress = v_gatewayipaddress,
+		pool_key = v_pool_key,
+		expiry_time = CURRENT_TIMESTAMP + v_lease_duration * INTERVAL '1' SECOND(1)
+	WHERE framedipaddress = r_address;
 
-        -- Return the address that we allocated
-        COMMIT;
-        RETURN r_address;
+	-- Return the address that we allocated
+	COMMIT;
+	RETURN r_address;
 
 END;
 

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -38,8 +38,11 @@ allocate_commit = ""
 #		SELECT id FROM ( \
 #			SELECT * \
 #			FROM ${ippool_table} \
+#			JOIN dhcpstatus \
+#			ON ${ippool_table}.status_id = dhcpstatus.status_id \
 #			WHERE pool_name = '%{control:${pool_name}}' \
 #			AND expiry_time < current_timestamp \
+#			AND dhcpstatus.status = 'dynamic' \
 #			ORDER BY DBMS_RANDOM.VALUE \
 #		) WHERE ROWNUM <= 1 \
 #	) FOR UPDATE"
@@ -53,8 +56,11 @@ allocate_commit = ""
 #		SELECT id FROM (\
 #			SELECT * \
 #			FROM ${ippool_table} \
+#			JOIN dhcpstatus \
+#			ON ${ippool_table}.status_id = dhcpstatus.status_id \
 #			WHERE pool_name = '%{control:${pool_name}}' \
 #			AND expiry_time < current_timestamp \
+#			AND dhcpstatus.status = 'dynamic' \
 #			ORDER BY DBMS_RANDOM.VALUE \
 #		) WHERE ROWNUM <= 1 \
 #	) FOR UPDATE SKIP LOCKED"
@@ -65,11 +71,14 @@ allocate_commit = ""
 #allocate_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} WHERE id IN (
 #		SELECT id FROM ${ippool_table} \
+#		JOIN dhcpstatus \
+#		ON ${ippool_table}.status_id = dhcpstatus.status_id \
 #		WHERE pool_name = '%{control:${pool_name}}' \
 #		AND expiry_time < current_timestamp \
+#		AND dhcpstatus.status = 'dynamic' \
 #		ORDER BY DBMS_RANDOM.VALUE \
 #		FETCH FIRST 1 ROWS ONLY
-#	) FROM UPDATE SKIP LOCKED"
+#	) FOR UPDATE SKIP LOCKED"
 
 #
 #  If an IP could not be allocated, check to see whether the pool exists or not

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -19,10 +19,8 @@ off_begin = "commit"
 #
 allocate_begin = ""
 allocate_find = "\
-	SELECT fr_allocate_previous_or_new_framedipaddress( \
+	SELECT fr_dhcp_allocate_previous_or_new_framedipaddress( \
 		'%{control:${pool_name}}', \
-		'', \
-		'', \
 		'%{DHCP-Gateway-IP-Address}', \
 		'${pool_key}', \
 		'${lease_duration}' \
@@ -95,7 +93,7 @@ pool_check = "\
 allocate_update = "\
 	UPDATE ${ippool_table} \
 	SET \
-		nasipaddress = '%{DHCP-Gateway-IP-Address}', \
+		gatewayipaddress = '%{DHCP-Gateway-IP-Address}', \
 		pool_key = '${pool_key}', \
 		expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
 	WHERE framedipaddress = '%I'"
@@ -113,7 +111,7 @@ start_update = ""
 stop_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
-		nasipaddress = '', \
+		gatewayipaddress = '', \
 		pool_key = '0', \
 		expiry_time = current_timestamp - INTERVAL '1' second(1) \
 	WHERE pool_name = '%{control:${pool_name}}' \

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/schema.sql
@@ -1,18 +1,15 @@
-CREATE SEQUENCE radippool_seq START WITH 1 INCREMENT BY 1;
+CREATE SEQUENCE dhcpippool_seq START WITH 1 INCREMENT BY 1;
 
-CREATE TABLE radippool (
-	id                      INT DEFAULT ON NULL radippool_seq.NEXTVAL PRIMARY KEY,
+CREATE TABLE dhcpippool (
+	id                      INT DEFAULT ON NULL dhcpippool_seq.NEXTVAL PRIMARY KEY,
 	pool_name               VARCHAR(30) NOT NULL,
 	framedipaddress         VARCHAR(15) NOT NULL,
-	nasipaddress            VARCHAR(15) DEFAULT '',
 	pool_key                VARCHAR(30) DEFAULT '',
-	CalledStationId         VARCHAR(64) DEFAULT '',
-	CallingStationId        VARCHAR(64) DEFAULT '',
-	expiry_time             timestamp(0) DEFAULT CURRENT_TIMESTAMP,
-	username                VARCHAR(64) DEFAULT ''
+	gatewayipaddress        VARCHAR(15) DEFAULT '',
+	expiry_time             timestamp(0) DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE INDEX radippool_poolname_expire ON radippool (pool_name, expiry_time);
-CREATE INDEX radippool_framedipaddress ON radippool (framedipaddress);
-CREATE INDEX radippool_poolname_poolkey_ipaddress ON radippool (pool_name, pool_key, framedipaddress);
+CREATE INDEX dhcpippool_poolname_expire ON dhcpippool (pool_name, expiry_time);
+CREATE INDEX dhcpippool_framedipaddress ON dhcpippool (framedipaddress);
+CREATE INDEX dhcpippool_poolname_poolkey_ipaddress ON dhcpippool (pool_name, pool_key, framedipaddress);
 

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/schema.sql
@@ -1,3 +1,13 @@
+CREATE TABLE dhcpstatus (
+	status_id		INT PRIMARY KEY,
+	status			VARCHAR(10) NOT NULL
+);
+
+INSERT INTO dhcpstatus (status_id, status) VALUES (1, 'dynamic');
+INSERT INTO dhcpstatus (status_id, status) VALUES (2, 'static');
+INSERT INTO dhcpstatus (status_id, status) VALUES (3, 'declined');
+INSERT INTO dhcpstatus (status_id, status) VALUES (4, 'disabled');
+
 CREATE SEQUENCE dhcpippool_seq START WITH 1 INCREMENT BY 1;
 
 CREATE TABLE dhcpippool (
@@ -6,7 +16,9 @@ CREATE TABLE dhcpippool (
 	framedipaddress         VARCHAR(15) NOT NULL,
 	pool_key                VARCHAR(30) DEFAULT '',
 	gatewayipaddress        VARCHAR(15) DEFAULT '',
-	expiry_time             timestamp(0) DEFAULT CURRENT_TIMESTAMP
+	expiry_time             timestamp(0) DEFAULT CURRENT_TIMESTAMP,
+	status_id		INT DEFAULT 1,
+	FOREIGN KEY (status_id) REFERENCES dhcpstatus(status_id)
 );
 
 CREATE INDEX dhcpippool_poolname_expire ON dhcpippool (pool_name, expiry_time);

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/procedure.sql
@@ -47,6 +47,7 @@ BEGIN
 		WHERE pool_name = v_pool_name
 			AND pool_key = v_pool_key
 			AND expiry_time > NOW()
+			AND status IN ('dynamic', 'static')
 		LIMIT 1 FOR UPDATE SKIP LOCKED )
 	UPDATE dhcpippool
 	SET expiry_time = NOW() + v_lease_duration * interval '1 sec'
@@ -64,6 +65,7 @@ BEGIN
 	--	SELECT framedipaddress FROM dhcpippool
 	--	WHERE pool_name = v_pool_name
 	--		AND pool_key = v_pool_key
+	--		AND status IN ('dynamic', 'static')
 	--	LIMIT 1 FOR UPDATE SKIP LOCKED )
 	-- UPDATE dhcpippool
 	-- SET expiry_time = NOW + v_lease_duration * interval '1 sec'
@@ -79,6 +81,7 @@ BEGIN
 			SELECT framedipaddress FROM dhcpippool
 			WHERE pool_name = v_pool_name
 				AND expiry_time < NOW()
+				AND status = 'dynamic'
 			ORDER BY expiry_time
 			LIMIT 1 FOR UPDATE SKIP LOCKED )
 		UPDATE dhcpippool

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -19,10 +19,8 @@
 allocate_begin = ""
 allocate_find = "\
 	/*NO LOAD BALANCE*/ \
-	SELECT fr_allocate_previous_or_new_framedipaddress( \
+	SELECT fr_dhcp_allocate_previous_or_new_framedipaddress( \
 		'%{control:${pool_name}}', \
-		'', \
-		'', \
 		'%{DHCP-Gateway-IP-Address}', \
 		'${pool_key}', \
 		'${lease_duration}' \
@@ -55,7 +53,7 @@ allocate_commit = ""
 #	UPDATE ${ippool_table} \
 #	SET pool_key = '${pool_key}', \
 #	expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval, \
-#	nasipaddress = '%{DHCP-Gateway-IP-Address}' \
+#	gatewayipaddress = '%{DHCP-Gateway-IP-Address}' \
 #	WHERE id IN ( \
 #		SELECT id \
 #		FROM ${ippool_table} \
@@ -108,7 +106,7 @@ allocate_commit = ""
 #allocate_update = "\
 #	UPDATE ${ippool_table} \
 #	SET \
-#		nasipaddress = '%{DHCP-Gateway-IP-Address}', \
+#		gatewayipaddress = '%{DHCP-Gateway-IP-Address}', \
 #		pool_key = '${pool_key}', \
 #		expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval \
 #	WHERE framedipaddress = '%I'"
@@ -138,7 +136,7 @@ start_update = ""
 stop_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
-		nasipaddress = '', \
+		gatewayipaddress = '', \
 		pool_key = 0, \
 		expiry_time = 'now'::timestamp(0) - '1 second'::interval \
 	WHERE pool_name = '%{control:${pool_name}}' \

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -64,12 +64,14 @@ allocate_commit = ""
 #					FROM ${ippool_table} \
 #					WHERE pool_name = '%{control:${pool_name}}' \
 #					AND expiry_time < 'now'::timestamp(0) \
+#					AND status = 'dynamic' \
 #					ORDER BY expiry_time LIMIT 1 \
 #				) UNION ( \
 #					SELECT id, pool_key, expiry_time \
 #					FROM ${ippool_table} \
 #					WHERE pool_name = '%{control:${pool_name}}' \
 #					AND pool_key = '${pool_key}' \
+#					AND status IN ('dynamic', 'static') \
 #				) \
 #			) AS iplist \
 #		) ORDER BY (pool_key <> '${pool_key}'), expiry_time \
@@ -85,6 +87,7 @@ allocate_commit = ""
 #allocate_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} \
 #	WHERE pool_name = '%{control:${pool_name}}' AND expiry_time < 'now'::timestamp(0) \
+#	AND status = 'dynamic' \
 #	ORDER BY RANDOM() \
 #	LIMIT 1 \
 #	FOR UPDATE"
@@ -95,6 +98,7 @@ allocate_commit = ""
 #allocate_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} \
 #	WHERE pool_name = '%{control:${pool_name}}' AND expiry_time < 'now'::timestamp(0) \
+#	AND status = 'dynamic' \
 #	ORDER BY RANDOM() \
 #	LIMIT 1 \
 #	FOR UPDATE SKIP LOCKED"

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/schema.sql
@@ -5,13 +5,16 @@
 -- a stored procedure that gives much faster response.
 --
 
+CREATE TYPE dhcp_status AS ENUM ('dynamic', 'static', 'declined', 'disabled');
+
 CREATE TABLE dhcpippool (
 	id			BIGSERIAL PRIMARY KEY,
 	pool_name		varchar(64) NOT NULL,
 	FramedIPAddress		INET NOT NULL,
 	pool_key		VARCHAR(64) NOT NULL default '0',
 	GatewayIPAddress	VARCHAR(16) NOT NULL default '',
-	expiry_time		TIMESTAMP(0) without time zone NOT NULL default NOW()
+	expiry_time		TIMESTAMP(0) without time zone NOT NULL default NOW(),
+	status			dhcp_status DEFAULT 'dynamic'
 );
 
 CREATE INDEX dhcpippool_poolname_expire ON dhcpippool USING btree (pool_name, expiry_time);

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/schema.sql
@@ -1,22 +1,19 @@
 --
--- Table structure for table 'radippool'
+-- Table structure for table 'dhcpippool'
 --
--- See also "procedure.sql" in this directory for additional
--- indices and a stored procedure that is much faster.
+-- See also "procedure.sql" in this directory for
+-- a stored procedure that gives much faster response.
 --
 
-CREATE TABLE radippool (
+CREATE TABLE dhcpippool (
 	id			BIGSERIAL PRIMARY KEY,
 	pool_name		varchar(64) NOT NULL,
 	FramedIPAddress		INET NOT NULL,
-	NASIPAddress		VARCHAR(16) NOT NULL default '',
-	pool_key		VARCHAR(64) NOT NULL default 0,
-	CalledStationId		VARCHAR(64),
-	CallingStationId	text NOT NULL default ''::text,
-	expiry_time		TIMESTAMP(0) without time zone NOT NULL default NOW(),
-	username		text DEFAULT ''::text
+	pool_key		VARCHAR(64) NOT NULL default '0',
+	GatewayIPAddress	VARCHAR(16) NOT NULL default '',
+	expiry_time		TIMESTAMP(0) without time zone NOT NULL default NOW()
 );
 
-CREATE INDEX radippool_poolname_expire ON radippool USING btree (pool_name, expiry_time);
-CREATE INDEX radippool_framedipaddress ON radippool USING btree (framedipaddress);
-CREATE INDEX radippool_poolname_poolkey_ipaddress ON radippool USING btree (pool_name, pool_key, framedipaddress);
+CREATE INDEX dhcpippool_poolname_expire ON dhcpippool USING btree (pool_name, expiry_time);
+CREATE INDEX dhcpippool_framedipaddress ON dhcpippool USING btree (framedipaddress);
+CREATE INDEX dhcpippool_poolname_poolkey_ipaddress ON dhcpippool USING btree (pool_name, pool_key, framedipaddress);

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -85,7 +85,7 @@ pool_check = "\
 allocate_update = "\
 	UPDATE ${ippool_table} \
 	SET \
-		nasipaddress = '%{DHCP-Gateway-IP-Address}', \
+		gatewayipaddress = '%{DHCP-Gateway-IP-Address}', \
 		pool_key = '${pool_key}', \
 		expiry_time = datetime(strftime('%%s', 'now') + ${lease_duration}, 'unixepoch') \
 	WHERE framedipaddress = '%I'"
@@ -103,7 +103,7 @@ start_update = ""
 stop_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
-		nasipaddress = '', \
+		gatewayipaddress = '', \
 		pool_key = 0, \
 		expiry_time = datetime('now') \
 	WHERE pool_name = '%{control:${pool_name}}' \

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -32,21 +32,27 @@ allocate_commit = "COMMIT"
 #  IP if it exists, otherwise an expired one.
 #
 allocate_find = "\
-	SELECT framedipaddress, pool_key, expiry_time \
+	SELECT framedipaddress, expiry_time \
 	FROM ( \
-		SELECT framedipaddress, pool_key, expiry_time \
+		SELECT framedipaddress, expiry_time \
 		FROM ${ippool_table} \
+		JOIN dhcpstatus \
+		ON ${ippool_table}.status_id = dhcpstatus.status_id \
 		WHERE pool_name = '%{control:${pool_name}}' \
 		AND pool_key = '${pool_key}' \
+		AND status IN ('dynamic', 'static') \
 		ORDER BY expiry_time DESC \
 		LIMIT 1 \
 	) UNION \
-	SELECT framedipaddress, pool_key, expiry_time \
+	SELECT framedipaddress, expiry_time \
 	FROM ( \
-		SELECT framedipaddress, pool_key, expiry_time \
+		SELECT framedipaddress, expiry_time \
 		FROM ${ippool_table} \
+		JOIN dhcpstatus \
+		ON ${ippool_table}.status_id = dhcpstatus.status_id \
 		WHERE pool_name = '%{control:${pool_name}}' \
 		AND expiry_time < datetime('now') \
+		AND status = 'dynamic' \
 		ORDER BY expiry_time LIMIT 1 \
 	) \
 	ORDER BY \
@@ -62,8 +68,11 @@ allocate_find = "\
 #allocate_find = "\
 #	SELECT framedipaddress \
 #	FROM ${ippool_table} \
+#	JOIN dhcpstatus \
+#	ON ${ippool_table}.status_id = dhcpstatus.status_id \
 # 	WHERE pool_name = '%{control:${pool_name}}' \
 #	AND expiry_time < datetime('now') \
+#	AND status = 'dynamic' \
 #	ORDER BY RAND() \
 
 

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
@@ -1,13 +1,22 @@
 --
 -- Table structure for table 'dhcpippool'
 --
+CREATE TABLE dhcpstatus (
+  status_id             int PRIMARY KEY,
+  status		varchar(10) NOT NULL
+)
+
+INSERT INTO dhcpstatus (status_id, status) VALUES (1, 'dynamic'), (2, 'static'), (3, 'declined'), (4, 'disabled');
+
 CREATE TABLE dhcpippool (
   id                    int(11) PRIMARY KEY,
   pool_name             varchar(30) NOT NULL,
   framedipaddress       varchar(15) NOT NULL default '',
   pool_key              varchar(30) NOT NULL default '',
   gatewayipaddress      varchar(15) NOT NULL default '',
-  expiry_time           DATETIME NOT NULL default (DATETIME('now'))
+  expiry_time           DATETIME NOT NULL default (DATETIME('now')),
+  status_id		int NOT NULL default 1,
+  FOREIGN KEY(status_id) REFERENCES dhcpstatus(status_id)
 );
 
 CREATE INDEX dhcpippool_poolname_expire ON dhcpippool(pool_name, expiry_time);

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
@@ -1,18 +1,15 @@
 --
--- Table structure for table 'radippool'
+-- Table structure for table 'dhcpippool'
 --
-CREATE TABLE radippool (
+CREATE TABLE dhcpippool (
   id                    int(11) PRIMARY KEY,
   pool_name             varchar(30) NOT NULL,
   framedipaddress       varchar(15) NOT NULL default '',
-  nasipaddress          varchar(15) NOT NULL default '',
-  calledstationid       VARCHAR(30) NOT NULL default '',
-  callingstationid      VARCHAR(30) NOT NULL default '',
-  expiry_time           DATETIME NOT NULL default (DATETIME('now')),
-  username              varchar(64) NOT NULL default '',
-  pool_key              varchar(30) NOT NULL default ''
+  pool_key              varchar(30) NOT NULL default '',
+  gatewayipaddress      varchar(15) NOT NULL default '',
+  expiry_time           DATETIME NOT NULL default (DATETIME('now'))
 );
 
-CREATE INDEX radippool_poolname_expire ON radippool(pool_name, expiry_time);
-CREATE INDEX radippool_framedipaddress ON radippool(framedipaddress);
-CREATE INDEX radippool_nasip_poolkey_ipaddress ON radippool(pool_name, pool_key, framedipaddress);
+CREATE INDEX dhcpippool_poolname_expire ON dhcpippool(pool_name, expiry_time);
+CREATE INDEX dhcpippool_framedipaddress ON dhcpippool(framedipaddress);
+CREATE INDEX dhcpippool_nasip_poolkey_ipaddress ON dhcpippool(pool_name, pool_key, framedipaddress);

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
@@ -12,4 +12,4 @@ CREATE TABLE dhcpippool (
 
 CREATE INDEX dhcpippool_poolname_expire ON dhcpippool(pool_name, expiry_time);
 CREATE INDEX dhcpippool_framedipaddress ON dhcpippool(framedipaddress);
-CREATE INDEX dhcpippool_nasip_poolkey_ipaddress ON dhcpippool(pool_name, pool_key, framedipaddress);
+CREATE INDEX dhcpippool_poolname_poolkey_ipaddress ON dhcpippool(pool_name, pool_key, framedipaddress);


### PR DESCRIPTION
The status field enables IPs in the pool to be marked as dynamic, static, declined or disabled to allow for managing static IPs within the pool and handling DHCP-Decline packets
