### PR TITLE
Add DHCP-Network-IP-Address and fix matching in rlm_files

### DIFF
--- a/share/dictionary/dhcpv4/dictionary.freeradius.internal
+++ b/share/dictionary/dhcpv4/dictionary.freeradius.internal
@@ -105,3 +105,10 @@ VALUE	Packet-Type			DHCP-Lease-Unknown	12
 VALUE	Packet-Type			DHCP-Lease-Active	13
 VALUE	Packet-Type			DHCP-Bulk-Lease-Query	14
 VALUE	Packet-Type			DHCP-Lease-Query-Done	15
+
+# This address is assigned on a hierarchical basis to then determine
+# the subnet which the client belongs to
+ATTRIBUTE	DHCP-Network-IP-Address			274	ipaddr
+# This is a name for the group(s) a client belongs to, used for
+# looking up of options
+ATTRIBUTE	DHCP-Group-Name				275	string

--- a/share/dictionary/dhcpv4/dictionary.freeradius.internal
+++ b/share/dictionary/dhcpv4/dictionary.freeradius.internal
@@ -107,8 +107,9 @@ VALUE	Packet-Type			DHCP-Bulk-Lease-Query	14
 VALUE	Packet-Type			DHCP-Lease-Query-Done	15
 
 # This address is assigned on a hierarchical basis to then determine
-# the subnet which the client belongs to
-ATTRIBUTE	DHCP-Network-IP-Address			274	ipaddr
+# the subnet which the client belongs to.  Stored as a prefix to
+# enable closest subnet matching
+ATTRIBUTE	DHCP-Network-IP-Address			274	ipv4prefix
 # This is a name for the group(s) a client belongs to, used for
 # looking up of options
 ATTRIBUTE	DHCP-Group-Name				275	string

--- a/share/dictionary/dhcpv4/dictionary.rfc2131
+++ b/share/dictionary/dhcpv4/dictionary.rfc2131
@@ -225,7 +225,7 @@ ATTRIBUTE	DHCP-Auto-Config			116	byte
 # Name Service Search
 ATTRIBUTE	DHCP-Name-Service-Search		117	octets
 # Subnet Selection Option
-ATTRIBUTE	DHCP-Subnet-Selection-Option		118	octets
+ATTRIBUTE	DHCP-Subnet-Selection-Option		118	ipaddr
 # DNS domain serach list
 ATTRIBUTE	DHCP-Domain-Search			119	octets
 # SIP-Servers DHCP Option

--- a/src/modules/rlm_files/rlm_files.c
+++ b/src/modules/rlm_files/rlm_files.c
@@ -373,6 +373,9 @@ static rlm_rcode_t file_common(rlm_files_t const *inst, REQUEST *request, char c
 			 */
 			if (!fall_through(pl->reply)) break;
 		}
+
+		/* Ensure temporary check list is clear before next match */
+		fr_pair_list_free(&check_tmp);
 	}
 
 	/*

--- a/src/modules/rlm_files/rlm_files.c
+++ b/src/modules/rlm_files/rlm_files.c
@@ -454,5 +454,18 @@ module_t rlm_files = {
 		[MOD_PREACCT]		= mod_preacct,
 		[MOD_POST_AUTH]		= mod_post_auth
 	},
-};
+	.method_names = (module_method_names_t[]){
+		/*
+		 * Use mod_authorize for all DHCP processing - for consistent
+		 * use of data in the file referenced by "filename"
+		 */
+		{ "recv",	"DHCP-Discover",	mod_authorize },
+		{ "recv",	"DHCP-Request",		mod_authorize },
+		{ "recv",	"DHCP-Inform",		mod_authorize },
+		{ "recv",	"DHCP-Release",		mod_authorize },
+		{ "recv",	"DHCP-Decline",		mod_authorize },
 
+		MODULE_NAME_TERMINATOR
+	}
+
+};

--- a/src/protocols/dhcpv4/attrs.h
+++ b/src/protocols/dhcpv4/attrs.h
@@ -49,3 +49,6 @@ extern fr_dict_attr_t const *attr_dhcp_message_type;
 extern fr_dict_attr_t const *attr_dhcp_parameter_request_list;
 extern fr_dict_attr_t const *attr_dhcp_overload;
 extern fr_dict_attr_t const *attr_dhcp_vendor_class_identifier;
+extern fr_dict_attr_t const *attr_dhcp_relay_link_selection;
+extern fr_dict_attr_t const *attr_dhcp_subnet_selection_option;
+extern fr_dict_attr_t const *attr_dhcp_network_ip_address;

--- a/src/protocols/dhcpv4/base.c
+++ b/src/protocols/dhcpv4/base.c
@@ -66,6 +66,9 @@ fr_dict_attr_t const *attr_dhcp_message_type;
 fr_dict_attr_t const *attr_dhcp_parameter_request_list;
 fr_dict_attr_t const *attr_dhcp_overload;
 fr_dict_attr_t const *attr_dhcp_vendor_class_identifier;
+fr_dict_attr_t const *attr_dhcp_relay_link_selection;
+fr_dict_attr_t const *attr_dhcp_subnet_selection_option;
+fr_dict_attr_t const *attr_dhcp_network_ip_address;
 
 extern fr_dict_attr_autoload_t dhcpv4_dict_attr[];
 fr_dict_attr_autoload_t dhcpv4_dict_attr[] = {
@@ -89,6 +92,9 @@ fr_dict_attr_autoload_t dhcpv4_dict_attr[] = {
 	{ .out = &attr_dhcp_parameter_request_list, .name = "DHCP-Parameter-Request-List", .type = FR_TYPE_UINT8, .dict = &dict_dhcpv4 },
 	{ .out = &attr_dhcp_overload, .name = "DHCP-Overload", .type = FR_TYPE_UINT8, .dict = &dict_dhcpv4 },
 	{ .out = &attr_dhcp_vendor_class_identifier, .name = "DHCP-Vendor-Class-Identifier", .type = FR_TYPE_OCTETS, .dict = &dict_dhcpv4 },
+	{ .out = &attr_dhcp_relay_link_selection, .name = "DHCP-Relay-Link-Selection", .type = FR_TYPE_IPV4_ADDR, .dict = &dict_dhcpv4 },
+	{ .out = &attr_dhcp_subnet_selection_option, .name = "DHCP-Subnet-Selection-Option", .type = FR_TYPE_IPV4_ADDR, .dict = &dict_dhcpv4 },
+	{ .out = &attr_dhcp_network_ip_address, .name = "DHCP-Network-IP-Address", .type = FR_TYPE_IPV4_ADDR, .dict = &dict_dhcpv4 },
 	{ NULL }
 };
 

--- a/src/protocols/dhcpv4/base.c
+++ b/src/protocols/dhcpv4/base.c
@@ -94,7 +94,7 @@ fr_dict_attr_autoload_t dhcpv4_dict_attr[] = {
 	{ .out = &attr_dhcp_vendor_class_identifier, .name = "DHCP-Vendor-Class-Identifier", .type = FR_TYPE_OCTETS, .dict = &dict_dhcpv4 },
 	{ .out = &attr_dhcp_relay_link_selection, .name = "DHCP-Relay-Link-Selection", .type = FR_TYPE_IPV4_ADDR, .dict = &dict_dhcpv4 },
 	{ .out = &attr_dhcp_subnet_selection_option, .name = "DHCP-Subnet-Selection-Option", .type = FR_TYPE_IPV4_ADDR, .dict = &dict_dhcpv4 },
-	{ .out = &attr_dhcp_network_ip_address, .name = "DHCP-Network-IP-Address", .type = FR_TYPE_IPV4_ADDR, .dict = &dict_dhcpv4 },
+	{ .out = &attr_dhcp_network_ip_address, .name = "DHCP-Network-IP-Address", .type = FR_TYPE_IPV4_PREFIX, .dict = &dict_dhcpv4 },
 	{ NULL }
 };
 


### PR DESCRIPTION
Add DHCP-Network-IP-Address as per changes already applied to v3, to allow determining of the network which a DHCP client belongs to.

`rlm_files` was not correctly clearing the temporary list of check items after failed matches, causing subsequent matches to be done against previous values.