### PR TITLE
Add allocate_existing query

### DIFF
--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -4,38 +4,84 @@
 #
 #  $Id$
 
-# MSSQL-specific syntax
-allocate_begin = "BEGIN TRAN"
-allocate_commit = "COMMIT TRAN"
-
 #
 #  This series of queries allocates an IP address
+#
+
+#
+#  MSSQL-specific syntax - required if finding the address and updating
+#  it are separate queries
+#
+#allocate_begin = "BEGIN TRAN"
+#allocate_commit = "COMMIT TRAN"
+
+allocate_begin = ""
+allocate_commit = ""
+
+#
+#  Attempt to find the most recent existing IP address for the client
+#
+allocate_existing = "\
+	WITH cte AS (
+		SELECT TOP(1) framedipaddress, expiry_time, gateway \
+		FROM ${ippool_table} WITH (xlock rowlock readpast) \
+		WHERE pool_name = '%{control:${pool_name}}' \
+		AND pool_key = '%{pool_key}' \
+		ORDER BY expiry_time DESC \
+	) \
+	UPDATE cte \
+	SET expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP), \
+	gateway = '%{DHCP-Gateway-IP-Address}' \
+	OUTPUT INSERTED.FramedIPAddress \
+	FROM ${ippool_table}"
+
+#
+#  If the existing address can't be found this query will be run to
+#  find a free address
+#
+allocate_find = "\
+	WITH cte AS (
+		SELECT TOP(1) framedipaddress, expiry_time, gateway, pool_key \
+		FROM ${ippool_table} WITH (xlock rowlock readpast) \
+		WHERE pool_name = '%{control:${pool_name}}' \
+		AND expiry_time < CURRENT_TIMESTAMP \
+		ORDER BY expiry_time \
+	) \
+	UPDATE cte \
+	SET expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP), \
+	gateway = '%{DHCP-Gateway-IP-Address}' \
+	pool_key = '${pool_key}' \
+	OUTPUT INSERTED.FramedIPAddress \
+	FROM ${ippool_table}"
+
+#
+#  Alternatively attempt both in one, more complex, query
 #
 #  The ORDER BY clause of this query tries to allocate the same IP-address
 #  which user had last session.  Ensure that pool_key is unique to the user
 #  within a given pool.
 #
-
-allocate_find = "\
-	UPDATE TOP(1) ${ippool_table} \
-	SET FramedIPAddress = FramedIPAddress, \
-	pool_key = '${pool_key}', \
-	expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP), \
-	GatewayIPAddress = '%{DHCP-Gateway-IP-Address}' \
-	OUTPUT INSERTED.FramedIPAddress \
-	FROM ${ippool_table} \
-	WHERE ${ippool_table}.id IN ( \
-		SELECT TOP (1) id FROM ${ippool_table} WHERE id IN ( \
-			(SELECT TOP(1) id FROM ${ippool_table} WITH (xlock rowlock readpast) \
-			WHERE pool_name = '%{control:${pool_name}}' \
-			AND pool_key = '${pool_key}' ) \
-			UNION \
-			(SELECT TOP(1) id FROM ${ippool_table} WITH (xlock rowlock readpast) \
-			WHERE pool_name = '%{control:${pool_name}}' \
-			AND expiry_time < CURRENT_TIMESTAMP) \
-		) \
-		ORDER BY CASE WHEN pool_key = '${pool_key}' THEN 0 ELSE 1 END, expiry_time \
-	)"
+#allocate_find = "\
+#	UPDATE TOP(1) ${ippool_table} \
+#	SET FramedIPAddress = FramedIPAddress, \
+#	pool_key = '${pool_key}', \
+#	expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP), \
+#	GatewayIPAddress = '%{DHCP-Gateway-IP-Address}' \
+#	OUTPUT INSERTED.FramedIPAddress \
+#	FROM ${ippool_table} \
+#	WHERE ${ippool_table}.id IN ( \
+#		SELECT TOP (1) id FROM ${ippool_table} WHERE id IN ( \
+#			(SELECT TOP(1) id FROM ${ippool_table} WITH (xlock rowlock readpast) \
+#			WHERE pool_name = '%{control:${pool_name}}' \
+#			AND pool_key = '${pool_key}' ) \
+#			UNION \
+#			(SELECT TOP(1) id FROM ${ippool_table} WITH (xlock rowlock readpast) \
+#			WHERE pool_name = '%{control:${pool_name}}' \
+#			AND expiry_time < CURRENT_TIMESTAMP \
+#			ORDER BY expiry_time) \
+#		) \
+#		ORDER BY CASE WHEN pool_key = '${pool_key}' THEN 0 ELSE 1 END, expiry_time \
+#	)"
 
 #
 #  If you prefer to allocate a random IP address every time, use this query instead.
@@ -100,6 +146,7 @@ start_update = ""
 #  Free an IP when an accounting STOP record arrives - for DHCP this
 #  is when a Release occurs
 #
+stop_begin = ""
 stop_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
@@ -109,6 +156,7 @@ stop_clear = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND FramedIPAddress = '%{DHCP-Client-IP-Address}'"
+stop_commit = ""
 
 #
 #  This query is not applicable to DHCP as there are no accounting

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -6,25 +6,49 @@
 
 #
 #  This series of queries allocates an IP address
+
+#  If using MySQL < 8.0.1 then remove SKIP LOCKED
+#
+#  Attempt to find the most recent existing IP address for the client
+#
+allocate_existing = "\
+	SELECT framedipaddress FROM ${ippool_table} \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	ORDER BY expiry_time DESC LIMIT 1 FOR UPDATE SKIP LOCKED"
+
+#
+#  If the existing address can't be found this query will be run to
+#  find a free address
+#
+allocate_find = "\
+	SELECT framedipaddress FROM ${ippool_table} \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND expiry_time < NOW() \
+	ORDER BY expiry_time LIMIT 1 FOR UPDATE SKIP LOCKED"
+
 #
 #  The ORDER BY clause of this query tries to allocate the same IP-address
 #  which the user last had.  Ensure that pool_key is unique to the user
 #  within a given pool.
 #
-#  If using MySQL < 8.0.1 then remove SKIP LOCKED
 
-allocate_find = "\
-	(SELECT framedipaddress, pool_key, expiry_time FROM ${ippool_table} \
-		WHERE pool_name = '%{control:${pool_name}}' \
-		AND pool_key = '${pool_key}' \
-		ORDER BY expiry_time DESC LIMIT 1 FOR UPDATE SKIP LOCKED \
-	) UNION ( \
-	SELECT framedipaddress, pool_key, expiry_time FROM ${ippool_table} \
-		WHERE pool_name = '%{control:${pool_name}}' \
-		AND expiry_time < NOW() \
-		ORDER BY expiry_time LIMIT 1 FOR UPDATE SKIP LOCKED \
-	) ORDER BY (pool_key <> '${pool_key}'), expiry_time \
-	LIMIT 1"
+#
+#  Alternatively do both operations in one query.  Depending on transaction
+#  isolation mode, this can cause deadlocks
+#
+#allocate_find = "\
+#	(SELECT framedipaddress, pool_key, expiry_time FROM ${ippool_table} \
+#		WHERE pool_name = '%{control:${pool_name}}' \
+#		AND pool_key = '${pool_key}' \
+#		ORDER BY expiry_time DESC LIMIT 1 FOR UPDATE SKIP LOCKED \
+#	) UNION ( \
+#	SELECT framedipaddress, pool_key, expiry_time FROM ${ippool_table} \
+#		WHERE pool_name = '%{control:${pool_name}}' \
+#		AND expiry_time < NOW() \
+#		ORDER BY expiry_time LIMIT 1 FOR UPDATE SKIP LOCKED \
+#	) ORDER BY (pool_key <> '${pool_key}'), expiry_time \
+#	LIMIT 1"
 
 #
 #  If you prefer to allocate a random IP address every time, use this query instead.

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -36,45 +36,50 @@ allocate_commit = ""
 #
 
 #
-#  This query allocates an IP address from the Pool
-#  The ORDER BY clause of this query tries to allocate the same IP-address
-#  to the user that they had last session.  Ensure that pool_key is unique
-#  to the user within a given pool.
+#  This sequence of queries allocates an IP address from the Pool
 #
-#  Since PostgreSQL doesn't support FOR UPDATE inside a UNION we start
-#  by locking the table.  PostgreSQL has an UPDATE ... RETURNING syntax
-#  allowing the find and update queries to be merged into one
-#  reducing round trips to the database.   If you use this allocate_find
-#  query, keep allocate_update commented out.
+#allocate_begin = "BEGIN"
+
 #
-#allocate_begin = "BEGIN; LOCK TABLE ${ippool_table}"
+#  Attempt to find the most recent existing IP address for the client
+#
+#allocate_existing = "\
+#	SELECT framedipaddress FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' \
+#	AND pool_key = '${pool_key}' \
+#	ORDER BY expiry_time DESC \
+#	LIMIT 1 \
+#	FOR UPDATE"
+
+#  The same query with SKIP LOCKED - requires PostgreSQL >= 9.5
+# allocate_existing = "\
+#	SELECT framedipaddress FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' \
+#	AND pool_key = '${pool_key}' \
+#	ORDER BY expiry_time DESC \
+#	LIMIT 1 \
+#	FOR UPDATE SKIP LOCKED"
+
+#
+#  If the existing address can't be found this query will be run to
+#  find a free address
 #
 #allocate_find = "\
-#	UPDATE ${ippool_table} \
-#	SET pool_key = '${pool_key}', \
-#	expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval, \
-#	gatewayipaddress = '%{DHCP-Gateway-IP-Address}' \
-#	WHERE id IN ( \
-#		SELECT id \
-#		FROM ${ippool_table} \
-#		WHERE id IN ( \
-#			SELECT id FROM ( \
-#				( \
-#					SELECT id, pool_key, expiry_time \
-#					FROM ${ippool_table} \
-#					WHERE pool_name = '%{control:${pool_name}}' \
-#					AND expiry_time < 'now'::timestamp(0) \
-#					ORDER BY expiry_time LIMIT 1 \
-#				) UNION ( \
-#					SELECT id, pool_key, expiry_time \
-#					FROM ${ippool_table} \
-#					WHERE pool_name = '%{control:${pool_name}}' \
-#					AND pool_key = '${pool_key}' \
-#				) \
-#			) AS iplist \
-#		) ORDER BY (pool_key <> '${pool_key}'), expiry_time \
-#		LIMIT 1) \
-#	RETURNING framedipaddress"
+#	SELECT framedipaddress FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' \
+#	AND expiry_time < 'now'::timestamp(0) \
+#	ORDER BY expiry_time \
+#	LIMIT 1 \
+#	FOR UPDATE"
+
+#  The same query with SKIP LOCKED - requires PostgreSQL >= 9.5
+#allocate_find = "\
+#	SELECT framedipaddress FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' \
+#	AND expiry_time < 'now'::timestamp(0) \
+#	ORDER BY expiry_time \
+#	LIMIT 1 \
+#	FOR UPDATE SKIP LOCKED"
 
 #
 #  If you prefer to allocate a random IP address every time, use this query instead
@@ -106,10 +111,46 @@ allocate_commit = ""
 #allocate_update = "\
 #	UPDATE ${ippool_table} \
 #	SET \
-#		gatewayipaddress = '%{DHCP-Gateway-IP-Address}', \
+#		gateway = '%{DHCP-Gateway-IP-Address}', \
 #		pool_key = '${pool_key}', \
 #		expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval \
 #	WHERE framedipaddress = '%I'"
+
+
+#
+#  Alternatively, merge the matching of existing IP and free IP into a single query
+#  This version does the update as well - so allocate_begin, allocate_update and
+#  allocate_commit should be blank
+#
+#allocate_find = "\
+#	WITH found AS ( \
+#		WITH existing AS ( \
+#			SELECT framedipaddress, pool_key, expiry_time FROM ${ippool_table} \
+#			WHERE pool_name = '%{control:${pool_name}}' \
+#			AND pool_key = '${pool_key}' \
+#			ORDER BY expiry_time DESC \
+#			LIMIT 1 \
+#			FOR UPDATE SKIP LOCKED \
+#		), new AS ( \
+#			SELECT framedipaddress, pool_key, expiry_time FROM ${ippool_table} \
+#			WHERE pool_name = '%{control:${pool_name}}' \
+#			AND expiry_time < 'now'::timestamp(0) \
+#			ORDER BY expiry_time \
+#			LIMIT 1 \
+#			FOR UPDATE SKIP LOCKED \
+#		) \
+#		SELECT framedipaddress, pool_key, expiry_time FROM existing \
+#		UNION ALL \
+#		SELECT framedipaddress, pool_key, expiry_time FROM new \
+#		ORDER BY expiry_time DESC LIMIT 1 \
+#	) \
+#	UPDATE ${ippool_table} \
+#	SET pool_key = '${pool_key}', \
+#	expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval \
+#	gateway = '%{DHCP-Gateway-IP-Address}' \
+#	FROM found \
+#	WHERE found.framedipaddress = ${ippool_table}.framedipaddress \
+#	RETURNING found.framedipaddress"
 
 #
 #  If an IP could not be allocated, check to see whether the pool exists or not
@@ -136,7 +177,7 @@ start_update = ""
 stop_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
-		gatewayipaddress = '', \
+		gateway = '', \
 		pool_key = 0, \
 		expiry_time = 'now'::timestamp(0) - '1 second'::interval \
 	WHERE pool_name = '%{control:${pool_name}}' \

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -146,7 +146,7 @@ allocate_commit = ""
 #	) \
 #	UPDATE ${ippool_table} \
 #	SET pool_key = '${pool_key}', \
-#	expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval \
+#	expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval, \
 #	gateway = '%{DHCP-Gateway-IP-Address}' \
 #	FROM found \
 #	WHERE found.framedipaddress = ${ippool_table}.framedipaddress \


### PR DESCRIPTION
Allow for a separate query (allocate_existing) to find existing IP
addresses, split from allocate_find, which can then be used for finding
an un-allocated address.

Allows for much more efficient queries for most databases.