### PR TITLE
Fix DIAG_{ON,OFF} for external includes

### DIFF
--- a/src/include/atomic_queue.h
+++ b/src/include/atomic_queue.h
@@ -25,7 +25,13 @@
  */
 RCSIDH(atomic_queue_h, "$Id$")
 
+#ifdef HAVE_WDOCUMENTATION
+DIAG_OFF(documentation)
+#endif
 #include <talloc.h>
+#ifdef HAVE_WDOCUMENTATION
+DIAG_ON(documentation)
+#endif
 #include <stdbool.h>
 
 #ifdef HAVE_STDATOMIC_H

--- a/src/include/libradius.h
+++ b/src/include/libradius.h
@@ -57,7 +57,13 @@ RCSIDH(libradius_h, "$Id$")
  *  Talloc memory allocation is used in preference to malloc throughout
  *  the libraries and server.
  */
+#ifdef HAVE_WDOCUMENTATION
+DIAG_OFF(documentation)
+#endif
 #include <talloc.h>
+#ifdef HAVE_WDOCUMENTATION
+DIAG_ON(documentation)
+#endif
 
 /*
  *  Defines signatures for any missing functions.

--- a/src/modules/rlm_rest/rest.h
+++ b/src/modules/rlm_rest/rest.h
@@ -31,12 +31,20 @@ RCSIDH(other_h, "$Id$")
 #define CURL_NO_OLDIES 1
 #include <curl/curl.h>
 
+#ifdef HAVE_WDOCUMENTATION
+DIAG_OFF(documentation)
+#endif
+
 #ifdef HAVE_JSON
 #  if defined(HAVE_JSONMC_JSON_H)
 #    include <json-c/json.h>
 #  elif defined(HAVE_JSON_JSON_H)
 #    include <json/json.h>
 #  endif
+#endif
+
+#ifdef HAVE_WDOCUMENTATION
+DIAG_ON(documentation)
 #endif
 
 #define REST_URI_MAX_LEN		2048


### PR DESCRIPTION
Just to mute warnings with external headers.