### PR TITLE
Implement DHCP-Decline packet handling

### DIFF
--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -180,6 +180,12 @@ alive_update = ""
 on_clear = ""
 
 #
-#  This query is not applicable to DHCP
+#  This query marks an IP address as declined when a DHCP Decline
+#  packet arrives
 #
-off_clear = ""
+off_clear = "\
+	UPDATE ${ippool_table} \
+	SET status_id = (SELECT status_id FROM dhcpstatus WHERE status = 'declined') \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -150,6 +150,12 @@ alive_update = ""
 on_clear = ""
 
 #
-#  This query is not applicable to DHCP
+#  This query marks an IP address as declined when a DHCP Decline
+#  packet arrives
 #
-off_clear = ""
+off_clear = "\
+	UPDATE ${ippool_table} \
+	SET status = 'declined' \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -139,6 +139,12 @@ alive_update = ""
 on_clear = ""
 
 #
-#  This query is not applicable to DHCP
+#  This query marks an IP address as declined when a DHCP Decline
+#  packet arrives
 #
-off_clear = ""
+off_clear = "\
+	UPDATE ${ippool_table} \
+	SET status_id = (SELECT status_id FROM dhcpstatus WHERE status = 'declined') \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -202,6 +202,12 @@ alive_update = ""
 on_clear = ""
 
 #
-#  This query is not applicable to DHCP
+#  This query marks an IP address as declined when a DHCP Decline
+#  packet arrives
 #
-off_clear = ""
+off_clear = "\
+	UPDATE ${ippool_table} \
+	SET status = 'declined' \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -131,7 +131,13 @@ alive_update = ""
 on_clear = ""
 
 #
-#  This query is not applicable to DHCP
+#  This query marks an IP address as declined when a DHCP Decline
+#  packet arrives
 #
-off_clear = ""
+off_clear = "\
+	UPDATE ${ippool_table} \
+	SET status_id = (SELECT status_id FROM dhcpstatus WHERE status = 'declined') \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
 

--- a/raddb/policy.d/dhcp
+++ b/raddb/policy.d/dhcp
@@ -13,3 +13,16 @@ dhcp_sqlippool_release {
 
 }
 
+#  Assign compatibility data to request for sqlippool for DHCP Decline
+dhcp_sqlippool_decline {
+
+	#  Do a minor hack to the request so that it looks
+	#  like a RADIUS Accounting Off request to the SQL IP Pool module.
+	update request {
+		&Acct-Status-Type = Accounting-Off
+	}
+
+	#  Call the actual module in accounting context
+	dhcp_sqlippool.accounting
+
+}

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -242,6 +242,14 @@ dhcp DHCP-Request {
 #  not defined here will be responded to with a DHCP-NAK.
 
 dhcp DHCP-Decline {
+
+	#  If using IPs from a DHCP pool in SQL then you may need to set the
+	#  pool name here if you haven't set it elsewhere and release the IP.
+#	update control {
+#		&Pool-Name := "local"
+#	}
+#	dhcp_sqlippool_decline
+
 	update reply {
 	       &DHCP-Message-Type = DHCP-Do-Not-Respond
 	}


### PR DESCRIPTION
Make use of the unused "off" queries to handle a DHCP-Decline packet and
mark addresses as declined.