### PR TITLE
v3: Correct behaviour of allow_multiple_keys in rlm_passwd

### DIFF
--- a/src/modules/rlm_passwd/rlm_passwd.c
+++ b/src/modules/rlm_passwd/rlm_passwd.c
@@ -166,6 +166,7 @@ static struct hashtable * build_hash_table (char const * file, int nfields,
 	size_t len;
 	unsigned int h;
 	struct mypasswd *hashentry, *hashentry1;
+	struct mypasswd **lastentry; /* temp pointers to end of lists */
 	char *list;
 	char *nextlist=0;
 	int i;
@@ -212,6 +213,20 @@ static struct hashtable * build_hash_table (char const * file, int nfields,
 		return ht;
 	}
 	memset(ht->table, 0, tablesize * sizeof(struct mypasswd *));
+
+	/*
+	 * Initialise temporary pointers to last entries in has table
+	 */
+	lastentry = (struct mypasswd **) rad_malloc (tablesize * sizeof(struct mypasswd *));
+	if (!lastentry) {
+		/*
+		 * Unable to allocate memory for temp pointers
+		 */
+		ht->tablesize = 0;
+		return ht;
+	}
+	memset(lastentry, 0, tablesize * sizeof(struct mypasswd *));
+
 	while (fgets(buffer, 1024, ht->fp)) {
 		if(*buffer && *buffer!='\n' && (!ignorenis || (*buffer != '+' && *buffer != '-')) ){
 			if(!(hashentry = mypasswd_malloc(buffer, nfields, &len))){
@@ -231,8 +246,9 @@ static struct hashtable * build_hash_table (char const * file, int nfields,
 				else nextlist = 0;
 			}
 			h = hash(hashentry->field[keyfield], tablesize);
-			hashentry->next = ht->table[h];
-			ht->table[h] = hashentry;
+			if (!ht->table[h]) ht->table[h] = hashentry;
+			if (lastentry[h]) lastentry[h]->next = hashentry;
+			lastentry[h] = hashentry;
 			if (islist) {
 				for(list=nextlist; nextlist; list = nextlist){
 					for (nextlist = list; *nextlist && *nextlist!=','; nextlist++);
@@ -245,12 +261,14 @@ static struct hashtable * build_hash_table (char const * file, int nfields,
 					for (i=0; i<nfields; i++) hashentry1->field[i] = hashentry->field[i];
 					hashentry1->field[keyfield] = list;
 					h = hash(list, tablesize);
-					hashentry1->next = ht->table[h];
-					ht->table[h] = hashentry1;
+					if (!ht->table[h]) ht->table[h] = hashentry1;
+					if (lastentry[h]) lastentry[h]->next = hashentry1;
+					lastentry[h] = hashentry1;
 				}
 			}
 		}
 	}
+	free(lastentry);
 	fclose(ht->fp);
 	ht->fp = NULL;
 	return ht;
@@ -565,6 +583,10 @@ static rlm_rcode_t CC_HINT(nonnull) mod_passwd_map(void *instance, REQUEST *requ
 			addresult(request, inst, request, &request->config, pw, 0, "config");
 			addresult(request->reply, inst, request, &request->reply->vps, pw, 1, "reply_items");
 			addresult(request->packet, inst, request, &request->packet->vps, pw, 2, "request_items");
+
+			if (!inst->allow_multiple) {
+				break;
+			}
 		} while ((pw = get_next(buffer, inst->ht, &last_found)));
 
 		found++;


### PR DESCRIPTION
Amend rlm_passwd so the allow_mulitple_keys behaviour matches documentation - only using the first matching record in the data file.