### PR TITLE
v3.0.x DHCP fixes: Honour hinted IP address; Proper handling of DHCP REQUESTs

### DIFF
--- a/raddb/mods-available/dhcp_sqlippool
+++ b/raddb/mods-available/dhcp_sqlippool
@@ -32,6 +32,9 @@ sqlippool dhcp_sqlippool {
 	# SQL table to use for ippool range and lease info
 	ippool_table = "dhcpippool"
 
+	# The duration for which a lease is reserved whilst under offer
+	offer_duration = 10
+
 	# IP lease duration. (Leases expire even if no DHCP-Release packet is received)
 	lease_duration = 7200
 

--- a/raddb/mods-available/dhcp_sqlippool
+++ b/raddb/mods-available/dhcp_sqlippool
@@ -38,10 +38,13 @@ sqlippool dhcp_sqlippool {
 	#  The attribute in which the IP address is returned in the reply
 	attribute_name = "DHCP-Your-IP-Address"
 
-	#  Assign the IP address, even if the Framed-IP-Address attribute
-	#  already exists in the reply.
+	#  Assign the IP address, even if the above attribute already exists in
+	#  the reply.
 	#
 #	allow_duplicates = no
+
+	#  The attribute in which an IP address hint may be supplied
+	req_attribute_name = "DHCP-Requested-IP-Address"
 
 	#
 	#  RFC 2132 allows the DHCP client to supply a unique

--- a/raddb/mods-available/sqlippool
+++ b/raddb/mods-available/sqlippool
@@ -66,6 +66,9 @@ sqlippool {
 	#
 #	allow_duplicates = no
 
+	#  The attribute in which an IP address hint may be supplied
+	req_attribute_name = Framed-IP-Address
+
 	# Attribute which should be considered unique per NAS
 	#
 	#  Using NAS-Port gives behaviour similar to rlm_ippool. (And ACS)

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/procedure.sql
@@ -21,7 +21,8 @@
 --              @v_pool_name = '%{control:${pool_name}}', \
 --              @v_gateway = '%{DHCP-Gateway-IP-Address}', \
 --              @v_pool_key = '${pool_key}', \
---              @v_lease_duration = ${lease_duration} \
+--              @v_lease_duration = ${lease_duration}, \
+--              @v_requested_address = '%{%{${req_attribute_name}}:-0.0.0.0}' \
 --      "
 -- allocate_update = ""
 -- allocate_commit = ""
@@ -31,7 +32,8 @@ CREATE OR ALTER PROCEDURE fr_dhcp_allocate_previous_or_new_framedipaddress
 	@v_pool_name VARCHAR(64),
 	@v_gateway VARCHAR(15),
 	@v_pool_key VARCHAR(64),
-	@v_lease_duration INT
+	@v_lease_duration INT,
+	@v_requested_address VARCHAR(15)
 AS
 	BEGIN
 
@@ -54,7 +56,7 @@ AS
 		--
 		WITH cte AS (
 			SELECT TOP(1) FramedIPAddress
-			FROM dhcpippool
+			FROM dhcpippool WITH (rowlock, readpast)
 			JOIN dhcpstatus
 			ON dhcpstatus.status_id = dhcpippool.status_id
 			WHERE pool_name = @v_pool_name
@@ -62,7 +64,7 @@ AS
 				AND pool_key = @v_pool_key
 				AND dhcpstatus.status IN ('dynamic', 'static')
 		)
-		UPDATE cte WITH (rowlock, readpast)
+		UPDATE cte
 		SET FramedIPAddress = FramedIPAddress
 		OUTPUT INSERTED.FramedIPAddress INTO @r_address_tab;
 		SELECT @r_address = id FROM @r_address_tab;
@@ -76,17 +78,37 @@ AS
 		--
 		-- WITH cte AS (
 		-- 	SELECT TOP(1) FramedIPAddress
-		-- 	FROM dhcpippool
+		-- 	FROM dhcpippool WITH (rowlock, readpast)
 		--	JOIN dhcpstatus
 		--	ON dhcpstatus.status_id = dhcpippool.status_id
 		-- 	WHERE pool_name = @v_pool_name
 		-- 		AND pool_key = @v_pool_key
 		--		AND dhcpstatus.status IN ('dynamic', 'static')
 		-- )
-		-- UPDATE cte WITH (rowlock, readpast)
+		-- UPDATE cte
 		-- SET FramedIPAddress = FramedIPAddress
 		-- OUTPUT INSERTED.FramedIPAddress INTO @r_address_tab;
 		-- SELECT @r_address = id FROM @r_address_tab;
+
+		-- Issue the requested IP address if it is available
+		--
+		IF @r_address IS NULL AND @v_requested_address <> '0.0.0.0'
+		BEGIN
+			WITH cte AS (
+				SELECT TOP(1) FramedIPAddress
+				FROM dhcpippool WITH (rowlock, readpast)
+				JOIN dhcpstatus
+				ON dhcpstatus.status_id = dhcpippool.status_id
+				WHERE pool_name = @v_pool_name
+					AND framedipaddress = @v_requested_address
+					AND dhcpstatus.status = 'dynamic'
+					AND ( pool_key = @v_pool_name OR expiry_time < CURRENT_TIMESTAMP )
+			)
+			UPDATE cte
+			SET FramedIPAddress = FramedIPAddress
+			OUTPUT INSERTED.FramedIPAddress INTO @r_address_tab;
+			SELECT @r_address = id FROM @r_address_tab;
+		END
 
 		-- If we didn't reallocate a previous address then pick the least
 		-- recently used address from the pool which maximises the likelihood
@@ -96,7 +118,7 @@ AS
 		BEGIN
 			WITH cte AS (
 				SELECT TOP(1) FramedIPAddress
-				FROM dhcpippool
+				FROM dhcpippool WITH (rowlock, readpast)
 				JOIN dhcpstatus
 				ON dhcpstatus.status_id = dhcpippool.status_id
 				WHERE pool_name = @v_pool_name
@@ -105,7 +127,7 @@ AS
 				ORDER BY
 					expiry_time
 			)
-			UPDATE cte WITH (rowlock, readpast)
+			UPDATE cte
 			SET FramedIPAddress = FramedIPAddress
 			OUTPUT INSERTED.FramedIPAddress INTO @r_address_tab;
 			SELECT @r_address = id FROM @r_address_tab;

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -32,7 +32,7 @@ allocate_existing = "\
 		ORDER BY expiry_time DESC \
 	) \
 	UPDATE cte \
-	SET expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP), \
+	SET expiry_time = DATEADD(SECOND,${offer_duration},CURRENT_TIMESTAMP), \
 	gateway = '%{DHCP-Gateway-IP-Address}' \
 	OUTPUT INSERTED.FramedIPAddress \
 	FROM ${ippool_table}"
@@ -52,7 +52,7 @@ allocate_find = "\
 		ORDER BY expiry_time \
 	) \
 	UPDATE cte \
-	SET expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP), \
+	SET expiry_time = DATEADD(SECOND,${offer_duration},CURRENT_TIMESTAMP), \
 	gateway = '%{DHCP-Gateway-IP-Address}' \
 	pool_key = '${pool_key}' \
 	OUTPUT INSERTED.FramedIPAddress \
@@ -69,7 +69,7 @@ allocate_find = "\
 #	UPDATE TOP(1) ${ippool_table} \
 #	SET FramedIPAddress = FramedIPAddress, \
 #	pool_key = '${pool_key}', \
-#	expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP), \
+#	expiry_time = DATEADD(SECOND,${offer_duration},CURRENT_TIMESTAMP), \
 #	GatewayIPAddress = '%{DHCP-Gateway-IP-Address}' \
 #	OUTPUT INSERTED.FramedIPAddress \
 #	FROM ${ippool_table} \
@@ -128,7 +128,7 @@ pool_check = "\
 #	UPDATE ${ippool_table} \
 #	SET \
 #		gateway = '%{DHCP-Gateway-IP-Address}', pool_key = '${pool_key}', \
-#		expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
+#		expiry_time = DATEADD(SECOND,${offer_duration},CURRENT_TIMESTAMP) \
 #	WHERE FramedIPAddress = '%I'"
 
 #
@@ -141,7 +141,7 @@ pool_check = "\
 #		@v_pool_name = '%{control:${pool_name}}', \
 #		@v_gateway = '%{DHCP-Gateway-IP-Address}', \
 #		@v_pool_key = '${pool_key}', \
-#		@v_lease_duration = ${lease_duration} \
+#		@v_lease_duration = ${offer_duration} \
 #	"
 #allocate_update = ""
 #allocate_commit = ""

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -26,12 +26,12 @@ allocate_commit = ""
 #  Attempt to find the most recent existing IP address for the client
 #
 allocate_existing = "\
-	WITH cte AS (
+	WITH cte AS ( \
 		SELECT TOP(1) framedipaddress, expiry_time, gateway \
 		FROM ${ippool_table} WITH (xlock rowlock readpast) \
 		JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
 		WHERE pool_name = '%{control:${pool_name}}' \
-		AND pool_key = '%{pool_key}' \
+		AND pool_key = '${pool_key}' \
 		AND dhcpstatus.status IN ('dynamic', 'static') \
 		ORDER BY expiry_time DESC \
 	) \
@@ -45,18 +45,19 @@ allocate_existing = "\
 #  Determine whether the requested IP address is available
 #
 allocate_requested = "\
-	WITH cte AS (
+	WITH cte AS ( \
 		SELECT TOP(1) framedipaddress, expiry_time, gateway \
 		FROM ${ippool_table} WITH (xlock rowlock readpast) \
 		JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
 		WHERE pool_name = '%{control:${pool_name}}' \
 		AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
 		AND dhcpstatus.status = 'dynamic' \
-		AND ( pool_key = '%{pool_key}' OR expiry_time < CURRENT_TIMESTAMP ) \
+		AND expiry_time < CURRENT_TIMESTAMP \
 	) \
 	UPDATE cte \
 	SET expiry_time = DATEADD(SECOND,${offer_duration},CURRENT_TIMESTAMP), \
-	gateway = '%{DHCP-Gateway-IP-Address}' \
+	gateway = '%{DHCP-Gateway-IP-Address}', \
+	pool_key = '${pool_key}' \
 	OUTPUT INSERTED.FramedIPAddress \
 	FROM ${ippool_table}"
 
@@ -65,7 +66,7 @@ allocate_requested = "\
 #  find a free address
 #
 allocate_find = "\
-	WITH cte AS (
+	WITH cte AS ( \
 		SELECT TOP(1) framedipaddress, expiry_time, gateway, pool_key \
 		FROM ${ippool_table} WITH (xlock rowlock readpast) \
 		JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
@@ -76,7 +77,7 @@ allocate_find = "\
 	) \
 	UPDATE cte \
 	SET expiry_time = DATEADD(SECOND,${offer_duration},CURRENT_TIMESTAMP), \
-	gateway = '%{DHCP-Gateway-IP-Address}' \
+	gateway = '%{DHCP-Gateway-IP-Address}', \
 	pool_key = '${pool_key}' \
 	OUTPUT INSERTED.FramedIPAddress \
 	FROM ${ippool_table}"

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -42,6 +42,25 @@ allocate_existing = "\
 	FROM ${ippool_table}"
 
 #
+#  Determine whether the requested IP address is available
+#
+allocate_requested = "\
+	WITH cte AS (
+		SELECT TOP(1) framedipaddress, expiry_time, gateway \
+		FROM ${ippool_table} WITH (xlock rowlock readpast) \
+		JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
+		WHERE pool_name = '%{control:${pool_name}}' \
+		AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
+		AND dhcpstatus.status = 'dynamic' \
+		AND ( pool_key = '%{pool_key}' OR expiry_time < CURRENT_TIMESTAMP ) \
+	) \
+	UPDATE cte \
+	SET expiry_time = DATEADD(SECOND,${offer_duration},CURRENT_TIMESTAMP), \
+	gateway = '%{DHCP-Gateway-IP-Address}' \
+	OUTPUT INSERTED.FramedIPAddress \
+	FROM ${ippool_table}"
+
+#
 #  If the existing address can't be found this query will be run to
 #  find a free address
 #
@@ -63,7 +82,7 @@ allocate_find = "\
 	FROM ${ippool_table}"
 
 #
-#  Alternatively attempt both in one, more complex, query
+#  Alternatively attempt all in one, more complex, query
 #
 #  The ORDER BY clause of this query tries to allocate the same IP-address
 #  which user had last session.  Ensure that pool_key is unique to the user
@@ -78,21 +97,27 @@ allocate_find = "\
 #	OUTPUT INSERTED.FramedIPAddress \
 #	FROM ${ippool_table} \
 #	WHERE ${ippool_table}.id IN ( \
-#		SELECT TOP (1) id FROM ${ippool_table} WHERE id IN ( \
-#			(SELECT TOP(1) id FROM ${ippool_table} WITH (xlock rowlock readpast) \
+#		SELECT TOP (1) id FROM ( \
+#			(SELECT TOP(1) id, 1 AS o FROM ${ippool_table} WITH (xlock rowlock readpast) \
 #			JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
 #			WHERE pool_name = '%{control:${pool_name}}' \
 #			AND pool_key = '${pool_key}' \
 #			AND dhcpstatus.status IN ('dynamic', 'static')) \
 #			UNION \
-#			(SELECT TOP(1) id FROM ${ippool_table} WITH (xlock rowlock readpast) \
+#			(SELECT TOP(1) id, 2 AS o FROM ${ippool_table} WITH (xlock rowlock readpast) \
+#			JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
+#			WHERE pool_name = '%{control:${pool_name}}' \
+#			AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
+#			AND dhcpstatus.status = 'dynamic' \
+#			AND ( pool_key = '%{pool_key}' OR expiry_time < CURRENT_TIMESTAMP )) \
+#			UNION \
+#			(SELECT TOP(1) id, 3 AS o FROM ${ippool_table} WITH (xlock rowlock readpast) \
 #			JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
 #			WHERE pool_name = '%{control:${pool_name}}' \
 #			AND expiry_time < CURRENT_TIMESTAMP \
 #			AND dhcpstatus.status = 'dynamic' \
 #			ORDER BY expiry_time) \
-#		) \
-#		ORDER BY CASE WHEN pool_key = '${pool_key}' THEN 0 ELSE 1 END, expiry_time \
+#		) AS q ORDER BY q.o \
 #	)"
 
 #
@@ -145,7 +170,8 @@ pool_check = "\
 #		@v_pool_name = '%{control:${pool_name}}', \
 #		@v_gateway = '%{DHCP-Gateway-IP-Address}', \
 #		@v_pool_key = '${pool_key}', \
-#		@v_lease_duration = ${offer_duration} \
+#		@v_lease_duration = ${offer_duration}, \
+#		@v_requested_address = '%{%{${req_attribute_name}}:-0.0.0.0}' \
 #	"
 #allocate_update = ""
 #allocate_commit = ""

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -4,6 +4,10 @@
 #
 #  $Id$
 
+#  *****************
+#  * DHCP DISCOVER *
+#  *****************
+
 #
 #  This series of queries allocates an IP address
 #
@@ -25,10 +29,10 @@ allocate_existing = "\
 	WITH cte AS (
 		SELECT TOP(1) framedipaddress, expiry_time, gateway \
 		FROM ${ippool_table} WITH (xlock rowlock readpast) \
-    JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
+		JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
 		WHERE pool_name = '%{control:${pool_name}}' \
 		AND pool_key = '%{pool_key}' \
-    AND dhcpstatus.status IN ('dynamic', 'static') \
+		AND dhcpstatus.status IN ('dynamic', 'static') \
 		ORDER BY expiry_time DESC \
 	) \
 	UPDATE cte \
@@ -45,10 +49,10 @@ allocate_find = "\
 	WITH cte AS (
 		SELECT TOP(1) framedipaddress, expiry_time, gateway, pool_key \
 		FROM ${ippool_table} WITH (xlock rowlock readpast) \
-    JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
+		JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
 		WHERE pool_name = '%{control:${pool_name}}' \
 		AND expiry_time < CURRENT_TIMESTAMP \
-    AND dhcpstatus.status = 'dynamic' \
+		AND dhcpstatus.status = 'dynamic' \
 		ORDER BY expiry_time \
 	) \
 	UPDATE cte \
@@ -146,46 +150,85 @@ pool_check = "\
 #allocate_update = ""
 #allocate_commit = ""
 
-#
-#  This query is not applicable to DHCP as there are no accounting
-#  START records
-#
-start_update = ""
+
+# ****************
+# * DHCP REQUEST *
+# ****************
 
 #
-#  Free an IP when an accounting STOP record arrives - for DHCP this
-#  is when a Release occurs
+#  This query revokes any active offers for addresses that a client is not
+#  requesting when a DHCP REQUEST packet arrives
+#
+start_begin = ""
+start_update = "\
+	UPDATE ${ippool_table} \
+	SET \
+		gateway = '', \
+		pool_key = '', \
+		expiry_time = CURRENT_TIMESTAMP \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress <> '%{DHCP-Requested-IP-Address}' \
+	AND expiry_time > CURRENT_TIMESTAMP \
+	AND ${ippool_table}.status_id IN \
+	(SELECT status_id FROM dhcpstatus WHERE status = 'dynamic')"
+start_commit = ""
+
+#
+#  This query extends an existing lease (or offer) when a DHCP REQUEST packet
+#  arrives
+#
+alive_begin = ""
+alive_update = "\
+	UPDATE ${ippool_table} \
+	SET \
+		expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
+alive_commit = ""
+
+
+# ****************
+# * DHCP RELEASE *
+# ****************
+
+#
+#  This query frees an IP address when a DHCP RELEASE packet arrives
 #
 stop_begin = ""
 stop_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		gateway = '', \
-		pool_key = '0', \
+		pool_key = '', \
 		expiry_time = CURRENT_TIMESTAMP \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
-	AND FramedIPAddress = '%{DHCP-Client-IP-Address}'"
+	AND FramedIPAddress = '%{DHCP-Client-IP-Address}' \
+	AND ${ippool_table}.status_id IN \
+	(SELECT status_id FROM dhcpstatus WHERE status = 'dynamic')"
 stop_commit = ""
-
-#
-#  This query is not applicable to DHCP as there are no accounting
-#  ALIVE records
-#
-alive_update = ""
 
 #
 #  This query is not applicable to DHCP
 #
 on_clear = ""
 
+
+# ****************
+# * DHCP DECLINE *
+# ****************
+
 #
 #  This query marks an IP address as declined when a DHCP Decline
 #  packet arrives
 #
+off_begin = ""
 off_clear = "\
 	UPDATE ${ippool_table} \
 	SET status_id = (SELECT status_id FROM dhcpstatus WHERE status = 'declined') \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+off_commit = ""

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -185,7 +185,6 @@ pool_check = "\
 #  This query revokes any active offers for addresses that a client is not
 #  requesting when a DHCP REQUEST packet arrives
 #
-start_begin = ""
 start_update = "\
 	UPDATE ${ippool_table} \
 	SET \
@@ -198,13 +197,11 @@ start_update = "\
 	AND expiry_time > CURRENT_TIMESTAMP \
 	AND ${ippool_table}.status_id IN \
 	(SELECT status_id FROM dhcpstatus WHERE status = 'dynamic')"
-start_commit = ""
 
 #
 #  This query extends an existing lease (or offer) when a DHCP REQUEST packet
 #  arrives
 #
-alive_begin = ""
 alive_update = "\
 	UPDATE ${ippool_table} \
 	SET \
@@ -212,7 +209,6 @@ alive_update = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
-alive_commit = ""
 
 
 # ****************
@@ -222,7 +218,6 @@ alive_commit = ""
 #
 #  This query frees an IP address when a DHCP RELEASE packet arrives
 #
-stop_begin = ""
 stop_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
@@ -234,7 +229,6 @@ stop_clear = "\
 	AND FramedIPAddress = '%{DHCP-Client-IP-Address}' \
 	AND ${ippool_table}.status_id IN \
 	(SELECT status_id FROM dhcpstatus WHERE status = 'dynamic')"
-stop_commit = ""
 
 #
 #  This query is not applicable to DHCP
@@ -250,11 +244,9 @@ on_clear = ""
 #  This query marks an IP address as declined when a DHCP Decline
 #  packet arrives
 #
-off_begin = ""
 off_clear = "\
 	UPDATE ${ippool_table} \
 	SET status_id = (SELECT status_id FROM dhcpstatus WHERE status = 'declined') \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
-off_commit = ""

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/procedure.sql
@@ -21,7 +21,8 @@
 -- 		'%{control:${pool_name}}', \
 -- 		'%{DHCP-Gateway-IP-Address}', \
 -- 		'${pool_key}', \
--- 		${lease_duration} \
+-- 		${lease_duration}, \
+-- 		'%{%{${req_attribute_name}}:-0.0.0.0}' \
 -- 	)"
 -- allocate_update = ""
 -- allocate_commit = ""
@@ -34,7 +35,8 @@ CREATE PROCEDURE fr_dhcp_allocate_previous_or_new_framedipaddress (
 	IN v_pool_name VARCHAR(30),
 	IN v_gateway VARCHAR(15),
 	IN v_pool_key VARCHAR(30),
-	IN v_lease_duration INT
+	IN v_lease_duration INT,
+	IN v_requested_address VARCHAR(15)
 )
 proc:BEGIN
 	DECLARE r_address VARCHAR(15);
@@ -78,6 +80,19 @@ proc:BEGIN
 	-- LIMIT 1
 	-- FOR UPDATE;
 	-- -- FOR UPDATE SKIP LOCKED;  -- Better performance, but limited support
+
+	-- Issue the requested IP address if it is available
+	--
+	IF r_address IS NULL AND v_requested_address <> '0.0.0.0' THEN
+		SELECT framedipaddress INTO r_address
+		FROM dhcpippool
+		WHERE pool_name = v_pool_name
+			AND framedipaddress = v_requested_address
+			AND `status` = 'dynamic'
+			AND ( pool_key = v_pool_key OR expiry_time < NOW() )
+		FOR UPDATE;
+--	      FOR UPDATE SKIP LOCKED;  -- Better performance, but limited support
+	END IF;
 
 	-- If we didn't reallocate a previous address then pick the least
 	-- recently used address from the pool which maximises the likelihood

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -151,7 +151,6 @@ allocate_update = "\
 #  This query revokes any active offers for addresses that a client is not
 #  requesting when a DHCP REQUEST packet arrives
 #
-start_begin = ""
 start_update = "\
 	UPDATE ${ippool_table} \
 	SET \
@@ -163,13 +162,11 @@ start_update = "\
 	AND framedipaddress <> '%{DHCP-Requested-IP-Address}' \
 	AND expiry_time > NOW() \
 	AND `status` = 'dynamic'"
-start_commit = ""
 
 #
 #  This query extends an existing lease (or offer) when a DHCP REQUEST packet
 #  arrives
 #
-alive_begin = ""
 alive_update = "\
 	UPDATE ${ippool_table} \
 	SET \
@@ -177,7 +174,6 @@ alive_update = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
-alive_commit = ""
 
 
 # ****************
@@ -187,7 +183,6 @@ alive_commit = ""
 #
 #  This query frees an IP address when a DHCP RELEASE packet arrives
 #
-stop_begin = ""
 stop_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
@@ -198,7 +193,6 @@ stop_clear = "\
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Client-IP-Address}' \
 	AND `status` = 'dynamic'"
-stop_commit = ""
 
 
 #
@@ -215,11 +209,9 @@ on_clear = ""
 #  This query marks an IP address as declined when a DHCP Decline
 #  packet arrives
 #
-off_begin = ""
 off_clear = "\
 	UPDATE ${ippool_table} \
 	SET status = 'declined' \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
-off_commit = ""

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -4,6 +4,10 @@
 #
 #  $Id$
 
+#  *****************
+#  * DHCP DISCOVER *
+#  *****************
+
 #
 #  This series of queries allocates an IP address
 
@@ -15,7 +19,7 @@ allocate_existing = "\
 	SELECT framedipaddress FROM ${ippool_table} \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
-  AND `status` IN ('dynamic', 'static') \
+	AND `status` IN ('dynamic', 'static') \
 	ORDER BY expiry_time DESC LIMIT 1 FOR UPDATE SKIP LOCKED"
 
 #
@@ -26,7 +30,7 @@ allocate_find = "\
 	SELECT framedipaddress FROM ${ippool_table} \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND expiry_time < NOW() \
-  AND `status` = 'dynamic' \
+	AND `status` = 'dynamic' \
 	ORDER BY expiry_time LIMIT 1 FOR UPDATE SKIP LOCKED"
 
 #
@@ -119,43 +123,84 @@ allocate_update = "\
 #allocate_update = ""
 #allocate_commit = ""
 
-#
-#  This query is not applicable to DHCP as there are no accounting
-#  START records
-#
-start_update = ""
+
+# ****************
+# * DHCP REQUEST *
+# ****************
 
 #
-#  This query frees an IP address when an accounting STOP record
-#  arrives - for DHCP this is when a Release occurs
+#  This query revokes any active offers for addresses that a client is not
+#  requesting when a DHCP REQUEST packet arrives
 #
+start_begin = ""
+start_update = "\
+	UPDATE ${ippool_table} \
+	SET \
+		gateway = '', \
+		pool_key = '', \
+		expiry_time = NOW() \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress <> '%{DHCP-Requested-IP-Address}' \
+	AND expiry_time > NOW() \
+	AND `status` = 'dynamic'"
+start_commit = ""
+
+#
+#  This query extends an existing lease (or offer) when a DHCP REQUEST packet
+#  arrives
+#
+alive_begin = ""
+alive_update = "\
+	UPDATE ${ippool_table} \
+	SET \
+		expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
+alive_commit = ""
+
+
+# ****************
+# * DHCP RELEASE *
+# ****************
+
+#
+#  This query frees an IP address when a DHCP RELEASE packet arrives
+#
+stop_begin = ""
 stop_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		gateway = '', \
-		pool_key = '0', \
+		pool_key = '', \
 		expiry_time = NOW() \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
-	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
+	AND framedipaddress = '%{DHCP-Client-IP-Address}' \
+	AND `status` = 'dynamic'"
+stop_commit = ""
 
-#
-#  This query is not applicable to DHCP as there are no accounting ALIVE records
-#
-alive_update = ""
 
 #
 #  This query is not applicable to DHCP
 #
 on_clear = ""
 
+
+# ****************
+# * DHCP DECLINE *
+# ****************
+
 #
 #  This query marks an IP address as declined when a DHCP Decline
 #  packet arrives
 #
+off_begin = ""
 off_clear = "\
 	UPDATE ${ippool_table} \
 	SET status = 'declined' \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+off_commit = ""

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -30,7 +30,7 @@ allocate_requested = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
 	AND `status` = 'dynamic' \
-	AND ( pool_key = '${pool_key}' OR expiry_time < NOW() ) \
+	AND expiry_time < NOW() \
 	FOR UPDATE SKIP LOCKED"
 
 #

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -23,6 +23,17 @@ allocate_existing = "\
 	ORDER BY expiry_time DESC LIMIT 1 FOR UPDATE SKIP LOCKED"
 
 #
+#  Determine whether the requested IP address is available
+#
+allocate_requested = "\
+	SELECT framedipaddress FROM ${ippool_table} \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
+	AND `status` = 'dynamic' \
+	AND ( pool_key = '${pool_key}' OR expiry_time < NOW() ) \
+	FOR UPDATE SKIP LOCKED"
+
+#
 #  If the existing address can't be found this query will be run to
 #  find a free address
 #
@@ -40,22 +51,29 @@ allocate_find = "\
 #
 
 #
-#  Alternatively do both operations in one query.  Depending on transaction
+#  Alternatively do the operations in one query.  Depending on transaction
 #  isolation mode, this can cause deadlocks
 #
 #allocate_find = "\
-#	(SELECT framedipaddress, pool_key, expiry_time FROM ${ippool_table} \
+#	(SELECT framedipaddress, 1 AS o FROM ${ippool_table} \
 #		WHERE pool_name = '%{control:${pool_name}}' \
 #		AND pool_key = '${pool_key}' \
 #		AND `status` IN ('dynamic', 'static') \
 #		ORDER BY expiry_time DESC LIMIT 1 FOR UPDATE SKIP LOCKED \
 #	) UNION ( \
-#	SELECT framedipaddress, pool_key, expiry_time FROM ${ippool_table} \
+#	SELECT framedipaddress, 2 AS o FROM ${ippool_table} \
+#		WHERE pool_name = '%{control:${pool_name}}' \
+#		AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
+#		AND `status` = 'dynamic' \
+#		AND ( pool_key = '${pool_key}' OR expiry_time < NOW() ) \
+#		FOR UPDATE SKIP LOCKED \
+#	) UNION ( \
+#	SELECT framedipaddress, 3 AS o FROM ${ippool_table} \
 #		WHERE pool_name = '%{control:${pool_name}}' \
 #		AND expiry_time < NOW() \
 #		AND `status` = 'dynamic' \
 #		ORDER BY expiry_time LIMIT 1 FOR UPDATE SKIP LOCKED \
-#	) ORDER BY (pool_key <> '${pool_key}'), expiry_time \
+#	) ORDER BY o \
 #	LIMIT 1"
 
 #
@@ -118,7 +136,8 @@ allocate_update = "\
 #		'%{control:${pool_name}}', \
 #		'%{DHCP-Gateway-IP-Address}', \
 #		'${pool_key}', \
-#		${offer_duration} \
+#		${offer_duration}, \
+#		'%{%{${req_attribute_name}}:-0.0.0.0}' \
 #	)"
 #allocate_update = ""
 #allocate_commit = ""

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -101,7 +101,7 @@ allocate_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		gateway = '%{DHCP-Gateway-IP-Address}', pool_key = '${pool_key}', \
-		expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
+		expiry_time = NOW() + INTERVAL ${offer_duration} SECOND \
 	WHERE framedipaddress = '%I'"
 
 #
@@ -114,7 +114,7 @@ allocate_update = "\
 #		'%{control:${pool_name}}', \
 #		'%{DHCP-Gateway-IP-Address}', \
 #		'${pool_key}', \
-#		${lease_duration} \
+#		${offer_duration} \
 #	)"
 #allocate_update = ""
 #allocate_commit = ""

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/procedure.sql
@@ -33,7 +33,7 @@ CREATE OR REPLACE FUNCTION fr_dhcp_allocate_previous_or_new_framedipaddress (
 	v_gateway IN VARCHAR2,
 	v_pool_key IN VARCHAR2,
 	v_lease_duration IN INTEGER,
-	v_requested_address IN VARCHAR2,
+	v_requested_address IN VARCHAR2
 )
 RETURN varchar2 IS
 	PRAGMA AUTONOMOUS_TRANSACTION;
@@ -136,7 +136,7 @@ BEGIN
 				WHERE pool_name = v_pool_name
 					AND framedipaddress = v_requested_address
 					AND dhcpstatus.status = 'dynamic'
-					AND ( pool_key = v_pool_key OR expiry_time < CURRENT_TIMESTAMP )
+					AND expiry_time < CURRENT_TIMESTAMP
 				) WHERE ROWNUM <= 1
 		) FOR UPDATE SKIP LOCKED;
 		EXCEPTION
@@ -156,7 +156,7 @@ BEGIN
 	--		WHERE pool_name = v_pool_name
 	--			AND framedipaddress = v_requested_address
 	--			AND dhcpstatus.status = 'dynamic'
-	--			AND ( pool_key = v_pool_key OR expiry_time < CURRENT_TIMESTAMP )
+	--			AND expiry_time < CURRENT_TIMESTAMP
 	--		FETCH FIRST 1 ROWS ONLY
 	--	) FOR UPDATE SKIP LOCKED;
 	--	EXCEPTION

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -23,7 +23,7 @@ allocate_find = "\
 		'%{control:${pool_name}}', \
 		'%{DHCP-Gateway-IP-Address}', \
 		'${pool_key}', \
-		'${lease_duration}' \
+		'${offer_duration}' \
 	)"
 allocate_update = ""
 allocate_commit = ""
@@ -97,14 +97,14 @@ pool_check = "\
 
 #
 #  This query marks the IP address handed out by "allocate-find" as used
-#  for the period of "lease_duration" after which time it may be reused.
+#  for the period of "offer_duration" after which time it may be reused.
 #
 allocate_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		gateway = '%{DHCP-Gateway-IP-Address}', \
 		pool_key = '${pool_key}', \
-		expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
+		expiry_time = current_timestamp + INTERVAL '${offer_duration}' second(1) \
 	WHERE framedipaddress = '%I'"
 
 #

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -11,6 +11,10 @@ on_begin = "commit"
 off_begin = "commit"
 
 
+#  *****************
+#  * DHCP DISCOVER *
+#  *****************
+
 #
 #  Use a stored procedure to find AND allocate the address. Read and customise
 #  `procedure.sql` in this directory to determine the optimal configuration.
@@ -107,15 +111,47 @@ allocate_update = "\
 		expiry_time = current_timestamp + INTERVAL '${offer_duration}' second(1) \
 	WHERE framedipaddress = '%I'"
 
-#
-#  This query is not applicable to DHCP as there are no accounting
-#  START records
-#
-start_update = ""
+
+# ****************
+# * DHCP REQUEST *
+# ****************
 
 #
-#  This query frees an IP address when an accounting STOP record arrives
-#  - for DHCP this is when a Release occurs
+#  This query revokes any active offers for addresses that a client is not
+#  requesting when a DHCP REQUEST packet arrives
+#
+start_update = "\
+	UPDATE ${ippool_table} \
+	SET \
+		gateway = '', \
+		pool_key = '0', \
+		expiry_time = current_timestamp - INTERVAL '1' second(1) \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress <> '%{DHCP-Requested-IP-Address}' \
+	AND expiry_time > current_timestamp \
+	AND ${ippool_table}.status_id IN \
+	(SELECT status_id FROM dhcpstatus WHERE status = 'dynamic')"
+
+#
+#  This query extends an existing lease (or offer) when a DHCP REQUEST packet
+#  arrives
+#
+alive_update = "\
+	UPDATE ${ippool_table} \
+	SET \
+		expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
+
+
+# ****************
+# * DHCP RELEASE *
+# ****************
+
+#
+#  This query frees an IP address when a DHCP RELEASE packet arrives
 #
 stop_clear = "\
 	UPDATE ${ippool_table} \
@@ -125,18 +161,20 @@ stop_clear = "\
 		expiry_time = current_timestamp - INTERVAL '1' second(1) \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
-	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
+	AND framedipaddress = '%{DHCP-Client-IP-Address}' \
+	AND ${ippool_table}.status_id IN \
+	(SELECT status_id FROM dhcpstatus WHERE status = 'dynamic')"
 
-#
-#  This query is not applicable to DHCP as there are no accounting
-#  ALIVE records
-#
-alive_update = ""
 
 #
 #  This query is not applicable to DHCP
 #
 on_clear = ""
+
+
+# ****************
+# * DHCP DECLINE *
+# ****************
 
 #
 #  This query marks an IP address as declined when a DHCP Decline

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -103,14 +103,16 @@ pool_check = "\
 #
 #  This query marks the IP address handed out by "allocate-find" as used
 #  for the period of "offer_duration" after which time it may be reused.
+#  Only needed if allocate_find is not using the stored procedure and therefore
+#  not updating the lease
 #
-allocate_update = "\
-	UPDATE ${ippool_table} \
-	SET \
-		gateway = '%{DHCP-Gateway-IP-Address}', \
-		pool_key = '${pool_key}', \
-		expiry_time = current_timestamp + INTERVAL '${offer_duration}' second(1) \
-	WHERE framedipaddress = '%I'"
+#allocate_update = "\
+#	UPDATE ${ippool_table} \
+#	SET \
+#		gateway = '%{DHCP-Gateway-IP-Address}', \
+#		pool_key = '${pool_key}', \
+#		expiry_time = current_timestamp + INTERVAL '${offer_duration}' second(1) \
+#	WHERE framedipaddress = '%I'"
 
 
 # ****************
@@ -133,6 +135,7 @@ start_update = "\
 	AND expiry_time > current_timestamp \
 	AND ${ippool_table}.status_id IN \
 	(SELECT status_id FROM dhcpstatus WHERE status = 'dynamic')"
+start_commit = "COMMIT"
 
 #
 #  This query extends an existing lease (or offer) when a DHCP REQUEST packet
@@ -145,6 +148,7 @@ alive_update = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
+alive_commit = "COMMIT"
 
 
 # ****************
@@ -165,6 +169,7 @@ stop_clear = "\
 	AND framedipaddress = '%{DHCP-Client-IP-Address}' \
 	AND ${ippool_table}.status_id IN \
 	(SELECT status_id FROM dhcpstatus WHERE status = 'dynamic')"
+stop_commit = "COMMIT"
 
 
 #
@@ -187,3 +192,5 @@ off_clear = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+off_commit = "COMMIT"
+

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -29,7 +29,7 @@ allocate_find = "\
 		'${pool_key}', \
 		'${offer_duration}', \
 		'%{%{${req_attribute_name}}:-0.0.0.0}' \
-	)"
+	) FROM dual"
 allocate_update = ""
 allocate_commit = ""
 

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -27,7 +27,8 @@ allocate_find = "\
 		'%{control:${pool_name}}', \
 		'%{DHCP-Gateway-IP-Address}', \
 		'${pool_key}', \
-		'${offer_duration}' \
+		'${offer_duration}', \
+		'%{%{${req_attribute_name}}:-0.0.0.0}' \
 	)"
 allocate_update = ""
 allocate_commit = ""

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -23,7 +23,8 @@ allocate_find = "\
 		'%{control:${pool_name}}', \
 		'%{DHCP-Gateway-IP-Address}', \
 		'${pool_key}', \
-		'${lease_duration}' \
+		'${lease_duration}', \
+		'%{%{${req_attribute_name}}:-0.0.0.0}' \
 	)"
 allocate_update = ""
 allocate_commit = ""
@@ -40,6 +41,7 @@ allocate_commit = ""
 #
 #allocate_begin = "BEGIN"
 
+
 #
 #  Attempt to find the most recent existing IP address for the client
 #
@@ -47,7 +49,7 @@ allocate_commit = ""
 #	SELECT framedipaddress FROM ${ippool_table} \
 #	WHERE pool_name = '%{control:${pool_name}}' \
 #	AND pool_key = '${pool_key}' \
-# AND status IN ('dynamic', 'static') \
+#	AND status IN ('dynamic', 'static') \
 #	ORDER BY expiry_time DESC \
 #	LIMIT 1 \
 #	FOR UPDATE"
@@ -57,11 +59,31 @@ allocate_commit = ""
 #	SELECT framedipaddress FROM ${ippool_table} \
 #	WHERE pool_name = '%{control:${pool_name}}' \
 #	AND pool_key = '${pool_key}' \
-# AND status IN ('dynamic', 'static') \
+#	AND status IN ('dynamic', 'static') \
 #	ORDER BY expiry_time DESC \
 #	LIMIT 1 \
 #	FOR UPDATE SKIP LOCKED"
 
+
+#
+#  Determine whether the requested IP address is available
+#
+#allocate_requested = "\
+#	SELECT framedipaddress FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' \
+#	AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
+#	AND status = 'dynamic' \
+#	AND ( pool_key = '${pool_key}' OR expiry_time < 'now'::timestamp(0) ) \
+#	FOR UPDATE"
+
+#  The same query with SKIP LOCKED - requires PostgreSQL >= 9.5
+#allocate_requested = "\
+#	SELECT framedipaddress FROM ${ippool_table} \
+#	WHERE pool_name = '%{control:${pool_name}}' \
+#	AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
+#	AND status = 'dynamic' \
+#	AND ( pool_key = '${pool_key}' OR expiry_time < 'now'::timestamp(0) ) \
+#	FOR UPDATE SKIP LOCKED"
 #
 #  If the existing address can't be found this query will be run to
 #  find a free address
@@ -70,7 +92,7 @@ allocate_commit = ""
 #	SELECT framedipaddress FROM ${ippool_table} \
 #	WHERE pool_name = '%{control:${pool_name}}' \
 #	AND expiry_time < 'now'::timestamp(0) \
-# AND status = 'dynamic' \
+#	AND status = 'dynamic' \
 #	ORDER BY expiry_time \
 #	LIMIT 1 \
 #	FOR UPDATE"
@@ -80,7 +102,7 @@ allocate_commit = ""
 #	SELECT framedipaddress FROM ${ippool_table} \
 #	WHERE pool_name = '%{control:${pool_name}}' \
 #	AND expiry_time < 'now'::timestamp(0) \
-# AND status = 'dynamic' \
+#	AND status = 'dynamic' \
 #	ORDER BY expiry_time \
 #	LIMIT 1 \
 #	FOR UPDATE SKIP LOCKED"
@@ -128,27 +150,38 @@ allocate_commit = ""
 #  This version does the update as well - so allocate_begin, allocate_update and
 #  allocate_commit should be blank
 #
+#allocate_begin = ""
 #allocate_find = "\
 #	WITH found AS ( \
 #		WITH existing AS ( \
-#			SELECT framedipaddress, pool_key, expiry_time FROM ${ippool_table} \
+#			SELECT framedipaddress FROM ${ippool_table} \
 #			WHERE pool_name = '%{control:${pool_name}}' \
 #			AND pool_key = '${pool_key}' \
 #			ORDER BY expiry_time DESC \
 #			LIMIT 1 \
 #			FOR UPDATE SKIP LOCKED \
+#		), requested AS ( \
+#			SELECT framedipaddress FROM ${ippool_table} \
+#			WHERE pool_name = '%{control:${pool_name}}' \
+#			AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
+#			AND status = 'dynamic' \
+#			AND ( pool_key = '${pool_key}' OR expiry_time < 'now'::timestamp(0) ) \
+#			FOR UPDATE SKIP LOCKED \
 #		), new AS ( \
-#			SELECT framedipaddress, pool_key, expiry_time FROM ${ippool_table} \
+#			SELECT framedipaddress FROM ${ippool_table} \
 #			WHERE pool_name = '%{control:${pool_name}}' \
 #			AND expiry_time < 'now'::timestamp(0) \
+#			AND status = 'dynamic' \
 #			ORDER BY expiry_time \
 #			LIMIT 1 \
 #			FOR UPDATE SKIP LOCKED \
 #		) \
-#		SELECT framedipaddress, pool_key, expiry_time FROM existing \
+#		SELECT framedipaddress, 1 AS o FROM existing \
 #		UNION ALL \
-#		SELECT framedipaddress, pool_key, expiry_time FROM new \
-#		ORDER BY expiry_time DESC LIMIT 1 \
+#		SELECT framedipaddress, 2 AS o FROM requested \
+#		UNION ALL \
+#		SELECT framedipaddress, 3 AS o FROM new \
+#		ORDER BY o LIMIT 1 \
 #	) \
 #	UPDATE ${ippool_table} \
 #	SET pool_key = '${pool_key}', \
@@ -157,6 +190,8 @@ allocate_commit = ""
 #	FROM found \
 #	WHERE found.framedipaddress = ${ippool_table}.framedipaddress \
 #	RETURNING found.framedipaddress"
+#allocate_update = ""
+#allocate_commit = ""
 
 #
 #  If an IP could not be allocated, check to see whether the pool exists or not

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -4,6 +4,10 @@
 #
 #  $Id$
 
+#  *****************
+#  * DHCP DISCOVER *
+#  *****************
+
 #
 #  Use a stored procedure to find AND allocate the address. Read and customise
 #  `procedure.sql` in this directory to determine the optimal configuration.
@@ -42,7 +46,6 @@ allocate_commit = ""
 #allocate_begin = "BEGIN"
 
 
-#
 #  Attempt to find the most recent existing IP address for the client
 #
 #allocate_existing = "\
@@ -84,6 +87,8 @@ allocate_commit = ""
 #	AND status = 'dynamic' \
 #	AND ( pool_key = '${pool_key}' OR expiry_time < 'now'::timestamp(0) ) \
 #	FOR UPDATE SKIP LOCKED"
+
+
 #
 #  If the existing address can't be found this query will be run to
 #  find a free address
@@ -193,6 +198,7 @@ allocate_commit = ""
 #allocate_update = ""
 #allocate_commit = ""
 
+
 #
 #  If an IP could not be allocated, check to see whether the pool exists or not
 #  This allows the module to differentiate between a full pool and no pool
@@ -205,44 +211,85 @@ pool_check = "\
 	WHERE pool_name='%{control:${pool_name}}' \
 	LIMIT 1"
 
-#
-#  This query is not applicable to DHCP as there are no accounting
-#  START records
-#
-start_update = ""
+
+# ****************
+# * DHCP REQUEST *
+# ****************
 
 #
-#  This query frees an IP address when an accounting
-#  STOP record arrives - for DHCP this is when a Release occurs
+#  This query revokes any active offers for addresses that a client is not
+#  requesting when a DHCP REQUEST packet arrives, i.e, each server (sharing the
+#  same database) may have simultaneously offered a unique address.
 #
+start_begin = ""
+start_update = "\
+	UPDATE ${ippool_table} \
+	SET \
+		gateway = '', \
+		pool_key = '', \
+		expiry_time = 'now'::timestamp(0) - '1 second'::interval \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress <> '%{DHCP-Requested-IP-Address}' \
+	AND expiry_time > 'now'::timestamp(0) \
+	AND status = 'dynamic'"
+start_commit = ""
+
+#
+#  This query extends an existing lease (or offer) when a DHCP REQUEST packet
+#  arrives
+#
+alive_begin = ""
+alive_update = "\
+	UPDATE ${ippool_table} \
+	SET \
+		expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
+alive_commit = ""
+
+
+# ****************
+# * DHCP RELEASE *
+# ****************
+
+#
+#  This query frees an IP address when a DHCP RELEASE packet arrives
+#
+stop_begin = ""
 stop_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		gateway = '', \
-		pool_key = 0, \
+		pool_key = '', \
 		expiry_time = 'now'::timestamp(0) - '1 second'::interval \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
-	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
+	AND framedipaddress = '%{DHCP-Client-IP-Address}' \
+	AND status = 'dynamic'"
+stop_commit = ""
 
-#
-#  This query is not applicable to DHCP as there are no accounting
-#  ALIVE records
-#
-alive_update = ""
 
 #
 #  This query is not applicable to DHCP
 #
 on_clear = ""
 
+
+# ****************
+# * DHCP DECLINE *
+# ****************
+
 #
-#  This query marks an IP address as declined when a DHCP Decline
-#  packet arrives
+#  This query marks an IP address as declined when a DHCP DECLINE packet
+#  arrives
 #
+off_begin = ""
 off_clear = "\
 	UPDATE ${ippool_table} \
 	SET status = 'declined' \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
+off_commit = ""

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -221,7 +221,6 @@ pool_check = "\
 #  requesting when a DHCP REQUEST packet arrives, i.e, each server (sharing the
 #  same database) may have simultaneously offered a unique address.
 #
-start_begin = ""
 start_update = "\
 	UPDATE ${ippool_table} \
 	SET \
@@ -233,13 +232,11 @@ start_update = "\
 	AND framedipaddress <> '%{DHCP-Requested-IP-Address}' \
 	AND expiry_time > 'now'::timestamp(0) \
 	AND status = 'dynamic'"
-start_commit = ""
 
 #
 #  This query extends an existing lease (or offer) when a DHCP REQUEST packet
 #  arrives
 #
-alive_begin = ""
 alive_update = "\
 	UPDATE ${ippool_table} \
 	SET \
@@ -247,7 +244,6 @@ alive_update = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
-alive_commit = ""
 
 
 # ****************
@@ -257,7 +253,6 @@ alive_commit = ""
 #
 #  This query frees an IP address when a DHCP RELEASE packet arrives
 #
-stop_begin = ""
 stop_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
@@ -268,7 +263,6 @@ stop_clear = "\
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Client-IP-Address}' \
 	AND status = 'dynamic'"
-stop_commit = ""
 
 
 #
@@ -285,11 +279,9 @@ on_clear = ""
 #  This query marks an IP address as declined when a DHCP DECLINE packet
 #  arrives
 #
-off_begin = ""
 off_clear = "\
 	UPDATE ${ippool_table} \
 	SET status = 'declined' \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}'"
-off_commit = ""

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -23,7 +23,7 @@ allocate_find = "\
 		'%{control:${pool_name}}', \
 		'%{DHCP-Gateway-IP-Address}', \
 		'${pool_key}', \
-		'${lease_duration}', \
+		'${offer_duration}', \
 		'%{%{${req_attribute_name}}:-0.0.0.0}' \
 	)"
 allocate_update = ""
@@ -141,7 +141,7 @@ allocate_commit = ""
 #	SET \
 #		gateway = '%{DHCP-Gateway-IP-Address}', \
 #		pool_key = '${pool_key}', \
-#		expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval \
+#		expiry_time = 'now'::timestamp(0) + '${offer_duration} second'::interval \
 #	WHERE framedipaddress = '%I'"
 
 
@@ -185,7 +185,7 @@ allocate_commit = ""
 #	) \
 #	UPDATE ${ippool_table} \
 #	SET pool_key = '${pool_key}', \
-#	expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval, \
+#	expiry_time = 'now'::timestamp(0) + '${offer_duration} second'::interval, \
 #	gateway = '%{DHCP-Gateway-IP-Address}' \
 #	FROM found \
 #	WHERE found.framedipaddress = ${ippool_table}.framedipaddress \

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -76,7 +76,7 @@ allocate_commit = ""
 #	WHERE pool_name = '%{control:${pool_name}}' \
 #	AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
 #	AND status = 'dynamic' \
-#	AND ( pool_key = '${pool_key}' OR expiry_time < 'now'::timestamp(0) ) \
+#	AND expiry_time < 'now'::timestamp(0) \
 #	FOR UPDATE"
 
 #  The same query with SKIP LOCKED - requires PostgreSQL >= 9.5
@@ -85,7 +85,7 @@ allocate_commit = ""
 #	WHERE pool_name = '%{control:${pool_name}}' \
 #	AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
 #	AND status = 'dynamic' \
-#	AND ( pool_key = '${pool_key}' OR expiry_time < 'now'::timestamp(0) ) \
+#	AND expiry_time < 'now'::timestamp(0) \
 #	FOR UPDATE SKIP LOCKED"
 
 

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -96,7 +96,7 @@ allocate_update = "\
 	SET \
 		gateway = '%{DHCP-Gateway-IP-Address}', \
 		pool_key = '${pool_key}', \
-		expiry_time = datetime(strftime('%%s', 'now') + ${lease_duration}, 'unixepoch') \
+		expiry_time = datetime(strftime('%%s', 'now') + ${offer_duration}, 'unixepoch') \
 	WHERE framedipaddress = '%I'"
 
 #

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -4,6 +4,10 @@
 #
 #  $Id$
 
+#  *****************
+#  * DHCP DISCOVER *
+#  *****************
+
 #
 #  SQLite does not implement SELECT FOR UPDATE which is normally used to place
 #  an exclusive lock over rows to prevent the same address from being
@@ -99,36 +103,70 @@ allocate_update = "\
 		expiry_time = datetime(strftime('%%s', 'now') + ${offer_duration}, 'unixepoch') \
 	WHERE framedipaddress = '%I'"
 
-#
-#  This query is not applicable to DHCP as there are no accounting
-#  START records
-#
-start_update = ""
+
+# ****************
+# * DHCP REQUEST *
+# ****************
 
 #
-#  Free an IP when an accounting STOP record arrives - for DHCP this
-#  is when a Release occurs
+#  This query revokes any active offers for addresses that a client is not
+#  requesting when a DHCP REQUEST packet arrives
+#
+start_update = "\
+	UPDATE ${ippool_table} \
+	SET \
+		gateway = '', \
+		pool_key = '', \
+		expiry_time = datetime('now') \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress <> '%{DHCP-Requested-IP-Address}' \
+	AND expiry_time > datetime('now') \
+	AND ${ippool_table}.status_id IN \
+	(SELECT status_id FROM dhcpstatus WHERE status = 'dynamic')"
+
+#
+#  This query extends an existing lease (or offer) when a DHCP REQUEST packet
+#  arrives
+#
+alive_update = "\
+	UPDATE ${ippool_table} \
+	SET \
+		expiry_time = datetime(strftime('%%s', 'now') + ${lease_duration}, 'unixepoch') \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
+
+
+# ****************
+# * DHCP RELEASE *
+# ****************
+
+#
+#  This query frees an IP address when a DHCP RELEASE packet arrives
 #
 stop_clear = "\
 	UPDATE ${ippool_table} \
 	SET \
 		gateway = '', \
-		pool_key = 0, \
+		pool_key = '', \
 		expiry_time = datetime('now') \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
-	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
+	AND framedipaddress = '%{DHCP-Client-IP-Address}' \
+	AND ${ippool_table}.status_id IN \
+	(SELECT status_id FROM dhcpstatus WHERE status = 'dynamic')"
 
-#
-#  This query is not applicable to DHCP as there are no accounting
-#  ALIVE records
-#
-alive_update = ""
 
 #
 #  This query is not applicable to DHCP
 #
 on_clear = ""
+
+
+# ****************
+# * DHCP DECLINE *
+# ****************
 
 #
 #  This query marks an IP address as declined when a DHCP Decline

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -26,6 +26,47 @@ allocate_begin = "BEGIN EXCLUSIVE"
 allocate_commit = "COMMIT"
 
 #
+#  Attempt to find the most recent existing IP address for the client
+#
+allocate_existing = "\
+	SELECT framedipaddress \
+	FROM ${ippool_table} \
+	JOIN dhcpstatus \
+	ON ${ippool_table}.status_id = dhcpstatus.status_id \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND status IN ('dynamic', 'static') \
+	ORDER BY expiry_time DESC \
+	LIMIT 1"
+
+#
+#  Determine whether the requested IP address is available
+#
+allocate_requested = "\
+	SELECT framedipaddress \
+	FROM ${ippool_table} \
+	JOIN dhcpstatus \
+	ON ${ippool_table}.status_id = dhcpstatus.status_id \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
+	AND status = 'dynamic' \
+	AND ( pool_key = '${pool_key}' OR expiry_time < datetime('now') )"
+
+#
+#  If the existing address can't be found this query will be run to
+#  find a free address
+#
+allocate_find = "\
+	SELECT framedipaddress \
+	FROM ${ippool_table} \
+	JOIN dhcpstatus \
+	ON ${ippool_table}.status_id = dhcpstatus.status_id \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND expiry_time < datetime('now') \
+	AND status = 'dynamic' \
+	ORDER BY expiry_time LIMIT 1"
+
+#
 #  This series of queries allocates an IP address
 #
 #  Either pull the most recent allocated IP for this client or the
@@ -35,33 +76,43 @@ allocate_commit = "COMMIT"
 #  Sorting the result by expiry_time DESC will return the client specific
 #  IP if it exists, otherwise an expired one.
 #
-allocate_find = "\
-	SELECT framedipaddress, expiry_time \
-	FROM ( \
-		SELECT framedipaddress, expiry_time \
-		FROM ${ippool_table} \
-		JOIN dhcpstatus \
-		ON ${ippool_table}.status_id = dhcpstatus.status_id \
-		WHERE pool_name = '%{control:${pool_name}}' \
-		AND pool_key = '${pool_key}' \
-		AND status IN ('dynamic', 'static') \
-		ORDER BY expiry_time DESC \
-		LIMIT 1 \
-	) UNION \
-	SELECT framedipaddress, expiry_time \
-	FROM ( \
-		SELECT framedipaddress, expiry_time \
-		FROM ${ippool_table} \
-		JOIN dhcpstatus \
-		ON ${ippool_table}.status_id = dhcpstatus.status_id \
-		WHERE pool_name = '%{control:${pool_name}}' \
-		AND expiry_time < datetime('now') \
-		AND status = 'dynamic' \
-		ORDER BY expiry_time LIMIT 1 \
-	) \
-	ORDER BY \
-		expiry_time DESC \
-	LIMIT 1"
+#allocate_find = "\
+#	SELECT framedipaddress, 1 AS o \
+#	FROM ( \
+#		SELECT framedipaddress \
+#		FROM ${ippool_table} \
+#		JOIN dhcpstatus \
+#		ON ${ippool_table}.status_id = dhcpstatus.status_id \
+#		WHERE pool_name = '%{control:${pool_name}}' \
+#		AND pool_key = '${pool_key}' \
+#		AND status IN ('dynamic', 'static') \
+#		ORDER BY expiry_time DESC \
+#		LIMIT 1 \
+#	) UNION \
+#	SELECT framedipaddress, 2 AS o \
+#	FROM ( \
+#		SELECT framedipaddress \
+#		FROM ${ippool_table} \
+#		JOIN dhcpstatus \
+#		ON ${ippool_table}.status_id = dhcpstatus.status_id \
+#		WHERE pool_name = '%{control:${pool_name}}' \
+#		AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
+#		AND status = 'dynamic' \
+#		AND ( pool_key = '${pool_key}' OR expiry_time < datetime('now') ) \
+#	) UNION \
+#	SELECT framedipaddress, 3 AS o \
+#	FROM ( \
+#		SELECT framedipaddress \
+#		FROM ${ippool_table} \
+#		JOIN dhcpstatus \
+#		ON ${ippool_table}.status_id = dhcpstatus.status_id \
+#		WHERE pool_name = '%{control:${pool_name}}' \
+#		AND expiry_time < datetime('now') \
+#		AND status = 'dynamic' \
+#		ORDER BY expiry_time LIMIT 1 \
+#	) \
+#	ORDER BY o \
+#	LIMIT 1"
 
 #
 #   If you prefer to allocate a random IP address every time, i

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -50,7 +50,7 @@ allocate_requested = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
 	AND status = 'dynamic' \
-	AND ( pool_key = '${pool_key}' OR expiry_time < datetime('now') )"
+	AND expiry_time < datetime('now')"
 
 #
 #  If the existing address can't be found this query will be run to

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
@@ -4,7 +4,7 @@
 CREATE TABLE dhcpstatus (
   status_id		int PRIMARY KEY,
   status		varchar(10) NOT NULL
-)
+);
 
 INSERT INTO dhcpstatus (status_id, status) VALUES (1, 'dynamic'), (2, 'static'), (3, 'declined'), (4, 'disabled');
 

--- a/raddb/policy.d/dhcp
+++ b/raddb/policy.d/dhcp
@@ -1,10 +1,41 @@
+#  Assign compatibility data to request for sqlippool for DHCP Request
+dhcp_sqlippool_request {
+
+	#
+	#  During initial address selection (DORA) the REQUEST is broadcast and
+	#  requested-ip must be provided. We revoke any active offers for addresses
+	#  not matching the requested-ip, i.e. those made by other servers when
+	#  processing the DISCOVER.
+	#
+	#  If there is only a single server then this optimisation can be disabled.
+	#
+	if (&DHCP-Requested-IP-Address) {
+		update request {
+			&Acct-Status-Type := Start
+		}
+		dhcp_sqlippool.accounting
+	}
+
+	#  Extend an existing offer or active lease
+	update request {
+		&Acct-Status-Type := Alive
+	}
+	dhcp_sqlippool.accounting {
+		notfound = return
+	}
+
+	update reply {
+		&DHCP-Your-IP-Address := "%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}"
+	}
+
+}
+
 #  Assign compatibility data to request for sqlippool for DHCP Release
 dhcp_sqlippool_release {
 
 	#  Do some minor hacks to the request so that it looks
 	#  like a RADIUS Accounting Stop request to the SQL IP Pool module.
 	update request {
-		&Framed-IP-Address = "%{DHCP-Client-IP-Address}"
 		&Acct-Status-Type = Stop
 	}
 

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -125,6 +125,11 @@ listen {
 
 dhcp DHCP-Discover {
 
+	#  The DHCP Server Identifier is set here since is returned in OFFERs
+	update control {
+		&DHCP-DHCP-Server-Identifier = 192.0.2.2
+	}
+
 	#  Set the type of packet to send in reply.
 	#
 	#  The server will look at the DHCP-Message-Type attribute to
@@ -152,7 +157,7 @@ dhcp DHCP-Discover {
 		&DHCP-Subnet-Mask = 255.255.255.0
 		&DHCP-Router-Address = 192.0.2.1
 #		&DHCP-IP-Address-Lease-Time = "${modules.sqlippool[dhcp_sqlippool].lease_duration}"
-		&DHCP-DHCP-Server-Identifier = 192.0.2.1
+		&DHCP-DHCP-Server-Identifier = &control:DHCP-DHCP-Server-Identifier
 	}
 
 	#  Do a simple mapping of MAC to assigned IP.
@@ -187,6 +192,19 @@ dhcp DHCP-Discover {
 
 dhcp DHCP-Request {
 
+	#  You must set the DHCP Server Identifier here since this is returned
+	#  in ACKs and is used to determine whether a request containing a
+	#  "server-ip" field is intended for this server
+	update control {
+		&DHCP-DHCP-Server-Identifier = 192.0.2.2
+	}
+
+	#  If the request is not for this server then silently discard it
+	if (&request:DHCP-DHCP-Server-Identifier && \
+	    &request:DHCP-DHCP-Server-Identifier != &control:DHCP-DHCP-Server-Identifier) {
+		do_not_respond
+	}
+
 	#  Response packet type. See DHCP-Discover section above.
 	#update reply {
 	#       &DHCP-Message-Type = DHCP-Ack
@@ -201,7 +219,7 @@ dhcp DHCP-Request {
 		&DHCP-Subnet-Mask = 255.255.255.0
 		&DHCP-Router-Address = 192.0.2.1
 #		&DHCP-IP-Address-Lease-Time = "${modules.sqlippool[dhcp_sqlippool].lease_duration}"
-		&DHCP-DHCP-Server-Identifier = 192.0.2.1
+		&DHCP-DHCP-Server-Identifier = &control:DHCP-DHCP-Server-Identifier
 	}
 
 	#  Do a simple mapping of MAC to assigned IP.

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -138,10 +138,10 @@ dhcp DHCP-Discover {
 	#  In the event that DHCP-Message-Type is not set then the
 	#  server will fall back to determining the type of reply
 	#  based on the rcode of this section.
-
-	update reply {
-	       DHCP-Message-Type = DHCP-Offer
-	}
+	#
+	#update reply {
+	#       DHCP-Message-Type = DHCP-Offer
+	#}
 
 	#  The contents here are invented.  Change them!
 	#  Lease time is referencing the lease time set in the
@@ -181,15 +181,16 @@ dhcp DHCP-Discover {
 	#  message.
 	#
 	#  Other rcodes will tell the server to not return any response.
-	ok
+	#
+	#ok
 }
 
 dhcp DHCP-Request {
 
-	# Response packet type. See DHCP-Discover section above.
-	update reply {
-	       &DHCP-Message-Type = DHCP-Ack
-	}
+	#  Response packet type. See DHCP-Discover section above.
+	#update reply {
+	#       &DHCP-Message-Type = DHCP-Ack
+	#}
 
 	#  The contents here are invented.  Change them!
 	#  Lease time is referencing the lease time set in the
@@ -231,7 +232,8 @@ dhcp DHCP-Request {
 	#
 	#  "handled" will not return a packet, all other rcodes will
 	#  send back a DHCP-NAK.
-	ok
+	#
+	#ok
 }
 
 #

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -223,7 +223,7 @@ dhcp DHCP-Request {
 #	update control {
 #		&Pool-Name := "local"
 #	}
-#	dhcp_sqlippool
+#	dhcp_sqlippool_request
 
 	#  If DHCP-Message-Type is not set, returning "ok" or
 	#  "updated" from this section will respond with a DHCP-Ack

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -202,7 +202,6 @@ dhcp DHCP-Request {
 		&DHCP-Router-Address = 192.0.2.1
 #		&DHCP-IP-Address-Lease-Time = "${modules.sqlippool[dhcp_sqlippool].lease_duration}"
 		&DHCP-DHCP-Server-Identifier = 192.0.2.1
-		&DHCP-Your-IP-Address = 192.0.2.9
 	}
 
 	#  Do a simple mapping of MAC to assigned IP.

--- a/src/modules/rlm_sqlippool/rlm_sqlippool.c
+++ b/src/modules/rlm_sqlippool/rlm_sqlippool.c
@@ -169,53 +169,53 @@ static CONF_PARSER module_config[] = {
 
 
 	{ "start-begin", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT | PW_TYPE_DEPRECATED, rlm_sqlippool_t, start_begin), NULL },
-	{ "start_begin", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, start_begin), "START TRANSACTION" },
+	{ "start_begin", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, start_begin), "" },
 
 	{ "start-update", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT | PW_TYPE_DEPRECATED, rlm_sqlippool_t, start_update), NULL },
 	{ "start_update", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT , rlm_sqlippool_t, start_update), ""  },
 
 	{ "start-commit", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT | PW_TYPE_DEPRECATED, rlm_sqlippool_t, start_commit), NULL },
-	{ "start_commit", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, start_commit), "COMMIT" },
+	{ "start_commit", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, start_commit), "" },
 
 
 	{ "alive-begin", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT | PW_TYPE_DEPRECATED, rlm_sqlippool_t, alive_begin), NULL },
-	{ "alive_begin", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, alive_begin), "START TRANSACTION" },
+	{ "alive_begin", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, alive_begin), "" },
 
 	{ "alive-update", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT | PW_TYPE_DEPRECATED, rlm_sqlippool_t, alive_update), NULL },
 	{ "alive_update", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT , rlm_sqlippool_t, alive_update), ""  },
 
 	{ "alive-commit", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT | PW_TYPE_DEPRECATED, rlm_sqlippool_t, alive_commit), NULL },
-	{ "alive_commit", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, alive_commit), "COMMIT" },
+	{ "alive_commit", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, alive_commit), "" },
 
 
 	{ "stop-begin", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT | PW_TYPE_DEPRECATED, rlm_sqlippool_t, stop_begin), NULL },
-	{ "stop_begin", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, stop_begin), "START TRANSACTION" },
+	{ "stop_begin", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, stop_begin), "" },
 
 	{ "stop-clear", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT | PW_TYPE_DEPRECATED, rlm_sqlippool_t, stop_clear), NULL },
 	{ "stop_clear", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT , rlm_sqlippool_t, stop_clear), ""  },
 
 	{ "stop-commit", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT | PW_TYPE_DEPRECATED, rlm_sqlippool_t, stop_commit), NULL },
-	{ "stop_commit", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, stop_commit), "COMMIT" },
+	{ "stop_commit", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, stop_commit), "" },
 
 
 	{ "on-begin", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT | PW_TYPE_DEPRECATED, rlm_sqlippool_t, on_begin), NULL },
-	{ "on_begin", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, on_begin), "START TRANSACTION" },
+	{ "on_begin", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, on_begin), "" },
 
 	{ "on-clear", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT | PW_TYPE_DEPRECATED, rlm_sqlippool_t, on_clear), NULL },
 	{ "on_clear", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT , rlm_sqlippool_t, on_clear), ""  },
 
 	{ "on-commit", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT | PW_TYPE_DEPRECATED, rlm_sqlippool_t, on_commit), NULL },
-	{ "on_commit", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, on_commit), "COMMIT" },
+	{ "on_commit", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, on_commit), "" },
 
 
 	{ "off-begin", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT | PW_TYPE_DEPRECATED, rlm_sqlippool_t, off_begin), NULL },
-	{ "off_begin", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, off_begin), "START TRANSACTION" },
+	{ "off_begin", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, off_begin), "" },
 
 	{ "off-clear", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT | PW_TYPE_DEPRECATED, rlm_sqlippool_t, off_clear), NULL },
 	{ "off_clear", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT , rlm_sqlippool_t, off_clear), ""  },
 
 	{ "off-commit", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT | PW_TYPE_DEPRECATED, rlm_sqlippool_t, off_commit), NULL },
-	{ "off_commit", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, off_commit), "COMMIT" },
+	{ "off_commit", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_sqlippool_t, off_commit), "" },
 
 	{ "messages", FR_CONF_POINTER(PW_TYPE_SUBSECTION, NULL), (void const *) message_config },
 	CONF_PARSER_TERMINATOR

--- a/src/modules/rlm_sqlippool/rlm_sqlippool.c
+++ b/src/modules/rlm_sqlippool/rlm_sqlippool.c
@@ -755,22 +755,23 @@ static rlm_rcode_t CC_HINT(nonnull) mod_post_auth(void *instance, REQUEST *reque
 static int mod_accounting_start(rlm_sql_handle_t **handle,
 				rlm_sqlippool_t *inst, REQUEST *request)
 {
-	int affected;
-
 	DO(start_begin);
-	DO_AFFECTED(start_update, affected);
+	DO(start_update);
 	DO(start_commit);
 
-	return (affected == 0 ? RLM_MODULE_NOOP : RLM_MODULE_OK);
+	return RLM_MODULE_OK;
 }
 
 static int mod_accounting_alive(rlm_sql_handle_t **handle,
 				rlm_sqlippool_t *inst, REQUEST *request)
 {
+	int affected;
+
 	DO(alive_begin);
-	DO(alive_update);
+	DO_AFFECTED(alive_update, affected);
 	DO(alive_commit);
-	return RLM_MODULE_OK;
+
+	return (affected == 0 ? RLM_MODULE_NOTFOUND : RLM_MODULE_OK);
 }
 
 static int mod_accounting_stop(rlm_sql_handle_t **handle,


### PR DESCRIPTION
Per RFCs for DHCP, we now honours an IP address hint by introducing a new configuration item `req_attribute_name` (request attribute containing the address hint) and `allocate_requested` query (and updating the SPs).

Differentiate REQUESTs from DISCOVERs and fixes a few issues and allows multiple FR instances sharing a database to serve the same set of clients, each receiving the same broadcast DHCP packets from clients:

* Fixes an issue with FR ACKing a different IP address that was requested by the client under some heavily loaded conditions, and when multiple servers sharing a database offer different addresses to the same client.
* Fixes an issue where renewals will not succeed because these REQUESTs will not thave a DHCP-Requested-IP-Address, only a DHCP-Client-IP-Address.
* Implements short offer times and releases all outstanding offers when a particular offer is requested. (As happens in multi-headed configurations.)
* Implements the RFC behaviour where a server should remain quiet when it is not being spoken to, i.e. a mismatching DHCP-Server-Identifier during a REQUEST.