### PR TITLE
Make sqlippool generic rather than protocol specific

### DIFF
--- a/doc/antora/modules/howto/pages/modules/sqlippool/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/sqlippool/index.adoc
@@ -68,15 +68,15 @@ address into the `Framed-IP-Address` attribute (as it is by default),
 and that attribute already exists, the module does nothing, and
 returns `noop`.
 
-. The module then runs the `allocate_existing` query, which looks for
+. The module then runs the `alloc_existing` query, which looks for
 the IP address last assigned to the device from the pool indicated by
 `Pool-Name`.  The device is identified using the `pool_key`
 configuration item (typically `NAS-Port`) and a NAS identifier (the
 `NAS-IP-Address`).
 
-. If no address was found using `allocate_existing`, the module then
-runs the `allocate_find` query, which chooses a free IP address from
-the pool indicated by `Pool-Name`.  If `allocate_find` does not return
+. If no address was found using `alloc_existing`, the module then
+runs the `alloc_find` query, which chooses a free IP address from
+the pool indicated by `Pool-Name`.  If `alloc_find` does not return
 an IP address, the `pool_check` query is run in order to determine
 why the allocation failed.  For example, either the requested pool is
 empty (i.e.  no free addresses), or it is non-existent.  This
@@ -84,7 +84,7 @@ information is returned in the `sqlippool` module return code, as
 `notfound`, or one of the other return codes.
 
 . If an IP address has been found, the module runs the
-`allocate_update` query.  This query assigns the IP address to the
+`alloc_update` query.  This query assigns the IP address to the
 device by updating the `radippool` row for the IP address with
 information about the lease.  The default information includes `expiry
 time` based on the configured `lease_duration`, a unique identifier
@@ -95,7 +95,7 @@ identifier (`User-Name`) and device identifier (`Calling-Station-Id`).
 This information can be used to assign the same IP to the same user or
 device, on subsequent allocation requests.  With some database backends
 (PostgreSQL and MS SQLServer) the update can be incorporated into the
-`allocate_existing` and `allocate_find` queries, reducing round trips
+`alloc_existing` and `alloc_find` queries, reducing round trips
 to the database and improving performance.
 
 . The module returns `updated` to indicate that it was successfull in
@@ -111,7 +111,7 @@ attribute holding the allocated IP address to the NAS.
 . The NAS sends an `Accounting Start` request to FreeRADIUS.  After some
 processing (modules. `unlang`, etc.), the `sqlippool` module is run.
 
-. The `sqlippol` module runs the `extend_update` query.  This query
+. The `sqlippol` module runs the `update_update` query.  This query
 uses the configured `pool_key` and NAS identifier in order to identify
 which entry in the `radippool` table to update.  The `expiry_time` is
 updated based on the configured `lease_duration`. This update extends
@@ -131,7 +131,7 @@ FreeRADIUS sends an Accounting-Response to the NAS.
 After some processing (modules. `unlang`, etc.), the `sqlippool`
 module is run.
 
-. The `sqlippol` module runs the `extend_update` query.  This query
+. The `sqlippol` module runs the `update_update` query.  This query
 uses the configured `pool_key` and NAS identifier in order to identify
 which entry in the `radippool` table to update.  The `expiry_time` is
 updated based on the configured `lease_duration`.
@@ -170,7 +170,7 @@ FreeRADIUS sends an Accounting-Response to the NAS.
 FreeRADIUS.  After some processing (modules. `unlang`, etc.), the
 `sqlippool` module is run.
 
-. The `sqlippol` module runs the `bulkrelease_clear` query.  This query
+. The `sqlippol` module runs the `bulk_release_clear` query.  This query
 uses the `NAS-IP-Address` in order to identify all leases in the
 `radippool` table which belong to the NAS in question.  The leases are
 cleared, and the IP addresses are immediately released for further
@@ -355,7 +355,7 @@ For performance reasons, if you are using a database that supports `SELECT ...
 FOR UPDATE SKIP LOCKED` then you should edit the
 `[raddb]/mods-config/sql/ippools/<dialect>/queries.conf` file corresponding to
 your database dialect to select the `SKIP LOCKED` variant of the
-`allocate_find` query. This will allow the database to remain responsive under
+`alloc_find` query. This will allow the database to remain responsive under
 concurrent load.
 
 
@@ -415,7 +415,7 @@ a concern, especially if sticky IPs are not enabled and a device that is
 repeatedly failing to establish a connection is able to continue to consume IP
 addresses. With some consideration, this initial lease could be amended to a
 short, fixed interval rather than the full lease duration. Replace
-`lease_duration` with a fixed value in seconds in the `allocate_update` query
+`lease_duration` with a fixed value in seconds in the `alloc_update` query
 in `queries.conf` or in the stored procedure in `procedure.sql`, whichever is
 in use. This fixed interval should be greater than the maximum time it could
 take for an Accounting Start to be received for successful connections.
@@ -771,7 +771,7 @@ NOTE: The above command assumes that passwordless login has been configured via
 the user’s `~/.my.cnf` file, or otherwise.
 
 Read the comments in the `procedure.sql` file which explain how to use
-the stored procedure, then amend the `allocate_find`, and
+the stored procedure, then amend the `alloc_find`, and
 `allocate_update` queries (as well as the corresponding start/end
 transaction query-parts) in the dialect's `queries.conf` file,
 *exactly as described*.
@@ -786,7 +786,7 @@ transaction query-parts) in the dialect's `queries.conf` file,
 ...
 allocate_begin = ""
 
-allocate_find = "\
+alloc_find = "\
       CALL fr_allocate_previous_or_new_framedipaddress( \
               '%{control:${pool_name}}', \
               '%{User-Name}', \
@@ -811,7 +811,7 @@ your configuration.
 
 === Customise the IP allocation policy
 
-The IP allocation policy is mainly configured by modifying the `allocate_find`
+The IP allocation policy is mainly configured by modifying the `alloc_find`
 query, however it is likely that the other queries will also need to be
 modified to get the results you want.
 
@@ -825,7 +825,7 @@ address, sometimes referred to as a "sticky IPs" policy.
 
 If you are using the base queries (rather than the recommended stored
 procedure) then the `queries.conf` file for your database dialect contains
-several example `allocate_find` queries for choosing either a dynamic or sticky
+several example `alloc_find` queries for choosing either a dynamic or sticky
 IP policy.
 
 If you are using the recommended stored procedure then the `procedure.sql` file
@@ -834,7 +834,7 @@ has comments that explain how to amend the procedure to choose either a dynamic
 or sticky IP policy.
 
 With a sticky IP policy it is necessary to amend the default actions
-of the `stop_clear`, `on_clear` and `off_clear` queries.  By default,
+of the `release_clear` and `bulk_release_clear` queries.  By default,
 each of these queries clobbers the `User-Name` and
 `Calling-Station-Id` attributes when sessions expire therefore erasing
 the affinity information.
@@ -857,8 +857,8 @@ any RADIUS attribute that is available during authentication can be used.
 [source,config]
 ----
 ...
-allocate_begin = ""
-allocate_find = "\
+alloc_begin = ""
+alloc_find = "\
         CALL fr_allocate_previous_or_new_framedipaddress( \
                 '%{control:${pool_name}}', \
                 '%{User-Name}', \
@@ -867,10 +867,10 @@ allocate_find = "\
                 '${pool_key}', \
                 ${lease_duration} \
         )"
-allocate_update = ""
-allocate_commit = ""
+alloc_update = ""
+alloc_commit = ""
 ...
-stop_clear = "\
+release_clear = "\
         UPDATE ${ippool_table} \
         SET \
                 nasipaddress = '', \
@@ -882,7 +882,7 @@ stop_clear = "\
         AND callingstationid = '%{Calling-Station-Id}' \
         AND framedipaddress = '%{${attribute_name}}'"
 
-on_clear = "\
+bulk_release_clear = "\
         UPDATE ${ippool_table} \
         SET \
                 nasipaddress = '', \
@@ -890,13 +890,6 @@ on_clear = "\
                 expiry_time = NOW() \
         WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"
 
-off_clear = "\
-        UPDATE ${ippool_table} \
-        SET \
-                nasipaddress = '', \
-                pool_key = 0, \
-                expiry_time = NOW() \
-        WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"
 ...
 ----
 

--- a/doc/antora/modules/howto/pages/modules/sqlippool/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/sqlippool/index.adoc
@@ -68,13 +68,20 @@ address into the `Framed-IP-Address` attribute (as it is by default),
 and that attribute already exists, the module does nothing, and
 returns `noop`.
 
-. The module then runs the `allocate_find` query, which chooses a free
-IP address from the pool indicated by `Pool-Name`.  If `allocate_find`
-does not return an IP address, the `pool_check` query is run in order
-to determine why the allocation failed.  For example, either the
-requested pool is empty (i.e.  no free addresses), or it is
-non-existent.  This information is returned in the `sqlippool` module
-return code, as `notfound`, or one of the other return codes.
+. The module then runs the `allocate_existing` query, which looks for
+the IP address last assigned to the device from the pool indicated by
+`Pool-Name`.  The device is identified using the `pool_key`
+configuration item (typically `NAS-Port`) and a NAS identifier (the
+`NAS-IP-Address`).
+
+. If no address was found using `allocate_existing`, the module then
+runs the `allocate_find` query, which chooses a free IP address from
+the pool indicated by `Pool-Name`.  If `allocate_find` does not return
+an IP address, the `pool_check` query is run in order to determine
+why the allocation failed.  For example, either the requested pool is
+empty (i.e.  no free addresses), or it is non-existent.  This
+information is returned in the `sqlippool` module return code, as
+`notfound`, or one of the other return codes.
 
 . If an IP address has been found, the module runs the
 `allocate_update` query.  This query assigns the IP address to the
@@ -86,7 +93,10 @@ for the device as specified by the `pool_key` configuration item
 Additionally, the default schema and queries record the user
 identifier (`User-Name`) and device identifier (`Calling-Station-Id`).
 This information can be used to assign the same IP to the same user or
-device, on subsequent allocation requests.
+device, on subsequent allocation requests.  With some database backends
+(PostgreSQL and MS SQLServer) the update can be incorporated into the
+`allocate_existing` and `allocate_find` queries, reducing round trips
+to the database and improving performance.
 
 . The module returns `updated` to indicate that it was successfull in
 allocating an IP address.
@@ -101,7 +111,7 @@ attribute holding the allocated IP address to the NAS.
 . The NAS sends an `Accounting Start` request to FreeRADIUS.  After some
 processing (modules. `unlang`, etc.), the `sqlippool` module is run.
 
-. The `sqlippol` module runs the `start_update` query.  This query
+. The `sqlippol` module runs the `extend_update` query.  This query
 uses the configured `pool_key` and NAS identifier in order to identify
 which entry in the `radippool` table to update.  The `expiry_time` is
 updated based on the configured `lease_duration`. This update extends
@@ -121,7 +131,7 @@ FreeRADIUS sends an Accounting-Response to the NAS.
 After some processing (modules. `unlang`, etc.), the `sqlippool`
 module is run.
 
-. The `sqlippol` module runs the `alive_update` query.  This query
+. The `sqlippol` module runs the `extend_update` query.  This query
 uses the configured `pool_key` and NAS identifier in order to identify
 which entry in the `radippool` table to update.  The `expiry_time` is
 updated based on the configured `lease_duration`.
@@ -138,7 +148,7 @@ FreeRADIUS sends an Accounting-Response to the NAS.
 some processing (modules. `unlang`, etc.), the `sqlippool` module is
 run.
 
-. The `sqlippol` module runs the `stop_clear` query.  This query uses
+. The `sqlippol` module runs the `release_clear` query.  This query uses
 the configured `pool_key` and NAS identifier in order to identify
 which entry in the `radippool` table to update.  The update "clears"
 the IP address, and marks it as free for later allocation.  Note that
@@ -160,8 +170,7 @@ FreeRADIUS sends an Accounting-Response to the NAS.
 FreeRADIUS.  After some processing (modules. `unlang`, etc.), the
 `sqlippool` module is run.
 
-. The `sqlippol` module runs the `on_clear` or `off_clear` query,
-depending on the `Acct-Status-Type` attribute on/off.  This query
+. The `sqlippol` module runs the `bulkrelease_clear` query.  This query
 uses the `NAS-IP-Address` in order to identify all leases in the
 `radippool` table which belong to the NAS in question.  The leases are
 cleared, and the IP addresses are immediately released for further

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -176,4 +176,5 @@ mark_update = "\
 	UPDATE ${ippool_table} \
 	SET status_id = (SELECT status_id FROM dhcpstatus WHERE status = 'declined') \
 	WHERE pool_name = '%{control:${pool_name}}' \
-	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}' \
+	AND pool_key = '${pool_key}'"

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -150,19 +150,16 @@ pool_check = "\
 #
 #  Queries to extend a lease - used in response to DHCP-Request packets
 #
-extend_begin = ""
 extend_update = "\
 	UPDATE ${ippool_table} \
 	SET expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
-extend_commit = ""
 
 #
 #  Queries to release a lease - used in response to DHCP-Release packets
 #
-release_begin = ""
 release_clear = "\
 	UPDATE ${ippool_table} \
 	SET gateway = '', \
@@ -171,15 +168,12 @@ release_clear = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
-release_commit = ""
 
 #
 #  Queries to mark leases as "bad" - used in response to DHCP-Decline
 #
-mark_begin = ""
 mark_update = "\
 	UPDATE ${ippool_table} \
 	SET status_id = (SELECT status_id FROM dhcpstatus WHERE status = 'declined') \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
-mark_commit = ""

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -148,9 +148,9 @@ pool_check = "\
 #alloc_commit = ""
 
 #
-#  Queries to extend a lease - used in response to DHCP-Request packets
+#  Queries to update a lease - used in response to DHCP-Request packets
 #
-extend_update = "\
+update_update = "\
 	UPDATE ${ippool_table} \
 	SET expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
 	WHERE pool_name = '%{control:${pool_name}}' \

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -155,7 +155,7 @@ update_update = "\
 	SET expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
-	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
 
 #
 #  Queries to release a lease - used in response to DHCP-Release packets

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -12,16 +12,16 @@
 #  MSSQL-specific syntax - required if finding the address and updating
 #  it are separate queries
 #
-#allocate_begin = "BEGIN TRAN"
-#allocate_commit = "COMMIT TRAN"
+#alloc_begin = "BEGIN TRAN"
+#alloc_commit = "COMMIT TRAN"
 
-allocate_begin = ""
-allocate_commit = ""
+alloc_begin = ""
+alloc_commit = ""
 
 #
 #  Attempt to find the most recent existing IP address for the client
 #
-allocate_existing = "\
+alloc_existing = "\
 	WITH cte AS (
 		SELECT TOP(1) framedipaddress, expiry_time, gateway \
 		FROM ${ippool_table} WITH (xlock rowlock readpast) \
@@ -41,7 +41,7 @@ allocate_existing = "\
 #  If the existing address can't be found this query will be run to
 #  find a free address
 #
-allocate_find = "\
+alloc_find = "\
 	WITH cte AS (
 		SELECT TOP(1) framedipaddress, expiry_time, gateway, pool_key \
 		FROM ${ippool_table} WITH (xlock rowlock readpast) \
@@ -65,7 +65,7 @@ allocate_find = "\
 #  which user had last session.  Ensure that pool_key is unique to the user
 #  within a given pool.
 #
-#allocate_find = "\
+#alloc_find = "\
 #	UPDATE TOP(1) ${ippool_table} \
 #	SET FramedIPAddress = FramedIPAddress, \
 #	pool_key = '${pool_key}', \
@@ -96,7 +96,7 @@ allocate_find = "\
 #  If you prefer to allocate a random IP address every time, use this query instead.
 #  Note: This is very slow if you have a lot of free IPs.
 #
-#allocate_find = "\
+#alloc_find = "\
 #	WITH cte AS ( \
 #		SELECT TOP(1) FramedIPAddress FROM ${ippool_table} \
 #		JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
@@ -125,7 +125,7 @@ pool_check = "\
 #  This is the final IP Allocation query, which saves the allocated ip details.
 #  Only needed if the initial "find" query is not storing the allocation.
 #
-#allocate_update = "\
+#alloc_update = "\
 #	UPDATE ${ippool_table} \
 #	SET \
 #		gateway = '%{DHCP-Gateway-IP-Address}', pool_key = '${pool_key}', \
@@ -136,16 +136,16 @@ pool_check = "\
 #  Use a stored procedure to find AND allocate the address. Read and customise
 #  `procedure.sql` in this directory to determine the optimal configuration.
 #
-#allocate_begin = ""
-#allocate_find = "\
+#alloc_begin = ""
+#alloc_find = "\
 #	EXEC fr_dhcp_allocate_previous_or_new_framedipaddress \
 #		@v_pool_name = '%{control:${pool_name}}', \
 #		@v_gateway = '%{DHCP-Gateway-IP-Address}', \
 #		@v_pool_key = '${pool_key}', \
 #		@v_lease_duration = ${lease_duration} \
 #	"
-#allocate_update = ""
-#allocate_commit = ""
+#alloc_update = ""
+#alloc_commit = ""
 
 #
 #  Queries to extend a lease - used in response to DHCP-Request packets

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -70,7 +70,7 @@ allocate_find = "\
 #	SET FramedIPAddress = FramedIPAddress, \
 #	pool_key = '${pool_key}', \
 #	expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP), \
-#	GatewayIPAddress = '%{DHCP-Gateway-IP-Address}' \
+#	gateway = '%{DHCP-Gateway-IP-Address}' \
 #	OUTPUT INSERTED.FramedIPAddress \
 #	FROM ${ippool_table} \
 #	WHERE ${ippool_table}.id IN ( \
@@ -128,7 +128,7 @@ pool_check = "\
 #allocate_update = "\
 #	UPDATE ${ippool_table} \
 #	SET \
-#		GatewayIPAddress = '%{DHCP-Gateway-IP-Address}', pool_key = '${pool_key}', \
+#		gateway = '%{DHCP-Gateway-IP-Address}', pool_key = '${pool_key}', \
 #		expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
 #	WHERE FramedIPAddress = '%I'"
 
@@ -140,7 +140,7 @@ pool_check = "\
 #allocate_find = "\
 #	EXEC fr_dhcp_allocate_previous_or_new_framedipaddress \
 #		@v_pool_name = '%{control:${pool_name}}', \
-#		@v_gatewayipaddress = '%{DHCP-Gateway-IP-Address}', \
+#		@v_gateway = '%{DHCP-Gateway-IP-Address}', \
 #		@v_pool_key = '${pool_key}', \
 #		@v_lease_duration = ${lease_duration} \
 #	"
@@ -148,39 +148,38 @@ pool_check = "\
 #allocate_commit = ""
 
 #
-#  This query is not applicable to DHCP as there are no accounting
-#  START records
+#  Queries to extend a lease - used in response to DHCP-Request packets
 #
-start_update = ""
+extend_begin = ""
+extend_update = "\
+	UPDATE ${ippool_table} \
+	SET expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+extend_commit = ""
 
 #
-#  Free an IP when an accounting STOP record arrives - for DHCP this
-#  is when a Release occurs
+#  Queries to release a lease - used in response to DHCP-Release packets
 #
-stop_begin = ""
-stop_clear = "\
+release_begin = ""
+release_clear = "\
 	UPDATE ${ippool_table} \
-	SET \
-		GatewayIPAddress = '', \
+	SET gateway = '', \
 		pool_key = '0', \
 		expiry_time = CURRENT_TIMESTAMP \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
-	AND FramedIPAddress = '%{DHCP-Client-IP-Address}'"
-stop_commit = ""
+	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
+release_commit = ""
 
 #
-#  This query is not applicable to DHCP as there are no accounting
-#  ALIVE records
+#  Queries to mark leases as "bad" - used in response to DHCP-Decline
 #
-alive_update = ""
-
-#
-#  This query is not applicable to DHCP
-#
-on_clear = ""
-
-#
-#  This query is not applicable to DHCP
-#
-off_clear = ""
+mark_begin = ""
+mark_update = "\
+	UPDATE ${ippool_table} \
+	SET status_id = (SELECT status_id FROM dhcpstatus WHERE status = 'declined') \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+mark_commit = ""

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -113,9 +113,9 @@ alloc_update = "\
 #alloc_commit = ""
 
 #
-#  Queries to extend a lease - used in response to DHCP-Request packets
+#  Queries to update a lease - used in response to DHCP-Request packets
 #
-extend_update = "\
+update_update = "\
 	UPDATE ${ippool_table} \
 	SET expiry_time = 'now'::timesheet(0) + '${lease_duration} second'::interval \
 	WHERE pool_name = '%{control:${pool_name}}' \

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -141,4 +141,5 @@ mark_update = "\
 	UPDATE ${ippool_table} \
 	SET `status` = 'declined' \
 	WHERE pool_name = '%{control:${pool_name}}' \
-	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}' \
+	AND pool_key = '${pool_key}'"

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -113,36 +113,38 @@ allocate_update = "\
 #allocate_commit = ""
 
 #
-#  This query is not applicable to DHCP as there are no accounting
-#  START records
+#  Queries to extend a lease - used in response to DHCP-Request packets
 #
-start_update = ""
+extend_begin = ""
+extend_update = "\
+	UPDATE ${ippool_table} \
+	SET expiry_time = 'now'::timesheet(0) + '${lease_duration} second'::interval \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+extend_commit = ""
 
 #
-#  This query frees an IP address when an accounting STOP record
-#  arrives - for DHCP this is when a Release occurs
+#  Queries to release a lease - used in response to DHCP-Release packets
 #
-stop_clear = "\
+release_begin = ""
+release_clear = "\
 	UPDATE ${ippool_table} \
-	SET \
-		gateway = '', \
+	SET gateway = '', \
 		pool_key = '0', \
 		expiry_time = NOW() \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
+release_commit = ""
 
 #
-#  This query is not applicable to DHCP as there are no accounting ALIVE records
+#  Queries to mark leases as "bad" - used in response to DHCP-Decline
 #
-alive_update = ""
-
-#
-#  This query is not applicable to DHCP
-#
-on_clear = ""
-
-#
-#  This query is not applicable to DHCP
-#
-off_clear = ""
+mark_begin = ""
+mark_update = "\
+	UPDATE ${ippool_table} \
+	SET `status` = 'declined' \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+mark_commit = ""

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -120,7 +120,7 @@ update_update = "\
 	SET expiry_time = 'now'::timesheet(0) + '${lease_duration} second'::interval \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
-	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
 
 #
 #  Queries to release a lease - used in response to DHCP-Release packets

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -18,7 +18,7 @@
 #
 #  This query attempts to find the most recent IP address for the client
 #
-allocate_existing = "\
+alloc_existing = "\
 	SELECT framedipaddress \
 	FROM ${ippool_table} \
 	WHERE pool_name = '%{control:${pool_name}}' \
@@ -32,7 +32,7 @@ allocate_existing = "\
 #  If the preceding query fails to find an IP address, the following
 #  one is used to select a free one from the pool
 #
-allocate_find = "\
+alloc_find = "\
 	SELECT framedipaddress \
 	FROM ${ippool_table} \
 	WHERE pool_name = '%{control:${pool_name}}' \
@@ -46,7 +46,7 @@ allocate_find = "\
 #  Alternatively the two queries can be combined into one, though
 #  depending on transaction isolation mode, this can case deadlocks
 #
-#allocate_find = "\
+#alloc_find = "\
 #	(SELECT framedipaddress, pool_key, expiry_time FROM radippool \
 #		WHERE pool_name = '%{control:${pool_name}}' \
 #		AND pool_key = '${pool_key}' \
@@ -65,7 +65,7 @@ allocate_find = "\
 #  If you prefer to allocate a random IP address every time, use this query instead.
 #  Note: This is very slow if you have a lot of free IPs.
 #
-#allocate_find = "\
+#alloc_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} \
 #	WHERE pool_name = '%{control:${pool_name}}' \
 #	AND expiry_time < NOW() \
@@ -90,7 +90,7 @@ pool_check = "\
 #
 #  This is the final IP Allocation query, which saves the allocated ip details.
 #
-allocate_update = "\
+alloc_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		gateway = '%{DHCP-Gateway-IP-Address}', pool_key = '${pool_key}', \
@@ -101,16 +101,16 @@ allocate_update = "\
 #  Use a stored procedure to find AND allocate the address. Read and customise
 #  `procedure.sql` in this directory to determine the optimal configuration.
 #
-#allocate_begin = ""
-#allocate_find = "\
+#alloc_begin = ""
+#alloc_find = "\
 #	CALL fr_dhcp_allocate_previous_or_new_framedipaddress( \
 #		'%{control:${pool_name}}', \
 #		'%{DHCP-Gateway-IP-Address}', \
 #		'${pool_key}', \
 #		${lease_duration} \
 #	)"
-#allocate_update = ""
-#allocate_commit = ""
+#alloc_update = ""
+#alloc_commit = ""
 
 #
 #  Queries to extend a lease - used in response to DHCP-Request packets

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -115,19 +115,16 @@ allocate_update = "\
 #
 #  Queries to extend a lease - used in response to DHCP-Request packets
 #
-extend_begin = ""
 extend_update = "\
 	UPDATE ${ippool_table} \
 	SET expiry_time = 'now'::timesheet(0) + '${lease_duration} second'::interval \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
-extend_commit = ""
 
 #
 #  Queries to release a lease - used in response to DHCP-Release packets
 #
-release_begin = ""
 release_clear = "\
 	UPDATE ${ippool_table} \
 	SET gateway = '', \
@@ -136,15 +133,12 @@ release_clear = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
-release_commit = ""
 
 #
 #  Queries to mark leases as "bad" - used in response to DHCP-Decline
 #
-mark_begin = ""
 mark_update = "\
 	UPDATE ${ippool_table} \
 	SET `status` = 'declined' \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
-mark_commit = ""

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -103,16 +103,16 @@ pool_check = "\
 #	WHERE framedipaddress = '%I'"
 
 #
-#  Queries to extend a lease - used in response to DHCP-Request packets
+#  Queries to update a lease - used in response to DHCP-Request packets
 #
-extend_begin = "commit"
-extend_update = "\
+update_begin = "commit"
+update_update = "\
 	UPDATE ${ippool_table} \
 	SET expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
-extend_commit = "commit"
+update_commit = "commit"
 
 #
 #  Queries to release a lease - used in response to DHCP-Release packets

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -13,23 +13,23 @@
 #  Oracle's locking mechanism limitations prevents the use of single queries
 #  that can either find a client's existing address or the first available one.
 #
-allocate_begin = ""
-allocate_find = "\
+alloc_begin = ""
+alloc_find = "\
 	SELECT fr_dhcp_allocate_previous_or_new_framedipaddress( \
 		'%{control:${pool_name}}', \
 		'%{DHCP-Gateway-IP-Address}', \
 		'${pool_key}', \
 		'${lease_duration}' \
 	)"
-allocate_update = ""
-allocate_commit = ""
+alloc_update = ""
+alloc_commit = ""
 
 
 #
 #  If you prefer to allocate a random IP address every time, use this query instead
 #  Note: This is very slow if you have a lot of free IPs.
 #
-#allocate_find = "\
+#alloc_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} WHERE id IN ( \
 #		SELECT id FROM ( \
 #			SELECT * \
@@ -47,7 +47,7 @@ allocate_commit = ""
 #  The above query again, but with SKIP LOCKED. This requires Oracle > 11g.
 #  It may work in 9i and 10g, but is not documented, so YMMV.
 #
-#allocate_find = "\
+#alloc_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} WHERE id IN ( \
 #		SELECT id FROM (\
 #			SELECT * \
@@ -64,7 +64,7 @@ allocate_commit = ""
 #
 # A tidier version that needs Oracle >= 12c
 #
-#allocate_find = "\
+#alloc_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} WHERE id IN (
 #		SELECT id FROM ${ippool_table} \
 #		JOIN dhcpstatus \
@@ -91,16 +91,16 @@ pool_check = "\
 	) WHERE ROWNUM = 1"
 
 #
-#  This query marks the IP address handed out by "allocate_find" as used
+#  This query marks the IP address handed out by "alloc_find" as used
 #  for the period of "lease_duration" after which time it may be reused.
 #
-allocate_update = "\
-	UPDATE ${ippool_table} \
-	SET \
-		gateway = '%{DHCP-Gateway-IP-Address}', \
-		pool_key = '${pool_key}', \
-		expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
-	WHERE framedipaddress = '%I'"
+#alloc_update = "\
+#	UPDATE ${ippool_table} \
+#	SET \
+#		gateway = '%{DHCP-Gateway-IP-Address}', \
+#		pool_key = '${pool_key}', \
+#		expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
+#	WHERE framedipaddress = '%I'"
 
 #
 #  Queries to extend a lease - used in response to DHCP-Request packets

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -107,6 +107,44 @@ allocate_update = "\
 	WHERE framedipaddress = '%I'"
 
 #
+#  Queries to extend a lease - used in response to DHCP-Request packets
+#
+extend_begin = ""
+extend_update = "\
+	UPDATE ${ippool_table} \
+	SET expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+extend_commit = ""
+
+#
+#  Queries to release a lease - used in response to DHCP-Release packets
+#
+release_begin = ""
+release_clear = "\
+	UPDATE ${ippool_table} \
+	SET gateway = '', \
+		pool_key = '0', \
+		expiry_time = current_timestamp \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
+release_commit = ""
+
+#
+#  Queries to mark leases as "bad" - used in response to DHCP-Decline
+#
+mark_begin = ""
+mark_update = "\
+	UPDATE ${ippool_table} \
+	SET status_id = (SELECT status_id FROM dhcpstatus WHERE status = 'declined') \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+mark_commit = ""
+
+
+#
 #  This query is not applicable to DHCP as there are no accounting
 #  START records
 #

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -136,5 +136,6 @@ mark_update = "\
 	UPDATE ${ippool_table} \
 	SET status_id = (SELECT status_id FROM dhcpstatus WHERE status = 'declined') \
 	WHERE pool_name = '%{control:${pool_name}}' \
-	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}' \
+	AND pool_key = '${pool_key}'"
 mark_commit = "commit"

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -4,13 +4,6 @@
 #
 #  $id: 416d59802a1321c16b936bb5e63c288ca3634bcd $
 
-start_begin = "commit"
-alive_begin = "commit"
-stop_begin = "commit"
-on_begin = "commit"
-off_begin = "commit"
-
-
 #
 #  Use a stored procedure to find AND allocate the address. Read and customise
 #  `procedure.sql` in this directory to determine the optimal configuration.
@@ -109,19 +102,19 @@ allocate_update = "\
 #
 #  Queries to extend a lease - used in response to DHCP-Request packets
 #
-extend_begin = ""
+extend_begin = "commit"
 extend_update = "\
 	UPDATE ${ippool_table} \
 	SET expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
-extend_commit = ""
+extend_commit = "commit"
 
 #
 #  Queries to release a lease - used in response to DHCP-Release packets
 #
-release_begin = ""
+release_begin = "commit"
 release_clear = "\
 	UPDATE ${ippool_table} \
 	SET gateway = '', \
@@ -130,18 +123,18 @@ release_clear = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
-release_commit = ""
+release_commit = "commit"
 
 #
 #  Queries to mark leases as "bad" - used in response to DHCP-Decline
 #
-mark_begin = ""
+mark_begin = "commit"
 mark_update = "\
 	UPDATE ${ippool_table} \
 	SET status_id = (SELECT status_id FROM dhcpstatus WHERE status = 'declined') \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
-mark_commit = ""
+mark_commit = "commit"
 
 
 #

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -5,6 +5,9 @@
 #  $id: 416d59802a1321c16b936bb5e63c288ca3634bcd $
 
 #
+#  Due to Oracle's transaction focus, update queries further down are
+#  wrapped in "commit" statements.
+#
 #  Use a stored procedure to find AND allocate the address. Read and customise
 #  `procedure.sql` in this directory to determine the optimal configuration.
 #  Oracle's locking mechanism limitations prevents the use of single queries
@@ -135,40 +138,3 @@ mark_update = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
 mark_commit = "commit"
-
-
-#
-#  This query is not applicable to DHCP as there are no accounting
-#  START records
-#
-start_update = ""
-
-#
-#  This query frees an IP address when an accounting STOP record arrives
-#  - for DHCP this is when a Release occurs
-#
-stop_clear = "\
-	UPDATE ${ippool_table} \
-	SET \
-		gateway = '', \
-		pool_key = '0', \
-		expiry_time = current_timestamp - INTERVAL '1' second(1) \
-	WHERE pool_name = '%{control:${pool_name}}' \
-	AND pool_key = '${pool_key}' \
-	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
-
-#
-#  This query is not applicable to DHCP as there are no accounting
-#  ALIVE records
-#
-alive_update = ""
-
-#
-#  This query is not applicable to DHCP
-#
-on_clear = ""
-
-#
-#  This query is not applicable to DHCP
-#
-off_clear = ""

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -111,7 +111,7 @@ update_update = "\
 	SET expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
-	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
 update_commit = "commit"
 
 #

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -4,7 +4,7 @@
 #
 #  $Id$
 
-#  Using SKIP LOCKED speed up the allocate_find query by 10
+#  Using SKIP LOCKED speed up the alloc_find query by 10
 #  times. However, it requires PostgreSQL >= 9.5.
 #
 #  If you are using an older version of PostgreSQL comment out the following:
@@ -16,12 +16,12 @@ skip_locked = "SKIP LOCKED"
 #  If the SELECT and UPDATE are in separate queries then set the following
 #  to "BEGIN" to wrap them as a transaction
 #
-allocate_begin = ""
+alloc_begin = ""
 
 #
 #  This query attempts to re-allocate the most recent IP address
 #  for the client
-allocate_existing = "\
+alloc_existing = "\
 	WITH cte AS ( \
 		SELECT framedipaddress \
 		FROM ${ippool_table} \
@@ -43,7 +43,7 @@ allocate_existing = "\
 #  If the preceding query doesn't find an address the following one
 #  is used for finding one from the pool
 #
-allocate_find = "\
+alloc_find = "\
 	WITH cte AS ( \
 		SELECT framedipaddress \
 		FROM ${ippool_table} \
@@ -64,10 +64,10 @@ allocate_find = "\
 #
 #  If you prefer to allocate a random IP address every time, use this query instead
 #  Note: This is very slow if you have a lot of free IPs.
-#  Use of either of these next two queries should have the allocate_begin line commented out
-#  and allocate_update below un-commented.
+#  Use of either of these next two queries should have the alloc_begin line commented out
+#  and alloc_update below un-commented.
 #
-#allocate_find = "\
+#alloc_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} \
 #	WHERE pool_name = '%{control:${pool_name}}' AND expiry_time < 'now'::timestamp(0) \
 #	AND status = 'dynamic' \
@@ -76,11 +76,11 @@ allocate_find = "\
 #	FOR UPDATE ${skip_locked}"
 
 #
-#  This query marks the IP address handed out by "allocate-find" as used
+#  This query marks the IP address handed out by "alloc_find" as used
 #  for the period of "lease_duration" after which time it may be reused.
 #  It is only needed if the SELECT query does not perform the update.
 #
-#allocate_update = "\
+#alloc_update = "\
 #	UPDATE ${ippool_table} \
 #	SET \
 #		gateway = '%{DHCP-Gateway-IP-Address}', \
@@ -92,7 +92,7 @@ allocate_find = "\
 #  If the SELECT and UPDATE are in separate queries then set the following
 #  to "COMMIT" to wrap them as a transaction
 #
-allocate_commit = ""
+alloc_commit = ""
 
 #
 #  If an IP could not be allocated, check to see whether the pool exists or not
@@ -118,8 +118,8 @@ pool_check = "\
 #  have this comment, the query may go to a read only server, and will fail.
 #  This has no negative effect if you are not using PgPool.
 #
-#allocate_begin = ""
-#allocate_find = "\
+#alloc_begin = ""
+#alloc_find = "\
 #	/*NO LOAD BALANCE*/ \
 #	SELECT fr_allocate_previous_or_new_framedipaddress( \
 #		'%{control:${pool_name}}', \
@@ -127,8 +127,8 @@ pool_check = "\
 #		'${pool_key}', \
 #		'${lease_duration}' \
 #	)"
-#allocate_update = ""
-#allocate_commit = ""
+#alloc_update = ""
+#alloc_commit = ""
 
 #
 #  Queries to extend a lease - used in response to DHCP-Request packets

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -131,37 +131,38 @@ pool_check = "\
 #allocate_commit = ""
 
 #
-#  This query is not applicable to DHCP as there are no accounting
-#  START records
+#  Queries to extend a lease - used in response to DHCP-Request packets
 #
-start_update = ""
+extend_begin = ""
+extend_update = "\
+	UPDATE ${ippool_table} \
+	SET expiry_time = 'now'::timesheet(0) + '${lease_duration} second'::interval \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+extend_commit = ""
 
 #
-#  This query frees an IP address when an accounting
-#  STOP record arrives - for DHCP this is when a Release occurs
+#  Queries to release a lease - used in response to DHCP-Release packets
 #
-stop_clear = "\
+release_begin = ""
+release_clear = "\
 	UPDATE ${ippool_table} \
-	SET \
-		gateway = '', \
-		pool_key = 0, \
+	SET gateway = '', \
+		pool_key = '0', \
 		expiry_time = 'now'::timestamp(0) - '1 second'::interval \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
+release_commit = ""
 
 #
-#  This query is not applicable to DHCP as there are no accounting
-#  ALIVE records
+#  Queries to mark leases as "bad" - used in response to DHCP-Decline
 #
-alive_update = ""
-
-#
-#  This query is not applicable to DHCP
-#
-on_clear = ""
-
-#
-#  This query is not applicable to DHCP
-#
-off_clear = ""
+mark_begin = ""
+mark_update = "\
+	UPDATE ${ippool_table} \
+	SET status = 'declined' \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+mark_commit = ""

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -138,7 +138,7 @@ update_update = "\
 	SET expiry_time = 'now'::timesheet(0) + '${lease_duration} second'::interval \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
-	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
 
 #
 #  Queries to release a lease - used in response to DHCP-Release packets

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -133,19 +133,16 @@ pool_check = "\
 #
 #  Queries to extend a lease - used in response to DHCP-Request packets
 #
-extend_begin = ""
 extend_update = "\
 	UPDATE ${ippool_table} \
 	SET expiry_time = 'now'::timesheet(0) + '${lease_duration} second'::interval \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
-extend_commit = ""
 
 #
 #  Queries to release a lease - used in response to DHCP-Release packets
 #
-release_begin = ""
 release_clear = "\
 	UPDATE ${ippool_table} \
 	SET gateway = '', \
@@ -154,15 +151,12 @@ release_clear = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
-release_commit = ""
 
 #
 #  Queries to mark leases as "bad" - used in response to DHCP-Decline
 #
-mark_begin = ""
 mark_update = "\
 	UPDATE ${ippool_table} \
 	SET status = 'declined' \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
-mark_commit = ""

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -131,9 +131,9 @@ pool_check = "\
 #alloc_commit = ""
 
 #
-#  Queries to extend a lease - used in response to DHCP-Request packets
+#  Queries to update a lease - used in response to DHCP-Request packets
 #
-extend_update = "\
+update_update = "\
 	UPDATE ${ippool_table} \
 	SET expiry_time = 'now'::timesheet(0) + '${lease_duration} second'::interval \
 	WHERE pool_name = '%{control:${pool_name}}' \

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -159,4 +159,5 @@ mark_update = "\
 	UPDATE ${ippool_table} \
 	SET status = 'declined' \
 	WHERE pool_name = '%{control:${pool_name}}' \
-	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}' \
+	AND pool_key = '${pool_key}'"

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -106,7 +106,7 @@ update_update = "\
 	SET expiry_time = datetime(strftime('%%s', 'now') + ${lease_duration}, 'unixepoch') \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
-	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
 
 #
 #  Queries to release a lease - used in response to DHCP-Release packets

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -127,5 +127,6 @@ mark_update = "\
 	UPDATE ${ippool_table} \
 	SET status_id = (SELECT status_id FROM dhcpstatus WHERE status = 'declined') \
 	WHERE pool_name = '%{control:${pool_name}}' \
-	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}' \
+	AND pool_key = '${pool_key}'"
 

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -101,19 +101,16 @@ allocate_update = "\
 #
 #  Queries to extend a lease - used in response to DHCP-Request packets
 #
-extend_begin = ""
 extend_update = "\
 	UPDATE ${ippool_table} \
 	SET expiry_time = datetime(strftime('%%s', 'now') + ${lease_duration}, 'unixepoch') \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
-extend_commit = ""
 
 #
 #  Queries to release a lease - used in response to DHCP-Release packets
 #
-release_begin = ""
 release_clear = "\
 	UPDATE ${ippool_table} \
 	SET gateway = '', \
@@ -122,16 +119,13 @@ release_clear = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
-release_commit = ""
 
 #
 #  Queries to mark leases as "bad" - used in response to DHCP-Decline
 #
-mark_begin = ""
 mark_update = "\
 	UPDATE ${ippool_table} \
 	SET status_id = (SELECT status_id FROM dhcpstatus WHERE status = 'declined') \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
-mark_commit = ""
 

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -99,9 +99,9 @@ alloc_update = "\
 	AND expiry_time IS NULL"
 
 #
-#  Queries to extend a lease - used in response to DHCP-Request packets
+#  Queries to update a lease - used in response to DHCP-Request packets
 #
-extend_update = "\
+update_update = "\
 	UPDATE ${ippool_table} \
 	SET expiry_time = datetime(strftime('%%s', 'now') + ${lease_duration}, 'unixepoch') \
 	WHERE pool_name = '%{control:${pool_name}}' \

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -22,7 +22,8 @@ allocate_begin = "BEGIN EXCLUSIVE"
 allocate_commit = "COMMIT"
 
 #
-#  This series of queries allocates an IP address
+#  This series of queries allocates an IP address - used in response to
+#  DHCP Discover packets
 #
 #  Either pull the most recent allocated IP for this client or the
 #  oldest expired one.  The first sub query returns the most recent
@@ -98,38 +99,39 @@ allocate_update = "\
 	AND expiry_time IS NULL"
 
 #
-#  This query is not applicable to DHCP as there are no accounting
-#  START records
+#  Queries to extend a lease - used in response to DHCP-Request packets
 #
-start_update = ""
+extend_begin = ""
+extend_update = "\
+	UPDATE ${ippool_table} \
+	SET expiry_time = datetime(strftime('%%s', 'now') + ${lease_duration}, 'unixepoch') \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+extend_commit = ""
 
 #
-#  Free an IP when an accounting STOP record arrives - for DHCP this
-#  is when a Release occurs
+#  Queries to release a lease - used in response to DHCP-Release packets
 #
-stop_clear = "\
+release_begin = ""
+release_clear = "\
 	UPDATE ${ippool_table} \
-	SET \
-		gateway = '', \
+	SET gateway = '', \
 		pool_key = '0', \
 		expiry_time = datetime('now') \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
+release_commit = ""
 
 #
-#  This query is not applicable to DHCP as there are no accounting
-#  ALIVE records
+#  Queries to mark leases as "bad" - used in response to DHCP-Decline
 #
-alive_update = ""
-
-#
-#  This query is not applicable to DHCP
-#
-on_clear = ""
-
-#
-#  This query is not applicable to DHCP
-#
-off_clear = ""
+mark_begin = ""
+mark_update = "\
+	UPDATE ${ippool_table} \
+	SET status_id = (SELECT status_id FROM dhcpstatus WHERE status = 'declined') \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+mark_commit = ""
 

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -18,8 +18,8 @@
 #  automatic shared lock for the transaction to an exclusive lock for the
 #  subsequent UPDATE.
 #
-allocate_begin = "BEGIN EXCLUSIVE"
-allocate_commit = "COMMIT"
+alloc_begin = "BEGIN EXCLUSIVE"
+alloc_commit = "COMMIT"
 
 #
 #  This series of queries allocates an IP address - used in response to
@@ -32,7 +32,7 @@ allocate_commit = "COMMIT"
 #  Sorting the result by expiry_time DESC will return the client specific
 #  IP if it exists, otherwise an expired one.
 #
-allocate_find = "\
+alloc_find = "\
 	SELECT framedipaddress, expiry_time \
 	FROM ( \
 		SELECT framedipaddress, expiry_time \
@@ -63,7 +63,7 @@ allocate_find = "\
 #
 # If you prefer to allocate a random IP address every time, use this query instead
 #
-#allocate_find = "\
+#alloc_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} \
 #	JOIN dhcpstatus \
 #	ON ${ippool_table}.status_id = dhcpstatus.status_id \
@@ -89,7 +89,7 @@ pool_check = "\
 #
 #  This is the final IP Allocation query, which saves the allocated ip details
 #
-allocate_update = "\
+alloc_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		gateway = '%{DHCP-Gateway-IP-Address}', \

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
@@ -4,7 +4,7 @@
 CREATE TABLE dhcpstatus (
   status_id             int PRIMARY KEY,
   status		varchar(10) NOT NULL
-)
+);
 
 INSERT INTO dhcpstatus (status_id, status) VALUES (1, 'dynamic'), (2, 'static'), (3, 'declined'), (4, 'disabled');
 
@@ -24,8 +24,8 @@ CREATE INDEX dhcpippool_framedipaddress ON dhcpippool(framedipaddress);
 CREATE INDEX dhcpippool_poolname_poolkey ON dhcpippool(pool_name, pool_key, framedipaddress);
 
 -- Example of how to put IPs in the pool
--- INSERT INTO radippool (pool_name, framedipaddress) VALUES ('local', '192.168.5.10');
--- INSERT INTO radippool (pool_name, framedipaddress) VALUES ('local', '192.168.5.11');
--- INSERT INTO radippool (pool_name, framedipaddress) VALUES ('local', '192.168.5.12');
--- INSERT INTO radippool (pool_name, framedipaddress) VALUES ('local', '192.168.5.13');
+-- INSERT INTO dhcpippool (pool_name, framedipaddress) VALUES ('local', '192.168.5.10');
+-- INSERT INTO dhcpippool (pool_name, framedipaddress) VALUES ('local', '192.168.5.11');
+-- INSERT INTO dhcpippool (pool_name, framedipaddress) VALUES ('local', '192.168.5.12');
+-- INSERT INTO dhcpippool (pool_name, framedipaddress) VALUES ('local', '192.168.5.13');
 

--- a/raddb/mods-config/sql/ippool/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mssql/queries.conf
@@ -6,14 +6,16 @@
 
 # MSSQL-specific syntax - only needed if the queries need wrapping as
 # a transaction - specifically when the SELECT and UPDATE are separate queries
-#allocate_begin = "BEGIN TRAN"
-#allocate_commit = "COMMIT TRAN"
+#alloc_begin = "BEGIN TRAN"
+#alloc_commit = "COMMIT TRAN"
+alloc_begin = ""
+alloc_commit = ""
 
 #
 #  This query tries to allocate the same IP-address to the user
 #  that they had last session
 #
-allocate_existing = "\
+alloc_existing = "\
 	WITH cte AS ( \
 		SELECT TOP(1) \
 		FramedIPAddress, NASIPAddress, pool_key, CallingStationId, UserName, expiry_time \
@@ -35,7 +37,7 @@ allocate_existing = "\
 #  If no address was returned by the above query, use the following
 #  to find a free one in the pool
 #
-allocate_find = "\
+alloc_find = "\
 	WITH cte AS ( \
 		SELECT TOP(1) \
 		FramedIPAddress, NASIPAddress, pool_key, CallingStationId, UserName, expiry_time \
@@ -60,7 +62,7 @@ allocate_find = "\
 #  the pool so a separate allocate_update will be required, as will the allocate_begin
 #  and allocate_commit transaction wrappers.
 #
-#allocate_find = "\
+#alloc_find = "\
 #	WITH cte AS ( \
 #		SELECT TOP(1) FramedIPAddress FROM ${ippool_table} \
 #		WHERE pool_name = '%{control:${pool_name}}' \
@@ -86,7 +88,7 @@ pool_check = "\
 #
 #  This is the final IP Allocation query, which saves the allocated ip details.
 #
-#allocate_update = "\
+#alloc_update = "\
 #	UPDATE ${ippool_table} \
 #	SET \
 #		NASIPAddress = '%{NAS-IP-Address}', pool_key = '${pool_key}', \
@@ -98,8 +100,8 @@ pool_check = "\
 #  Use a stored procedure to find AND allocate the address. Read and customise
 #  `procedure.sql` in this directory to determine the optimal configuration.
 #
-#allocate_begin = ""
-#allocate_find = "\
+#alloc_begin = ""
+#alloc_find = "\
 #	EXEC fr_allocate_previous_or_new_framedipaddress \
 #		@v_pool_name = '%{control:${pool_name}}', \
 #		@v_username = '%{User-Name}', \
@@ -108,8 +110,8 @@ pool_check = "\
 #		@v_pool_key = '${pool_key}', \
 #		@v_lease_duration = ${lease_duration} \
 #	"
-#allocate_update = ""
-#allocate_commit = ""
+#alloc_update = ""
+#alloc_commit = ""
 
 #
 #  This series of queries extends an IP lease when an accounting START / ALIVE record arrives.

--- a/raddb/mods-config/sql/ippool/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mssql/queries.conf
@@ -146,7 +146,7 @@ release_clear = "\
 #
 #  Frees all IPs allocated to a NAS when an accounting ON / OFF record arrives
 #
-bulkrelease_clear = "\
+bulk_release_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		NASIPAddress = '', \

--- a/raddb/mods-config/sql/ippool/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mssql/queries.conf
@@ -112,13 +112,13 @@ pool_check = "\
 #allocate_commit = ""
 
 #
-#  This series of queries frees an IP number when an accounting START record arrives.
+#  This series of queries frees an IP number when an accounting START / ALIVE record arrives.
 #
-start_update = "\
+extend_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
-	WHERE NASIPAddress = '%{NAS-IP-Address}' \
+	WHERE NASIPAddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}' \
 	AND pool_key = '${pool_key}' \
 	AND UserName = '%{User-Name}' \
 	AND CallingStationId = '%{Calling-Station-Id}' \
@@ -127,7 +127,7 @@ start_update = "\
 #
 #  Free an IP when an accounting STOP record arrives
 #
-stop_clear = "\
+release_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		NASIPAddress = '', \
@@ -142,35 +142,9 @@ stop_clear = "\
 	AND FramedIPAddress = '%{${attribute_name}}'"
 
 #
-#  Update the expiry time for an IP when an accounting ALIVE record arrives
+#  Frees all IPs allocated to a NAS when an accounting ON / OFF record arrives
 #
-alive_update = "\
-	UPDATE ${ippool_table} \
-	SET \
-		expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
-	WHERE NASIPAddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}' \
-	AND pool_key = '${pool_key}' \
-	AND UserName = '%{User-Name}' \
-	AND CallingStationId = '%{Calling-Station-Id}' \
-	AND FramedIPAddress = '%{${attribute_name}}'"
-
-#
-#  Frees all IPs allocated to a NAS when an accounting ON record arrives
-#
-on_clear = "\
-	UPDATE ${ippool_table} \
-	SET \
-		NASIPAddress = '', \
-		pool_key = '0', \
-		CallingStationId = '', \
-		UserName = '', \
-		expiry_time = CURRENT_TIMESTAMP \
-	WHERE NASIPAddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"
-
-#
-#  Frees all IPs allocated to a NAS when an accounting OFF record arrives
-#
-off_clear = "\
+bulkrelease_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		NASIPAddress = '', \

--- a/raddb/mods-config/sql/ippool/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mssql/queries.conf
@@ -114,9 +114,9 @@ pool_check = "\
 #alloc_commit = ""
 
 #
-#  This series of queries extends an IP lease when an accounting START / ALIVE record arrives.
+#  This query updates an IP lease when an accounting START / ALIVE record arrives.
 #
-extend_update = "\
+update_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \

--- a/raddb/mods-config/sql/ippool/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mssql/queries.conf
@@ -112,7 +112,7 @@ pool_check = "\
 #allocate_commit = ""
 
 #
-#  This series of queries frees an IP number when an accounting START / ALIVE record arrives.
+#  This series of queries extends an IP lease when an accounting START / ALIVE record arrives.
 #
 extend_update = "\
 	UPDATE ${ippool_table} \

--- a/raddb/mods-config/sql/ippool/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mysql/queries.conf
@@ -8,7 +8,9 @@
 #
 #    * If ${attribute_name} already set, do nothing (return noop)
 #    * If no Pool-Name defined, do nothing (return noop)
-#    * Run allocate_find to get an ip address
+#    * Run alloc_existing (if defined) to look for the previous address
+#      allocated to the client
+#    * If not found, run alloc_find to get a free ip address
 #    * If not found, run pool_check (if defined)
 #      * If pool exists, assume full and return notfound
 #      * If pool does not exist, or pool_check not defined, return noop
@@ -45,10 +47,10 @@
 #skip_locked = "SKIP LOCKED"
 
 #
-#  allocate_existing looks up a user's IP-address from their
+#  alloc_existing looks up a user's IP-address from their
 #  last session.
 #
-allocate_existing = "\
+alloc_existing = "\
 	SELECT framedipaddress FROM ${ippool_table} \
 	WHERE pool_lane = '%{control:Pool-Name}' \
 	AND nasipaddress = '%{NAS-IP-Address}' \
@@ -58,11 +60,11 @@ allocate_existing = "\
 	FOR UPDATE ${skip_locked}"
 #
 #  If the previous query doesn't find an address then
-#  allocate_find obtains a free ip address to satisfy a new request
+#  alloc_find obtains a free ip address to satisfy a new request
 #
 #  Limit 1 to ensure only one result is returned
 #
-allocate_find = "\
+alloc_find = "\
 	SELECT framedipaddress FROM ${ippool_table} \
 	WHERE pool_name = '%{control:Pool-Name}' \
 	AND expiry_time < NOW() \
@@ -74,7 +76,7 @@ allocate_find = "\
 #  If you prefer to allocate a random IP address every time, use this query instead.
 #  Note: This is very slow if you have a lot of free IPs.
 #
-#allocate_find = "\
+#alloc_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} \
 #	WHERE pool_name = '%{control:Pool-Name}' \
 #	AND expiry_time IS 0 \
@@ -100,14 +102,14 @@ pool_check = "\
 	LIMIT 1"
 
 #
-#  allocate_update is the final IP Allocation query, which saves the
+#  alloc_update is the final IP Allocation query, which saves the
 #  allocated IP details, officially allocating the IP address to the user.
 #
 #  WARNING: "WHERE framedipaddress = '%I'" MUST use %I instead of %{${attribute_name}}
 #           (because ${attribute_name} hasn't been set yet, that's what we're in the
 #            process of doing)
 #
-allocate_update = "\
+alloc_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '%{NAS-IP-Address}', pool_key = '${pool_key}', \
@@ -119,9 +121,9 @@ allocate_update = "\
 #  Use a stored procedure to find AND allocate the address. Read and customise
 #  `procedure.sql` in this directory to determine the optimal configuration.
 #
-#allocate_begin = ""
-#allocate_existing = ""
-#allocate_find = "\
+#alloc_begin = ""
+#alloc_existing = ""
+#alloc_find = "\
 #	CALL fr_allocate_previous_or_new_framedipaddress( \
 #		'%{control:${pool_name}}', \
 #		'%{User-Name}', \
@@ -130,8 +132,8 @@ allocate_update = "\
 #		'${pool_key}', \
 #		${lease_duration} \
 #	)"
-#allocate_update = ""
-#allocate_commit = ""
+#alloc_update = ""
+#alloc_commit = ""
 
 #
 #  start_update updates allocation info when an accounting START / ALIVE record arrives.

--- a/raddb/mods-config/sql/ippool/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mysql/queries.conf
@@ -134,9 +134,9 @@ allocate_update = "\
 #allocate_commit = ""
 
 #
-#  start_update updates allocation info when an accounting START record arrives.
+#  start_update updates allocation info when an accounting START / ALIVE record arrives.
 #
-start_update = "\
+extend_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
@@ -154,7 +154,7 @@ start_update = "\
 #
 #  The second version clears everything
 #
-# stop_clear = "\
+# release_clear = "\
 #         UPDATE ${ippool_table} \
 #         SET \
 #                 expiry_time = NOW() \
@@ -164,7 +164,7 @@ start_update = "\
 #         AND callingstationid = '%{Calling-Station-Id}' \
 #         AND framedipaddress = '%{${attribute_name}}'"
 
-stop_clear = "\
+release_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '', \
@@ -172,20 +172,6 @@ stop_clear = "\
 		callingstationid = '', \
 		username = '', \
 		expiry_time = NOW() \
-	WHERE nasipaddress = '%{Nas-IP-Address}' \
-	AND pool_key = '${pool_key}' \
-	AND username = '%{User-Name}' \
-	AND callingstationid = '%{Calling-Station-Id}' \
-	AND framedipaddress = '%{${attribute_name}}'"
-
-#
-#  alive_update updates allocation info when an accounting ALIVE (Interim-Update)
-#  record arrives.
-#
-alive_update = "\
-	UPDATE ${ippool_table} \
-	SET \
-		expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
 	WHERE nasipaddress = '%{Nas-IP-Address}' \
 	AND pool_key = '${pool_key}' \
 	AND username = '%{User-Name}' \
@@ -194,27 +180,12 @@ alive_update = "\
 
 #
 #  on_clear clears the IP addresses allocated to a NAS when
-#  an accounting ON record arrives (i.e. the NAS is starting up)
+#  an accounting ON / OFF record arrives (i.e. the NAS is
+#  starting up / shutting down)
 #  Comment out if you want users to be able to obtain their
 #  same address after an outage.
 #
-on_clear = "\
-	UPDATE ${ippool_table} \
-	SET \
-		nasipaddress = '', \
-		pool_key = '0', \
-		callingstationid = '', \
-		username = '', \
-		expiry_time = NOW() \
-	WHERE nasipaddress = '%{Nas-IP-Address}'"
-
-#
-#  off_clear clears the IP addresses allocated to a NAS when
-#  an accounting OFF record arrives (i.e. the NAS is shutting down)
-#  Comment out if you want users to be able to obtain their
-#  same address after an outage.
-#
-off_clear = "\
+bulkrelease_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '', \

--- a/raddb/mods-config/sql/ippool/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mysql/queries.conf
@@ -136,9 +136,9 @@ alloc_update = "\
 #alloc_commit = ""
 
 #
-#  start_update updates allocation info when an accounting START / ALIVE record arrives.
+#  update_update updates allocation info when an accounting START / ALIVE record arrives.
 #
-extend_update = "\
+update_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \

--- a/raddb/mods-config/sql/ippool/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mysql/queries.conf
@@ -187,7 +187,7 @@ release_clear = "\
 #  Comment out if you want users to be able to obtain their
 #  same address after an outage.
 #
-bulkrelease_clear = "\
+bulk_release_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '', \

--- a/raddb/mods-config/sql/ippool/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool/oracle/queries.conf
@@ -132,19 +132,22 @@ allocate_update = "\
 
 #
 #  This query extends an IP address lease by "lease_duration" when an accounting
-#  START record arrives
+#  START / ALIVE record arrives
 #
-start_update = "\
+extend_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
 	WHERE nasipaddress = '%{NAS-IP-Address}' \
-	AND pool_key = '${pool_key}'"
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{${attribute_name}}' \
+	AND username = '%{SQL-User-Name}' \
+	AND callingstationid = '%{%{Calling-Station-Id}:-0}'"
 
 #
 #  This query frees an IP address when an accounting STOP record arrives
 #
-stop_clear = "\
+release_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '0', \
@@ -158,37 +161,10 @@ stop_clear = "\
 	AND framedipaddress = '%{${attribute_name}}'"
 
 #
-#  This query extends an IP address lease by "lease_duration" when an accounting
-#  ALIVE record arrives
-#
-alive_update = "\
-	UPDATE ${ippool_table} \
-	SET \
-		expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
-	WHERE nasipaddress = '%{Nas-IP-Address}' \
-	AND pool_key = '${pool_key}' \
-	AND framedipaddress = '%{${attribute_name}}' \
-	AND username = '%{SQL-User-Name}' \
-	AND callingstationid = '%{%{Calling-Station-Id}:-0}'"
-
-#
 #  This query frees all IP addresses allocated to a NAS when an
-#  accounting ON record arrives from that NAS
+#  accounting ON / OFF record arrives from that NAS
 #
-on_clear = "\
-	UPDATE ${ippool_table} \
-	SET \
-		nasipaddress = '0', \
-		pool_key = '0', \
-		callingstationid = '0', \
-		expiry_time = current_timestamp - INTERVAL '1' second(1) \
-	WHERE nasipaddress = '%{Nas-IP-Address}'"
-
-#
-#  This query frees all IP addresses allocated to a NAS when an
-#  accounting OFF record arrives from that NAS
-#
-off_clear = "\
+bulkrelease_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '0', \

--- a/raddb/mods-config/sql/ippool/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool/oracle/queries.conf
@@ -4,13 +4,6 @@
 #
 #  $Id$
 
-allocate_begin = "commit"
-start_begin = "commit"
-alive_begin = "commit"
-stop_begin = "commit"
-on_begin = "commit"
-off_begin = "commit"
-
 #
 #  This query allocates an IP address from the Pool
 #  The ORDER BY clause of this query tries to allocate the same IP-address
@@ -134,6 +127,7 @@ allocate_update = "\
 #  This query extends an IP address lease by "lease_duration" when an accounting
 #  START / ALIVE record arrives
 #
+extend_begin = "commit"
 extend_update = "\
 	UPDATE ${ippool_table} \
 	SET \
@@ -143,10 +137,12 @@ extend_update = "\
 	AND framedipaddress = '%{${attribute_name}}' \
 	AND username = '%{SQL-User-Name}' \
 	AND callingstationid = '%{%{Calling-Station-Id}:-0}'"
+extend_commit = "commit"
 
 #
 #  This query frees an IP address when an accounting STOP record arrives
 #
+release_begin = "commit"
 release_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
@@ -159,11 +155,13 @@ release_clear = "\
 	AND username = '%{SQL-User-Name}' \
 	AND callingstationid = '%{%{Calling-Station-Id}:-0}' \
 	AND framedipaddress = '%{${attribute_name}}'"
+release_commit = "commit"
 
 #
 #  This query frees all IP addresses allocated to a NAS when an
 #  accounting ON / OFF record arrives from that NAS
 #
+bulkrelease_begin = "commit"
 bulkrelease_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
@@ -172,3 +170,4 @@ bulkrelease_clear = "\
 		callingstationid = '0', \
 		expiry_time = current_timestamp - INTERVAL '1' second(1) \
 	WHERE nasipaddress = '%{Nas-IP-Address}'"
+bulkrelease_commit = "commit"

--- a/raddb/mods-config/sql/ippool/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool/oracle/queries.conf
@@ -5,6 +5,9 @@
 #  $Id$
 
 #
+#  Due to Oracle's transaction focus, update queries further down are
+#  wrapped in "commit" statements.
+#
 #  This query allocates an IP address from the Pool
 #  The ORDER BY clause of this query tries to allocate the same IP-address
 #  to the user that they had last session...

--- a/raddb/mods-config/sql/ippool/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool/oracle/queries.conf
@@ -130,8 +130,8 @@ alloc_update = "\
 #  This query extends an IP address lease by "lease_duration" when an accounting
 #  START / ALIVE record arrives
 #
-extend_begin = "commit"
-extend_update = "\
+update_begin = "commit"
+update_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
@@ -140,7 +140,7 @@ extend_update = "\
 	AND framedipaddress = '%{${attribute_name}}' \
 	AND username = '%{SQL-User-Name}' \
 	AND callingstationid = '%{%{Calling-Station-Id}:-0}'"
-extend_commit = "commit"
+update_commit = "commit"
 
 #
 #  This query frees an IP address when an accounting STOP record arrives

--- a/raddb/mods-config/sql/ippool/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool/oracle/queries.conf
@@ -164,8 +164,8 @@ release_commit = "commit"
 #  This query frees all IP addresses allocated to a NAS when an
 #  accounting ON / OFF record arrives from that NAS
 #
-bulkrelease_begin = "commit"
-bulkrelease_clear = "\
+bulk_release_begin = "commit"
+bulk_release_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '0', \
@@ -173,4 +173,4 @@ bulkrelease_clear = "\
 		callingstationid = '0', \
 		expiry_time = current_timestamp - INTERVAL '1' second(1) \
 	WHERE nasipaddress = '%{Nas-IP-Address}'"
-bulkrelease_commit = "commit"
+bulk_release_commit = "commit"

--- a/raddb/mods-config/sql/ippool/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool/oracle/queries.conf
@@ -12,7 +12,7 @@
 #  The ORDER BY clause of this query tries to allocate the same IP-address
 #  to the user that they had last session...
 #
-allocate_find = "\
+alloc_find = "\
 	SELECT framedipaddress FROM ${ippool_table} WHERE id IN ( \
 		SELECT id FROM ( \
 			SELECT * \
@@ -33,7 +33,7 @@ allocate_find = "\
 #  The above query again, but with SKIP LOCKED. This requires Oracle > 11g.
 #  It may work in 9i and 10g, but is not documented, so YMMV.
 #
-#allocate_find = "\
+#alloc_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} WHERE id IN ( \
 #		SELECT id FROM ( \
 #			SELECT * \
@@ -54,7 +54,7 @@ allocate_find = "\
 #  If you prefer to allocate a random IP address every time, use this query instead
 #  Note: This is very slow if you have a lot of free IPs.
 #
-#allocate_find = "\
+#alloc_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} WHERE id IN ( \
 #		SELECT id FROM ( \
 #			SELECT * \
@@ -69,7 +69,7 @@ allocate_find = "\
 #  The above query again, but with SKIP LOCKED. This requires Oracle > 11g.
 #  It may work in 9i and 10g, but is not documented, so YMMV.
 #
-#allocate_find = "\
+#alloc_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} WHERE id IN ( \
 #		SELECT id FROM (\
 #			SELECT * \
@@ -96,10 +96,10 @@ pool_check = "\
 	WHERE ROWNUM = 1"
 
 #
-#  This query marks the IP address handed out by "allocate-find" as used
+#  This query marks the IP address handed out by "alloc_find" as used
 #  for the period of "lease_duration" after which time it may be reused.
 #
-allocate_update = "\
+alloc_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '%{NAS-IP-Address}', \
@@ -113,8 +113,8 @@ allocate_update = "\
 #  Use a stored procedure to find AND allocate the address. Read and customise
 #  `procedure.sql` in this directory to determine the optimal configuration.
 #
-#allocate_begin = ""
-#allocate_find = "\
+#alloc_begin = ""
+#alloc_find = "\
 #	SELECT fr_allocate_previous_or_new_framedipaddress( \
 #		'%{control:Pool-Name}', \
 #		'%{SQL-User-Name}', \
@@ -123,8 +123,8 @@ allocate_update = "\
 #		'${pool_key}', \
 #		'${lease_duration}' \
 #	)"
-#allocate_update = ""
-#allocate_commit = ""
+#alloc_update = ""
+#alloc_commit = ""
 
 #
 #  This query extends an IP address lease by "lease_duration" when an accounting

--- a/raddb/mods-config/sql/ippool/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool/postgresql/queries.conf
@@ -138,7 +138,7 @@ pool_check = "\
 #  This query extends an IP address lease by "lease_duration" when an accounting
 #  START / ALIVE record arrives
 #
-extend_update = "\
+update_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval \

--- a/raddb/mods-config/sql/ippool/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool/postgresql/queries.conf
@@ -136,20 +136,23 @@ pool_check = "\
 
 #
 #  This query extends an IP address lease by "lease_duration" when an accounting
-#  START record arrives
+#  START / ALIVE record arrives
 #
-start_update = "\
+extend_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval \
 	WHERE nasipaddress = '%{NAS-IP-Address}' \
-	AND pool_key = '${pool_key}'"
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{${attribute_name}}' \
+	AND username = '%{SQL-User-Name}' \
+	AND callingstationid = '%{Calling-Station-Id}'"
 
 #
 #  This query frees an IP address when an accounting
 #  STOP record arrives
 #
-stop_clear = "\
+release_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '', \
@@ -163,37 +166,10 @@ stop_clear = "\
 	AND framedipaddress = '%{${attribute_name}}'"
 
 #
-#  This query extends an IP address lease by "lease_duration" when an accounting
-#  ALIVE record arrives
-#
-alive_update = "\
-	UPDATE ${ippool_table} \
-	SET \
-		expiry_time = 'now'::timestamp(0) + '${lease_duration} seconds'::interval \
-	WHERE nasipaddress = '%{Nas-IP-Address}' \
-	AND pool_key = '${pool_key}' \
-	AND framedipaddress = '%{${attribute_name}}' \
-	AND username = '%{SQL-User-Name}' \
-	AND callingstationid = '%{Calling-Station-Id}'"
-
-#
 #  This query frees all IP addresses allocated to a NAS when an
-#  accounting ON record arrives from that NAS
+#  accounting ON / OFF record arrives from that NAS
 #
-on_clear = "\
-	UPDATE ${ippool_table} \
-	SET \
-		nasipaddress = '', \
-		pool_key = '0', \
-		callingstationid = '', \
-		expiry_time = 'now'::timestamp(0) - '1 second'::interval \
-	WHERE nasipaddress = '%{Nas-IP-Address}'"
-
-#
-#  This query frees all IP addresses allocated to a NAS when an
-#  accounting OFF record arrives from that NAS
-#
-off_clear = "\
+bulkrelease_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '', \

--- a/raddb/mods-config/sql/ippool/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool/postgresql/queries.conf
@@ -169,7 +169,7 @@ release_clear = "\
 #  This query frees all IP addresses allocated to a NAS when an
 #  accounting ON / OFF record arrives from that NAS
 #
-bulkrelease_clear = "\
+bulk_release_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '', \

--- a/raddb/mods-config/sql/ippool/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool/postgresql/queries.conf
@@ -4,7 +4,7 @@
 #
 #  $Id$
 
-#  Using SKIP LOCKED speed up the allocate_find query by 10
+#  Using SKIP LOCKED speed up the alloc_find query by 10
 #  times. However, it requires PostgreSQL >= 9.5.
 #
 #  If you are using an older version of PostgreSQL comment out the following:
@@ -14,7 +14,7 @@ skip_locked = "SKIP LOCKED"
 #  This query tries to allocate the same IP-address to the user
 #  that they had last session
 #
-allocate_existing "\
+alloc_existing "\
 	WITH cte AS ( \
 		SELECT framedipaddress \
 		FROM ${ippool_table} \
@@ -39,7 +39,7 @@ allocate_existing "\
 #  If no address was returned by the above query, use the following
 #  to find a free one in the pool
 #
-allocate_find = "\
+alloc_find = "\
 	WITH cte AS ( \
 		SELECT framedipaddress \
 		FROM ${ippool_table} \
@@ -65,15 +65,15 @@ allocate_find = "\
 #  do not need transactions and the update is done within the same query
 #
 
-allocate_begin = ""
-allocate_update = ""
-allocate_commit = ""
+alloc_begin = ""
+alloc_update = ""
+alloc_commit = ""
 
 #
 #  If you prefer to allocate a random IP address every time, use this query instead
 #  Note: This is very slow if you have a lot of free IPs.
 #
-#allocate_find = "\
+#alloc_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} \
 #	WHERE pool_name = '%{control:${pool_name}}' AND expiry_time < 'now'::timestamp(0) \
 #	ORDER BY RANDOM() \
@@ -93,12 +93,12 @@ pool_check = "\
 	LIMIT 1"
 
 #
-#  This query marks the IP address handed out by "allocate-find" as used
+#  This query marks the IP address handed out by "alloc_find" as used
 #  for the period of "lease_duration" after which time it may be reused.
 #  It is only needed if the update of the record is not done within the
 #  query that selects the address.
 #
-#allocate_update = "\
+#alloc_update = "\
 #	UPDATE ${ippool_table} \
 #	SET \
 #		nasipaddress = '%{NAS-IP-Address}', \
@@ -120,8 +120,8 @@ pool_check = "\
 #  have this comment, the query may go to a read only server, and will fail.
 #  This has no negative effect if you are not using PgPool.
 #
-#allocate_begin = ""
-#allocate_find = "\
+#alloc_begin = ""
+#alloc_find = "\
 #	/*NO LOAD BALANCE*/ \
 #	SELECT fr_allocate_previous_or_new_framedipaddress( \
 #		'%{control:${pool_name}}', \
@@ -131,8 +131,8 @@ pool_check = "\
 #		'${pool_key}', \
 #		'${lease_duration}' \
 #	)"
-#allocate_update = ""
-#allocate_commit = ""
+#alloc_update = ""
+#alloc_commit = ""
 
 #
 #  This query extends an IP address lease by "lease_duration" when an accounting

--- a/raddb/mods-config/sql/ippool/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool/sqlite/queries.conf
@@ -85,13 +85,13 @@ allocate_update = "\
 	WHERE framedipaddress = '%I'"
 
 #
-#  Free an IP when an accounting START record arrives
+#  Extend an IP when an accounting START / ALIVE record arrives
 #
-start_update = "\
+extend_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		expiry_time = datetime(strftime('%%s', 'now') + ${lease_duration}, 'unixepoch') \
-	WHERE nasipaddress = '%{NAS-IP-Address}' \
+	WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}' \
 	AND pool_key = '${pool_key}' \
 	AND username = '%{User-Name}' \
 	AND callingstationid = '%{Calling-Station-Id}' \
@@ -100,7 +100,7 @@ start_update = "\
 #
 #  Free an IP when an accounting STOP record arrives
 #
-stop_clear = "\
+release_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '', \
@@ -115,22 +115,9 @@ stop_clear = "\
 	AND framedipaddress = '%{${attribute_name}}'"
 
 #
-#  Update the expiry time for an IP when an accounting ALIVE record arrives
+#  Frees all IPs allocated to a NAS when an accounting ON / OFF record arrives
 #
-alive_update = "\
-	UPDATE ${ippool_table} \
-	SET \
-		expiry_time = datetime(strftime('%%s', 'now') + ${lease_duration}, 'unixepoch') \
-	WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}' \
-	AND pool_key = '${pool_key}' \
-	AND username = '%{User-Name}' \
-	AND callingstationid = '%{Calling-Station-Id}' \
-	AND framedipaddress = '%{${attribute_name}}'"
-
-#
-#  Frees all IPs allocated to a NAS when an accounting ON record arrives
-#
-on_clear = "\
+bulkrelease_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '', \
@@ -139,17 +126,3 @@ on_clear = "\
 		username = '', \
 		expiry_time = datetime('now') \
 	WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"
-
-#
-#  Frees all IPs allocated to a NAS when an accounting OFF record arrives
-#
-off_clear = "\
-	UPDATE ${ippool_table} \
-	SET \
-		nasipaddress = '', \
-		pool_key = '0', \
-		callingstationid = '', \
-		username = '', \
-		expiry_time = datetime('now') \
-	WHERE nasipaddress = '%{%{Nas-IP-Address}:-%{Nas-IPv6-Address}}'"
-

--- a/raddb/mods-config/sql/ippool/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool/sqlite/queries.conf
@@ -117,7 +117,7 @@ release_clear = "\
 #
 #  Frees all IPs allocated to a NAS when an accounting ON / OFF record arrives
 #
-bulkrelease_clear = "\
+bulk_release_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '', \

--- a/raddb/mods-config/sql/ippool/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool/sqlite/queries.conf
@@ -85,9 +85,9 @@ alloc_update = "\
 	WHERE framedipaddress = '%I'"
 
 #
-#  Extend an IP when an accounting START / ALIVE record arrives
+#  Update an IP when an accounting START / ALIVE record arrives
 #
-extend_update = "\
+update_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		expiry_time = datetime(strftime('%%s', 'now') + ${lease_duration}, 'unixepoch') \

--- a/raddb/mods-config/sql/ippool/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool/sqlite/queries.conf
@@ -18,13 +18,13 @@
 #  automatic shared lock for the transaction to an exclusive lock for the
 #  subsequent UPDATE.
 #
-allocate_begin = "BEGIN EXCLUSIVE"
-allocate_commit = "COMMIT"
+alloc_begin = "BEGIN EXCLUSIVE"
+alloc_commit = "COMMIT"
 
 #
-#  allocate_exsiting looks for a user's IP-Address from their last session
+#  alloc_exsiting looks for a user's IP-Address from their last session
 #
-allocate_existing = "\
+alloc_existing = "\
 	SELECT framedipaddress \
 	FROM ${ippool_table} \
 	WHERE pool_name = '%{control:${pool_name}}' \
@@ -35,9 +35,9 @@ allocate_existing = "\
 
 #
 #  If the previous query does not return an address then
-#  allocate_find will find a free address from the pool
+#  alloc_find will find a free address from the pool
 #
-allocate_find = "\
+alloc_find = "\
 	SELECT framedipaddress \
 	FROM ${ippool_table} \
 	WHERE pool_name = '%{control:${pool_name}}' \
@@ -51,7 +51,7 @@ allocate_find = "\
 #   Note: This is very slow if you have a lot of free IPs.
 #
 
-#allocate_find = "\
+#alloc_find = "\
 #	SELECT framedipaddress \
 #	FROM ${ippool_table} \
 # 	WHERE pool_name = '%{control:${pool_name}}' \
@@ -74,7 +74,7 @@ pool_check = "\
 #
 #  This is the final IP Allocation query, which saves the allocated ip details
 #
-allocate_update = "\
+alloc_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		nasipaddress = '%{NAS-IP-Address}', \

--- a/src/modules/rlm_sqlippool/rlm_sqlippool.c
+++ b/src/modules/rlm_sqlippool/rlm_sqlippool.c
@@ -58,30 +58,25 @@ typedef struct {
 
 	char const	*pool_check;		//!< Query to check for the existence of the pool.
 
-						/* Start sequence */
-	char const	*start_begin;		//!< SQL query to begin.
-	char const	*start_update;		//!< SQL query to update an IP entry.
-	char const	*start_commit;		//!< SQL query to commit.
+						/* Extend sequence */
+	char const	*extend_begin;		//!< SQL query to begin.
+	char const	*extend_update;		//!< SQL query to update an IP entry.
+	char const	*extend_commit;		//!< SQL query to commit.
 
-						/* Alive sequence */
-	char const	*alive_begin;		//!< SQL query to begin.
-	char const	*alive_update;		//!< SQL query to update an IP entry.
-	char const	*alive_commit;		//!< SQL query to commit.
+						/* Release sequence */
+	char const	*release_begin;		//!< SQL query to begin.
+	char const	*release_clear;       	//!< SQL query to clear an IP entry.
+	char const	*release_commit;	//!< SQL query to commit.
 
-						/* Stop sequence */
-	char const	*stop_begin;		//!< SQL query to begin.
-	char const	*stop_clear;		//!< SQL query to clear an IP.
-	char const	*stop_commit;		//!< SQL query to commit.
+						/* Bulk release sequence */
+	char const	*bulkrelease_begin;	//!< SQL query to begin.
+	char const	*bulkrelease_clear;	//!< SQL query to bulk clear several IPs.
+	char const	*bulkrelease_commit;	//!< SQL query to commit.
 
-						/* On sequence */
-	char const	*on_begin;		//!< SQL query to begin.
-	char const	*on_clear;		//!< SQL query to clear an entire NAS.
-	char const	*on_commit;		//!< SQL query to commit.
-
-						/* Off sequence */
-	char const	*off_begin;		//!< SQL query to begin.
-	char const	*off_clear;		//!< SQL query to clear an entire NAS.
-	char const	*off_commit;		//!< SQL query to commit.
+						/* Mark sequence */
+	char const	*mark_begin;		//!< SQL query to begin.
+	char const	*mark_update;		//!< SQL query to mark an IP.
+	char const	*mark_commit;		//!< SQL query to commit.
 
 						/* Logging Section */
 	char const	*log_exists;		//!< There was an ip address already assigned.
@@ -130,39 +125,33 @@ static CONF_PARSER module_config[] = {
 	{ FR_CONF_OFFSET("pool_check", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, pool_check), .dflt = "" },
 
 
-	{ FR_CONF_OFFSET("start_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, start_begin), .dflt = "START TRANSACTION" },
+	{ FR_CONF_OFFSET("extend_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, extend_begin), .dflt = "START TRANSACTION" },
 
-	{ FR_CONF_OFFSET("start_update", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, start_update), .dflt = "" },
+	{ FR_CONF_OFFSET("extend_update", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, extend_update), .dflt = "" },
 
-	{ FR_CONF_OFFSET("start_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, start_commit), .dflt = "COMMIT" },
-
-
-	{ FR_CONF_OFFSET("alive_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, alive_begin), .dflt = "START TRANSACTION" },
-
-	{ FR_CONF_OFFSET("alive_update", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, alive_update), .dflt = "" },
-
-	{ FR_CONF_OFFSET("alive_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, alive_commit), .dflt = "COMMIT" },
+	{ FR_CONF_OFFSET("extend_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, extend_commit), .dflt = "COMMIT" },
 
 
-	{ FR_CONF_OFFSET("stop_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, stop_begin), .dflt = "START TRANSACTION" },
+	{ FR_CONF_OFFSET("release_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, release_begin), .dflt = "START TRANSACTION" },
 
-	{ FR_CONF_OFFSET("stop_clear", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, stop_clear), .dflt = "" },
+	{ FR_CONF_OFFSET("release_clear", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, release_clear), .dflt = "" },
 
-	{ FR_CONF_OFFSET("stop_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, stop_commit), .dflt = "COMMIT" },
-
-
-	{ FR_CONF_OFFSET("on_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, on_begin), .dflt = "START TRANSACTION" },
-
-	{ FR_CONF_OFFSET("on_clear", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, on_clear), .dflt = "" },
-
-	{ FR_CONF_OFFSET("on_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, on_commit), .dflt = "COMMIT" },
+	{ FR_CONF_OFFSET("release_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, release_commit), .dflt = "COMMIT" },
 
 
-	{ FR_CONF_OFFSET("off_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, off_begin), .dflt = "START TRANSACTION" },
+	{ FR_CONF_OFFSET("bulkrelease_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, bulkrelease_begin), .dflt = "START TRANSACTION" },
 
-	{ FR_CONF_OFFSET("off_clear", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, off_clear), .dflt = "" },
+	{ FR_CONF_OFFSET("bulkrelease_clear", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, bulkrelease_clear), .dflt = "" },
 
-	{ FR_CONF_OFFSET("off_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, off_commit), .dflt = "COMMIT" },
+	{ FR_CONF_OFFSET("bulkrelease_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, bulkrelease_commit), .dflt = "COMMIT" },
+
+
+	{ FR_CONF_OFFSET("mark_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, mark_begin), .dflt = "START TRANSACTION" },
+
+	{ FR_CONF_OFFSET("mark_update", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, mark_update), .dflt = "" },
+
+	{ FR_CONF_OFFSET("mark_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, mark_commit), .dflt = "COMMIT" },
+
 
 	{ FR_CONF_POINTER("messages", FR_TYPE_SUBSECTION, NULL), .subcs = (void const *) message_config },
 	CONF_PARSER_TERMINATOR
@@ -625,9 +614,9 @@ static rlm_rcode_t CC_HINT(nonnull) mod_post_auth(module_ctx_t const *mctx, REQU
 static int mod_accounting_start(rlm_sql_handle_t **handle,
 				rlm_sqlippool_t const *inst, REQUEST *request)
 {
-	DO(start_begin);
-	DO(start_update);
-	DO(start_commit);
+	DO(extend_begin);
+	DO(extend_update);
+	DO(extend_commit);
 
 	return RLM_MODULE_OK;
 }
@@ -635,18 +624,18 @@ static int mod_accounting_start(rlm_sql_handle_t **handle,
 static int mod_accounting_alive(rlm_sql_handle_t **handle,
 				rlm_sqlippool_t const *inst, REQUEST *request)
 {
-	DO(alive_begin);
-	DO(alive_update);
-	DO(alive_commit);
+	DO(extend_begin);
+	DO(extend_update);
+	DO(extend_commit);
 	return RLM_MODULE_OK;
 }
 
 static int mod_accounting_stop(rlm_sql_handle_t **handle,
 			       rlm_sqlippool_t const *inst, REQUEST *request)
 {
-	DO(stop_begin);
-	DO(stop_clear);
-	DO(stop_commit);
+	DO(release_begin);
+	DO(release_clear);
+	DO(release_commit);
 
 	return do_logging(inst, request, inst->log_clear, RLM_MODULE_OK);
 }
@@ -654,9 +643,9 @@ static int mod_accounting_stop(rlm_sql_handle_t **handle,
 static int mod_accounting_on(rlm_sql_handle_t **handle,
 			     rlm_sqlippool_t const *inst, REQUEST *request)
 {
-	DO(on_begin);
-	DO(on_clear);
-	DO(on_commit);
+	DO(bulkrelease_begin);
+	DO(bulkrelease_clear);
+	DO(bulkrelease_commit);
 
 	return RLM_MODULE_OK;
 }
@@ -664,9 +653,9 @@ static int mod_accounting_on(rlm_sql_handle_t **handle,
 static int mod_accounting_off(rlm_sql_handle_t **handle,
 			      rlm_sqlippool_t const *inst, REQUEST *request)
 {
-	DO(off_begin);
-	DO(off_clear);
-	DO(off_commit);
+	DO(bulkrelease_begin);
+	DO(bulkrelease_clear);
+	DO(bulkrelease_commit);
 
 	return RLM_MODULE_OK;
 }

--- a/src/modules/rlm_sqlippool/rlm_sqlippool.c
+++ b/src/modules/rlm_sqlippool/rlm_sqlippool.c
@@ -278,6 +278,7 @@ static int sqlippool_command(char const *fmt, rlm_sql_handle_t **handle,
 	char *expanded = NULL;
 
 	int ret;
+	int affected;
 
 	/*
 	 *	If we don't have a command, do nothing.
@@ -308,9 +309,11 @@ static int sqlippool_command(char const *fmt, rlm_sql_handle_t **handle,
 	 */
 	if (!*handle) return -1;
 
+	affected = (data->sql_inst->driver->sql_affected_rows)(*handle, data->sql_inst->config);
+
 	(data->sql_inst->driver->sql_finish_query)(*handle, data->sql_inst->config);
 
-	return 0;
+	return affected;
 }
 
 /*

--- a/src/modules/rlm_sqlippool/rlm_sqlippool.c
+++ b/src/modules/rlm_sqlippool/rlm_sqlippool.c
@@ -825,6 +825,12 @@ module_t rlm_sqlippool = {
 		{ "recv",	"DHCP-Release",		mod_release },
 		{ "recv",	"DHCP-Decline",		mod_mark },
 
+		{ "ippool",	"alloc",		mod_alloc },
+		{ "ippool",	"update",		mod_update },
+		{ "ippool",	"release",		mod_release },
+		{ "ippool",	"bulk-release",		mod_bulk_release },
+		{ "ippool",	"mark",			mod_mark },
+
 		MODULE_NAME_TERMINATOR
 	}
 

--- a/src/modules/rlm_sqlippool/rlm_sqlippool.c
+++ b/src/modules/rlm_sqlippool/rlm_sqlippool.c
@@ -320,8 +320,9 @@ static int sqlippool_command(char const *fmt, rlm_sql_handle_t **handle,
  *	Don't repeat yourself
  */
 #undef DO
-#define DO(_x) sqlippool_command(inst->_x, handle, inst, request, NULL, 0)
-#define DO_PART(_x) sqlippool_command(inst->_x, &handle, inst, request, NULL, 0)
+#define DO(_x) if(sqlippool_command(inst->_x, handle, inst, request, NULL, 0) < 0) return RLM_MODULE_FAIL
+#define DO_AFFECTED(_x, _affected) _affected = sqlippool_command(inst->_x, handle, inst, request, NULL, 0); if (_affected < 0) return RLM_MODULE_FAIL
+#define DO_PART(_x) if(sqlippool_command(inst->_x, &handle, inst, request, NULL, 0) <0) goto error
 
 /*
  * Query the database expecting a single result row
@@ -604,8 +605,12 @@ static rlm_rcode_t CC_HINT(nonnull) mod_post_auth(module_ctx_t const *mctx, REQU
 	/*
 	 *	UPDATE
 	 */
-	sqlippool_command(inst->allocate_update, &handle, inst, request,
-			  allocation, allocation_len);
+	if (sqlippool_command(inst->allocate_update, &handle, inst, request,
+			      allocation, allocation_len) < 0) {
+	error:
+		if (handle) fr_pool_connection_release(inst->sql_inst->pool, request, handle);
+		return RLM_MODULE_FAIL;
+	}
 
 	DO_PART(allocate_commit);
 

--- a/src/modules/rlm_sqlippool/rlm_sqlippool.c
+++ b/src/modules/rlm_sqlippool/rlm_sqlippool.c
@@ -726,35 +726,6 @@ static rlm_rcode_t CC_HINT(nonnull) mod_mark(module_ctx_t const *mctx, REQUEST *
 	return RLM_MODULE_FAIL;
 }
 
-static int mod_accounting_start(rlm_sql_handle_t **handle,
-				rlm_sqlippool_t const *inst, REQUEST *request)
-{
-	DO(update_begin);
-	DO(update_update);
-	DO(update_commit);
-
-	return RLM_MODULE_OK;
-}
-
-static int mod_accounting_alive(rlm_sql_handle_t **handle,
-				rlm_sqlippool_t const *inst, REQUEST *request)
-{
-	DO(update_begin);
-	DO(update_update);
-	DO(update_commit);
-	return RLM_MODULE_OK;
-}
-
-static int mod_accounting_stop(rlm_sql_handle_t **handle,
-			       rlm_sqlippool_t const *inst, REQUEST *request)
-{
-	DO(release_begin);
-	DO(release_clear);
-	DO(release_commit);
-
-	return do_logging(inst, request, inst->log_clear, RLM_MODULE_OK);
-}
-
 static int mod_accounting_on(rlm_sql_handle_t **handle,
 			     rlm_sqlippool_t const *inst, REQUEST *request)
 {
@@ -776,9 +747,8 @@ static int mod_accounting_off(rlm_sql_handle_t **handle,
 }
 
 /*
- *	Check for an Accounting-Stop
- *	If we find one and we have allocated an IP to this nas/port
- *	combination, then deallocate it.
+ *	Check Accounting packets for their accoutning status
+ *	Call the relevant module based on the status
  */
 static rlm_rcode_t CC_HINT(nonnull) mod_accounting(module_ctx_t const *mctx, REQUEST *request)
 {
@@ -824,7 +794,7 @@ static rlm_rcode_t CC_HINT(nonnull) mod_accounting(module_ctx_t const *mctx, REQ
 		break;
 
 	case FR_STATUS_STOP:
-		rcode = mod_accounting_stop(&handle, inst, request);
+		rcode = mod_release(mctx, request);
 		break;
 
 	case FR_STATUS_ACCOUNTING_ON:

--- a/src/modules/rlm_sqlippool/rlm_sqlippool.c
+++ b/src/modules/rlm_sqlippool/rlm_sqlippool.c
@@ -104,7 +104,7 @@ static CONF_PARSER module_config[] = {
 
 	{ FR_CONF_OFFSET("lease_duration", FR_TYPE_UINT32, rlm_sqlippool_t, lease_duration), .dflt = "86400" },
 
-	{ FR_CONF_OFFSET("pool_name", FR_TYPE_STRING, rlm_sqlippool_t, pool_name), .dflt = "" },
+	{ FR_CONF_OFFSET("pool_name", FR_TYPE_STRING, rlm_sqlippool_t, pool_name) },
 
 	{ FR_CONF_OFFSET("attribute_name", FR_TYPE_STRING | FR_TYPE_REQUIRED | FR_TYPE_NOT_EMPTY, rlm_sqlippool_t, attribute_name), .dflt = "Framed-IP-Address" },
 
@@ -113,44 +113,44 @@ static CONF_PARSER module_config[] = {
 
 	{ FR_CONF_OFFSET("allocate_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, allocate_begin), .dflt = "START TRANSACTION" },
 
-	{ FR_CONF_OFFSET("allocate_existing", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, allocate_existing), .dflt = "" },
+	{ FR_CONF_OFFSET("allocate_existing", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, allocate_existing) },
 
-	{ FR_CONF_OFFSET("allocate_find", FR_TYPE_STRING | FR_TYPE_XLAT | FR_TYPE_REQUIRED, rlm_sqlippool_t, allocate_find), .dflt = "" },
+	{ FR_CONF_OFFSET("allocate_find", FR_TYPE_STRING | FR_TYPE_XLAT | FR_TYPE_REQUIRED, rlm_sqlippool_t, allocate_find) },
 
-	{ FR_CONF_OFFSET("allocate_update", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, allocate_update), .dflt = "" },
+	{ FR_CONF_OFFSET("allocate_update", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, allocate_update) },
 
 	{ FR_CONF_OFFSET("allocate_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, allocate_commit), .dflt = "COMMIT" },
 
 
-	{ FR_CONF_OFFSET("pool_check", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, pool_check), .dflt = "" },
+	{ FR_CONF_OFFSET("pool_check", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, pool_check) },
 
 
-	{ FR_CONF_OFFSET("extend_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, extend_begin), .dflt = "" },
+	{ FR_CONF_OFFSET("extend_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, extend_begin) },
 
-	{ FR_CONF_OFFSET("extend_update", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, extend_update), .dflt = "" },
+	{ FR_CONF_OFFSET("extend_update", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, extend_update) },
 
-	{ FR_CONF_OFFSET("extend_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, extend_commit), .dflt = "" },
-
-
-	{ FR_CONF_OFFSET("release_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, release_begin), .dflt = "" },
-
-	{ FR_CONF_OFFSET("release_clear", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, release_clear), .dflt = "" },
-
-	{ FR_CONF_OFFSET("release_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, release_commit), .dflt = "" },
+	{ FR_CONF_OFFSET("extend_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, extend_commit) },
 
 
-	{ FR_CONF_OFFSET("bulkrelease_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, bulkrelease_begin), .dflt = "" },
+	{ FR_CONF_OFFSET("release_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, release_begin) },
 
-	{ FR_CONF_OFFSET("bulkrelease_clear", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, bulkrelease_clear), .dflt = "" },
+	{ FR_CONF_OFFSET("release_clear", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, release_clear) },
 
-	{ FR_CONF_OFFSET("bulkrelease_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, bulkrelease_commit), .dflt = "" },
+	{ FR_CONF_OFFSET("release_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, release_commit) },
 
 
-	{ FR_CONF_OFFSET("mark_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, mark_begin), .dflt = "" },
+	{ FR_CONF_OFFSET("bulkrelease_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, bulkrelease_begin) },
 
-	{ FR_CONF_OFFSET("mark_update", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, mark_update), .dflt = "" },
+	{ FR_CONF_OFFSET("bulkrelease_clear", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, bulkrelease_clear) },
 
-	{ FR_CONF_OFFSET("mark_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, mark_commit), .dflt = "" },
+	{ FR_CONF_OFFSET("bulkrelease_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, bulkrelease_commit) },
+
+
+	{ FR_CONF_OFFSET("mark_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, mark_begin) },
+
+	{ FR_CONF_OFFSET("mark_update", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, mark_update) },
+
+	{ FR_CONF_OFFSET("mark_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, mark_commit) },
 
 
 	{ FR_CONF_POINTER("messages", FR_TYPE_SUBSECTION, NULL), .subcs = (void const *) message_config },

--- a/src/modules/rlm_sqlippool/rlm_sqlippool.c
+++ b/src/modules/rlm_sqlippool/rlm_sqlippool.c
@@ -473,7 +473,7 @@ static int do_logging(UNUSED rlm_sqlippool_t const *inst, REQUEST *request, char
 /*
  *	Allocate an IP number from the pool.
  */
-static rlm_rcode_t CC_HINT(nonnull) mod_post_auth(module_ctx_t const *mctx, REQUEST *request)
+static rlm_rcode_t CC_HINT(nonnull) mod_allocate(module_ctx_t const *mctx, REQUEST *request)
 {
 	rlm_sqlippool_t		*inst = talloc_get_type_abort(mctx->instance, rlm_sqlippool_t);
 	char			allocation[FR_MAX_STRING_LEN];
@@ -755,6 +755,15 @@ module_t rlm_sqlippool = {
 	.instantiate	= mod_instantiate,
 	.methods = {
 		[MOD_ACCOUNTING]	= mod_accounting,
-		[MOD_POST_AUTH]		= mod_post_auth
+		[MOD_POST_AUTH]		= mod_allocate
 	},
+	.method_names = (module_method_names_t[]){
+		{ "recv",	"DHCP-Discover",	mod_allocate },
+//		{ "recv",	"DHCP-Request",		mod_extend },
+//		{ "recv",	"DHCP-Release",		mod_release },
+//		{ "recv",	"DHCP-Decline",		mod_mark },
+
+		MODULE_NAME_TERMINATOR
+	}
+
 };

--- a/src/modules/rlm_sqlippool/rlm_sqlippool.c
+++ b/src/modules/rlm_sqlippool/rlm_sqlippool.c
@@ -125,32 +125,32 @@ static CONF_PARSER module_config[] = {
 	{ FR_CONF_OFFSET("pool_check", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, pool_check), .dflt = "" },
 
 
-	{ FR_CONF_OFFSET("extend_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, extend_begin), .dflt = "START TRANSACTION" },
+	{ FR_CONF_OFFSET("extend_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, extend_begin), .dflt = "" },
 
 	{ FR_CONF_OFFSET("extend_update", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, extend_update), .dflt = "" },
 
-	{ FR_CONF_OFFSET("extend_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, extend_commit), .dflt = "COMMIT" },
+	{ FR_CONF_OFFSET("extend_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, extend_commit), .dflt = "" },
 
 
-	{ FR_CONF_OFFSET("release_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, release_begin), .dflt = "START TRANSACTION" },
+	{ FR_CONF_OFFSET("release_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, release_begin), .dflt = "" },
 
 	{ FR_CONF_OFFSET("release_clear", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, release_clear), .dflt = "" },
 
-	{ FR_CONF_OFFSET("release_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, release_commit), .dflt = "COMMIT" },
+	{ FR_CONF_OFFSET("release_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, release_commit), .dflt = "" },
 
 
-	{ FR_CONF_OFFSET("bulkrelease_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, bulkrelease_begin), .dflt = "START TRANSACTION" },
+	{ FR_CONF_OFFSET("bulkrelease_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, bulkrelease_begin), .dflt = "" },
 
 	{ FR_CONF_OFFSET("bulkrelease_clear", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, bulkrelease_clear), .dflt = "" },
 
-	{ FR_CONF_OFFSET("bulkrelease_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, bulkrelease_commit), .dflt = "COMMIT" },
+	{ FR_CONF_OFFSET("bulkrelease_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, bulkrelease_commit), .dflt = "" },
 
 
-	{ FR_CONF_OFFSET("mark_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, mark_begin), .dflt = "START TRANSACTION" },
+	{ FR_CONF_OFFSET("mark_begin", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, mark_begin), .dflt = "" },
 
 	{ FR_CONF_OFFSET("mark_update", FR_TYPE_STRING | FR_TYPE_XLAT , rlm_sqlippool_t, mark_update), .dflt = "" },
 
-	{ FR_CONF_OFFSET("mark_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, mark_commit), .dflt = "COMMIT" },
+	{ FR_CONF_OFFSET("mark_commit", FR_TYPE_STRING | FR_TYPE_XLAT, rlm_sqlippool_t, mark_commit), .dflt = "" },
 
 
 	{ FR_CONF_POINTER("messages", FR_TYPE_SUBSECTION, NULL), .subcs = (void const *) message_config },


### PR DESCRIPTION
Rename the queries used by sqlippool to reflect their actions rather than protocol specific packets