### PR TITLE
Add counter to DHCP ippool schema

### DIFF
--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -201,7 +201,9 @@ start_update = "\
 
 #
 #  This query extends an existing lease (or offer) when a DHCP REQUEST packet
-#  arrives
+#  arrives.  This query must update a row when a lease is succesfully requested
+#  - queries that update no rows will result in a NAK reply.  In this example
+#  incrementing "counter" is used to achieve this.
 #
 alive_update = "\
 	UPDATE ${ippool_table} \

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -206,7 +206,8 @@ start_update = "\
 alive_update = "\
 	UPDATE ${ippool_table} \
 	SET \
-		expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP) \
+		expiry_time = DATEADD(SECOND,${lease_duration},CURRENT_TIMESTAMP), \
+		counter = counter + 1 \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/queries.conf
@@ -202,7 +202,8 @@ start_update = "\
 #
 #  This query extends an existing lease (or offer) when a DHCP REQUEST packet
 #  arrives.  This query must update a row when a lease is succesfully requested
-#  - queries that update no rows will result in a NAK reply.  In this example
+#  - queries that update no rows will result in a "notfound" response to
+#  the module which by default will give a DHCP-NAK reply.  In this example
 #  incrementing "counter" is used to achieve this.
 #
 alive_update = "\

--- a/raddb/mods-config/sql/ippool-dhcp/mssql/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mssql/schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE dhcpippool (
 	gateway			varchar(15) NOT NULL default '',
 	expiry_time		DATETIME NOT NULL default CURRENT_TIMESTAMP,
 	status_id		int NOT NULL default 1,
+	counter			int NOT NULL default 0,
 	CONSTRAINT fk_status_id FOREIGN KEY (status_id) REFERENCES dhcpstatus (status_id),
 	PRIMARY KEY (id)
 )

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -165,7 +165,9 @@ start_update = "\
 
 #
 #  This query extends an existing lease (or offer) when a DHCP REQUEST packet
-#  arrives
+#  arrives.  This query must update a row when a lease is succesfully requested
+#  - queries that update no rows will result in a NAK reply.  In this example
+#  incrementing "counter" is used to achieve this.
 #
 alive_update = "\
 	UPDATE ${ippool_table} \

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -170,7 +170,8 @@ start_update = "\
 alive_update = "\
 	UPDATE ${ippool_table} \
 	SET \
-		expiry_time = NOW() + INTERVAL ${lease_duration} SECOND \
+		expiry_time = NOW() + INTERVAL ${lease_duration} SECOND, \
+		counter = counter + 1 \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/queries.conf
@@ -166,7 +166,8 @@ start_update = "\
 #
 #  This query extends an existing lease (or offer) when a DHCP REQUEST packet
 #  arrives.  This query must update a row when a lease is succesfully requested
-#  - queries that update no rows will result in a NAK reply.  In this example
+#  - queries that update no rows will result in a "notfound" response to
+#  the module which by default will give a DHCP-NAK reply.  In this example
 #  incrementing "counter" is used to achieve this.
 #
 alive_update = "\

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/schema.sql
@@ -13,6 +13,7 @@ CREATE TABLE dhcpippool (
 	gateway			varchar(15) NOT NULL default '',
 	expiry_time		DATETIME NOT NULL default NOW(),
 	`status`		ENUM('dynamic', 'static', 'declined', 'disabled') DEFAULT 'dynamic',
+	counter			int unsigned NOT NULL default 0,
 	PRIMARY KEY (id),
 	KEY dhcpippool_poolname_expire (pool_name, expiry_time),
 	KEY framedipaddress (framedipaddress),

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -140,7 +140,8 @@ start_commit = "COMMIT"
 #
 #  This query extends an existing lease (or offer) when a DHCP REQUEST packet
 #  arrives.  This query must update a row when a lease is succesfully requested
-#  - queries that update no rows will result in a NAK reply.  In this example
+#  - queries that update no rows will result in a "notfound" response to
+#  the module which by default will give a DHCP-NAK reply.  In this example
 #  incrementing "counter" is used to achieve this.
 #
 alive_update = "\

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -139,7 +139,9 @@ start_commit = "COMMIT"
 
 #
 #  This query extends an existing lease (or offer) when a DHCP REQUEST packet
-#  arrives
+#  arrives.  This query must update a row when a lease is succesfully requested
+#  - queries that update no rows will result in a NAK reply.  In this example
+#  incrementing "counter" is used to achieve this.
 #
 alive_update = "\
 	UPDATE ${ippool_table} \

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/queries.conf
@@ -144,7 +144,8 @@ start_commit = "COMMIT"
 alive_update = "\
 	UPDATE ${ippool_table} \
 	SET \
-		expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1) \
+		expiry_time = current_timestamp + INTERVAL '${lease_duration}' second(1), \
+		counter = counter + 1 \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"

--- a/raddb/mods-config/sql/ippool-dhcp/oracle/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/oracle/schema.sql
@@ -18,6 +18,7 @@ CREATE TABLE dhcpippool (
 	gateway			VARCHAR(15) DEFAULT '',
 	expiry_time		timestamp(0) DEFAULT CURRENT_TIMESTAMP,
 	status_id		INT DEFAULT 1,
+	counter			INT DEFAULT 0,
 	FOREIGN KEY (status_id) REFERENCES dhcpstatus(status_id)
 );
 

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -240,7 +240,8 @@ start_update = "\
 alive_update = "\
 	UPDATE ${ippool_table} \
 	SET \
-		expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval \
+		expiry_time = 'now'::timestamp(0) + '${lease_duration} second'::interval, \
+		counter = counter + 1 \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -235,7 +235,9 @@ start_update = "\
 
 #
 #  This query extends an existing lease (or offer) when a DHCP REQUEST packet
-#  arrives
+#  arrives.  This query must update a row when a lease is succesfully requested
+#  - queries that update no rows will result in a NAK reply.  In this example
+#  incrementing "counter" is used to achieve this.
 #
 alive_update = "\
 	UPDATE ${ippool_table} \

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/queries.conf
@@ -236,7 +236,8 @@ start_update = "\
 #
 #  This query extends an existing lease (or offer) when a DHCP REQUEST packet
 #  arrives.  This query must update a row when a lease is succesfully requested
-#  - queries that update no rows will result in a NAK reply.  In this example
+#  - queries that update no rows will result in a "notfound" response to
+#  the module which by default will give a DHCP-NAK reply.  In this example
 #  incrementing "counter" is used to achieve this.
 #
 alive_update = "\

--- a/raddb/mods-config/sql/ippool-dhcp/postgresql/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/postgresql/schema.sql
@@ -14,7 +14,8 @@ CREATE TABLE dhcpippool (
 	pool_key		VARCHAR(64) NOT NULL default '0',
 	gateway			VARCHAR(16) NOT NULL default '',
 	expiry_time		TIMESTAMP(0) without time zone NOT NULL default NOW(),
-	status			dhcp_status DEFAULT 'dynamic'
+	status			dhcp_status DEFAULT 'dynamic',
+	counter			INT NOT NULL default 0
 );
 
 CREATE INDEX dhcpippool_poolname_expire ON dhcpippool USING btree (pool_name, expiry_time);

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -178,7 +178,9 @@ start_update = "\
 
 #
 #  This query extends an existing lease (or offer) when a DHCP REQUEST packet
-#  arrives
+#  arrives.  This query must update a row when a lease is succesfully requested
+#  - queries that update no rows will result in a NAK reply.  In this example
+#  incrementing "counter" is used to achieve this.
 #
 alive_update = "\
 	UPDATE ${ippool_table} \

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -179,7 +179,8 @@ start_update = "\
 #
 #  This query extends an existing lease (or offer) when a DHCP REQUEST packet
 #  arrives.  This query must update a row when a lease is succesfully requested
-#  - queries that update no rows will result in a NAK reply.  In this example
+#  - queries that update no rows will result in a "notfound" response to
+#  the module which by default will give a DHCP-NAK reply.  In this example
 #  incrementing "counter" is used to achieve this.
 #
 alive_update = "\

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/queries.conf
@@ -183,7 +183,8 @@ start_update = "\
 alive_update = "\
 	UPDATE ${ippool_table} \
 	SET \
-		expiry_time = datetime(strftime('%%s', 'now') + ${lease_duration}, 'unixepoch') \
+		expiry_time = datetime(strftime('%%s', 'now') + ${lease_duration}, 'unixepoch'), \
+		counter = counter + 1 \
 	WHERE pool_name = '%{control:${pool_name}}' \
 	AND pool_key = '${pool_key}' \
 	AND framedipaddress = '%{%{DHCP-Requested-IP-Address}:-%{DHCP-Client-IP-Address}}'"

--- a/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/sqlite/schema.sql
@@ -16,6 +16,7 @@ CREATE TABLE dhcpippool (
 	gateway			varchar(15) NOT NULL default '',
 	expiry_time		DATETIME NOT NULL default (DATETIME('now')),
 	status_id		int NOT NULL default 1,
+	counter			int NOT NULL default 0,
 	FOREIGN KEY(status_id) REFERENCES dhcpstatus(status_id)
 );
 


### PR DESCRIPTION
By updating a counter every time a REQUEST is responded to successfully
we ensure that records are changed, thus all database engines return an
affected row count of 1 for successful matches.  This safeguards the new
DHCP site config which uses the affected row count to determine between
ACK and NAK responses.