### PR TITLE
v3: Add prepend operator for inserting attributes at the beginning of lists

### DIFF
--- a/src/include/libradius.h
+++ b/src/include/libradius.h
@@ -639,7 +639,7 @@ void		fr_pair_value_strsteal(VALUE_PAIR *vp, char const *src);
 void		fr_pair_value_strcpy(VALUE_PAIR *vp, char const * src);
 void		fr_pair_value_bstrncpy(VALUE_PAIR *vp, void const * src, size_t len);
 void		fr_pair_value_sprintf(VALUE_PAIR *vp, char const * fmt, ...) CC_HINT(format (printf, 2, 3));
-void		fr_pair_list_move(TALLOC_CTX *ctx, VALUE_PAIR **to, VALUE_PAIR **from);
+void		fr_pair_list_move(TALLOC_CTX *ctx, VALUE_PAIR **to, VALUE_PAIR **from, FR_TOKEN op);
 void		fr_pair_list_move_by_num(TALLOC_CTX *ctx, VALUE_PAIR **to, VALUE_PAIR **from,
 					 unsigned int attr, unsigned int vendor, int8_t tag);
 void		fr_pair_list_mcopy_by_num(TALLOC_CTX *ctx, VALUE_PAIR **to, VALUE_PAIR **from,

--- a/src/include/libradius.h
+++ b/src/include/libradius.h
@@ -617,6 +617,7 @@ VALUE_PAIR	*fr_cursor_remove(vp_cursor_t *cursor);
 VALUE_PAIR	*fr_cursor_replace(vp_cursor_t *cursor, VALUE_PAIR *new);
 void		fr_pair_delete_by_num(VALUE_PAIR **, unsigned int attr, unsigned int vendor, int8_t tag);
 void		fr_pair_add(VALUE_PAIR **, VALUE_PAIR *);
+void		fr_pair_prepend(VALUE_PAIR **, VALUE_PAIR *);
 void		fr_pair_replace(VALUE_PAIR **first, VALUE_PAIR *add);
 int		fr_pair_cmp(VALUE_PAIR *a, VALUE_PAIR *b);
 int		fr_pair_list_cmp(VALUE_PAIR *a, VALUE_PAIR *b);

--- a/src/include/token.h
+++ b/src/include/token.h
@@ -56,16 +56,17 @@ typedef enum fr_token_t {
 	T_OP_CMP_TRUE,			/* =* 		20 */
 	T_OP_CMP_FALSE,			/* !* */
 	T_OP_CMP_EQ,			/* == */
+	T_OP_PREPEND,			/* ^= */
 	T_HASH,				/* # */
-	T_BARE_WORD,			/* bare word */
-	T_DOUBLE_QUOTED_STRING,		/* "foo" 	25 */
+	T_BARE_WORD,			/* bare word    25 */
+	T_DOUBLE_QUOTED_STRING,		/* "foo" */
 	T_SINGLE_QUOTED_STRING,		/* 'foo' */
 	T_BACK_QUOTED_STRING,		/* `foo` */
 	T_TOKEN_LAST
 } FR_TOKEN;
 
 #define T_EQSTART	T_OP_ADD
-#define	T_EQEND		(T_OP_CMP_EQ + 1)
+#define	T_EQEND		(T_OP_PREPEND + 1)
 
 typedef struct FR_NAME_NUMBER {
 	char const	*name;

--- a/src/lib/pair.c
+++ b/src/lib/pair.c
@@ -286,6 +286,43 @@ void fr_pair_add(VALUE_PAIR **first, VALUE_PAIR *add)
 	i->next = add;
 }
 
+/** Add a VP to the start of the list.
+ *
+ * Links the new VP to 'first', then points 'first' at the new VP.
+ *
+ * @param[in] first VP in linked list. Will add new VP to the start of this list.
+ * @param[in] add VP to add to list.
+ */
+void fr_pair_prepend(VALUE_PAIR **first, VALUE_PAIR *add)
+{
+	VALUE_PAIR *i;
+
+	if (!add) return;
+
+	VERIFY_VP(add);
+
+	if (*first == NULL) {
+		*first = add;
+		return;
+	}
+
+	/*
+	 *	Find the end of the list to be prepended
+	 */
+	for (i = add; i->next; i = i->next) {
+#ifdef WITH_VERIFY_PTR
+		VERIFY_VP(i);
+		/*
+		 *	The same VP should never by added multiple times
+		 *	to the same list.
+		 */
+		fr_assert(*first != i);
+#endif
+	}
+	i->next = *first;
+	*first = add;
+}
+
 /** Replace all matching VPs
  *
  * Walks over 'first', and replaces the first VP that matches 'replace'.

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -42,6 +42,7 @@ const FR_NAME_NUMBER fr_tokens[] = {
 	{ "=*", T_OP_CMP_TRUE,  },
 	{ "!*", T_OP_CMP_FALSE, },
 	{ "==",	T_OP_CMP_EQ,	},
+	{ "^=", T_OP_PREPEND,	},
 	{ "=",	T_OP_EQ,	},
 	{ "!=",	T_OP_NE,	},
 	{ ">=",	T_OP_GE,	},
@@ -67,20 +68,21 @@ const bool fr_assignment_op[] = {
 	true,		/* += */
 	true,		/* -=  		10 */
 	true,		/* := */
+	true,		/* ^= */
 	true,		/* = */
 	false,		/* != */
-	false,		/* >= */
-	false,		/* > 		15 */
+	false,		/* >= 		15 */
+	false,		/* > */
 	false,		/* <= */
 	false,		/* < */
 	false,		/* =~ */
-	false,		/* !~ */
-	false,		/* =* 		20 */
+	false,		/* !~ 		20 */
+	false,		/* =* */
 	false,		/* !* */
 	false,		/* == */
-	false,				/* # */
-	false,		/* bare word */
-	false,		/* "foo" 	25 */
+	false,		/* # */
+	false,		/* bare word 	25 */
+	false,		/* "foo" */
 	false,		/* 'foo' */
 	false,		/* `foo` */
 	false
@@ -100,20 +102,21 @@ const bool fr_equality_op[] = {
 	false,		/* += */
 	false,		/* -=  		10 */
 	false,		/* := */
+	false,		/* ^= */
 	false,		/* = */
 	true,		/* != */
-	true,		/* >= */
-	true,		/* > 		15 */
+	true,		/* >= 		15 */
+	true,		/* > */
 	true,		/* <= */
 	true,		/* < */
 	true,		/* =~ */
-	true,		/* !~ */
-	true,		/* =* 		20 */
+	true,		/* !~		20 */
+	true,		/* =* */
 	true,		/* !* */
 	true,		/* == */
-	false,				/* # */
-	false,		/* bare word */
-	false,		/* "foo" 	25 */
+	false,		/* # */
+	false,		/* bare word 	25 */
+	false,		/* "foo" */
 	false,		/* 'foo' */
 	false,		/* `foo` */
 	false
@@ -133,20 +136,21 @@ const bool fr_str_tok[] = {
 	false,		/* += */
 	false,		/* -=  		10 */
 	false,		/* := */
+	false,		/* ^= */
 	false,		/* = */
 	false,		/* != */
-	false,		/* >= */
-	false,		/* > 		15 */
+	false,		/* >= 		15 */
+	false,		/* > */
 	false,		/* <= */
 	false,		/* < */
 	false,		/* =~ */
-	false,		/* !~ */
-	false,		/* =* 		20 */
+	false,		/* !~		20 */
+	false,		/* =* */
 	false,		/* !* */
 	false,		/* == */
-	false,				/* # */
-	true,		/* bare word */
-	true,		/* "foo" 	25 */
+	false,		/* # */
+	true,		/* bare word 	25 */
+	true,		/* "foo" */
 	true,		/* 'foo' */
 	true,		/* `foo` */
 	false

--- a/src/lib/token.c
+++ b/src/lib/token.c
@@ -68,18 +68,18 @@ const bool fr_assignment_op[] = {
 	true,		/* += */
 	true,		/* -=  		10 */
 	true,		/* := */
-	true,		/* ^= */
 	true,		/* = */
 	false,		/* != */
-	false,		/* >= 		15 */
-	false,		/* > */
+	false,		/* >= */
+	false,		/* > 		15 */
 	false,		/* <= */
 	false,		/* < */
 	false,		/* =~ */
-	false,		/* !~ 		20 */
-	false,		/* =* */
+	false,		/* !~ */
+	false,		/* =* 		20 */
 	false,		/* !* */
 	false,		/* == */
+	true,		/* ^= */
 	false,		/* # */
 	false,		/* bare word 	25 */
 	false,		/* "foo" */
@@ -102,18 +102,18 @@ const bool fr_equality_op[] = {
 	false,		/* += */
 	false,		/* -=  		10 */
 	false,		/* := */
-	false,		/* ^= */
 	false,		/* = */
 	true,		/* != */
-	true,		/* >= 		15 */
-	true,		/* > */
+	true,		/* >= */
+	true,		/* > 		15 */
 	true,		/* <= */
 	true,		/* < */
 	true,		/* =~ */
-	true,		/* !~		20 */
-	true,		/* =* */
+	true,		/* !~ */
+	true,		/* =*		20 */
 	true,		/* !* */
 	true,		/* == */
+	false,		/* ^= */
 	false,		/* # */
 	false,		/* bare word 	25 */
 	false,		/* "foo" */
@@ -136,18 +136,18 @@ const bool fr_str_tok[] = {
 	false,		/* += */
 	false,		/* -=  		10 */
 	false,		/* := */
-	false,		/* ^= */
 	false,		/* = */
 	false,		/* != */
-	false,		/* >= 		15 */
-	false,		/* > */
+	false,		/* >= */
+	false,		/* > 		15 */
 	false,		/* <= */
 	false,		/* < */
 	false,		/* =~ */
-	false,		/* !~		20 */
-	false,		/* =* */
+	false,		/* !~ */
+	false,		/* =* 		20 */
 	false,		/* !* */
 	false,		/* == */
+	false,		/* ^= */
 	false,		/* # */
 	true,		/* bare word 	25 */
 	true,		/* "foo" */

--- a/src/main/conffile.c
+++ b/src/main/conffile.c
@@ -2794,6 +2794,7 @@ static int cf_section_read(char const *filename, int *lineno, FILE *fp,
 
 		case T_OP_EQ:
 		case T_OP_SET:
+		case T_OP_PREPEND:
 			while (isspace((int) *ptr)) ptr++;
 
 			/*

--- a/src/main/evaluate.c
+++ b/src/main/evaluate.c
@@ -790,7 +790,7 @@ int radius_evaluate_cond(REQUEST *request, int modreturn, int depth, fr_cond_t c
 
 
 /*
- *	The fr_pair_list_move() function in src/lib/valuepair.c does all sorts of
+ *	The fr_pair_list_move() function in src/lib/pair.c does all sorts of
  *	extra magic that we don't want here.
  *
  *	FIXME: integrate this with the code calling it, so that we

--- a/src/main/map.c
+++ b/src/main/map.c
@@ -1177,6 +1177,10 @@ int map_to_request(REQUEST *request, vp_map_t const *map, radius_map_getvalue_t 
 				fr_pair_list_free(&head);
 			}
 			goto finish;
+		case T_OP_PREPEND:
+			fr_pair_list_move(parent, list, &head, T_OP_PREPEND);
+			fr_pair_list_free(&head);
+			goto finish;
 
 		default:
 			fr_pair_list_free(&head);

--- a/src/main/map.c
+++ b/src/main/map.c
@@ -1173,7 +1173,7 @@ int map_to_request(REQUEST *request, vp_map_t const *map, radius_map_getvalue_t 
 				rad_assert(map->rhs->type == TMPL_TYPE_EXEC);
 				/* FALL-THROUGH */
 		case T_OP_ADD:
-				fr_pair_list_move(parent, list, &head);
+				fr_pair_list_move(parent, list, &head, map->op);
 				fr_pair_list_free(&head);
 			}
 			goto finish;

--- a/src/main/map.c
+++ b/src/main/map.c
@@ -1342,6 +1342,14 @@ int map_to_request(REQUEST *request, vp_map_t const *map, radius_map_getvalue_t 
 		break;
 
 	/*
+	 *	^= - Prepend src_list attributes to the destination
+	 */
+	case T_OP_PREPEND:
+		fr_pair_prepend(list, head);
+		head = NULL;
+		break;
+
+	/*
 	 *	+= - Add all src_list attributes to the destination
 	 */
 	case T_OP_ADD:

--- a/src/main/modcall.c
+++ b/src/main/modcall.c
@@ -1516,7 +1516,6 @@ static const int authtype_actions[GROUPTYPE_COUNT][RLM_MODULE_NUMCODES] =
 int modcall_fixup_update(vp_map_t *map, UNUSED void *ctx)
 {
 	CONF_PAIR *cp = cf_item_to_pair(map->ci);
-
 	/*
 	 *	Anal-retentive checks.
 	 */
@@ -1593,7 +1592,7 @@ int modcall_fixup_update(vp_map_t *map, UNUSED void *ctx)
 		}
 
 		/*
-		 *	Only += and :=, and !* operators are supported
+		 *	Only += and :=, and !*, and ^= operators are supported
 		 *	for lists.
 		 */
 		switch (map->op) {
@@ -1623,6 +1622,14 @@ int modcall_fixup_update(vp_map_t *map, UNUSED void *ctx)
 		case T_OP_EQ:
 			if (map->rhs->type != TMPL_TYPE_EXEC) {
 				cf_log_err(map->ci, "Invalid source for list assignment '%s = ...'", map->lhs->name);
+				return -1;
+			}
+			break;
+
+		case T_OP_PREPEND:
+			if ((map->rhs->type != TMPL_TYPE_LIST) &&
+			    (map->rhs->type != TMPL_TYPE_EXEC)) {
+				cf_log_err(map->ci, "Invalid source for list assignment '%s ^= ...'", map->lhs->name);
 				return -1;
 			}
 			break;

--- a/src/modules/proto_dhcp/rlm_dhcp.c
+++ b/src/modules/proto_dhcp/rlm_dhcp.c
@@ -97,7 +97,7 @@ static ssize_t dhcp_options_xlat(UNUSED void *instance, REQUEST *request,
 			decoded++;
 		}
 
-		fr_pair_list_move(request->packet, &(request->packet->vps), &head);
+		fr_pair_list_move(request->packet, &(request->packet->vps), &head, T_OP_ADD);
 
 		/* Free any unmoved pairs */
 		fr_pair_list_free(&head);

--- a/src/modules/rlm_exec/rlm_exec.c
+++ b/src/modules/rlm_exec/rlm_exec.c
@@ -353,7 +353,7 @@ static rlm_rcode_t CC_HINT(nonnull) mod_exec_dispatch(void *instance, REQUEST *r
 	 *	If we're not waiting, then there are no output pairs.
 	 */
 	if (inst->output) {
-		fr_pair_list_move(ctx, output_pairs, &answer);
+		fr_pair_list_move(ctx, output_pairs, &answer, T_OP_ADD);
 	}
 	fr_pair_list_free(&answer);
 
@@ -399,7 +399,7 @@ static rlm_rcode_t CC_HINT(nonnull) mod_post_auth(void *instance, REQUEST *reque
 	/*
 	 *	Always add the value-pairs to the reply.
 	 */
-	fr_pair_list_move(request->reply, &request->reply->vps, &tmp);
+	fr_pair_list_move(request->reply, &request->reply->vps, &tmp, T_OP_ADD);
 	fr_pair_list_free(&tmp);
 
 	finish:

--- a/src/modules/rlm_files/rlm_files.c
+++ b/src/modules/rlm_files/rlm_files.c
@@ -422,7 +422,7 @@ static rlm_rcode_t file_common(rlm_files_t *inst, REQUEST *request, char const *
 			/* ctx may be reply or proxy */
 			reply_tmp = fr_pair_list_copy(reply_packet, pl->reply);
 			radius_pairmove(request, &reply_packet->vps, reply_tmp, true);
-			fr_pair_list_move(request, &request->config, &check_tmp);
+			fr_pair_list_move(request, &request->config, &check_tmp, T_OP_ADD);
 			fr_pair_list_free(&check_tmp);
 
 			/*

--- a/src/tests/keywords/update-prepend
+++ b/src/tests/keywords/update-prepend
@@ -1,0 +1,65 @@
+#
+#  PRE: update
+#
+update control {
+	&Tmp-String-0 := 'foo'
+	&Tmp-String-0 += 'baz'
+}
+
+# Reset the request list
+update {
+	&request !* ANY
+	&request += &control
+}
+
+debug_request
+
+# Prepend a single value
+update request {
+	&Tmp-String-0 ^= 'boink'
+}
+
+# The prepended value should be first followd by the other two
+if (("%{Tmp-String-0[0]}" != 'boink') || ("%{Tmp-String-0[1]}" != 'foo') || ("%{Tmp-String-0[2]}" != 'baz')) {
+	update reply {
+		Filter-Id += "fail 1"
+	}
+}
+
+if ("%{Tmp-String-0[#]}" != 3)
+	update reply {
+		Filter-Id += "fail 1a"
+	}
+}
+
+# Add an extra element to the start of control
+update control {
+	&Tmp-String-0 ^= 'wibble'
+}
+
+# Prepend control to request
+update {
+	&request ^= &control
+}
+
+debug_request
+
+# The attributes should now be "wibble", "foo", "baz", "boink", "foo", "baz"
+if (("%{Tmp-String-0[0]}" != 'wibble') || ("%{Tmp-String-0[1]}" != 'foo') || ("%{Tmp-String-0[2]}" != 'baz') || ("%{Tmp-String-0[3]}" != 'boink') || ("%{Tmp-String-0[4]}" != 'foo') || ("%{Tmp-String-0[5]}" != 'baz'))
+	update reply {
+		Filter-Id += "fail 2"
+	}
+}
+
+if ("%{Tmp-String-0[#]}" != 6) {
+	update reply {
+		Filter-Id += "fail 2a"
+	}
+}
+
+if (!reply:Filter-Id) {
+	update {
+		&request:User-Password := 'hello'
+		&reply:Filter-Id := 'filter'
+	}
+}

--- a/src/tests/keywords/update-prepend
+++ b/src/tests/keywords/update-prepend
@@ -26,7 +26,7 @@ if (("%{Tmp-String-0[0]}" != 'boink') || ("%{Tmp-String-0[1]}" != 'foo') || ("%{
 	}
 }
 
-if ("%{Tmp-String-0[#]}" != 3)
+if ("%{Tmp-String-0[#]}" != 3) {
 	update reply {
 		Filter-Id += "fail 1a"
 	}
@@ -45,7 +45,7 @@ update {
 debug_request
 
 # The attributes should now be "wibble", "foo", "baz", "boink", "foo", "baz"
-if (("%{Tmp-String-0[0]}" != 'wibble') || ("%{Tmp-String-0[1]}" != 'foo') || ("%{Tmp-String-0[2]}" != 'baz') || ("%{Tmp-String-0[3]}" != 'boink') || ("%{Tmp-String-0[4]}" != 'foo') || ("%{Tmp-String-0[5]}" != 'baz'))
+if (("%{Tmp-String-0[0]}" != 'wibble') || ("%{Tmp-String-0[1]}" != 'foo') || ("%{Tmp-String-0[2]}" != 'baz') || ("%{Tmp-String-0[3]}" != 'boink') || ("%{Tmp-String-0[4]}" != 'foo') || ("%{Tmp-String-0[5]}" != 'baz')) {
 	update reply {
 		Filter-Id += "fail 2"
 	}


### PR DESCRIPTION
For DHCP, the sequence of a repeated attribute can be significant.  

Adding a prepend operator ^= allows for policy to specifically add attributes at the beginning of a list to specify the sequence of a repeated attribute when returned to the client.