### PR TITLE
v3.0.x: DHCP default policy improvements

### DIFF
--- a/raddb/mods-available/dhcp_files
+++ b/raddb/mods-available/dhcp_files
@@ -5,13 +5,23 @@
 # Instances of the "files" module for managing DHCP options
 #
 files dhcp_network {
-	#  The file containing DHCP options mapping
+	#  The file containing network-specific DHCP options mapping
 	filename = ${modconfdir}/files/dhcp
 
 	#  For network lookups we use a fixed key.  Matching
 	#  actual networks is done by additional filtering within
 	#  the file
 	key = "network"
+}
+
+files dhcp_subnet {
+	#  The file containing subnet-specific DHCP options mapping
+	filename = ${modconfdir}/files/dhcp
+
+	#  For subnet lookups we use a fixed key.  Matching
+	#  actual subnets is done by additional filtering within
+	#  the file
+	key = "subnet"
 }
 
 files dhcp_set_group_options {

--- a/raddb/mods-available/dhcp_passwd
+++ b/raddb/mods-available/dhcp_passwd
@@ -13,7 +13,7 @@
 
 passwd dhcp_group_membership {
 	filename = "${modconfdir}/files/dhcp_groups"
-	format = "DHCP-Group-Name:*,DHCP-Client-Hardware-Address"
+	format = "~DHCP-Group-Name:*,DHCP-Client-Hardware-Address"
 	hash_size = 100
 	allow_multiple_keys = yes
 	delimiter = "|"

--- a/raddb/mods-config/files/dhcp
+++ b/raddb/mods-config/files/dhcp
@@ -42,5 +42,5 @@ host-00:10:20:30:40:50
 	DHCP-Boot-Filename := "customboot.pxe"
 
 host-10:90:80:70:aa:bb
-	DHCP-Font-Server := 10.20.1.10,
+	DHCP-X-Window-Font-Server := 10.20.1.10,
 	DHCP-Impress-Server := 10.20.1.20

--- a/raddb/mods-config/files/dhcp
+++ b/raddb/mods-config/files/dhcp
@@ -30,7 +30,7 @@ network
 
 #
 #  The following examples set options specific to the Layer 2 network, matched
-#  on whether the internal attribute DHCP-Network-IP-Address (that acts as a
+#  on whether the internal attribute DHCP-Network-Subnet (that acts as a
 #  network identifier) is within the indicated range. This is equivalent to a
 #  "shared-network" or "multinet" configuration (i.e. one that is possibly
 #  composed of multiple subnets) as defined by some other DHCP servers.
@@ -46,7 +46,7 @@ network
 #  then by placing all subnet-related options here we can avoid calling the
 #  dhcp_subnet policy after IP allocation.
 #
-network	DHCP-Network-IP-Address < 10.20.0.0/16, Pool-Name := "smalldept"
+network	DHCP-Network-Subnet < 10.20.0.0/16, Pool-Name := "smalldept"
 	DHCP-IP-Address-Lease-Time := 3600,
 	DHCP-Domain-Name := "smalldept.example.org",
 	DHCP-Subnet-Mask := 255.255.0.0,
@@ -64,7 +64,7 @@ network	DHCP-Network-IP-Address < 10.20.0.0/16, Pool-Name := "smalldept"
 #  address has been allocated. Only then do we know which subnet parameters are
 #  required. See the next section.
 #
-network	DHCP-Network-IP-Address < 10.30.0.0/16, Pool-Name := "bigdept"
+network	DHCP-Network-Subnet < 10.30.0.0/16, Pool-Name := "bigdept"
 	DHCP-Domain-Name := "bigdept.example.org"
 
 
@@ -72,8 +72,8 @@ network	DHCP-Network-IP-Address < 10.30.0.0/16, Pool-Name := "bigdept"
 #  Here is an example for a network that has a dedicated pool for admin staff
 #  and a seperate pool for everything else.
 #
-network	DHCP-Network-IP-Address < 192.0.2.0/24, DHCP-Group-Name == "admin", Pool-Name := "admin-only"
-network	DHCP-Network-IP-Address < 192.0.2.0/24, Pool-Name := "general"
+network	DHCP-Network-Subnet < 192.0.2.0/24, DHCP-Group-Name == "admin", Pool-Name := "admin-only"
+network	DHCP-Network-Subnet < 192.0.2.0/24, Pool-Name := "general"
 
 
 ################################
@@ -82,7 +82,7 @@ network	DHCP-Network-IP-Address < 192.0.2.0/24, Pool-Name := "general"
 
 #
 #  Note: This section is matched by calling the dhcp_subnet policy which sets
-#  DHCP-Network-IP-Address to the allocated IP address of the device and then
+#  DHCP-Network-Subnet to the allocated IP address of the device and then
 #  calls the dhcp_subnet instance of the files module.
 #
 #  Layer 2 networks many contain multiple subnets, each with their own gateway.
@@ -96,12 +96,12 @@ network	DHCP-Network-IP-Address < 192.0.2.0/24, Pool-Name := "general"
 #  Subnet-specific options, matched on whether the allocated IP address is
 #  within the indicated range.
 #
-subnet	DHCP-Network-IP-Address < 10.30.10.0/24
+subnet	DHCP-Network-Subnet < 10.30.10.0/24
 	DHCP-Subnet-Mask := 255.255.255.0,
 	DHCP-Router-Address := 10.30.10.1,
 	DHCP-Broadcast-Address := 10.30.10.255
 
-subnet	DHCP-Network-IP-Address < 10.30.20.0/24
+subnet	DHCP-Network-Subnet < 10.30.20.0/24
 	DHCP-Subnet-Mask := 255.255.255.0,
 	DHCP-Router-Address := 10.30.20.1,
 	DHCP-Broadcast-Address := 10.30.20.255

--- a/raddb/mods-config/files/dhcp
+++ b/raddb/mods-config/files/dhcp
@@ -32,8 +32,8 @@ network
 #  The following examples set options specific to the Layer 2 network, matched
 #  on whether the internal attribute DHCP-Network-IP-Address (that acts as a
 #  network identifier) is within the indicated range. This is equivalent to a
-#  "shared-network" (i.e. one that is possibly composed of multiple subnets) as
-#  defined by some other DHCP servers.
+#  "shared-network" or "multinet" configuration (i.e. one that is possibly
+#  composed of multiple subnets) as defined by some other DHCP servers.
 #
 
 #

--- a/raddb/mods-config/files/dhcp
+++ b/raddb/mods-config/files/dhcp
@@ -1,12 +1,23 @@
 #
-#  Global and network specific parameters
+#  This configuration file that may be used by multiple instances of rlm_files
+#  to set reply and control options for defining DHCP replies.
+#
+#  The content of this file is all made up and needs to be set appropriate to
+#  the network being served.
 #
 
+############################################
+#  Global and network-specific parameters  #
+############################################
+
 #
-#  First set default global attributes.
-#  These can be overwritten by subnets below.
-#  This is all made up and needs to be set appropriate to the network
-#  being served.
+#  Note: This section is matched by calling the dhcp_network instance of the
+#  files module.
+#
+
+
+#
+#  Default options that can be overridden by subsequent matches.
 #
 network
 	DHCP-Domain-Name-Server := 192.0.1.100,
@@ -16,27 +27,110 @@ network
 	DHCP-IP-Address-Lease-Time := 7200,
 	Fall-Through := yes
 
-#
-#  Set options relevant to subnets
-#
-network	DHCP-Network-IP-Address < 10.20.0.0/16, Pool-Name := "staff"
-	DHCP-Router-Address := 10.20.1.1
-
-network	DHCP-Network-IP-Address < 10.30.0.0/16, Pool-Name := "visitors"
-	DHCP-Router-Address := 10.30.1.1,
-	DHCP-Domain-Name := "guests.example.org",
-	DHCP-IP-Address-Lease-Time := 3600
 
 #
-#  Set group specific options
+#  The following examples set options specific to the Layer 2 network, matched
+#  on whether the internal attribute DHCP-Network-IP-Address (that acts as a
+#  network identifier) is within the indicated range. This is equivalent to a
+#  "shared-network" (i.e. one that is possibly composed of multiple subnets) as
+#  defined by some other DHCP servers.
+#
+
+#
+#  Here is an example for a network containing a single IP subnet. We can set
+#  the network-specific options *and* we directly set the DHCP-Subnet-Mask,
+#  DHCP-Router-Address and DHCP-Broadcast-Address since it is a common reply
+#  parameter for all DHCP requests originating from this network.
+#
+#  Note: If the architecture has only a single subnet for each Layer 2 network
+#  then by placing all subnet-related options here we can avoid calling the
+#  dhcp_subnet policy after IP allocation.
+#
+network	DHCP-Network-IP-Address < 10.20.0.0/16, Pool-Name := "smalldept"
+	DHCP-IP-Address-Lease-Time := 3600,
+	DHCP-Domain-Name := "smalldept.example.org",
+	DHCP-Subnet-Mask := 255.255.0.0,
+	DHCP-Router-Address := 10.20.0.1,
+	DHCP-Broadcast-Address := 10.20.255.255
+
+#
+#  Here is an example for a network that consists of multiple IP subnets, each
+#  of which is valid for a DHCP request originating from the network. We set
+#  the Pool-Name parameter to identify a single pool that contains the IP
+#  address within each subnet, any of which is suitable.
+#
+#  We set the options that are common to the network but we defer the setting
+#  of DHCP-Subnet-Mask, DHCP-Router-Address and DHCP-Broadcast-Address until an
+#  address has been allocated. Only then do we know which subnet parameters are
+#  required. See the next section.
+#
+network	DHCP-Network-IP-Address < 10.30.0.0/16, Pool-Name := "bigdept"
+	DHCP-Domain-Name := "bigdept.example.org"
+
+
+################################
+#  Subnet-specific parameters  #
+################################
+
+#
+#  Note: This section is matched by calling the dhcp_subnet policy which sets
+#  DHCP-Network-IP-Address to the allocated IP address of the device and then
+#  calls the dhcp_subnet instance of the files module.
+#
+#  Layer 2 networks many contain multiple subnets, each with their own gateway.
+#  We call this section *after* the allocation of an IP address (e.g. from a
+#  single pool containing addresses within multiple equally-valid subnets for
+#  the network) so that we then know which subnet-specific parameters to
+#  return.
+#
+
+#
+#  Subnet-specific options, matched on whether the allocated IP address is
+#  within the indicated range.
+#
+subnet	DHCP-Network-IP-Address < 10.30.10.0/24
+	DHCP-Subnet-Mask := 255.255.255.0,
+	DHCP-Router-Address := 10.30.10.1,
+	DHCP-Broadcast-Address := 10.30.10.255
+
+subnet	DHCP-Network-IP-Address < 10.30.20.0/24
+	DHCP-Subnet-Mask := 255.255.255.0,
+	DHCP-Router-Address := 10.30.20.1,
+	DHCP-Broadcast-Address := 10.30.20.255
+
+
+###############################
+#  Group-specific parameters  #
+###############################
+
+#
+#  Note: This section is matched by calling the dhcp_group_options policy.
+#
+#  It should be called *after* defining the device's group memberships in
+#  DHCP-Group-Name control attributes. In the default dhcp virtual server
+#  this is demonstrated with the help of the dhcp_group_membership instance of
+#  the passwd module.
+#
+
+#
+#  Group-specific options, keyed by DHCP-Group-Name
 #
 group1
 	DHCP-Server-Host-Name := "terminal-booter.example.org",
 	DHCP-Boot-Filename := "bootfile.pxe"
 
 
+##############################
+#  Host-specific parameters  #
+##############################
+
 #
-#  Set host specific options
+#  Note: This section is matched by calling the dhcp_hosts instance of the
+#  files module.
+#
+
+#
+#  Host-specific options, keyed by DHCP-Client-Hardware-Address
 #
 host-00:10:20:30:40:50
 	DHCP-Boot-Filename := "customboot.pxe"

--- a/raddb/mods-config/files/dhcp
+++ b/raddb/mods-config/files/dhcp
@@ -68,6 +68,14 @@ network	DHCP-Network-IP-Address < 10.30.0.0/16, Pool-Name := "bigdept"
 	DHCP-Domain-Name := "bigdept.example.org"
 
 
+#
+#  Here is an example for a network that has a dedicated pool for admin staff
+#  and a seperate pool for everything else.
+#
+network	DHCP-Network-IP-Address < 192.0.2.0/24, DHCP-Group-Name == "admin", Pool-Name := "admin-only"
+network	DHCP-Network-IP-Address < 192.0.2.0/24, Pool-Name := "general"
+
+
 ################################
 #  Subnet-specific parameters  #
 ################################
@@ -107,9 +115,9 @@ subnet	DHCP-Network-IP-Address < 10.30.20.0/24
 #  Note: This section is matched by calling the dhcp_group_options policy.
 #
 #  It should be called *after* defining the device's group memberships in
-#  DHCP-Group-Name control attributes. In the default dhcp virtual server
-#  this is demonstrated with the help of the dhcp_group_membership instance of
-#  the passwd module.
+#  DHCP-Group-Name request attributes. In the default dhcp virtual server this
+#  is demonstrated with the help of the dhcp_group_membership instance of the
+#  passwd module.
 #
 
 #

--- a/raddb/policy.d/dhcp
+++ b/raddb/policy.d/dhcp
@@ -21,7 +21,7 @@ dhcp_common {
 #	}
 #}
 
-#  Policy to override DHCP-Network-IP-Address
+#  Policy to override DHCP-Network-Subnet
 #
 #  Some networks have a "shared-network" or "multinet" configuration (as
 #  defined by some other DHCP servers) in which multiple IP subnets may
@@ -42,12 +42,12 @@ dhcp_common {
 #  with unique identifiers in the *network-specific* section of
 #  mods-config/files/dhcp.
 #
-#  By default DHCP-Network-IP-Address is populated such that it normally
+#  By default DHCP-Network-Subnet is populated such that it normally
 #  refers to the Layer 2 network from which the DHCP query originates - we
 #  cannot know the intended subnet for the device without additional input to
 #  the policy.
 #
-#  Override DHCP-Network-IP-Address to be an address within the desired
+#  Override DHCP-Network-Subnet to be an address within the desired
 #  network to force selection of a particular address pool and/or network
 #  parameters.
 #
@@ -61,17 +61,17 @@ dhcp_common {
 #dhcp_override_network {
 #	if (&DHCP-Vendor-Class-Identifier && &DHCP-Vendor-Class-Identifier == "SIP100")
 #		update request {
-#			DHCP-Network-IP-Address := 10.10.0.0
+#			DHCP-Network-Subnet := 10.10.0.0
 #		}
 #	}
 #}
 
 
 #  Policy that calls the files instance of the same name after first making
-#  DHCP-Network-IP-Address specific to the allocated IP address of the client.
+#  DHCP-Network-Subnet specific to the allocated IP address of the client.
 #dhcp_subnet {
 #	update {
-#		&DHCP-Network-IP-Address := "%{%{reply:DHCP-Your-IP-Address}:-%{DHCP-Client-IP-Address}}"
+#		&DHCP-Network-Subnet := "%{%{reply:DHCP-Your-IP-Address}:-%{DHCP-Client-IP-Address}}"
 #	}
 #
 #	# Call the dhcp_subnet instance of the files module

--- a/raddb/policy.d/dhcp
+++ b/raddb/policy.d/dhcp
@@ -23,8 +23,9 @@ dhcp_common {
 
 #  Policy to override DHCP-Network-IP-Address
 #
-#  Some network configurations have "shared-networks" in which multiple IP
-#  subnets may co-exist in a single Layer 2 network (or VLAN).
+#  Some networks have a "shared-network" or "multinet" configuration (as
+#  defined by some other DHCP servers) in which multiple IP subnets may
+#  co-exist in a single Layer 2 network (or VLAN).
 #
 #  In enterprise environments this is often for the purpose of providing loose
 #  segregation between classes of devices such as local network-attached

--- a/raddb/policy.d/dhcp
+++ b/raddb/policy.d/dhcp
@@ -24,11 +24,17 @@ dhcp_common {
 #  Policy to override DHCP-Network-IP-Address
 #
 #  Some network configurations have "shared-networks" in which multiple IP
-#  subnets may co-exist in a single Layer 2 network (or VLAN) for the purpose
-#  of provide loose segregation between classes of devices such as local
-#  network atached storage or IP telephony. (There may be valid reasons why
-#  each of the subnets is not seperately VLANed, such as to enable the use of
-#  ICMP redirects to avoid routing cross-subnet traffic via a gateway.)
+#  subnets may co-exist in a single Layer 2 network (or VLAN).
+#
+#  In enterprise environments this is often for the purpose of providing loose
+#  segregation between classes of devices such as local network-attached
+#  storage or IP telephony. There are valid reasons why each of the subnets is
+#  not seperately VLANed, such as to enable the use of ICMP redirects to avoid
+#  hairpinning of cross-subnet traffic via a gateway.
+#
+#  In ISP environments this is a common configuration for edge networks whose
+#  access is provided by DOCSIS cable modems that share a VLAN with the devices
+#  they provide a service to but are seperately addressed.
 #
 #  Where it is necessary to force the selection of a particular subnet for a
 #  device, multiple pools must be configured for each subnet and referenced

--- a/raddb/policy.d/dhcp
+++ b/raddb/policy.d/dhcp
@@ -16,7 +16,7 @@ dhcp_common {
 #  of multiple groups so can cover the ISC concepts of "group" and "class"
 #  To use this enable the "dhcp_files" module
 #dhcp_group_options {
-#	foreach &control:DHCP-Group-Name {
+#	foreach &request:DHCP-Group-Name {
 #		dhcp_set_group_options
 #	}
 #}

--- a/raddb/policy.d/dhcp
+++ b/raddb/policy.d/dhcp
@@ -6,6 +6,7 @@ dhcp_common {
 		&DHCP-Domain-Name-Server = 127.0.0.2
 		&DHCP-Subnet-Mask = 255.255.255.0
 		&DHCP-Router-Address = 192.0.2.1
+		&DHCP-Broadcast-Address = 192.0.2.255
 		&DHCP-IP-Address-Lease-Time = 7200
 		&DHCP-DHCP-Server-Identifier = &control:DHCP-DHCP-Server-Identifier
 	}
@@ -23,23 +24,51 @@ dhcp_common {
 #  Policy to override DHCP-Network-IP-Address
 #
 #  Some network configurations have "shared-networks" in which multiple IP
-#  subnets may co-exist in a single Layer 2 network (or VLAN).  This may be
-#  due to discontinuous extension of the original address plan or it may be
-#  to provide loose segregation between classes of devices such as local
-#  network atached storage or IP telephony.
+#  subnets may co-exist in a single Layer 2 network (or VLAN) for the purpose
+#  of provide loose segregation between classes of devices such as local
+#  network atached storage or IP telephony. (There may be valid reasons why
+#  each of the subnets is not seperately VLANed, such as to enable the use of
+#  ICMP redirects to avoid routing cross-subnet traffic via a gateway.)
+#
+#  Where it is necessary to force the selection of a particular subnet for a
+#  device, multiple pools must be configured for each subnet and referenced
+#  with unique identifiers in the *network-specific* section of
+#  mods-config/files/dhcp.
 #
 #  By default DHCP-Network-IP-Address is populated such that it normally
-#  refers to the Layer 2 network from which the DHCP query originates - it
-#  cannot know the intended subnet for the device without policy input.
+#  refers to the Layer 2 network from which the DHCP query originates - we
+#  cannot know the intended subnet for the device without additional input to
+#  the policy.
+#
 #  Override DHCP-Network-IP-Address to be an address within the desired
-#  subnet to force selection of particular network parameters including
-#  the address pool
+#  network to force selection of a particular address pool and/or network
+#  parameters.
+#
+#  Note: If each subnet within a network is equally valid for the DHCP requests
+#  originating from that network then you do not need to call this policy,
+#  rather look at the examples concerning dhcp_subnet in
+#  mods-config/files/dhcp instead, which use a single pool containing addresses
+#  from all subnets then set the correct subnet-specific options based on the
+#  randomly assigned IP address.
+#
 #dhcp_override_network {
 #	if (&DHCP-Vendor-Class-Identifier && &DHCP-Vendor-Class-Identifier == "SIP100")
 #		update request {
 #			DHCP-Network-IP-Address := 10.10.0.0
 #		}
 #	}
+#}
+
+
+#  Policy that calls the files instance of the same name after first making
+#  DHCP-Network-IP-Address specific to the allocated IP address of the client.
+#dhcp_subnet {
+#	update {
+#		&DHCP-Network-IP-Address := "%{%{reply:DHCP-Your-IP-Address}:-%{DHCP-Client-IP-Address}}"
+#	}
+#
+#	# Call the dhcp_subnet instance of the files module
+#	dhcp_subnet
 #}
 
 #  Assign compatibility data to request for sqlippool for DHCP Request

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -304,6 +304,10 @@ dhcp DHCP-Request {
 
 dhcp DHCP-Decline {
 
+	#  Optionally override the network address based on client attributes
+	#  See Discover section
+	#dhcp_override_network
+
 	#  Use a "files" module to lookup global and subnet options
 	#  Enable mods-available/dhcp_files to use this
 	#  Options are set in mods-config/files/dhcp
@@ -372,6 +376,10 @@ dhcp DHCP-Inform {
 #}
 
 dhcp DHCP-Release {
+
+	#  Optionally override the network address based on client attributes
+	#  See Discover section
+	#dhcp_override_network
 
 	#  Use a "files" module to lookup global and subnet options
 	#  For multiple subnets use this in place of dhcp_common

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -147,10 +147,13 @@ listen {
 #  define the required IP allocated policy, DHCP-Network-IP-Address may be
 #  overridden to force the selection of a particular pool.
 #
-#  The IP addresses belonging to a single pool covering a shared-network may be
-#  members of different subnets in which case the dhcp_subnet policy can be
-#  used to set the correct DHCP-Subnet-Mask, DHCP-Router-Address and
-#  DHCP-Broadcast-Address options based on the allocated IP.
+#  IP addresses belonging to a single pool that is designated for a Layer 2
+#  network containing multiple subnets (a "shared-network" or "multinet"
+#  configuration as defined by some other DHCP servers), will by definition be
+#  members of distinct subnets that require their own DHCP reply parameters. In
+#  this case the dhcp_subnet policy can be used to set the correct
+#  DHCP-Subnet-Mask, DHCP-Router-Address and DHCP-Broadcast-Address options
+#  based on the allocated IP.
 
 dhcp DHCP-Discover {
 

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -123,7 +123,7 @@ listen {
 #  At least one of these attributes should be set at the end of each
 #  section for a response to be sent.
 
-#  An internal attribute of DHCP-Network-IP-Address is set to provide
+#  An internal attribute of DHCP-Network-Subnet is set to provide
 #  a basis for determining the network that a client belongs to.  This
 #  is a hierarchical assignment based on:
 #
@@ -140,11 +140,11 @@ listen {
 #  devices designated as users of the pool. During IP allocation the choice of
 #  pool is driven by setting the Pool-Name attribute which may either be
 #  specified directly or chosen (usually with the help of the dhcp_network
-#  module) based on the initial value of DHCP-Network-IP-Address.
+#  module) based on the initial value of DHCP-Network-Subnet.
 #
-#  DHCP-Network-IP-Address indicates the network from which the request is
+#  DHCP-Network-Subnet indicates the network from which the request is
 #  originating. In cases where the originating network alone is insufficent to
-#  define the required IP allocated policy, DHCP-Network-IP-Address may be
+#  define the required IP allocated policy, DHCP-Network-Subnet may be
 #  overridden to force the selection of a particular pool.
 #
 #  IP addresses belonging to a single pool that is designated for a Layer 2
@@ -171,7 +171,7 @@ dhcp DHCP-Discover {
 
 	#  If clients need to be assigned to a particular network based on
 	#  an attribute in the packet rather than the calculated
-	#  DHCP-Network-IP-Address described above, then call a policy
+	#  DHCP-Network-Subnet described above, then call a policy
 	#  (defined in policy.d/dhcp) to perform the override
 	#dhcp_override_network
 

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -205,6 +205,9 @@ dhcp DHCP-Discover {
 	#
 	#  Set any subnet-specific parameters using this policy.
 	#
+	#  Enable mods-available/dhcp_files AND uncomment dhcp_subnet in
+	#  policy.d/dhcp to use this.
+	#
 	#dhcp_subnet
 
 	#  Use a "passwd" module to determine group membership
@@ -277,7 +280,8 @@ dhcp DHCP-Request {
 
 	#  Use a "files" module to lookup global and subnet options
 	#  For multiple subnets use this in place of dhcp_common
-	#  Enable mods-available/dhcp_files to use this
+	#  Enable mods-available/dhcp_files AND uncomment dhcp_subnet in
+	#  policy.d/dhcp to use this
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_network
 
@@ -387,7 +391,8 @@ dhcp DHCP-Inform {
 
 	#  Use a policy with calls a "files" module of the same name to lookup
 	#  subnet options
-	#  Enable mods-available/dhcp_files to use this
+	#  Enable mods-available/dhcp_files AND uncomment dhcp_subnet in
+	#  policy.d/dhcp to use this
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_subnet
 

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -127,11 +127,30 @@ listen {
 #  a basis for determining the network that a client belongs to.  This
 #  is a hierarchical assignment based on:
 #
-#  - DHCP-Relay-Link-Selection
-#  - DHCP-Subnet-Selection-Option
-#  - DHCP-Gateway-IP-Address
-#  - DHCP-Client-IP-Address
-
+#    - DHCP-Relay-Link-Selection
+#    - DHCP-Subnet-Selection-Option
+#    - DHCP-Gateway-IP-Address
+#    - DHCP-Client-IP-Address
+#
+#  Except for cases where all IP allocation is performed using a mapping from
+#  the device MAC address to a fixed IP address the DHCP configuration will
+#  involve the use of one or more pools.
+#
+#  Each pool should be composed of a set of equally valid IP addresses for the
+#  devices designated as users of the pool. During IP allocation the choice of
+#  pool is driven by setting the Pool-Name attribute which may either be
+#  specified directly or chosen (usually with the help of the dhcp_network
+#  module) based on the initial value of DHCP-Network-IP-Address.
+#
+#  DHCP-Network-IP-Address indicates the network from which the request is
+#  originating. In cases where the originating network alone is insufficent to
+#  define the required IP allocated policy, DHCP-Network-IP-Address may be
+#  overridden to force the selection of a particular pool.
+#
+#  The IP addresses belonging to a single pool covering a shared-network may be
+#  members of different subnets in which case the dhcp_subnet policy can be
+#  used to set the correct DHCP-Subnet-Mask, DHCP-Router-Address and
+#  DHCP-Broadcast-Address options based on the allocated IP.
 
 dhcp DHCP-Discover {
 
@@ -155,6 +174,36 @@ dhcp DHCP-Discover {
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_network
 
+	#  Do a simple mapping of MAC to assigned IP.
+	#
+	#  See below for the definition of the "mac2ip"
+	#  module.
+	#
+	#mac2ip
+
+	#  Or, allocate IPs from the DHCP pool in SQL. You may need to
+	#  set the pool name here if you haven't set it elsewhere.
+	#update control {
+	#	&Pool-Name := "local"
+	#}
+	#dhcp_sqlippool
+
+	#  If the IP address was not allocated, do something else.
+	#  You could call a Perl, Python, or Java script here.
+	#if (notfound) {
+	# ...
+	#}
+
+	#  "Shared-networks" may have multiple IP subnets co-existing in a
+	#  single Layer 2 network. If the pool for the network contains
+	#  addresses from more that one subnet then the setting subnet-specific
+	#  DHCP-Subnet-Mask, DHCP-Router-Address and DHCP-Broadcast-Address
+	#  parameters must be performed after the allocation of the IP address.
+	#
+	#  Set any subnet-specific parameters using this policy.
+	#
+	#dhcp_subnet
+
 	#  Use a "passwd" module to determine group membership
 	#  Enable mods-available/dhcp_passwd to use this
 	#dhcp_group_membership
@@ -168,27 +217,6 @@ dhcp DHCP-Discover {
 	#  Enable mods-available/dhcp_files to use this
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_hosts
-
-	#  Do a simple mapping of MAC to assigned IP.
-	#
-	#  See below for the definition of the "mac2ip"
-	#  module.
-	#
-	#mac2ip
-
-	#  If the MAC wasn't found in that list, do something else.
-	#  You could call a Perl, Python, or Java script here.
-
-	#if (notfound) {
-	# ...
-	#}
-
-	#  Or, allocate IPs from the DHCP pool in SQL. You may need to
-	#  set the pool name here if you haven't set it elsewhere.
-#	update control {
-#		&Pool-Name := "local"
-#	}
-#	dhcp_sqlippool
 
 	#  Set the type of packet to send in reply.
 	#
@@ -250,6 +278,36 @@ dhcp DHCP-Request {
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_network
 
+	#  Do a simple mapping of MAC to assigned IP.
+	#
+	#  See below for the definition of the "mac2ip"
+	#  module.
+	#
+	#mac2ip
+
+	#  Or, allocate IPs from the DHCP pool in SQL. You may need to
+	#  set the pool name here if you haven't set it elsewhere.
+#	update control {
+#		&Pool-Name := "local"
+#	}
+#	dhcp_sqlippool_request
+
+	#  If the IP was not allocated, do something else.
+	#  You could call a Perl, Python, or Java script here.
+	#if (notfound) {
+	# ...
+	#}
+
+	#  "Shared-networks" may have multiple IP subnets co-existing in a
+	#  single Layer 2 network. If the pool for the network contains
+	#  addresses from more that one subnet then the setting subnet-specific
+	#  DHCP-Subnet-Mask, DHCP-Router-Address and DHCP-Broadcast-Address
+	#  parameters must be performed after the allocation of the IP address.
+	#
+	#  Set any subnet-specific parameters using this policy.
+	#
+	#dhcp_subnet
+
 	#  Use a "passwd" module to determine group membership
 	#  Enable mods-available/dhcp_passwd to use this
 	#dhcp_group_membership
@@ -263,27 +321,6 @@ dhcp DHCP-Request {
 	#  Enable mods-available/dhcp_files to use this
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_hosts
-
-	#  Do a simple mapping of MAC to assigned IP.
-	#
-	#  See below for the definition of the "mac2ip"
-	#  module.
-	#
-	#mac2ip
-
-	#  If the MAC wasn't found in that list, do something else.
-	#  You could call a Perl, Python, or Java script here.
-
-	#if (notfound) {
-	# ...
-	#}
-
-	#  Or, allocate IPs from the DHCP pool in SQL. You may need to
-	#  set the pool name here if you haven't set it elsewhere.
-#	update control {
-#		&Pool-Name := "local"
-#	}
-#	dhcp_sqlippool_request
 
 	#  If DHCP-Message-Type is not set, returning "ok" or
 	#  "updated" from this section will respond with a DHCP-Ack
@@ -339,11 +376,17 @@ dhcp DHCP-Inform {
 	#  See Discover section
 	#dhcp_override_network
 
-	#  Use a "files" module to lookup global and subnet options
-	#  For multiple subnets use this in place of dhcp_common
+	#  Use a "files" module to lookup global and network options
+	#  For multiple networks use this in place of dhcp_common
 	#  Enable mods-available/dhcp_files to use this
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_network
+
+	#  Use a policy with calls a "files" module of the same name to lookup
+	#  subnet options
+	#  Enable mods-available/dhcp_files to use this
+	#  Options are set in mods-config/files/dhcp
+	#dhcp_subnet
 
 	#  Use a "passwd" module to determine group membership
 	#  Enable mods-available/dhcp_passwd to use this

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -165,6 +165,10 @@ dhcp DHCP-Discover {
 	#  Call a policy (defined in policy.d/dhcp) to set common reply attributes
 	dhcp_common
 
+	#  Use a "passwd" module to set group memberships in DHCP-Group-Name
+	#  Enable mods-available/dhcp_passwd to use this
+	#dhcp_group_membership
+
 	#  If clients need to be assigned to a particular network based on
 	#  an attribute in the packet rather than the calculated
 	#  DHCP-Network-IP-Address described above, then call a policy
@@ -210,11 +214,7 @@ dhcp DHCP-Discover {
 	#
 	#dhcp_subnet
 
-	#  Use a "passwd" module to determine group membership
-	#  Enable mods-available/dhcp_passwd to use this
-	#dhcp_group_membership
-
-	#  Use a "files" module to lookup group specific options
+	#  Use a "files" module to lookup options based on DHCP-Group-Name
 	#  Enable mods-available/dhcp_files to use this
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_group_options
@@ -274,6 +274,10 @@ dhcp DHCP-Request {
 	#  Call a policy (defined in policy.d/dhcp) to set common reply attributes
 	dhcp_common
 
+	#  Use a "passwd" module to set group memberships in DHCP-Group-Name
+	#  Enable mods-available/dhcp_passwd to use this
+	#dhcp_group_membership
+
 	#  Optionally override the network address based on client attributes
 	#  See Discover section
 	#dhcp_override_network
@@ -315,11 +319,7 @@ dhcp DHCP-Request {
 	#
 	#dhcp_subnet
 
-	#  Use a "passwd" module to determine group membership
-	#  Enable mods-available/dhcp_passwd to use this
-	#dhcp_group_membership
-
-	#  Use a "files" module to lookup group specific options
+	#  Use a "files" module to lookup options based on DHCP-Group-Name
 	#  Enable mods-available/dhcp_files to use this
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_group_options
@@ -348,11 +348,16 @@ dhcp DHCP-Request {
 
 dhcp DHCP-Decline {
 
+	#  Use a "passwd" module to set group memberships in DHCP-Group-Name
+	#  Enable mods-available/dhcp_passwd to use this
+	#dhcp_group_membership
+
 	#  Optionally override the network address based on client attributes
 	#  See Discover section
 	#dhcp_override_network
 
 	#  Use a "files" module to lookup global and subnet options
+	#  For multiple networks use this in place of dhcp_common
 	#  Enable mods-available/dhcp_files to use this
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_network
@@ -379,6 +384,10 @@ dhcp DHCP-Inform {
 	#  Call a policy (defined in policy.d/dhcp) to set common reply attributes
 	dhcp_common
 
+	#  Use a "passwd" module to set group memberships in DHCP-Group-Name
+	#  Enable mods-available/dhcp_passwd to use this
+	#dhcp_group_membership
+
 	#  Optionally override the network address based on client attributes
 	#  See Discover section
 	#dhcp_override_network
@@ -396,11 +405,7 @@ dhcp DHCP-Inform {
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_subnet
 
-	#  Use a "passwd" module to determine group membership
-	#  Enable mods-available/dhcp_passwd to use this
-	#dhcp_group_membership
-
-	#  Use a "files" module to lookup group specific options
+	#  Use a "files" module to lookup options based on DHCP-Group-Name
 	#  Enable mods-available/dhcp_files to use this
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_group_options
@@ -427,6 +432,10 @@ dhcp DHCP-Inform {
 #}
 
 dhcp DHCP-Release {
+
+	#  Use a "passwd" module to set group memberships in DHCP-Group-Name
+	#  Enable mods-available/dhcp_passwd to use this
+	#dhcp_group_membership
 
 	#  Optionally override the network address based on client attributes
 	#  See Discover section

--- a/share/dictionary.dhcp
+++ b/share/dictionary.dhcp
@@ -63,7 +63,7 @@ ATTRIBUTE	DHCP-Relay-IP-Address			272	ipaddr
 # This address is assigned on a hierarchical basis to then determine
 # the subnet which the client belongs to.  Stored as an ipv4prefix
 # to allow closest subnet matching in rlm_files
-ATTRIBUTE	DHCP-Network-IP-Address			274	ipv4prefix
+ATTRIBUTE	DHCP-Network-Subnet			274	ipv4prefix
 # This is a name for the group a client belongs to then used for
 # looking up of options
 ATTRIBUTE	DHCP-Group-Name				275	string

--- a/src/modules/proto_dhcp/dhcp.c
+++ b/src/modules/proto_dhcp/dhcp.c
@@ -1143,7 +1143,7 @@ int fr_dhcp_decode(RADIUS_PACKET *packet)
 	 *	client belongs to based on packet data.  The sequence here
 	 *	is based on ISC DHCP behaviour and RFCs 3527 and 3011.  We
 	 *	store the found address in an internal attribute of 274 -
-	 *	DHCP-Network-IP-Address.  This is stored as an IPv4 prefix
+	 *	DHCP-Network-Subnet.  This is stored as an IPv4 prefix
 	 *	with a /32 netmask allowing "closest containing subnet"
 	 *	matching in rlm_files
 	 */


### PR DESCRIPTION
Reviewed-by @ndptech up to fa0fff2.

Mainly: DHCP: Policy support for shared-network: Layer 2 with multiple subnets

    Many networks support multiple co-existing subnets without VLAN separation, i.e. we have 
    one pool containing equally valid IP addresses from each subnet.

    To support this configuration we differentiate selecting a pool based on the default or
    overridden DHCP-Network-IP-Address (indicating the Layer 2 network originating the
    request) versus setting the reply options for the subnet to which the allocated IP 
    address belongs, in particular the DHCP-Router-Address.

Also:

  * Allow group membership to be used to guard access to pools (akin to "allow members of")
  * s/DHCP-Network-IP-Address/DHCP-Network-Subnet/g
  * Some additional minor attribute name fixes in the examples
  * Lots of improvements to the text.
