### PR TITLE
Fixed repeated accounting for closed row

### DIFF
--- a/raddb/mods-config/sql/main/postgresql/process-radacct.sql
+++ b/raddb/mods-config/sql/main/postgresql/process-radacct.sql
@@ -108,7 +108,9 @@ BEGIN
         SET
             acctinputoctets = data_usage_by_period.acctinputoctets + EXCLUDED.acctinputoctets,
             acctoutputoctets = data_usage_by_period.acctoutputoctets + EXCLUDED.acctoutputoctets,
-            period_end = v_end;
+            period_end = v_end
+        WHERE
+            data_usage_by_period.period_end IS NULL;
 
     --
     -- Create an open-ended "next period" for all ongoing sessions and carry a


### PR DESCRIPTION
Row with period_end that is not null should not be incremented despite its period_start is lesser then acctstoptime of rows in radacct. A check for null for period_end is added before update to prevent such data usage accounting error.