### PR TITLE
tacacs: Fix priority set

### DIFF
--- a/src/modules/proto_tacacs/proto_tacacs.c
+++ b/src/modules/proto_tacacs/proto_tacacs.c
@@ -523,8 +523,6 @@ static int mod_priority_set(UNUSED void const *instance, UNUSED uint8_t const *b
 	 */
 	if (!inst->priorities[buffer[1]]) return 0;
 
-	if (!inst->type_submodule_by_code[buffer[1]]) return -1;
-
 	/*
 	 *	@todo - if we cared, we could also return -1 for "this
 	 *	is a bad packet".  But that's really only for

--- a/src/modules/proto_tacacs/proto_tacacs_tcp.c
+++ b/src/modules/proto_tacacs/proto_tacacs_tcp.c
@@ -177,7 +177,7 @@ static ssize_t mod_read(fr_listen_t *li, UNUSED void **packet_ctx, UNUSED fr_tim
 	FR_PROTO_HEX_DUMP(buffer, packet_len, "tacacs_tcp_recv");
 
 	DEBUG2("proto_tacacs_tcp - Received %s seq_no %d length %d %s",
-	       fr_tacacs_packet_codes[buffer[1]], buffer[2],
+	       fr_tacacs_get_type_name(buffer[1]), buffer[2],
 	       (int) packet_len, thread->name);
 
 	return packet_len;

--- a/src/modules/proto_tacacs/proto_tacacs_tcp.c
+++ b/src/modules/proto_tacacs/proto_tacacs_tcp.c
@@ -366,7 +366,7 @@ static int mod_compare(UNUSED void const *instance, UNUSED void *thread_instance
 	if (rcode != 0) return rcode;
 
 	/*
-	 *	Then ordered by our synthentic packet type.
+	 *	Then ordered by our synthetic packet type.
 	 */
 	return (a->type < b->type) - (a->type > b->type);
 }

--- a/src/protocols/tacacs/base.c
+++ b/src/protocols/tacacs/base.c
@@ -250,10 +250,8 @@ ssize_t fr_tacacs_length(uint8_t const *buffer, size_t buffer_len)
 	case FR_TAC_PLUS_AUTHEN:
 		if (packet_is_authen_start_request(pkt)) {
 			want = sizeof(pkt->hdr) + sizeof(pkt->authen.start);
-
 		} else if (packet_is_authen_continue(pkt)) {
 			want = sizeof(pkt->hdr) + sizeof(pkt->authen.cont);
-
 		} else {
 			fr_assert(packet_is_authen_reply(pkt));
 			want = sizeof(pkt->hdr) + sizeof(pkt->authen.reply);
@@ -280,7 +278,7 @@ ssize_t fr_tacacs_length(uint8_t const *buffer, size_t buffer_len)
 	}
 
 	if (want > length) {
-		fr_strerror_printf("Packet is too small.  Want %zu, got %zu", want, length);
+		fr_strerror_printf("Packet is too small. Want %zu, got %zu", want, length);
 		return -1;
 	}
 

--- a/src/protocols/tacacs/base.c
+++ b/src/protocols/tacacs/base.c
@@ -105,7 +105,6 @@ fr_dict_attr_autoload_t libfreeradius_tacacs_dict_attr[] = {
 	{ NULL }
 };
 
-
 char const *fr_tacacs_packet_codes[] = {
 	[FR_PACKET_TYPE_VALUE_AUTHENTICATION_START] = "Authentication-Start",
 	[FR_PACKET_TYPE_VALUE_AUTHENTICATION_CONTINUE] = "Authentication-Continue",
@@ -115,7 +114,6 @@ char const *fr_tacacs_packet_codes[] = {
 	[FR_PACKET_TYPE_VALUE_ACCOUNTING_REQUEST] = "Accounting-Request",
 	[FR_PACKET_TYPE_VALUE_ACCOUNTING_REPLY] = "Accounting-Reply",
 };
-
 
 int fr_tacacs_init(void)
 {
@@ -287,4 +285,13 @@ ssize_t fr_tacacs_length(uint8_t const *buffer, size_t buffer_len)
 	}
 
 	return length;
+}
+
+char const *fr_tacacs_get_type_name(fr_tacacs_type_t type) {
+	switch (type) {
+		case FR_TAC_PLUS_AUTHEN: return "Authentication";
+		case FR_TAC_PLUS_AUTHOR: return "Authorization";
+		case FR_TAC_PLUS_ACCT: return "Accounting";
+		default: return "Unknown";
+	}
 }

--- a/src/protocols/tacacs/tacacs.h
+++ b/src/protocols/tacacs/tacacs.h
@@ -299,3 +299,5 @@ int		fr_tacacs_init(void);
 void		fr_tacacs_free(void);
 
 int fr_tacacs_body_xor(fr_tacacs_packet_t const *pkt, uint8_t *body, size_t body_len, char const *secret, size_t secret_len);
+
+char const *fr_tacacs_get_type_name(fr_tacacs_type_t type);


### PR DESCRIPTION
Our packets are separated by synthetic (code) and original packets (type).
Therefore, due to we set based on the type, we don't need to use
the 'type_submodule_by_code'