### PR TITLE
v3: Expand sample DHCP config

### DIFF
--- a/raddb/mods-available/dhcp_files
+++ b/raddb/mods-available/dhcp_files
@@ -13,3 +13,15 @@ files dhcp_subnet {
 	#  the file
 	key = "network"
 }
+
+files dhcp_hosts {
+	#  An example of a DHCP host mapping for option setting
+
+	#  Use the same file as for subnets - could be split
+	#  for large, complex installations
+	filename = ${modconfdir}/files/dhcp
+
+	#  If a different identifier is needed for looking up
+	#  host specific entries then amend this key.
+	key = "host-%{DHCP-Client-Hardware-Address}"
+}

--- a/raddb/mods-available/dhcp_files
+++ b/raddb/mods-available/dhcp_files
@@ -4,12 +4,12 @@
 
 # Instances of the "files" module for managing DHCP options
 #
-files dhcp_subnet {
+files dhcp_network {
 	#  The file containing DHCP options mapping
 	filename = ${modconfdir}/files/dhcp
 
-	#  For subnet lookups we use a fixed key.  Matching
-	#  actual subnets is done by additional filtering within
+	#  For network lookups we use a fixed key.  Matching
+	#  actual networks is done by additional filtering within
 	#  the file
 	key = "network"
 }
@@ -17,18 +17,20 @@ files dhcp_subnet {
 files dhcp_set_group_options {
 	#  An example of looking up DHCP group options.  This
 	#  is designed to be called from a policy configured in
-	#  policy.d/dhcp.  If clients are never members of more
-	#  than one group, then this could be simplified such that
-	#  DHCP-Group-Name is used here in place of Tmp-String-0
-	#  and this module instance called directly rather than
-	#  the policy
+	#  policy.d/dhcp.
+	#
+	#  If clients are never members of more than one group,
+	#  then this could be simplified such that DHCP-Group-Name
+	#  is used here in place of Foreach-Variable-0 and this
+	#  module instance called directly rather than the policy
 
 	#  Use the same file as for subnets - could be split
 	#  for large, complex installations
 	filename = ${modconfdir}/files/dhcp
 
 	#  The key is a temporary string populated by the calling policy
-	key = "%{control:Tmp-String-0}"
+	#  which uses a foreach loop.
+	key = "%{Foreach-Variable-0}"
 }
 
 files dhcp_hosts {

--- a/raddb/mods-available/dhcp_files
+++ b/raddb/mods-available/dhcp_files
@@ -1,0 +1,15 @@
+# -*- text -*-
+#
+#  $Id$
+
+# Instances of the "files" module for managing DHCP options
+#
+files dhcp_subnet {
+	#  The file containing DHCP options mapping
+	filename = ${modconfdir}/files/dhcp
+
+	#  For subnet lookups we use a fixed key.  Matching
+	#  actual subnets is done by additional filtering within
+	#  the file
+	key = "network"
+}

--- a/raddb/mods-available/dhcp_files
+++ b/raddb/mods-available/dhcp_files
@@ -14,6 +14,23 @@ files dhcp_subnet {
 	key = "network"
 }
 
+files dhcp_set_group_options {
+	#  An example of looking up DHCP group options.  This
+	#  is designed to be called from a policy configured in
+	#  policy.d/dhcp.  If clients are never members of more
+	#  than one group, then this could be simplified such that
+	#  DHCP-Group-Name is used here in place of Tmp-String-0
+	#  and this module instance called directly rather than
+	#  the policy
+
+	#  Use the same file as for subnets - could be split
+	#  for large, complex installations
+	filename = ${modconfdir}/files/dhcp
+
+	#  The key is a temporary string populated by the calling policy
+	key = "%{control:Tmp-String-0}"
+}
+
 files dhcp_hosts {
 	#  An example of a DHCP host mapping for option setting
 

--- a/raddb/mods-available/dhcp_passwd
+++ b/raddb/mods-available/dhcp_passwd
@@ -1,0 +1,20 @@
+# -*- text -*-
+#
+#  $Id$
+
+#  An instance of the passwd module designed for looking up
+#  DHCP client membership.  This example is based on hardware
+#  address.
+#  The "groups" file should be of the format:
+#  <group name>|<hardware address>,<hardware address>,<hardware address>
+#  <group name>|<hardware address>,<hardware address>,<hardware address>
+#
+#  See the passwd module for more details.
+
+passwd dhcp_group_membership {
+	filename = "${modconfdir}/files/dhcp_groups"
+	format = "DHCP-Group-Name:*,DHCP-Client-Hardware-Address"
+	hash_size = 100
+	allow_multiple_keys = yes
+	delimiter = "|"
+}

--- a/raddb/mods-available/dhcp_sqlippool
+++ b/raddb/mods-available/dhcp_sqlippool
@@ -36,7 +36,9 @@ sqlippool dhcp_sqlippool {
 	offer_duration = 10
 
 	# IP lease duration. (Leases expire even if no DHCP-Release packet is received)
-	lease_duration = 7200
+	# Either use the value to be sent to the client or a hard coded one.
+	lease_duration = "%{reply:DHCP-IP-Address-Lease-Time}"
+	#lease_duration = 7200
 
 	#  The attribute in which the IP address is returned in the reply
 	attribute_name = "DHCP-Your-IP-Address"

--- a/raddb/mods-config/files/dhcp
+++ b/raddb/mods-config/files/dhcp
@@ -27,12 +27,19 @@ network	DHCP-Network-IP-Address < 10.30.0.0/16, Pool-Name := "visitors"
 	DHCP-Domain-Name := "guests.example.org",
 	DHCP-IP-Address-Lease-Time := 3600
 
+#
+#  Set group specific options
+#
+group1
+	DHCP-Server-Host-Name := "terminal-booter.example.org",
+	DHCP-Boot-Filename := "bootfile.pxe"
+
 
 #
 #  Set host specific options
 #
 host-00:10:20:30:40:50
-	DHCP-Filename := "customboot.pxe"
+	DHCP-Boot-Filename := "customboot.pxe"
 
 host-10:90:80:70:aa:bb
 	DHCP-Font-Server := 10.20.1.10,

--- a/raddb/mods-config/files/dhcp
+++ b/raddb/mods-config/files/dhcp
@@ -26,3 +26,14 @@ network	DHCP-Network-IP-Address < 10.30.0.0/16, Pool-Name := "visitors"
 	DHCP-Router-Address := 10.30.1.1,
 	DHCP-Domain-Name := "guests.example.org",
 	DHCP-IP-Address-Lease-Time := 3600
+
+
+#
+#  Set host specific options
+#
+host-00:10:20:30:40:50
+	DHCP-Filename := "customboot.pxe"
+
+host-10:90:80:70:aa:bb
+	DHCP-Font-Server := 10.20.1.10,
+	DHCP-Impress-Server := 10.20.1.20

--- a/raddb/mods-config/files/dhcp
+++ b/raddb/mods-config/files/dhcp
@@ -1,0 +1,28 @@
+#
+#  Global and network specific parameters
+#
+
+#
+#  First set default global attributes.
+#  These can be overwritten by subnets below.
+#  This is all made up and needs to be set appropriate to the network
+#  being served.
+#
+network
+	DHCP-Domain-Name-Server := 192.0.1.100,
+	DHCP-Domain-Name-Server += 192.0.1.101,
+	DHCP-Time-Server := 192.0.1.200,
+	DHCP-Domain-Name := "example.org",
+	DHCP-IP-Address-Lease-Time := 7200,
+	Fall-Through := yes
+
+#
+#  Set options relevant to subnets
+#
+network	DHCP-Network-IP-Address < 10.20.0.0/16, Pool-Name := "staff"
+	DHCP-Router-Address := 10.20.1.1
+
+network	DHCP-Network-IP-Address < 10.30.0.0/16, Pool-Name := "visitors"
+	DHCP-Router-Address := 10.30.1.1,
+	DHCP-Domain-Name := "guests.example.org",
+	DHCP-IP-Address-Lease-Time := 3600

--- a/raddb/policy.d/dhcp
+++ b/raddb/policy.d/dhcp
@@ -16,13 +16,25 @@ dhcp_common {
 #  To use this enable the "dhcp_files" module
 #dhcp_group_options {
 #	foreach &control:DHCP-Group-Name {
-#		update control {
-#		       Tmp-String-0 := "%{Foreach-Variable-0}"
-#		}
 #		dhcp_set_group_options
 #	}
 #}
 
+#  Policy to override DHCP-Network-IP-Address
+#
+#  Typical use may be IP telephony where a specific subnet is
+#  assigned to telephony devices, distinct from other clients
+#  on the network.
+#
+#  Set DHCP-Network-IP-Address to any address within the desired
+#  network
+#dhcp_override_network {
+#	if (&DHCP-Vendor-Class-Identifier && &DHCP-Vendor-Class-Identifier == "SIP100")
+#		update request {
+#			DHCP-Network-IP-Address := 10.10.0.0
+#		}
+#	}
+#}
 
 #  Assign compatibility data to request for sqlippool for DHCP Request
 dhcp_sqlippool_request {

--- a/raddb/policy.d/dhcp
+++ b/raddb/policy.d/dhcp
@@ -11,6 +11,19 @@ dhcp_common {
 	}
 }
 
+#  Lookup DHCP group based options.  This policy allows  for membership
+#  of multiple groups so can cover the ISC concepts of "group" and "class"
+#  To use this enable the "dhcp_files" module
+#dhcp_group_options {
+#	foreach &control:DHCP-Group-Name {
+#		update control {
+#		       Tmp-String-0 := "%{Foreach-Variable-0}"
+#		}
+#		dhcp_set_group_options
+#	}
+#}
+
+
 #  Assign compatibility data to request for sqlippool for DHCP Request
 dhcp_sqlippool_request {
 

--- a/raddb/policy.d/dhcp
+++ b/raddb/policy.d/dhcp
@@ -1,47 +1,12 @@
-#  Determine subnet name to use in looking up options
-dhcp_determine_subnet {
-
-	#
-	#  If multiple subnets are in use, configure logic here to choose the
-	#  appropriate one.  DHCP-Network-IP-Address contains the address
-	#  to match into subnets, based on data provided in the DHCP packet.
-	#
-	#  With IP addresses the "<" operator can be used to match addresses
-	#  to subnets.
-	#
-	#  This is a made up example that should be customised to the real
-	#  Network environment
-	#
-
-	#  if (&DHCP-Network-IP-Address < 10.1.0.0/16) {
-	#	update control {
-	#		&DHCP-Subnet-Name = network1
-	#	}
-	#  } elsif (&DHCP-Network-IP-Address < 10.2.0.0/16) {
-	#	update control {
-	#		&DHCP-Subnet-Name = network2
-	#	}
-	#  } else {
-	#	update control {
-	#	       &DHCP-Subnet-Name = default
-	#	}
-	#  }
-}
-
 #  Assign common DHCP reply packet options
 dhcp_common {
 	#  The contents here are invented.  Change them!
-	#  Lease time should either be set here or can
-	#  reference the lease time set in the named
-	#  sqlipppol module instance configuration if that
-	#  is in use for lease management
 	update reply {
 		&DHCP-Domain-Name-Server = 127.0.0.1
 		&DHCP-Domain-Name-Server = 127.0.0.2
 		&DHCP-Subnet-Mask = 255.255.255.0
 		&DHCP-Router-Address = 192.0.2.1
 		&DHCP-IP-Address-Lease-Time = 7200
-#		&DHCP-IP-Address-Lease-Time = "${modules.sqlippool[dhcp_sqlippool].lease_duration}"
 		&DHCP-DHCP-Server-Identifier = &control:DHCP-DHCP-Server-Identifier
 	}
 }

--- a/raddb/policy.d/dhcp
+++ b/raddb/policy.d/dhcp
@@ -22,12 +22,18 @@ dhcp_common {
 
 #  Policy to override DHCP-Network-IP-Address
 #
-#  Typical use may be IP telephony where a specific subnet is
-#  assigned to telephony devices, distinct from other clients
-#  on the network.
+#  Some network configurations have "shared-networks" in which multiple IP
+#  subnets may co-exist in a single Layer 2 network (or VLAN).  This may be
+#  due to discontinuous extension of the original address plan or it may be
+#  to provide loose segregation between classes of devices such as local
+#  network atached storage or IP telephony.
 #
-#  Set DHCP-Network-IP-Address to any address within the desired
-#  network
+#  By default DHCP-Network-IP-Address is populated such that it normally
+#  refers to the Layer 2 network from which the DHCP query originates - it
+#  cannot know the intended subnet for the device without policy input.
+#  Override DHCP-Network-IP-Address to be an address within the desired
+#  subnet to force selection of particular network parameters including
+#  the address pool
 #dhcp_override_network {
 #	if (&DHCP-Vendor-Class-Identifier && &DHCP-Vendor-Class-Identifier == "SIP100")
 #		update request {

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -157,6 +157,11 @@ dhcp DHCP-Discover {
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_network
 
+	#  Use a "files" module to lookup host specific options
+	#  Enable mods-available/dhcp_files to use this
+	#  Options are set in mods-config/files/dhcp
+	#dhcp_hosts
+
 	#  Do a simple mapping of MAC to assigned IP.
 	#
 	#  See below for the definition of the "mac2ip"
@@ -234,6 +239,11 @@ dhcp DHCP-Request {
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_network
 
+	#  Use a "files" module to lookup host specific options
+	#  Enable mods-available/dhcp_files to use this
+	#  Options are set in mods-config/files/dhcp
+	#dhcp_hosts
+
 	#  Do a simple mapping of MAC to assigned IP.
 	#
 	#  See below for the definition of the "mac2ip"
@@ -306,6 +316,11 @@ dhcp DHCP-Inform {
 	#  Enable mods-available/dhcp_files to use this
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_network
+
+	#  Use a "files" module to lookup host specific options
+	#  Enable mods-available/dhcp_files to use this
+	#  Options are set in mods-config/files/dhcp
+	#dhcp_hosts
 
 	ok
 }

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -155,6 +155,12 @@ dhcp DHCP-Discover {
 	#  Call a policy (defined in policy.d/dhcp) to set common reply attributes
 	dhcp_common
 
+	#  Use a "files" module to lookup global and subnet options
+	#  For multiple subnets use this in place of dhcp_common
+	#  Enable mods-available/dhcp_files to use this
+	#  Options are set in mods-config/files/dhcp
+	#dhcp_network
+
 	#  Do a simple mapping of MAC to assigned IP.
 	#
 	#  See below for the definition of the "mac2ip"
@@ -230,6 +236,12 @@ dhcp DHCP-Request {
 	#  Call a policy (defined in policy.d/dhcp) to set common reply attributes
 	dhcp_common
 
+	#  Use a "files" module to lookup global and subnet options
+	#  For multiple subnets use this in place of dhcp_common
+	#  Enable mods-available/dhcp_files to use this
+	#  Options are set in mods-config/files/dhcp
+	#dhcp_network
+
 	#  Do a simple mapping of MAC to assigned IP.
 	#
 	#  See below for the definition of the "mac2ip"
@@ -270,9 +282,10 @@ dhcp DHCP-Request {
 
 dhcp DHCP-Decline {
 
-	#  If multiple subnets are being served, use a policy (defined in
-	#  policy.d/dhcp) to determine the subnet name.
-	#  dhcp_determine_subnet
+	#  Use a "files" module to lookup global and subnet options
+	#  Enable mods-available/dhcp_files to use this
+	#  Options are set in mods-config/files/dhcp
+	#dhcp_network
 
 	#  If using IPs from a DHCP pool in SQL then you may need to set the
 	#  pool name here if you haven't set it elsewhere and release the IP.
@@ -293,13 +306,15 @@ dhcp DHCP-Decline {
 #  must not set Your-IP-Address or IP-Address-Lease-Time
 #
 dhcp DHCP-Inform {
-	#  If multiple subnets are being served, use a policy (defined in
-	#  policy.d/dhcp) to determine the subnet name.
-	#  dhcp_determine_subnet
-
 	#  Call a policy (defined in policy.d/dhcp) to set common reply attributes
 	dhcp_common
-  
+
+	#  Use a "files" module to lookup global and subnet options
+	#  For multiple subnets use this in place of dhcp_common
+	#  Enable mods-available/dhcp_files to use this
+	#  Options are set in mods-config/files/dhcp
+	#dhcp_network
+
 	ok
 }
 
@@ -318,9 +333,11 @@ dhcp DHCP-Inform {
 
 dhcp DHCP-Release {
 
-	#  If multiple subnets are being served, use a policy (defined in
-	#  policy.d/dhcp) to determine the subnet name.
-	#  dhcp_determine_subnet
+	#  Use a "files" module to lookup global and subnet options
+	#  For multiple subnets use this in place of dhcp_common
+	#  Enable mods-available/dhcp_files to use this
+	#  Options are set in mods-config/files/dhcp
+	#dhcp_network
 
 	#  If using IPs from a DHCP pool in SQL then you may need to set the
 	#  pool name here if you haven't set it elsewhere and release the IP.

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -130,10 +130,6 @@ dhcp DHCP-Discover {
 		&DHCP-DHCP-Server-Identifier = 192.0.2.2
 	}
 
-	#  If multiple subnets are being served, use a policy (defined in
-	#  policy.d/dhcp) to determine the subnet name.
-	#  dhcp_determine_subnet
-
 	#  Set the type of packet to send in reply.
 	#
 	#  The server will look at the DHCP-Message-Type attribute to
@@ -223,10 +219,6 @@ dhcp DHCP-Request {
 	    &request:DHCP-DHCP-Server-Identifier != &control:DHCP-DHCP-Server-Identifier) {
 		do_not_respond
 	}
-
-	#  If multiple subnets are being served, use a policy (defined in
-	#  policy.d/dhcp) to determine the subnet name.
-	#  dhcp_determine_subnet
 
 	#  Response packet type. See DHCP-Discover section above.
 	#update reply {

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -130,24 +130,6 @@ dhcp DHCP-Discover {
 		&DHCP-DHCP-Server-Identifier = 192.0.2.2
 	}
 
-	#  Set the type of packet to send in reply.
-	#
-	#  The server will look at the DHCP-Message-Type attribute to
-	#  determine which type of packet to send in reply. Common
-	#  values would be DHCP-Offer, DHCP-Ack or DHCP-NAK. See
-	#  dictionary.dhcp for all the possible values.
-	#
-	#  DHCP-Do-Not-Respond can be used to tell the server to not
-	#  respond.
-	#
-	#  In the event that DHCP-Message-Type is not set then the
-	#  server will fall back to determining the type of reply
-	#  based on the rcode of this section.
-	#
-	#update reply {
-	#       DHCP-Message-Type = DHCP-Offer
-	#}
-
 	#  Call a policy (defined in policy.d/dhcp) to set common reply attributes
 	dhcp_common
 

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -139,6 +139,15 @@ dhcp DHCP-Discover {
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_network
 
+	#  Use a "passwd" module to determine group membership
+	#  Enable mods-available/dhcp_passwd to use this
+	#dhcp_group_membership
+
+	#  Use a "files" module to lookup group specific options
+	#  Enable mods-available/dhcp_files to use this
+	#  Options are set in mods-config/files/dhcp
+	#dhcp_group_options
+
 	#  Use a "files" module to lookup host specific options
 	#  Enable mods-available/dhcp_files to use this
 	#  Options are set in mods-config/files/dhcp
@@ -221,6 +230,15 @@ dhcp DHCP-Request {
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_network
 
+	#  Use a "passwd" module to determine group membership
+	#  Enable mods-available/dhcp_passwd to use this
+	#dhcp_group_membership
+
+	#  Use a "files" module to lookup group specific options
+	#  Enable mods-available/dhcp_files to use this
+	#  Options are set in mods-config/files/dhcp
+	#dhcp_group_options
+
 	#  Use a "files" module to lookup host specific options
 	#  Enable mods-available/dhcp_files to use this
 	#  Options are set in mods-config/files/dhcp
@@ -298,6 +316,15 @@ dhcp DHCP-Inform {
 	#  Enable mods-available/dhcp_files to use this
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_network
+
+	#  Use a "passwd" module to determine group membership
+	#  Enable mods-available/dhcp_passwd to use this
+	#dhcp_group_membership
+
+	#  Use a "files" module to lookup group specific options
+	#  Enable mods-available/dhcp_files to use this
+	#  Options are set in mods-config/files/dhcp
+	#dhcp_group_options
 
 	#  Use a "files" module to lookup host specific options
 	#  Enable mods-available/dhcp_files to use this

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -123,6 +123,16 @@ listen {
 #  At least one of these attributes should be set at the end of each
 #  section for a response to be sent.
 
+#  An internal attribute of DHCP-Network-IP-Address is set to provide
+#  a basis for determining the network that a client belongs to.  This
+#  is a hierarchical assignment based on:
+#
+#  - DHCP-Relay-Link-Selection
+#  - DHCP-Subnet-Selection-Option
+#  - DHCP-Gateway-IP-Address
+#  - DHCP-Client-IP-Address
+
+
 dhcp DHCP-Discover {
 
 	#  The DHCP Server Identifier is set here since is returned in OFFERs
@@ -132,6 +142,12 @@ dhcp DHCP-Discover {
 
 	#  Call a policy (defined in policy.d/dhcp) to set common reply attributes
 	dhcp_common
+
+	#  If clients need to be assigned to a particular network based on
+	#  an attribute in the packet rather than the calculated
+	#  DHCP-Network-IP-Address described above, then call a policy
+	#  (defined in policy.d/dhcp) to perform the override
+	#dhcp_override_network
 
 	#  Use a "files" module to lookup global and subnet options
 	#  For multiple subnets use this in place of dhcp_common
@@ -224,6 +240,10 @@ dhcp DHCP-Request {
 	#  Call a policy (defined in policy.d/dhcp) to set common reply attributes
 	dhcp_common
 
+	#  Optionally override the network address based on client attributes
+	#  See Discover section
+	#dhcp_override_network
+
 	#  Use a "files" module to lookup global and subnet options
 	#  For multiple subnets use this in place of dhcp_common
 	#  Enable mods-available/dhcp_files to use this
@@ -310,6 +330,10 @@ dhcp DHCP-Decline {
 dhcp DHCP-Inform {
 	#  Call a policy (defined in policy.d/dhcp) to set common reply attributes
 	dhcp_common
+
+	#  Optionally override the network address based on client attributes
+	#  See Discover section
+	#dhcp_override_network
 
 	#  Use a "files" module to lookup global and subnet options
 	#  For multiple subnets use this in place of dhcp_common

--- a/share/dictionary.dhcp
+++ b/share/dictionary.dhcp
@@ -61,8 +61,9 @@ ATTRIBUTE	DHCP-Relay-Max-Hop-Count		271	integer
 ATTRIBUTE	DHCP-Relay-IP-Address			272	ipaddr
 
 # This address is assigned on a hierarchical basis to then determine
-# the subnet which the client belongs to
-ATTRIBUTE	DHCP-Network-IP-Address			274	ipaddr
+# the subnet which the client belongs to.  Stored as an ipv4prefix
+# to allow closest subnet matching in rlm_files
+ATTRIBUTE	DHCP-Network-IP-Address			274	ipv4prefix
 # This is a name for the subnet a client belongs to then used for
 # looking up of options
 ATTRIBUTE	DHCP-Subnet-Name			275	string

--- a/share/dictionary.dhcp
+++ b/share/dictionary.dhcp
@@ -64,9 +64,9 @@ ATTRIBUTE	DHCP-Relay-IP-Address			272	ipaddr
 # the subnet which the client belongs to.  Stored as an ipv4prefix
 # to allow closest subnet matching in rlm_files
 ATTRIBUTE	DHCP-Network-IP-Address			274	ipv4prefix
-# This is a name for the subnet a client belongs to then used for
+# This is a name for the group a client belongs to then used for
 # looking up of options
-ATTRIBUTE	DHCP-Subnet-Name			275	string
+ATTRIBUTE	DHCP-Group-Name				275	string
 
 VALUE	DHCP-Flags			Broadcast		0x8000
 

--- a/src/modules/proto_dhcp/dhcp.c
+++ b/src/modules/proto_dhcp/dhcp.c
@@ -1143,7 +1143,7 @@ int fr_dhcp_decode(RADIUS_PACKET *packet)
 	 *	client belongs to based on packet data.  The sequence here
 	 *	is based on ISC DHCP behaviour and RFCs 3527 and 3011.  We
 	 *	store the found address in an internal attribute of 274 -
-	 *	DHCP-Network-IP-Address.  Thisis stored as an IPv4 prefix
+	 *	DHCP-Network-IP-Address.  This is stored as an IPv4 prefix
 	 *	with a /32 netmask allowing "closest containing subnet"
 	 *	matching in rlm_files
 	 */


### PR DESCRIPTION
Implement sample DHCP config to:

- demonstrate setting of DHCP options at global / network / group / host level using `rlm_files` and `rlm_passwd` modules
- add explanatory comments regarding the setting of internal parameter `DHCP-Network-IP-Address`

Update `DHCP-Network-IP-Address` to be an IPv4 prefix allowing closest enclosing subnet matching using `rlm_files` `<` and `<=` operators.