### PR TITLE
eap-pwd: fix consistency check failed

### DIFF
--- a/src/modules/rlm_eap/types/rlm_eap_pwd/rlm_eap_pwd.c
+++ b/src/modules/rlm_eap/types/rlm_eap_pwd/rlm_eap_pwd.c
@@ -290,7 +290,7 @@ static int fetch_and_process_password(pwd_session_t *session, REQUEST *request, 
 	fr_pair_add(&fake->packet->vps, fake->username);
 
 	if (inst->prep >= 0) {
-		vp = fr_pair_afrom_num(fake, PW_EAP_PWD_PASSWORD_PREP, 0);
+		vp = fr_pair_afrom_num(fake->packet, PW_EAP_PWD_PASSWORD_PREP, 0);
 		rad_assert(vp != NULL);
 		vp->vp_byte = inst->prep;
 		fr_pair_add(&fake->packet->vps, vp);


### PR DESCRIPTION
Resolve EAP-PWD implosion caused by https://github.com/FreeRADIUS/freeradius-server/pull/3344

CONSISTENCY CHECK FAILED src/main/modcall.c[455]: Expected VALUE_PAIR "EAP-Pwd-Password-Prep" to be parented by 0x55d8d1359760 (RADIUS_PACKET) name request, instead parented by 0x55d8d13595b0 (REQUEST)