### PR TITLE
Alter DHCP queries to take advantage of allocate_existing

### DIFF
--- a/raddb/mods-config/sql/ippool-dhcp/mssql/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/procedure.sql
@@ -1,0 +1,137 @@
+--
+-- A stored procedure to reallocate a user's previous address, otherwise
+-- provide a free address.
+--
+-- Using this SP reduces the usual set dialogue of queries to a single
+-- query:
+--
+--   BEGIN TRAN; "SELECT FOR UPDATE"; UPDATE; COMMIT TRAN;  ->  EXEC sp
+--
+-- The stored procedure is executed on an database instance within a single
+-- round trip which often leads to reduced deadlocking and significant
+-- performance improvements especially on multi-master clusters, perhaps even
+-- by an order of magnitude or more.
+--
+-- To use this stored procedure the corresponding queries.conf statements must
+-- be configured as follows:
+--
+-- allocate_begin = ""
+-- allocate_find = "\
+--      EXEC fr_dhcp_allocate_previous_or_new_framedipaddress \
+--              @v_pool_name = '%{control:${pool_name}}', \
+--              @v_gateway = '%{DHCP-Gateway-IP-Address}', \
+--              @v_pool_key = '${pool_key}', \
+--              @v_lease_duration = ${lease_duration} \
+--      "
+-- allocate_update = ""
+-- allocate_commit = ""
+--
+
+CREATE OR ALTER PROCEDURE fr_dhcp_allocate_previous_or_new_framedipaddress
+	@v_pool_name VARCHAR(64),
+	@v_gateway VARCHAR(15),
+	@v_pool_key VARCHAR(64),
+	@v_lease_duration INT
+AS
+	BEGIN
+
+		-- MS SQL lacks a "SELECT FOR UPDATE" statement, and its table
+		-- hints do not provide a direct means to implement the row-level
+		-- read lock needed to guarentee that concurrent queries do not
+		-- select the same Framed-IP-Address for allocation to distinct
+		-- users.
+		--
+		-- The "WITH cte AS ( SELECT ... ) UPDATE cte ... OUTPUT INTO"
+		-- patterns in this procedure body compensate by wrapping
+		-- the SELECT in a synthetic UPDATE which locks the row.
+
+		DECLARE @r_address_tab TABLE(id VARCHAR(15));
+		DECLARE @r_address VARCHAR(15);
+
+		BEGIN TRAN;
+
+		-- Reissue an existing IP address lease when re-authenticating a session
+		--
+		WITH cte AS (
+			SELECT TOP(1) FramedIPAddress
+			FROM dhcpippool
+			JOIN dhcpstatus
+			ON dhcpstatus.status_id = dhcpippool.status_id
+			WHERE pool_name = @v_pool_name
+				AND expiry_time > CURRENT_TIMESTAMP
+				AND pool_key = @v_pool_key
+				AND dhcpstatus.status IN ('dynamic', 'static')
+		)
+		UPDATE cte WITH (rowlock, readpast)
+		SET FramedIPAddress = FramedIPAddress
+		OUTPUT INSERTED.FramedIPAddress INTO @r_address_tab;
+		SELECT @r_address = id FROM @r_address_tab;
+
+		-- Reissue an user's previous IP address, provided that the lease is
+		-- available (i.e. enable sticky IPs)
+		--
+		-- When using this SELECT you should delete the one above. You must also
+		-- set allocate_clear = "" in queries.conf to persist the associations
+		-- for expired leases.
+		--
+		-- WITH cte AS (
+		-- 	SELECT TOP(1) FramedIPAddress
+		-- 	FROM dhcpippool
+		--	JOIN dhcpstatus
+		--	ON dhcpstatus.status_id = dhcpippool.status_id
+		-- 	WHERE pool_name = @v_pool_name
+		-- 		AND pool_key = @v_pool_key
+		--		AND dhcpstatus.status IN ('dynamic', 'static')
+		-- )
+		-- UPDATE cte WITH (rowlock, readpast)
+		-- SET FramedIPAddress = FramedIPAddress
+		-- OUTPUT INSERTED.FramedIPAddress INTO @r_address_tab;
+		-- SELECT @r_address = id FROM @r_address_tab;
+
+		-- If we didn't reallocate a previous address then pick the least
+		-- recently used address from the pool which maximises the likelihood
+		-- of re-assigning the other addresses to their recent user
+		--
+		IF @r_address IS NULL
+		BEGIN
+			WITH cte AS (
+				SELECT TOP(1) FramedIPAddress
+				FROM dhcpippool WITH (xlock rowlock readpast)
+				JOIN dhcpstatus
+				ON dhcpstatus.status_id = dhcpippool.status_id
+				WHERE pool_name = @v_pool_name
+					AND expiry_time < CURRENT_TIMESTAMP
+					AND dhcpstatus.status = 'dynamic'
+				ORDER BY
+					expiry_time
+			)
+			UPDATE cte
+			SET FramedIPAddress = FramedIPAddress
+			OUTPUT INSERTED.FramedIPAddress INTO @r_address_tab;
+			SELECT @r_address = id FROM @r_address_tab;
+		END
+
+		-- Return nothing if we failed to allocated an address
+		--
+		IF @r_address IS NULL
+		BEGIN
+			COMMIT TRAN;
+			RETURN;
+		END
+
+		-- Update the pool having allocated an IP address
+		--
+		UPDATE dhcpippool
+		SET
+			gateway = @v_gateway,
+			pool_key = @v_pool_key,
+			expiry_time = DATEADD(SECOND,@v_lease_duration,CURRENT_TIMESTAMP)
+		WHERE framedipaddress = @r_address;
+
+		COMMIT TRAN;
+
+		-- Return the address that we allocated
+		SELECT @r_address;
+
+	END
+GO

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -1,0 +1,186 @@
+# -*- text -*-
+#
+#  ippool-dhcp/mssql/queries.conf -- MSSQL queries for rlm_sqlippool
+#
+#  $Id$
+
+#
+#  This series of queries allocates an IP address
+#
+
+#
+#  MSSQL-specific syntax - required if finding the address and updating
+#  it are separate queries
+#
+#allocate_begin = "BEGIN TRAN"
+#allocate_commit = "COMMIT TRAN"
+
+allocate_begin = ""
+allocate_commit = ""
+
+#
+#  Attempt to find the most recent existing IP address for the client
+#
+allocate_existing = "\
+	WITH cte AS (
+		SELECT TOP(1) framedipaddress, expiry_time, gateway \
+		FROM ${ippool_table} WITH (xlock rowlock readpast) \
+		JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
+		WHERE pool_name = '%{control:${pool_name}}' \
+		AND pool_key = '%{pool_key}' \
+		AND dhcpstatus.status IN ('dynamic', 'static') \
+		ORDER BY expiry_time DESC \
+	) \
+	UPDATE cte \
+	SET expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP), \
+	gateway = '%{DHCP-Gateway-IP-Address}' \
+	OUTPUT INSERTED.FramedIPAddress \
+	FROM ${ippool_table}"
+
+#
+#  If the existing address can't be found this query will be run to
+#  find a free address
+#
+allocate_find = "\
+	WITH cte AS (
+		SELECT TOP(1) framedipaddress, expiry_time, gateway, pool_key \
+		FROM ${ippool_table} WITH (xlock rowlock readpast) \
+		JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
+		WHERE pool_name = '%{control:${pool_name}}' \
+		AND expiry_time < CURRENT_TIMESTAMP \
+		AND dhcpstatus.status = 'dynamic' \
+		ORDER BY expiry_time \
+	) \
+	UPDATE cte \
+	SET expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP), \
+	gateway = '%{DHCP-Gateway-IP-Address}' \
+	pool_key = '${pool_key}' \
+	OUTPUT INSERTED.FramedIPAddress \
+	FROM ${ippool_table}"
+
+#
+#  Alternatively attempt both in one, more complex, query
+#
+#  The ORDER BY clause of this query tries to allocate the same IP-address
+#  which user had last session.  Ensure that pool_key is unique to the user
+#  within a given pool.
+#
+#allocate_find = "\
+#	UPDATE TOP(1) ${ippool_table} \
+#	SET FramedIPAddress = FramedIPAddress, \
+#	pool_key = '${pool_key}', \
+#	expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP), \
+#	GatewayIPAddress = '%{DHCP-Gateway-IP-Address}' \
+#	OUTPUT INSERTED.FramedIPAddress \
+#	FROM ${ippool_table} \
+#	WHERE ${ippool_table}.id IN ( \
+#		SELECT TOP (1) id FROM ${ippool_table} WHERE id IN ( \
+#			(SELECT TOP(1) id FROM ${ippool_table} WITH (xlock rowlock readpast) \
+#			JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
+#			WHERE pool_name = '%{control:${pool_name}}' \
+#			AND pool_key = '${pool_key}' \
+#			AND dhcpstatus.status IN ('dynamic', 'static') \
+#			ORDER BY expiry_time DESC) \
+#			UNION \
+#			(SELECT TOP(1) id FROM ${ippool_table} WITH (xlock rowlock readpast) \
+#			JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
+#			WHERE pool_name = '%{control:${pool_name}}' \
+#			AND expiry_time < CURRENT_TIMESTAMP \
+#			AND dhcpstatus.status = 'dynamic' \
+#			ORDER BY expiry_time) \
+#		) \
+#		ORDER BY CASE WHEN pool_key = '${pool_key}' THEN 0 ELSE 1 END, expiry_time \
+#	)"
+
+#
+#  If you prefer to allocate a random IP address every time, use this query instead.
+#  Note: This is very slow if you have a lot of free IPs.
+#
+#allocate_find = "\
+#	WITH cte AS ( \
+#		SELECT TOP(1) FramedIPAddress FROM ${ippool_table} \
+#		JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
+#		WHERE pool_name = '%{control:${pool_name}}' \
+#		AND expiry_time < CURRENT_TIMESTAMP \
+#		AND dhcpstatus.status = 'dynamic' \
+#		ORDER BY \
+#			newid() \
+#	) \
+#	UPDATE cte WITH (rowlock, readpast) \
+#	SET FramedIPAddress = FramedIPAddress \
+#	OUTPUT INSERTED.FramedIPAddress"
+
+#
+#  If an IP could not be allocated, check to see if the pool exists or not
+#  This allows the module to differentiate between a full pool and no pool
+#  Note: If you are not running redundant pool modules this query may be
+#  commented out to save running this query every time an ip is not allocated.
+#
+pool_check = "\
+	SELECT TOP(1) id \
+	FROM ${ippool_table} \
+	WHERE pool_name='%{control:${pool_name}}'"
+
+#
+#  This is the final IP Allocation query, which saves the allocated ip details.
+#  Only needed if the initial "find" query is not storing the allocation.
+#
+#allocate_update = "\
+#	UPDATE ${ippool_table} \
+#	SET \
+#		GatewayIPAddress = '%{DHCP-Gateway-IP-Address}', pool_key = '${pool_key}', \
+#		expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
+#	WHERE FramedIPAddress = '%I'"
+
+#
+#  Use a stored procedure to find AND allocate the address. Read and customise
+#  `procedure.sql` in this directory to determine the optimal configuration.
+#
+#allocate_begin = ""
+#allocate_find = "\
+#	EXEC fr_dhcp_allocate_previous_or_new_framedipaddress \
+#		@v_pool_name = '%{control:${pool_name}}', \
+#		@v_gatewayipaddress = '%{DHCP-Gateway-IP-Address}', \
+#		@v_pool_key = '${pool_key}', \
+#		@v_lease_duration = ${lease_duration} \
+#	"
+#allocate_update = ""
+#allocate_commit = ""
+
+#
+#  This query is not applicable to DHCP as there are no accounting
+#  START records
+#
+start_update = ""
+
+#
+#  Free an IP when an accounting STOP record arrives - for DHCP this
+#  is when a Release occurs
+#
+stop_begin = ""
+stop_clear = "\
+	UPDATE ${ippool_table} \
+	SET \
+		GatewayIPAddress = '', \
+		pool_key = '0', \
+		expiry_time = CURRENT_TIMESTAMP \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND FramedIPAddress = '%{DHCP-Client-IP-Address}'"
+stop_commit = ""
+
+#
+#  This query is not applicable to DHCP as there are no accounting
+#  ALIVE records
+#
+alive_update = ""
+
+#
+#  This query is not applicable to DHCP
+#
+on_clear = ""
+
+#
+#  This query is not applicable to DHCP
+#
+off_clear = ""

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/schema.sql
@@ -1,0 +1,39 @@
+--
+-- Table structure for table 'dhcpippool'
+--
+-- See also "procedure.sql" in this directory for
+-- a stored procedure that gives much faster response.
+--
+
+CREATE TABLE dhcpstatus (
+	status_id	int NOT NULL,
+	status		varchar(10) NOT NULL,
+	PRIMARY KEY (status_id)
+)
+GO
+
+INSERT INTO dhcpstatus (status_id, status) VALUES (1, 'dynamic'), (2, 'static'), (3, 'declined'), (4, 'disabled')
+GO
+
+CREATE TABLE dhcpippool (
+	id			int IDENTITY (1,1) NOT NULL,
+	pool_name		varchar(30) NOT NULL,
+	FramedIPAddress		varchar(15) NOT NULL default '',
+	pool_key		varchar(30) NOT NULL default '',
+	gateway			varchar(15) NOT NULL default '',
+	expiry_time		DATETIME NOT NULL default CURRENT_TIMESTAMP,
+	status_id		int NOT NULL default 1,
+	CONSTRAINT fk_status_id FOREIGN KEY (status_id) REFERENCES dhcpstatus (status_id),
+	PRIMARY KEY (id)
+)
+GO
+
+CREATE INDEX dhcp_poolname_expire ON dhcpippool(pool_name, expiry_time)
+GO
+
+CREATE INDEX dhcp_FramedIPAddress ON dhcpippool(FramedIPAddress)
+GO
+
+CREATE INDEX dhcp_poolname_poolkey_FramedIPAddress ON dhcpippool(pool_name, pool_key, FramedIPAddress)
+GO
+

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -4,29 +4,62 @@
 #
 #  $Id$
 
+
+#  Using SKIP LOCKED speeds up selection queries
+#  However, it requires MySQL >= 8.0.1.  Uncomment the
+#  following if you are running a suitable version of MySQL
+#
+#  skip_locked = "SKIP LOCKED"
+
 #
 #  This series of queries allocates an IP address
 #
-#  The ORDER BY clause of this query tries to allocate the same IP-address
-#  which the user last had.  Ensure that pool_key is unique to the user
-#  within a given pool.
-#
-#  If using MySQL < 8.0.1 then remove SKIP LOCKED
 
+#
+#  This query attempts to find the most recent IP address for the client
+#
+allocate_existing = "\
+	SELECT framedipaddress \
+	FROM ${ippool_table} \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND `status` IN ('dynamic', 'static') \
+	ORDER BY expiry_time DESC \
+	LIMIT 1 \
+	FOR UPDATE ${skip_locked}"
+
+#
+#  If the preceding query fails to find an IP address, the following
+#  one is used to select a free one from the pool
+#
 allocate_find = "\
-	(SELECT framedipaddress, pool_key, expiry_time FROM radippool \
-		WHERE pool_name = '%{control:${pool_name}}' \
-		AND pool_key = '${pool_key}' \
-		AND `status` IN ('dynamic', 'static') \
-		ORDER BY expiry_time DESC LIMIT 1 FOR UPDATE SKIP LOCKED \
-	) UNION ( \
-	SELECT framedipaddress, pool_key, expiry_time FROM radippool \
-		WHERE pool_name = '%{control:${pool_name}}' \
-		AND expiry_time < NOW() \
-		AND `status` = 'dynamic' \
-		ORDER BY expiry_time LIMIT 1 FOR UPDATE SKIP LOCKED \
-	) ORDER BY (pool_key <> '${pool_key}'), expiry_time \
-	LIMIT 1"
+	SELECT framedipaddress \
+	FROM ${ippool_table} \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND expiry_time < NOW() \
+	AND `status` = 'dynamic' \
+	ORDER BY expiry_time \
+	LIMIT 1 \
+	FOR UPDATE ${skip_locked}"
+
+#
+#  Alternatively the two queries can be combined into one, though
+#  depending on transaction isolation mode, this can case deadlocks
+#
+#allocate_find = "\
+#	(SELECT framedipaddress, pool_key, expiry_time FROM radippool \
+#		WHERE pool_name = '%{control:${pool_name}}' \
+#		AND pool_key = '${pool_key}' \
+#		AND `status` IN ('dynamic', 'static') \
+#		ORDER BY expiry_time DESC LIMIT 1 FOR UPDATE ${skip_locked} \
+#	) UNION ( \
+#	SELECT framedipaddress, pool_key, expiry_time FROM radippool \
+#		WHERE pool_name = '%{control:${pool_name}}' \
+#		AND expiry_time < NOW() \
+#		AND `status` = 'dynamic' \
+#		ORDER BY expiry_time LIMIT 1 FOR UPDATE ${skip_locked} \
+#	) ORDER BY (pool_key <> '${pool_key}'), expiry_time \
+#	LIMIT 1"
 
 #
 #  If you prefer to allocate a random IP address every time, use this query instead.
@@ -40,21 +73,7 @@ allocate_find = "\
 #	ORDER BY \
 #		RAND() \
 #	LIMIT 1 \
-#	FOR UPDATE"
-
-#
-#  The above query again, but with SKIP LOCKED. This requires MySQL >= 8.0.1,
-#  and InnoDB.
-#
-#allocate_find = "\
-#	SELECT framedipaddress FROM ${ippool_table} \
-#	WHERE pool_name = '%{control:${pool_name}}' \
-#	AND expiry_time < NOW() \
-#	AND `status` = 'dynamic' \
-#	ORDER BY \
-#		RAND() \
-#	LIMIT 1 \
-#	FOR UPDATE SKIP LOCKED"
+#	FOR UPDATE ${skip_locked}"
 
 #
 #  If an IP could not be allocated, check to see if the pool exists or not

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -4,79 +4,62 @@
 #
 #  $Id$
 
+#  Using SKIP LOCKED speed up the allocate_find query by 10
+#  times. However, it requires PostgreSQL >= 9.5.
 #
-#  Use a stored procedure to find AND allocate the address. Read and customise
-#  `procedure.sql` in this directory to determine the optimal configuration.
+#  If you are using an older version of PostgreSQL comment out the following:
+skip_locked = "SKIP LOCKED"
+
 #
-#  This requires PostgreSQL >= 9.5 as SKIP LOCKED is used.
+#  This sequence of queries allocate an IP address from the Pool
 #
-#  The "NO LOAD BALANCE" comment is included here to indicate to a PgPool
-#  system that this needs to be a write transaction. PgPool itself cannot
-#  detect this from the statement alone. If you are using PgPool and do not
-#  have this comment, the query may go to a read only server, and will fail.
-#  This has no negative effect if you are not using PgPool.
+#  If the SELECT and UPDATE are in separate queries then set the following
+#  to "BEGIN" to wrap them as a transaction
 #
 allocate_begin = ""
+
+#
+#  This query attempts to re-allocate the most recent IP address
+#  for the client
+allocate_existing = "\
+	WITH cte AS ( \
+		SELECT framedipaddress \
+		FROM ${ippool_table} \
+		WHERE pool_name = '%{control:${pool_name}}' \
+		AND pool_key = '${pool_key}' \
+		AND status IN ('dynamic', 'static') \
+		ORDER BY expiry_time DESC \
+		LIMIT 1 \
+		FOR UPDATE ${skip_locked} \
+	) \
+	UPDATE ${ippool_table} \
+	SET expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval, \
+	gateway = '%{DHCP-Gateway-IP-Address}' \
+	FROM cte \
+	WHERE cte.framedipaddress = ${ippool_table}.framedipaddress \
+	RETURNING cte.framedipaddress"
+
+#
+#  If the preceding query doesn't find an address the following one
+#  is used for finding one from the pool
+#
 allocate_find = "\
-	/*NO LOAD BALANCE*/ \
-	SELECT fr_allocate_previous_or_new_framedipaddress( \
-		'%{control:${pool_name}}', \
-		'%{DHCP-Gateway-IP-Address}', \
-		'${pool_key}', \
-		'${lease_duration}' \
-	)"
-allocate_update = ""
-allocate_commit = ""
-
-#
-#  If stored procedures are not able to be used, the following queries can
-#  be used.
-#  Comment out all the above queries and choose the appropriate "allocate_find"
-#  to match the desired outcome and also the version of "allocate_update" below.
-#
-
-#
-#  This query allocates an IP address from the Pool
-#  The ORDER BY clause of this query tries to allocate the same IP-address
-#  to the user that they had last session.  Ensure that pool_key is unique
-#  to the user within a given pool.
-#
-#  Since PostgreSQL doesn't support FOR UPDATE inside a UNION we start
-#  by locking the table.  PostgreSQL has an UPDATE ... RETURNING syntax
-#  allowing the find and update queries to be merged into one
-#  reducing round trips to the database.   If you use this allocate_find
-#  query, keep allocate_update commented out.
-#
-#allocate_begin = "BEGIN; LOCK TABLE ${ippool_table}"
-#
-#allocate_find = "\
-#	UPDATE ${ippool_table} \
-#	SET pool_key = '${pool_key}', \
-#	expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval, \
-#	gateway = '%{DHCP-Gateway-IP-Address}' \
-#	WHERE id IN ( \
-#		SELECT id \
-#		FROM ${ippool_table} \
-#		WHERE id IN ( \
-#			SELECT id FROM ( \
-#				( \
-#					SELECT id, pool_key, expiry_time \
-#					FROM ${ippool_table} \
-#					WHERE pool_name = '%{control:${pool_name}}' \
-#					AND expiry_time < 'now'::timestamp(0) \
-#					AND status = 'dynamic' \
-#					ORDER BY expiry_time LIMIT 1 \
-#				) UNION ( \
-#					SELECT id, pool_key, expiry_time \
-#					FROM ${ippool_table} \
-#					WHERE pool_name = '%{control:${pool_name}}' \
-#					AND pool_key = '${pool_key}' \
-#					AND status IN ('dynamic', 'static') \
-#				) \
-#			) AS iplist \
-#		) ORDER BY (pool_key <> '${pool_key}'), expiry_time \
-#		LIMIT 1) \
-#	RETURNING framedipaddress"
+	WITH cte AS ( \
+		SELECT framedipaddress \
+		FROM ${ippool_table} \
+		WHERE pool_name = '%{control:${pool_name}}' \
+		AND expiry_time < 'now'::timestamp(0) \
+		AND status = 'dynamic' \
+		ORDER BY expiry_time \
+		LIMIT 1 \
+		FOR UPDATE ${skip_locked} \
+	) \
+	UPDATE ${ippool_table} \
+	SET pool_key = '${pool_key}', \
+	expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval, \
+	gateway = '%{DHCP-Gateway-IP-Address}' \
+	WHERE cte.framedipaddress = ${ippool_table}.framedipaddress \
+	RETURNING cte.framedipaddress"
 
 #
 #  If you prefer to allocate a random IP address every time, use this query instead
@@ -90,22 +73,12 @@ allocate_commit = ""
 #	AND status = 'dynamic' \
 #	ORDER BY RANDOM() \
 #	LIMIT 1 \
-#	FOR UPDATE"
-
-#
-#  The above query again, but with SKIP LOCKED. This requires PostgreSQL >= 9.5.
-#
-#allocate_find = "\
-#	SELECT framedipaddress FROM ${ippool_table} \
-#	WHERE pool_name = '%{control:${pool_name}}' AND expiry_time < 'now'::timestamp(0) \
-#	AND status = 'dynamic' \
-#	ORDER BY RANDOM() \
-#	LIMIT 1 \
-#	FOR UPDATE SKIP LOCKED"
+#	FOR UPDATE ${skip_locked}"
 
 #
 #  This query marks the IP address handed out by "allocate-find" as used
 #  for the period of "lease_duration" after which time it may be reused.
+#  It is only needed if the SELECT query does not perform the update.
 #
 #allocate_update = "\
 #	UPDATE ${ippool_table} \
@@ -114,6 +87,12 @@ allocate_commit = ""
 #		pool_key = '${pool_key}', \
 #		expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval \
 #	WHERE framedipaddress = '%I'"
+
+#
+#  If the SELECT and UPDATE are in separate queries then set the following
+#  to "COMMIT" to wrap them as a transaction
+#
+allocate_commit = ""
 
 #
 #  If an IP could not be allocated, check to see whether the pool exists or not
@@ -126,6 +105,30 @@ pool_check = "\
 	FROM ${ippool_table} \
 	WHERE pool_name='%{control:${pool_name}}' \
 	LIMIT 1"
+
+#
+#  Use a stored procedure to find AND allocate the address. Read and customise
+#  `procedure.sql` in this directory to determine the optimal configuration.
+#
+#  This requires PostgreSQL >= 9.5 as SKIP LOCKED is used.
+#
+#  The "NO LOAD BALANCE" comment is included here to indicate to a PgPool
+#  system that this needs to be a write transaction. PgPool itself cannot
+#  detect this from the statement alone. If you are using PgPool and do not
+#  have this comment, the query may go to a read only server, and will fail.
+#  This has no negative effect if you are not using PgPool.
+#
+#allocate_begin = ""
+#allocate_find = "\
+#	/*NO LOAD BALANCE*/ \
+#	SELECT fr_allocate_previous_or_new_framedipaddress( \
+#		'%{control:${pool_name}}', \
+#		'%{DHCP-Gateway-IP-Address}', \
+#		'${pool_key}', \
+#		'${lease_duration}' \
+#	)"
+#allocate_update = ""
+#allocate_commit = ""
 
 #
 #  This query is not applicable to DHCP as there are no accounting


### PR DESCRIPTION
Performance improvements for DHCP queries for databases where splitting the queries is advantageous.

Also, add schema and queries for MS SQL server