### PR TITLE
Make marker pointer advances past parent pointer advance parent point…

### DIFF
--- a/src/lib/util/dbuff.h
+++ b/src/lib/util/dbuff.h
@@ -75,6 +75,8 @@ struct fr_dbuff_s {
 						///< buffer changes.
 };
 
+static inline void fr_dbuff_set_to_marker(fr_dbuff_marker_t *m);
+
 /** @name utility macros
  * @{
  */
@@ -471,6 +473,11 @@ static inline void fr_dbuff_marker_release(fr_dbuff_marker_t *m)
  *	- 0 on failure (p out of range), marker position will remain unchanged.
  *	- >0 the number of bytes the marker advanced.
  *	- <0 the number of bytes the marker retreated.
+ *
+ * @note 	moving the marker's position past its parent's position is
+ *		effectively using part of the dbuff behind the parent's back
+ *		(fr_dbuff_used() won't see it), so in that case we set the
+ *		parent to match.
  */
 static inline ssize_t fr_dbuff_marker_set(fr_dbuff_marker_t *m, uint8_t const *p)
 {
@@ -481,6 +488,8 @@ static inline ssize_t fr_dbuff_marker_set(fr_dbuff_marker_t *m, uint8_t const *p
 	if (unlikely(p < dbuff->start)) return 0;
 
 	m->p_i = p;
+
+	if (m->p > dbuff->p) fr_dbuff_set_to_marker(m);
 
 	return p - current;
 }

--- a/src/lib/util/dbuff_tests.c
+++ b/src/lib/util/dbuff_tests.c
@@ -219,6 +219,26 @@ static void test_dbuff_net_encode(void)
 	TEST_CHECK(fr_dbuff_in(&dbuff, u64val) == -(ssize_t)(sizeof(uint64_t) - sizeof(uint32_t)));
 }
 
+static void test_dbuff_marker_set(void)
+{
+	uint8_t			buff[32];
+	fr_dbuff_t		dbuff;
+	fr_dbuff_marker_t	marker;
+
+	fr_dbuff_init(&dbuff, buff, sizeof(buff));
+	fr_dbuff_marker(&marker, &dbuff);
+
+	TEST_CASE("Marker moves within used area leave parent's position alone");
+	fr_dbuff_advance(&dbuff, 8);
+	fr_dbuff_marker_advance(&marker, 4);
+	TEST_CHECK(fr_dbuff_used(&dbuff) == 8);
+
+	TEST_CASE("Marker moves past parent's position advance parent's position");
+	fr_dbuff_marker_advance(&marker, 8);
+	TEST_CHECK(marker.p == dbuff.p);
+	TEST_CHECK(fr_dbuff_used(&dbuff) == 12);
+}
+
 
 TEST_LIST = {
 	/*
@@ -228,6 +248,7 @@ TEST_LIST = {
 	{ "fr_dbuff_init_no_parent",			test_dbuff_init_no_parent },
 	{ "fr_dbuff_max",				test_dbuff_max },
 	{ "fr_dbuff_in",			test_dbuff_net_encode },
+	{ "fr_dbuff_marker_set",			test_dbuff_marker_set },
 
 	{ NULL }
 };

--- a/src/lib/util/sbuff.h
+++ b/src/lib/util/sbuff.h
@@ -93,6 +93,8 @@ struct fr_sbuff_s {
 							///< buffer changes.
 };
 
+static inline ssize_t _fr_sbuff_set(fr_sbuff_t *sbuff, char const *p);
+
 /** Talloc sbuff extension structure
  *
  * Holds the data necessary for creating dynamically
@@ -870,6 +872,7 @@ static inline ssize_t _fr_sbuff_marker_set(fr_sbuff_marker_t *m, char const *p)
 	if (unlikely(p < sbuff->start)) return 0;
 
 	m->p_i = p;
+	if (m->p_i > sbuff->p_i) (void) _fr_sbuff_set(sbuff, p);
 
 	return p - current;
 }

--- a/src/lib/util/sbuff_tests.c
+++ b/src/lib/util/sbuff_tests.c
@@ -1369,6 +1369,26 @@ static void test_next_unless_char(void)
 	TEST_CHECK_STRCMP("", sbuff.p);
 }
 
+static void test_advance(void)
+{
+	fr_sbuff_t		sbuff;
+	fr_sbuff_marker_t	marker;
+	char const		in[] = "abcdefghijklm";
+
+	fr_sbuff_init(&sbuff, in, sizeof(in));
+	fr_sbuff_marker(&marker, &sbuff);
+
+	TEST_CASE("Marker moves within used area leave parent's position alone");
+	fr_sbuff_advance(&sbuff, 8);
+	fr_sbuff_advance(&marker, 4);
+	TEST_SBUFF_USED(&sbuff, 8);
+
+	TEST_CASE("Marker moves past parent's position advance parent's position");
+	fr_sbuff_advance(&marker, 8);
+	TEST_CHECK(marker.p == sbuff.p);
+	TEST_SBUFF_USED(&sbuff, 12);
+}
+
 TEST_LIST = {
 	/*
 	 *	Basic tests
@@ -1380,6 +1400,7 @@ TEST_LIST = {
 	{ "fr_sbuff_out_bstrncpy_until",	test_bstrncpy_until },
 	{ "multi-char terminals",		test_unescape_multi_char_terminals },
 	{ "fr_sbuff_out_unescape_until",	test_unescape_until },
+	{ "fr_sbuff_advance",			test_advance },
 
 	/*
 	 *	Extending buffer


### PR DESCRIPTION
…er too

Why? fr_[sd]buff_moves() with marker source/destination will advance the
marker pointer... but if that moves it past the parent's pointer, then
bytes are used that aren't reflected in fr_[sd]buff_used(). For dbuffs,
at least, this breaks the convention for encoding functions.

This change causes setting a marker pointers to check the parent's pointer
and, if and only if the set moves the marker pointer past the parent
pointer, advance the parent pointer to match the marker pointer.