### PR TITLE
v4 DHCP fixes: Honour hinted IP addresses; Proper handling of DHCP REQUESTs

### DIFF
--- a/raddb/mods-available/dhcp_sqlippool
+++ b/raddb/mods-available/dhcp_sqlippool
@@ -19,14 +19,31 @@
 #  ## Configuration Settings
 sqlippool dhcp_sqlippool {
 	#
-	#  See the `sqlippool` module for common configuration explanation.
+	#  SQL instance to use (from mods-available/sql)
 	#
-
+	#  If you have multiple sql instances such as "sql sql1 {...}",
+	#  use the *instance* name here: sql1
 	sql_module_instance = "sql"
 
+	#  This should be set the same as the dialect for the SQL
+	#  instance in use
+	dialect = "postgresql"
+
+	#  SQL table name to use for DHCP ip pools
 	ippool_table = "radippool"
 
+	#  Name of the attribute to be populated with the pool name
+	#  to pick addresses from
+	pool_name = "Pool-Name"
+
+	#  IP lease duration.  Used to set the expiry time of a lease
+	#  in the database in response to DHCP Request
 	lease_duration = 7200
+
+	#  How long to hold leases in the database between a Discover
+	#  and Request.  Setting this short prevents the pool being
+	#  exhausted by clients sending Discovers but never Reqiests.
+	offer_duration = 5
 
 	#
 	#  RFC 2132 allows the DHCP client to supply a unique
@@ -45,24 +62,22 @@ sqlippool dhcp_sqlippool {
 	#
 	#  pool_key = "%{DHCP-Client-Hardware-Address}"
 
-	attribute_name = DHCP-Your-IP-Address
+	#  The attribute in which the IP address is returned in the reply
+	attribute_name = "DHCPv4.DHCP-Your-IP-Address"
+
+	#  The attribute in which a requested IP address is received
+	req_attribute_name = "DHCPv4.DHCP-Requested-IP-Address"
 
 	#
-	#  The current sample is prepared to work with MySQL.
+	#  Load queries for the relevant SQL version
 	#
-	$INCLUDE ${modconfdir}/sql/ippool-dhcp/mysql/queries.conf
+	$INCLUDE ${modconfdir}/sql/ippool-dhcp/${dialect}/queries.conf
 
-	#
-	#  NOTE: To use sqlite you need to add `%` to `safe_characters` in
-	#  `raddb/mods-config/sql/main/sqlite/queries.conf.`
-	#
-#	$INCLUDE ${modconfdir}/sql/ippool-dhcp/sqlite/queries.conf
+	sqlippool_log_exists = "DHCP: Existing IP: %{reply:${attribute_name}} (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
 
-	sqlippool_log_exists = "DHCP: Existing IP: %{reply:${..attribute_name}} (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
+	sqlippool_log_success = "DHCP: Allocated IP: %{reply:${attribute_name}} from %{control:Pool-Name} (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
 
-	sqlippool_log_success = "DHCP: Allocated IP: %{reply:${..attribute_name}} from %{control:Pool-Name} (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
-
-	sqlippool_log_clear = "DHCP: Released IP %{${..attribute_name}} (did %{Called-Station-Id} cli %{Calling-Station-Id} user %{User-Name})"
+	sqlippool_log_clear = "DHCP: Released IP %{${attribute_name}} (did %{Called-Station-Id} cli %{Calling-Station-Id} user %{User-Name})"
 
 	sqlippool_log_failed = "DHCP: IP Allocation FAILED from %{control:Pool-Name} (did %{Called-Station-Id} cli %{Calling-Station-Id} port %{NAS-Port} user %{User-Name})"
 

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/procedure.sql
@@ -21,7 +21,7 @@
 --              @v_pool_name = '%{control:${pool_name}}', \
 --              @v_gateway = '%{DHCP-Gateway-IP-Address}', \
 --              @v_pool_key = '${pool_key}', \
---              @v_lease_duration = ${lease_duration}, \
+--              @v_lease_duration = ${offer_duration}, \
 --              @v_requested_address = '%{%{${req_attribute_name}}:-0.0.0.0}' \
 --      "
 -- allocate_update = ""

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/procedure.sql
@@ -21,7 +21,8 @@
 --              @v_pool_name = '%{control:${pool_name}}', \
 --              @v_gateway = '%{DHCP-Gateway-IP-Address}', \
 --              @v_pool_key = '${pool_key}', \
---              @v_lease_duration = ${lease_duration} \
+--              @v_lease_duration = ${lease_duration}, \
+--              @v_requested_address = '%{%{${req_attribute_name}}:-0.0.0.0}' \
 --      "
 -- allocate_update = ""
 -- allocate_commit = ""
@@ -31,7 +32,8 @@ CREATE OR ALTER PROCEDURE fr_dhcp_allocate_previous_or_new_framedipaddress
 	@v_pool_name VARCHAR(64),
 	@v_gateway VARCHAR(15),
 	@v_pool_key VARCHAR(64),
-	@v_lease_duration INT
+	@v_lease_duration INT,
+	@v_requested_address VARCHAR(15)
 AS
 	BEGIN
 
@@ -87,6 +89,26 @@ AS
 		-- SET FramedIPAddress = FramedIPAddress
 		-- OUTPUT INSERTED.FramedIPAddress INTO @r_address_tab;
 		-- SELECT @r_address = id FROM @r_address_tab;
+
+		-- Issue the requested IP address if it is available
+		--
+		IF @r_address IS NULL AND @v_requested_address <> '0.0.0.0'
+		BEGIN
+			WITH cte AS (
+				SELECT TOP(1) FramedIPAddress
+				FROM dhcpippool WITH (rowlock, readpast)
+				JOIN dhcpstatus
+				ON dhcpstatus.status_id = dhcpippool.status_id
+				WHERE pool_name = @v_pool_name
+					AND framedipaddress = @v_requested_address
+					AND dhcpstatus.status = 'dynamic'
+					AND expiry_time < CURRENT_TIMESTAMP
+			)
+			UPDATE cte
+			SET FramedIPAddress = FramedIPAddress
+			OUTPUT INSERTED.FramedIPAddress INTO @r_address_tab;
+			SELECT @r_address = id FROM @r_address_tab;
+		END
 
 		-- If we didn't reallocate a previous address then pick the least
 		-- recently used address from the pool which maximises the likelihood

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -201,7 +201,9 @@ update_free = "\
 #
 update_update = "\
 	UPDATE ${ippool_table} \
-	SET expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
+	SET \
+		expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP), \
+		counter = counter + 1 \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -4,9 +4,10 @@
 #
 #  $Id$
 
-#
-#  This series of queries allocates an IP address
-#
+
+#  *****************
+#  * DHCP DISCOVER *
+#  *****************
 
 #
 #  MSSQL-specific syntax - required if finding the address and updating
@@ -32,8 +33,28 @@ alloc_existing = "\
 		ORDER BY expiry_time DESC \
 	) \
 	UPDATE cte \
-	SET expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP), \
+	SET expiry_time = DATEADD(SECOND,${offer_duration},CURRENT_TIMESTAMP), \
 	gateway = '%{DHCP-Gateway-IP-Address}' \
+	OUTPUT INSERTED.FramedIPAddress \
+	FROM ${ippool_table}"
+
+#
+#  Determine whether the requested IP address is available
+#
+alloc_requested = "\
+	WITH cte AS (
+		SELECT TOP(1) framedipaddress, expiry_time, gateway \
+		FROM ${ippool_table} WITH (xlock rowlock readpast) \
+		JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
+		WHERE pool_name = '%{control:${pool_name}}' \
+		AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
+		AND dhcpstatus.status = 'dynamic' \
+		AND expiry_time < CURRENT_TIMESTAMP \
+	) \
+	UPDATE cte \
+	SET expiry_time = DATEADD(SECOND,${offer_duration},CURRENT_TIMESTAMP), \
+	gateway = '%{DHCP-Gateway-IP-Address}', \
+	pool_key = '${pool_key}' \
 	OUTPUT INSERTED.FramedIPAddress \
 	FROM ${ippool_table}"
 
@@ -52,7 +73,7 @@ alloc_find = "\
 		ORDER BY expiry_time \
 	) \
 	UPDATE cte \
-	SET expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP), \
+	SET expiry_time = DATEADD(SECOND,${offer_duration},CURRENT_TIMESTAMP), \
 	gateway = '%{DHCP-Gateway-IP-Address}' \
 	pool_key = '${pool_key}' \
 	OUTPUT INSERTED.FramedIPAddress \
@@ -69,27 +90,32 @@ alloc_find = "\
 #	UPDATE TOP(1) ${ippool_table} \
 #	SET FramedIPAddress = FramedIPAddress, \
 #	pool_key = '${pool_key}', \
-#	expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP), \
+#	expiry_time = DATEADD(SECOND,${offer_duration},CURRENT_TIMESTAMP), \
 #	gateway = '%{DHCP-Gateway-IP-Address}' \
 #	OUTPUT INSERTED.FramedIPAddress \
 #	FROM ${ippool_table} \
 #	WHERE ${ippool_table}.id IN ( \
-#		SELECT TOP (1) id FROM ${ippool_table} WHERE id IN ( \
-#			(SELECT TOP(1) id FROM ${ippool_table} WITH (xlock rowlock readpast) \
+#		SELECT TOP (1) id FROM ( \
+#			(SELECT TOP(1) id, 1 AS o FROM ${ippool_table} WITH (xlock rowlock readpast) \
 #			JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
 #			WHERE pool_name = '%{control:${pool_name}}' \
 #			AND pool_key = '${pool_key}' \
-#			AND dhcpstatus.status IN ('dynamic', 'static') \
-#			ORDER BY expiry_time DESC) \
+#			AND dhcpstatus.status IN ('dynamic', 'static')) \
 #			UNION \
-#			(SELECT TOP(1) id FROM ${ippool_table} WITH (xlock rowlock readpast) \
+#			(SELECT TOP(1) id, 2 AS o FROM ${ippool_table} WITH (xlock rowlock readpast) \
+#			JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
+#			WHERE pool_name = '%{control:${pool_name}}' \
+#			AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
+#			AND dhcpstatus.status = 'dynamic' \
+#			AND expiry_time < CURRENT_TIMESTAMP ) \
+#			UNION \
+#			(SELECT TOP(1) id, 3 AS o FROM ${ippool_table} WITH (xlock rowlock readpast) \
 #			JOIN dhcpstatus ON ${ippool_table}.status_id = dhcpstatus.status_id \
 #			WHERE pool_name = '%{control:${pool_name}}' \
 #			AND expiry_time < CURRENT_TIMESTAMP \
 #			AND dhcpstatus.status = 'dynamic' \
 #			ORDER BY expiry_time) \
-#		) \
-#		ORDER BY CASE WHEN pool_key = '${pool_key}' THEN 0 ELSE 1 END, expiry_time \
+#		) AS q ORDER BY q.o \
 #	)"
 
 #
@@ -129,7 +155,7 @@ pool_check = "\
 #	UPDATE ${ippool_table} \
 #	SET \
 #		gateway = '%{DHCP-Gateway-IP-Address}', pool_key = '${pool_key}', \
-#		expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
+#		expiry_time = DATEADD(SECOND,${offer_duration},CURRENT_TIMESTAMP) \
 #	WHERE FramedIPAddress = '%I'"
 
 #
@@ -142,10 +168,33 @@ pool_check = "\
 #		@v_pool_name = '%{control:${pool_name}}', \
 #		@v_gateway = '%{DHCP-Gateway-IP-Address}', \
 #		@v_pool_key = '${pool_key}', \
-#		@v_lease_duration = ${lease_duration} \
+#		@v_lease_duration = ${offer_duration}, \
+#		@v_requested_address = '%{%{${req_attribute_name}}:-0.0.0.0}'
 #	"
 #alloc_update = ""
 #alloc_commit = ""
+
+
+#  ****************
+#  * DHCP REQUEST *
+#  ****************
+
+#
+#  This query revokes any active offers for addresses that a client is not
+#  requesting when a DHCP REQUEST packet arrives
+#
+update_free = "\
+	UPDATE ${ippool_table} \
+	SET \
+		gateway = '', \
+		pool_key = '', \
+		expiry_time = CURRENT_TIMESTAMP \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress <> '%{DHCP-Requested-IP-Address}' \
+	AND expiry_time > CURRENT_TIMESTAMP \
+	AND ${ippool_table}.status_id IN \
+	(SELECT status_id FROM dhcpstatus WHERE status = 'dynamic')"
 
 #
 #  Queries to update a lease - used in response to DHCP-Request packets
@@ -156,6 +205,11 @@ update_update = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
+
+
+#  ****************
+#  * DHCP RELEASE *
+#  ****************
 
 #
 #  Queries to release a lease - used in response to DHCP-Release packets
@@ -168,6 +222,11 @@ release_clear = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
+
+
+#  ****************
+#  * DHCP DECLINE *
+#  ****************
 
 #
 #  Queries to mark leases as "bad" - used in response to DHCP-Decline

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -197,7 +197,11 @@ update_free = "\
 	(SELECT status_id FROM dhcpstatus WHERE status = 'dynamic')"
 
 #
-#  Queries to update a lease - used in response to DHCP-Request packets
+#  Queries to update a lease - used in response to DHCP-Request packets.
+#  This query must update a row when a lease is successfully requested -
+#  queries that update no rows will result in a "notfound" response to
+#  the module which by default will give a DHCP-NAK reply.  In this example
+#  incrementing "counter" is used to acheive this.
 #
 update_update = "\
 	UPDATE ${ippool_table} \

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE dhcpippool (
 	gateway			varchar(15) NOT NULL default '',
 	expiry_time		DATETIME NOT NULL default CURRENT_TIMESTAMP,
 	status_id		int NOT NULL default 1,
+	counter			int NOT NULL default 0,
 	CONSTRAINT fk_status_id FOREIGN KEY (status_id) REFERENCES dhcpstatus (status_id),
 	PRIMARY KEY (id)
 )

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/procedure.sql
@@ -21,7 +21,7 @@
 -- 		'%{control:${pool_name}}', \
 -- 		'%{DHCP-Gateway-IP-Address}', \
 -- 		'${pool_key}', \
--- 		${lease_duration}, \
+-- 		${offer_duration}, \
 --		'%{%{${req_attribute_name}}:-0.0.0.0}' \
 -- 	)"
 -- allocate_update = ""

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -161,7 +161,9 @@ update_free = "\
 #
 update_update = "\
 	UPDATE ${ippool_table} \
-	SET expiry_time = 'now'::timesheet(0) + '${lease_duration} second'::interval \
+	SET \
+		expiry_time = NOW() + INTERVAL ${lease_duration} SECOND, \
+		counter = counter + 1 \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -4,12 +4,15 @@
 #
 #  $Id$
 
-
 #  Using SKIP LOCKED speeds up selection queries
 #  However, it requires MySQL >= 8.0.1.  Uncomment the
 #  following if you are running a suitable version of MySQL
 #
 #  skip_locked = "SKIP LOCKED"
+
+#  *****************
+#  * DHCP DISCOVER *
+#  *****************
 
 #
 #  This series of queries allocates an IP address
@@ -29,6 +32,18 @@ alloc_existing = "\
 	FOR UPDATE ${skip_locked}"
 
 #
+#  Determine whether the requested IP address is available
+#
+alloc_requested = "\
+	SELECT framedipaddress \
+	FROM ${ippool_table} \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
+	AND `status` = 'dynamic' \
+	AND expiry_time < NOW() \
+	FOR UPDATE ${skip_locked}"
+
+#
 #  If the preceding query fails to find an IP address, the following
 #  one is used to select a free one from the pool
 #
@@ -43,22 +58,29 @@ alloc_find = "\
 	FOR UPDATE ${skip_locked}"
 
 #
-#  Alternatively the two queries can be combined into one, though
-#  depending on transaction isolation mode, this can case deadlocks
+#  Alternatively do the operations in one query.
+#  Depending on transaction isolation mode, this can cause deadlocks
 #
 #alloc_find = "\
-#	(SELECT framedipaddress, pool_key, expiry_time FROM radippool \
+#	(SELECT framedipaddress, 1 AS o FROM ${ippool_table} \
 #		WHERE pool_name = '%{control:${pool_name}}' \
 #		AND pool_key = '${pool_key}' \
 #		AND `status` IN ('dynamic', 'static') \
 #		ORDER BY expiry_time DESC LIMIT 1 FOR UPDATE ${skip_locked} \
 #	) UNION ( \
-#	SELECT framedipaddress, pool_key, expiry_time FROM radippool \
+#	SELECT framedipaddress, 2 AS o FROM ${ippool_table} \
+#		WHERE pool_name = '%{control:${pool_name}}' \
+#		AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
+#		AND `status` = 'dynamic' \
+#		AND expiry_time < NOW() \
+#		FOR UPDATE SKIP LOCKED \
+#	) UNION ( \
+#	SELECT framedipaddress, 3 AS o FROM ${ippool_name} \
 #		WHERE pool_name = '%{control:${pool_name}}' \
 #		AND expiry_time < NOW() \
 #		AND `status` = 'dynamic' \
 #		ORDER BY expiry_time LIMIT 1 FOR UPDATE ${skip_locked} \
-#	) ORDER BY (pool_key <> '${pool_key}'), expiry_time \
+#	) ORDER BY o \
 #	LIMIT 1"
 
 #
@@ -94,7 +116,7 @@ alloc_update = "\
 	UPDATE ${ippool_table} \
 	SET \
 		gateway = '%{DHCP-Gateway-IP-Address}', pool_key = '${pool_key}', \
-		expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
+		expiry_time = NOW() + INTERVAL ${offer_duration} SECOND \
 	WHERE framedipaddress = '%I'"
 
 #
@@ -107,10 +129,32 @@ alloc_update = "\
 #		'%{control:${pool_name}}', \
 #		'%{DHCP-Gateway-IP-Address}', \
 #		'${pool_key}', \
-#		${lease_duration} \
+#		${offer_duration}, \
+#		'%{%{${req_attribute_name}}:-0.0.0.0}'
 #	)"
 #alloc_update = ""
 #alloc_commit = ""
+
+
+#  ****************
+#  * DHCP REQUEST *
+#  ****************
+
+#
+#  This query revokes any active offers for addresses that a client is not
+#  requesting when a DHCP REQUEST packet arrives
+#
+update_free = "\
+	UPDATE ${ippool_table} \
+	SET \
+		gateway = '', \
+		pool_key = '', \
+		expiry_time = NOW() \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress <> '%{DHCP-Requested-IP-Address}' \
+	AND expiry_time > NOW() \
+	AND `status` = 'dynamic'"
 
 #
 #  Queries to update a lease - used in response to DHCP-Request packets
@@ -121,6 +165,11 @@ update_update = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
+
+
+#  ****************
+#  * DHCP RELEASE *
+#  ****************
 
 #
 #  Queries to release a lease - used in response to DHCP-Release packets
@@ -133,6 +182,11 @@ release_clear = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
+
+
+#  ****************
+#  * DHCP DECLINE *
+#  ****************
 
 #
 #  Queries to mark leases as "bad" - used in response to DHCP-Decline

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -157,7 +157,11 @@ update_free = "\
 	AND `status` = 'dynamic'"
 
 #
-#  Queries to update a lease - used in response to DHCP-Request packets
+#  Queries to update a lease - used in response to DHCP-Request packets.
+#  This query must update a row when a lease is successfully requested -
+#  queries that update no rows will result in a "notfound" response to
+#  the module which by default will give a DHCP-NAK reply.  In this example
+#  incrementing "counter" is used to acheive this.
 #
 update_update = "\
 	UPDATE ${ippool_table} \

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/schema.sql
@@ -2,13 +2,14 @@
 # Table structure for table 'dhcpippool'
 #
 CREATE TABLE dhcpippool (
-	id			int(11) unsigned NOT NULL auto_increment,
+	id			int unsigned NOT NULL auto_increment,
 	pool_name		varchar(30) NOT NULL,
 	framedipaddress		varchar(15) NOT NULL DEFAULT '',
 	pool_key		varchar(30) NOT NULL DEFAULT '',
 	gateway			varchar(15) NOT NULL DEFAULT '',
 	expiry_time		DATETIME NOT NULL DEFAULT NOW(),
 	status			ENUM('dynamic', 'static', 'declined', 'disabled') DEFAULT 'dynamic',
+	counter			int unsigned NOT NULL DEFAULT 0,
 	PRIMARY KEY (id),
 	KEY dhcpippool_poolname_expire (pool_name, expiry_time),
 	KEY framedipaddress (framedipaddress),

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/procedure.sql
@@ -21,7 +21,7 @@
 --		 '%{control:${pool_name}}', \
 --		 '%{DHCP-Gateway-IP-Address}', \
 --		 '${pool_key}', \
---		 ${lease_duration}, \
+--		 ${offer_duration}, \
 --		 '%{%{${req_attribute_name}}:-0.0.0.0}'
 --	 ) FROM dual"
 -- allocate_update = ""

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/procedure.sql
@@ -21,7 +21,8 @@
 --		 '%{control:${pool_name}}', \
 --		 '%{DHCP-Gateway-IP-Address}', \
 --		 '${pool_key}', \
---		 ${lease_duration} \
+--		 ${lease_duration}, \
+--		 '%{%{${req_attribute_name}}:-0.0.0.0}'
 --	 ) FROM dual"
 -- allocate_update = ""
 -- allocate_commit = ""
@@ -31,7 +32,8 @@ CREATE OR REPLACE FUNCTION fr_dhcp_allocate_previous_or_new_framedipaddress (
 	v_pool_name IN VARCHAR2,
 	v_gateway IN VARCHAR2,
 	v_pool_key IN VARCHAR2,
-	v_lease_duration IN INTEGER
+	v_lease_duration IN INTEGER,
+	v_requsted_address IN VARCHAR2
 )
 RETURN varchar2 IS
 	PRAGMA AUTONOMOUS_TRANSACTION;
@@ -116,6 +118,48 @@ BEGIN
 	--	WHEN NO_DATA_FOUND THEN
 	--		r_address := NULL;
 	-- END;
+
+	-- Issue the requested IP address if it is available
+	--
+	IF r_address IS NULL AND v_requested_address <> '0.0.0.0' THEN
+		BEGIN
+		SELECT framedipaddress INTO r_address FROM dhcpippool WHERE id IN (
+			SELECT id FROM (
+				SELECT *
+				FROM dhcpippool
+				JOIN dhcpstatus
+				ON dhcpstatus.status_id = dhcpippool.status_id
+				WHERE pool_name = v_pool_name
+					AND framedipaddress = v_requested_address
+					AND dhcpstatus.status = 'dynamic'
+					AND expiry_time < CURRENT_TIMESTAMP
+				) WHERE ROWNUM <= 1
+		) FOR UPDATE SKIP LOCKED;
+		EXCEPTION
+		WHEN NO_DATA_FOUND THEN
+			r_address := NULL;
+		END;
+	END IF;
+
+	-- Oracle >= 12c version of the above query
+	--
+	-- IF r_address IS NULL AND v_requested_address <> '0.0.0.0' THEN
+	--	BEGIN
+	--	SELECT framedipaddress INTO r_address FROM dhcpippool WHERE id IN (
+	--		SELECT id FROM dhcpippool
+	--		JOIN dhcpstatus
+	--		ON dhcpstatus.status_id = dhcpippool.status_id
+	--		WHERE pool_name = v_pool_name
+	--			AND framedipaddress = v_requested_address
+	--			AND dhcpstatus.status = 'dynamic'
+	--			AND expiry_time < CURRENT_TIMESTAMP
+	--		FETCH FIRST 1 ROWS ONLY
+	--	) FOR UPDATE SKIP LOCKED;
+	--	EXCEPTION
+	--	WHEN NO_DATA_FOUND THEN
+	--		r_address := NULL;
+	--	END;
+	-- END IF;
 
 	-- If we didn't reallocate a previous address then pick the least
 	-- recently used address from the pool which maximises the likelihood

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -120,7 +120,9 @@ pool_check = "\
 update_begin = "commit"
 update_update = "\
 	UPDATE ${ippool_table} \
-	SET expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
+	SET \
+		expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1), \
+		counter = counter + 1 \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -27,7 +27,7 @@ alloc_find = "\
 		'${pool_key}', \
 		'${offer_duration}', \
 		'%{%{${req_attribute_name}}:-0.0.0.0}'
-	)"
+	) FROM dual"
 alloc_update = ""
 alloc_commit = ""
 

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -7,6 +7,12 @@
 #
 #  Due to Oracle's transaction focus, update queries further down are
 #  wrapped in "commit" statements.
+
+
+#  *****************
+#  * DHCP DISCOVER *
+#  *****************
+
 #
 #  Use a stored procedure to find AND allocate the address. Read and customise
 #  `procedure.sql` in this directory to determine the optimal configuration.
@@ -19,7 +25,8 @@ alloc_find = "\
 		'%{control:${pool_name}}', \
 		'%{DHCP-Gateway-IP-Address}', \
 		'${pool_key}', \
-		'${lease_duration}' \
+		'${offer_duration}', \
+		'%{%{${req_attribute_name}}:-0.0.0.0}'
 	)"
 alloc_update = ""
 alloc_commit = ""
@@ -92,15 +99,20 @@ pool_check = "\
 
 #
 #  This query marks the IP address handed out by "alloc_find" as used
-#  for the period of "lease_duration" after which time it may be reused.
+#  for the period of "offer_duration" after which time it may be reused.
 #
 #alloc_update = "\
 #	UPDATE ${ippool_table} \
 #	SET \
 #		gateway = '%{DHCP-Gateway-IP-Address}', \
 #		pool_key = '${pool_key}', \
-#		expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
+#		expiry_time = current_timestamp + INTERVAL '${offer_duration}' second(1) \
 #	WHERE framedipaddress = '%I'"
+
+
+#  ****************
+#  * DHCP REQUEST *
+#  ****************
 
 #
 #  Queries to update a lease - used in response to DHCP-Request packets

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -115,7 +115,11 @@ pool_check = "\
 #  ****************
 
 #
-#  Queries to update a lease - used in response to DHCP-Request packets
+#  Queries to update a lease - used in response to DHCP-Request packets.
+#  This query must update a row when a lease is successfully requested -
+#  queries that update no rows will result in a "notfound" response to
+#  the module which by default will give a DHCP-NAK reply.  In this example
+#  incrementing "counter" is used to acheive this.
 #
 update_begin = "commit"
 update_update = "\

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/schema.sql
@@ -18,6 +18,7 @@ CREATE TABLE dhcpippool (
 	gateway			VARCHAR(15) NOT NULL,
 	expiry_time		TIMESTAMP(0) NOT NULL,
 	status_id		INT DEFAULT 1,
+	counter			INT DEFAULT 0,
 	FOREIGN KEY (status_id) REFERENCES dhcpstatus(status_id)
 );
 

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/procedure.sql
@@ -21,7 +21,8 @@
 --		'%{control:${pool_name}}', \
 --		'%{DHCP-Gateway-IP-Address}', \
 --		'${pool_key}', \
---		${lease_duration} \
+--		${lease_duration}, \
+--		'%{%{${req_attribute_name}}:-0.0.0.0}' \
 --	)"
 -- allocate_update = ""
 -- allocate_commit = ""
@@ -31,13 +32,14 @@ CREATE OR REPLACE FUNCTION fr_dhcp_allocate_previous_or_new_framedipaddress (
 	v_pool_name VARCHAR(64),
 	v_gateway VARCHAR(16),
 	v_pool_key VARCHAR(64),
-	v_lease_duration INT
+	v_lease_duration INT,
+	v_requested_address INET
 )
 RETURNS inet
 LANGUAGE plpgsql
 AS $$
 DECLARE
-	r_address inet;
+	r_address INET;
 BEGIN
 
 	-- Reissue an existing IP address lease when re-authenticating a session
@@ -71,6 +73,24 @@ BEGIN
 	-- SET expiry_time = NOW + v_lease_duration * interval '1 sec'
 	-- FROM ips WHERE dhcpippool.framedipaddress = ips.framedipaddress
 	-- RETURNING dhcpippool.framedipaddress INTO r_address;
+
+	-- Issue the requested IP address if it is available
+	--
+	IF r_address IS NULL AND v_requested_address != '0.0.0.0' THEN
+		WITH ips AS (
+			SELECT framedipaddress FROM dhcpippool
+			WHERE pool_name = v_pool_name
+				AND framedipaddress = v_requested_address
+				AND status = 'dynamic'
+				AND expiry_time < NOW()
+			LIMIT 1 FOR UPDATE SKIP LOCKED )
+		UPDATE dhcpippool
+		SET pool_key = v_pool_key,
+			expiry_time = NOW() + v_lease_duration * interval '1 sec',
+			gateway = v_gateway
+		FROM ips WHERE dhcpippool.framedipaddress = ips.framedipaddress
+		RETURNING dhcpippool.framedipaddress INTO r_address;
+	END IF;
 
 	-- If we didn't reallocate a previous address then pick the least
 	-- recently used address from the pool which maximises the likelihood

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/procedure.sql
@@ -21,7 +21,7 @@
 --		'%{control:${pool_name}}', \
 --		'%{DHCP-Gateway-IP-Address}', \
 --		'${pool_key}', \
---		${lease_duration}, \
+--		${offer_duration}, \
 --		'%{%{${req_attribute_name}}:-0.0.0.0}' \
 --	)"
 -- allocate_update = ""

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -177,7 +177,11 @@ update_free = "\
 	AND status = 'dynamic'"
 
 #
-#  Queries to update a lease - used in response to DHCP-Request packets
+#  Queries to update a lease - used in response to DHCP-Request packets.
+#  This query must update a row when a lease is successfully requested -
+#  queries that update no rows will result in a "notfound" response to
+#  the module which by default will give a DHCP-NAK reply.  In this example
+#  incrementing "counter" is used to acheive this.
 #
 update_update = "\
 	UPDATE ${ippool_table} \

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -10,6 +10,10 @@
 #  If you are using an older version of PostgreSQL comment out the following:
 skip_locked = "SKIP LOCKED"
 
+#  *****************
+#  * DHCP DISCOVER *
+#  *****************
+
 #
 #  This sequence of queries allocate an IP address from the Pool
 #
@@ -33,10 +37,31 @@ alloc_existing = "\
 		FOR UPDATE ${skip_locked} \
 	) \
 	UPDATE ${ippool_table} \
-	SET expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval, \
+	SET expiry_time = 'now'::timestamp(0) + '${offer_duration} second'::interval, \
 	gateway = '%{DHCP-Gateway-IP-Address}' \
 	FROM cte \
 	WHERE cte.framedipaddress = ${ippool_table}.framedipaddress \
+	RETURNING cte.framedipaddress"
+
+#
+#  If the preceding query doesn't find an address then the following
+#  can be used to check for the address requested by the client
+#
+alloc_requested = "\
+	WITH cte AS ( \
+		SELECT framedipaddress \
+		FROM ${ippool_table} \
+		WHERE pool_name = '%{control:${pool_name}}' \
+		AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
+		AND expiry_time < 'now'::timestamp(0) \
+		AND status = 'dynamic' \
+		FOR UPDATE ${skip_locked} \
+	) \
+	UPDATE ${ippool_table} \
+	SET pool_key = '${pool_key}', \
+	expiry_time = 'now'::timestamp(0) + '${offer_duration} second'::interval, \
+	gateway = '%{DHCP-Gateway-IP-Address}' \
+	WHERE cte.framedipaddress = ${ipppool_table}.framedipaddress \
 	RETURNING cte.framedipaddress"
 
 #
@@ -56,7 +81,7 @@ alloc_find = "\
 	) \
 	UPDATE ${ippool_table} \
 	SET pool_key = '${pool_key}', \
-	expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval, \
+	expiry_time = 'now'::timestamp(0) + '${offer_duration} second'::interval, \
 	gateway = '%{DHCP-Gateway-IP-Address}' \
 	WHERE cte.framedipaddress = ${ippool_table}.framedipaddress \
 	RETURNING cte.framedipaddress"
@@ -77,7 +102,7 @@ alloc_find = "\
 
 #
 #  This query marks the IP address handed out by "alloc_find" as used
-#  for the period of "lease_duration" after which time it may be reused.
+#  for the period of "offer_duration" after which time it may be reused.
 #  It is only needed if the SELECT query does not perform the update.
 #
 #alloc_update = "\
@@ -85,7 +110,7 @@ alloc_find = "\
 #	SET \
 #		gateway = '%{DHCP-Gateway-IP-Address}', \
 #		pool_key = '${pool_key}', \
-#		expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval \
+#		expiry_time = 'now'::timestamp(0) + '${offer_duration} second'::interval \
 #	WHERE framedipaddress = '%I'"
 
 #
@@ -125,20 +150,46 @@ pool_check = "\
 #		'%{control:${pool_name}}', \
 #		'%{DHCP-Gateway-IP-Address}', \
 #		'${pool_key}', \
-#		'${lease_duration}' \
+#		'${offer_duration}', \
+#		'%{%{${req_attribute_name}}:-0.0.0.0}' \
 #	)"
 #alloc_update = ""
 #alloc_commit = ""
+
+
+#  ****************
+#  * DHCP REQUEST *
+#  ****************
+
+#
+#  Query used to clear any other addresses that have been offered to the client
+#
+update_free = "\
+	UPDATE ${ippool_table} \
+	SET \
+		gateway = '', \
+		pool_key = '', \
+		expiry_time = 'now'::timestamp(0) - '1 second'::interval \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress <> '%{DHCP-Requested-IP-Address}' \
+	AND expiry_time > 'now'::timestamp(0) \
+	AND status = 'dynamic'"
 
 #
 #  Queries to update a lease - used in response to DHCP-Request packets
 #
 update_update = "\
 	UPDATE ${ippool_table} \
-	SET expiry_time = 'now'::timesheet(0) + '${lease_duration} second'::interval \
+	SET expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
+
+
+#  ****************
+#  * DHCP RELEASE *
+#  ****************
 
 #
 #  Queries to release a lease - used in response to DHCP-Release packets
@@ -146,11 +197,16 @@ update_update = "\
 release_clear = "\
 	UPDATE ${ippool_table} \
 	SET gateway = '', \
-		pool_key = '0', \
+		pool_key = '', \
 		expiry_time = 'now'::timestamp(0) - '1 second'::interval \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
+
+
+#  ****************
+#  * DHCP DECLINE *
+#  ****************
 
 #
 #  Queries to mark leases as "bad" - used in response to DHCP-Decline

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -181,7 +181,9 @@ update_free = "\
 #
 update_update = "\
 	UPDATE ${ippool_table} \
-	SET expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval \
+	SET \
+		expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval, \
+		counter = counter + 1 \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/schema.sql
@@ -14,7 +14,8 @@ CREATE TABLE dhcpippool (
 	pool_key		VARCHAR(64) NOT NULL default '0',
 	gateway			VARCHAR(16) NOT NULL default '',
 	expiry_time		TIMESTAMP(0) without time zone NOT NULL default NOW(),
-	status			dhcp_status DEFAULT 'dynamic'
+	status			dhcp_status DEFAULT 'dynamic',
+	counter			INT NOT NULL DEFAULT 0
 );
 
 CREATE INDEX dhcpippool_poolname_expire ON dhcpippool USING btree (pool_name, expiry_time);

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -128,7 +128,11 @@ update_free = "\
 	(SELECT status_id FROM dhcpstatus WHERE status = 'dynamic')"
 
 #
-#  Queries to update a lease - used in response to DHCP-Request packets
+#  Queries to update a lease - used in response to DHCP-Request packets.
+#  This query must update a row when a lease is successfully requested -
+#  queries that update no rows will result in a "notfound" response to
+#  the module which by default will give a DHCP-NAK reply.  In this example
+#  incrementing "counter" is used to acheive this.
 #
 update_update = "\
 	UPDATE ${ippool_table} \

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -132,7 +132,9 @@ update_free = "\
 #
 update_update = "\
 	UPDATE ${ippool_table} \
-	SET expiry_time = datetime(strftime('%%s', 'now') + ${lease_duration}, 'unixepoch') \
+	SET \
+		expiry_time = datetime(strftime('%%s', 'now') + ${lease_duration}, 'unixepoch'), \
+		counter = counter + 1 \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -4,6 +4,11 @@
 #
 #  $Id$
 
+
+#  *****************
+#  * DHCP DISCOVER *
+#  *****************
+
 #
 #  SQLite does not implement SELECT FOR UPDATE which is normally used to place
 #  an exclusive lock over rows to prevent the same address from being
@@ -25,40 +30,43 @@ alloc_commit = "COMMIT"
 #  This series of queries allocates an IP address - used in response to
 #  DHCP Discover packets
 #
-#  Either pull the most recent allocated IP for this client or the
-#  oldest expired one.  The first sub query returns the most recent
-#  lease for the client (if there is one), the second returns the
-#  oldest expired one.
-#  Sorting the result by expiry_time DESC will return the client specific
-#  IP if it exists, otherwise an expired one.
+
+#
+#  Is there an exsiting address for this client
+#
+alloc_existing = "SELECT framedipaddress \
+	FROM ${ippool_table} \
+	JOIN dhcpstatus \
+	ON ${ippool_table}.status_id = dhcpstatus.status_id \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND status IN ('dynamic', 'static') \
+	ORDER BY expiry_time DESC \
+	LIMIT 1"
+
+#
+#  If the client has requested an address, is it available
+#
+alloc_requested = "SELECT framedipaddress \
+	FROM ${ippool_table} \
+	JOIN dhcpstatus \
+	ON ${ippool_table}.status_id = dhcpstatus.status_id \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND framedipaddress = '%{%{${req_attribute_name}}:-0.0.0.0}' \
+	AND status = 'dynamic'"
+
+#
+#  Finally find a free address
 #
 alloc_find = "\
-	SELECT framedipaddress, expiry_time \
-	FROM ( \
-		SELECT framedipaddress, expiry_time \
-		FROM ${ippool_table} \
-		JOIN dhcpstatus \
-		ON ${ippool_table}.status_id = dhcpstatus.status_id \
-		WHERE pool_name = '%{control:${pool_name}}' \
-		AND pool_key = '${pool_key}' \
-		AND status IN ('dynamic', 'static') \
-		ORDER BY expiry_time DESC \
-		LIMIT 1 \
-	) UNION \
-	SELECT framedipaddress, expiry_time \
-	FROM ( \
-		SELECT framedipaddress, expiry_time \
-		FROM ${ippool_table} \
-		JOIN dhcpstatus \
-		ON ${ippool_table}.status_id = dhcpstatus.status_id \
-		WHERE pool_name = '%{control:${pool_name}}' \
-		AND expiry_time < datetime('now') \
-		AND status = 'dynamic' \
-		ORDER BY expiry_time LIMIT 1 \
-	) \
-	ORDER BY \
-		expiry_time DESC \
-	LIMIT 1"
+	SELECT framedipaddress \
+	FROM ${ippool_table} \
+	JOIN dhcpstatus \
+	ON ${ippool_table}.status_id = dhcpstatus.status_id \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND expiry_time < datetime('now') \
+	AND status = 'dynamic' \
+	ORDER BY expiry_time LIMIT 1"
 
 #
 # If you prefer to allocate a random IP address every time, use this query instead
@@ -67,12 +75,12 @@ alloc_find = "\
 #	SELECT framedipaddress FROM ${ippool_table} \
 #	JOIN dhcpstatus \
 #	ON ${ippool_table}.status_id = dhcpstatus.status_id \
-#	WHERE pool_name = '%{control:Pool-Name}' \
+#	WHERE pool_name = '%{control:${pool-name}}' \
 #	AND expiry_time IS NULL \
 #	AND status = 'dynamic' \
 #	ORDER BY RAND() \
-#	LIMIT 1 \
-#	FOR UPDATE"
+#	LIMIT 1"
+
 
 #
 #  If an IP could not be allocated, check to see if the pool exists or not
@@ -94,9 +102,30 @@ alloc_update = "\
 	SET \
 		gateway = '%{DHCP-Gateway-IP-Address}', \
 		pool_key = '${pool_key}', \
-		expiry_time = datetime(strftime('%%s', 'now') + ${lease_duration}, 'unixepoch') \
+		expiry_time = datetime(strftime('%%s', 'now') + ${offer_duration}, 'unixepoch') \
 	WHERE framedipaddress = '%I' \
 	AND expiry_time IS NULL"
+
+
+#  ****************
+#  * DHCP REQUEST *
+#  ****************
+
+#
+#  Query used to clear any other addresses that have been offered to the client
+#
+update_free = "\
+	UPDATE ${ippool_table} \
+	SET \
+		gateway = '', \
+		pool_key = '', \
+		expiry_time = datetime('now') \
+	WHERE pool_name = '%{control:${pool_name}}' \
+	AND pool_key = '${pool_key}' \
+	AND framedipaddress <> '%{DHCP-Requested-IP-Address}' \
+	AND expiry_time > datetime('now') \
+	AND ${ippool_table}.status_id IN \
+	(SELECT status_id FROM dhcpstatus WHERE status = 'dynamic')"
 
 #
 #  Queries to update a lease - used in response to DHCP-Request packets
@@ -108,6 +137,11 @@ update_update = "\
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"
 
+
+#  ****************
+#  * DHCP RELEASE *
+#  ****************
+
 #
 #  Queries to release a lease - used in response to DHCP-Release packets
 #
@@ -118,7 +152,14 @@ release_clear = "\
 		expiry_time = datetime('now') \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
-	AND framedipaddress = '%{DHCP-Client-IP-Address}'"
+	AND framedipaddress = '%{DHCP-Client-IP-Address}' \
+	AND ${ippool_table}.status_id IN \
+	(SELECT status_id FROM dhcpstatus WHERE status = 'dynamic')"
+
+
+#  ****************
+#  * DHCP DECLINE *
+#  ****************
 
 #
 #  Queries to mark leases as "bad" - used in response to DHCP-Decline
@@ -129,4 +170,3 @@ mark_update = "\
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND framedipaddress = '%{DHCP-Requested-IP-Address}' \
 	AND pool_key = '${pool_key}'"
-

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
@@ -16,6 +16,7 @@ CREATE TABLE dhcpippool (
 	gateway			varchar(15) NOT NULL DEFAULT '',
 	expiry_time		DATETIME NOT NULL default (DATETIME('now')),
 	status_id		int NOT NULL DEFAULT 1,
+	counter			int NOT NULL DEFAULT 0,
 	FOREIGN KEY(status_id) REFERENCES dhcpstatus(status_id)
 );
 

--- a/raddb/policy.d/dhcp
+++ b/raddb/policy.d/dhcp
@@ -1,0 +1,15 @@
+#  A policy to set options required in all DHCP replies
+dhcp_common {
+	#  The contents here are invented.  Change them!
+	#  Lease time is referencing the lease time set in the
+	#  named module instance configuration
+	update reply {
+		&DHCP-Domain-Name-Server = 127.0.0.1
+		&DHCP-Domain-Name-Server = 127.0.0.2
+		&DHCP-Subnet-Mask = 255.255.255.0
+		&DHCP-Router-Address = 192.0.2.1
+		&DHCP-IP-Address-Lease-Time = 7200
+#		&DHCP-IP-Address-Lease-Time = "${modules.sqlippool[dhcp_sqlippool].lease_duration}"
+		&DHCP-DHCP-Server-Identifier = &control:DHCP-DHCP-Server-Identifier
+	}
+}

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -126,6 +126,35 @@ listen {
 
 recv DHCP-Discover {
 
+	#  The DHCP Server Identifier is set here since it is returned in OFFERs
+	update control {
+		&DHCP-DHCP-Server-Identifier = 192.0.2.1
+	}
+
+	#  Call a policy (defined in policy.d/dhcp) to set common reply attributes
+	dhcp_common
+
+	#  Do a simple mapping of MAC to assigned IP.
+	#
+	#  See below for the definition of the "mac2ip"
+	#  module.
+	#
+	#mac2ip
+
+	#  If the MAC wasn't found in that list, do something else.
+	#  You could call a Perl, Python, or Java script here.
+
+	#if (notfound) {
+	#  ...
+	#}
+
+	#  Or, allocate IPs from the DHCP pool in SQL. You may need to
+	#  set the pool name here if you haven't set it elsewhere.
+#	update control {
+#		&Pool-Name := "local"
+#	}
+#	dhcp_sqlippool
+
 	#  Set the type of packet to send in reply.
 	#
 	#  The server will look at the DHCP-Message-Type attribute to
@@ -140,74 +169,38 @@ recv DHCP-Discover {
 	#  server will fall back to determining the type of reply
 	#  based on the rcode of this section.
 
-	update reply {
-	       &DHCP-Message-Type = DHCP-Offer
-	}
-
-	#  The contents here are invented.  Change them!
-	#  Lease time is referencing the lease time set in the
-	#  named module instance configuration
-	update reply {
-		&DHCP-Domain-Name-Server = 127.0.0.1
-		&DHCP-Domain-Name-Server = 127.0.0.2
-		&DHCP-Subnet-Mask = 255.255.255.0
-		&DHCP-Router-Address = 192.0.2.1
-#		&DHCP-IP-Address-Lease-Time = "${modules.sqlippool[dhcp_sqlippool].lease_duration}"
-		&DHCP-DHCP-Server-Identifier = 192.0.2.1
-	}
-
-	#  Do a simple mapping of MAC to assigned IP.
-	#
-	#  See below for the definition of the "mac2ip"
-	#  module.
-	#
-	#mac2ip
-
-	#  If the MAC wasn't found in that list, do something else.
-	#  You could call a Perl, Python, or Java script here.
-
-	#if (notfound) {
-	#  ...
+	#update reply {
+	#       &DHCP-Message-Type = DHCP-Offer
 	#}
-
-	#  Or, allocate IPs from the DHCP pool in SQL. You may need to
-	#  set the pool name here if you haven't set it elsewhere.
-#	update control {
-#		&Pool-Name := "local"
-#	}
-	# Update the request to contain fields needed for SQL pool
-	# address allocation
-#	update request {
-#		&Calling-Station-Id = "%{%{DHCP-Client-Identifier}:-%{DHCP-Client-Hardware-Address}}"
-#	}
-#	dhcp_sqlippool
 
 	#  If DHCP-Message-Type is not set, returning "ok" or
 	#  "updated" from this section will respond with a DHCP-Offer
 	#  message.
 	#
 	#  Other rcodes will tell the server to not return any response.
-	ok
+	#ok
 }
 
 recv DHCP-Request {
 
-	#  Response packet type. See DHCP-Discover section above.
-	update reply {
-	       &DHCP-Message-Type = DHCP-Ack
-	}
-
-	#  The contents here are invented.  Change them!
-	#  Lease time is referencing the lease time set in the
-	#  named module instance configuration
-	update reply {
-		&DHCP-Domain-Name-Server = 127.0.0.1
-		&DHCP-Domain-Name-Server = 127.0.0.2
-		&DHCP-Subnet-Mask = 255.255.255.0
-		&DHCP-Router-Address = 192.0.2.1
-#		&DHCP-IP-Address-Lease-Time = "${modules.sqlippool[dhcp_sqlippool].lease_duration}"
+	#  The DHCP Server Identifier is set here since it is returned in OFFERs
+	update control {
 		&DHCP-DHCP-Server-Identifier = 192.0.2.1
 	}
+
+	#  If the request is not for this server then silently discard it
+	if (&request:DHCP-DHCP-Server-Identifier && \
+	    &request:DHCP-DHCP-Server-Itentifier != &control:DHCP-DHCP-Server-Identifier) {
+	        do_not_respond
+	}
+
+	#  Response packet type. See DHCP-Discover section above.
+	#update reply {
+	#       &DHCP-Message-Type = DHCP-Ack
+	#}
+
+	#  Call a policy (defined in policy.d/dhcp) to set common reply attributes
+	dhcp_common
 
 	#  Do a simple mapping of MAC to assigned IP.
 	#
@@ -228,13 +221,13 @@ recv DHCP-Request {
 #	update control {
 #		&Pool-Name := "local"
 #	}
-	# Update the request to contain fields needed for SQL pool
-	# address allocation
-#	update request {
-#		&Calling-Station-Id = "%{%{DHCP-Client-Identifier}:-%{DHCP-Client-Hardware-Address}}"
-#		&NAS-IP-Address = "%{%{DHCP-Gateway-IP-Address}:-127.0.0.1}"
-#	}
 #	dhcp_sqlippool
+
+	if (ok) {
+		update reply {
+			&DHCP-Your-IP-Address := "%{%{request:DHCP-Requested-IP-Address}:-{request:DHCP-Client-IP-Address}}"
+		}
+	}
 
 	#  If DHCP-Message-Type is not set, returning "ok" or
 	#  "updated" from this section will respond with a DHCP-Ack
@@ -242,7 +235,7 @@ recv DHCP-Request {
 	#
 	#  "handled" will not return a packet, all other rcodes will
 	#  send back a DHCP-NAK.
-	ok
+	#ok
 }
 
 #
@@ -253,10 +246,14 @@ recv DHCP-Request {
 #  not defined here will be responded to with a DHCP-NAK.
 
 recv DHCP-Decline {
-	update reply {
-	       &DHCP-Message-Type = DHCP-Do-Not-Respond
-	}
-	reject
+	#  If using IPs from a DHCP pool in SQL then you may need to set the
+	#  pool name here if you haven't set it elsewhere and mark the IP as declined.
+#	update control {
+#		&Pool-Name := "local"
+#	}
+#	dhcp_sqlippool
+
+	ok
 }
 
 #
@@ -265,15 +262,9 @@ recv DHCP-Decline {
 #  must not set Your-IP-Address or IP-Address-Lease-Time
 #
 recv DHCP-Inform {
-	#  The contents here are invented.  Change them!
-	update reply {
-		&DHCP-Domain-Name-Server = 127.0.0.1
-		&DHCP-Domain-Name-Server = 127.0.0.2
-		&DHCP-Subnet-Mask = 255.255.255.0
-		&DHCP-Router-Address = 192.0.2.1
-		&DHCP-DHCP-Server-Identifier = 192.0.2.1
-		&DHCP-Message-Type = DHCP-Ack
-	}
+	#  Call a policy (defined in policy.d/dhcp) to set common reply attributes
+	dhcp_common
+
 	ok
 }
 
@@ -291,10 +282,14 @@ recv DHCP-Inform {
 #}
 
 recv DHCP-Release {
-	update reply {
-	       &DHCP-Message-Type = DHCP-Do-Not-Respond
-	}
-	reject
+	#  If using IPs from a DHCP pool in SQL then you may need to set the
+	#  pool name here if you haven't set it elsewhere and release the IP.
+#	update control {
+#		&Pool-Name := "local"
+#	}
+#	dhcp_sqlippool
+
+	ok
 }
 
 


### PR DESCRIPTION
Equivalent fixes to PR 3614 for FreeRAIDUS v4.

Specifically:

- we now honour IP address hints during DHCP Discover as per RFC 2131.  
- improved handling of DHCP REQUESTs when multiple FR instances are sharing a database.
- implements short offer time
- implements silent dropping of REQUEST packets not for the current server

Also, moved common `reply`attribute setting into policy such that it is only set in one place to simplify config
