### PR TITLE
v4: Remove requirement for Perl Template::Toolkit

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -78,8 +78,7 @@ Package: freeradius-utils
 Architecture: any
 Replaces: freeradius (<< 3)
 Conflicts: radiusd-livingston, yardradius
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends}, freeradius-common, freeradius-config, libfreeradius4 (= ${binary:Version}), libnet-ip-perl
-Recommends: libtemplate-perl, libdbi-perl, libyaml-libyaml-perl, libdbd-pg-perl, libdbd-mysql-perl, libdbd-sqlite3-perl, libdbd-sybase-perl
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends}, freeradius-common, freeradius-config, libfreeradius4 (= ${binary:Version})
 Description: FreeRADIUS client utilities
  This package contains various client programs and utilities from
  the FreeRADIUS Server project, including:
@@ -90,8 +89,14 @@ Description: FreeRADIUS client utilities
   - radtest
   - radwho
   - radzap
-  - rlm_sqlippool_tool
   - smbencrypt
+
+Package: freeradius-perl-util
+Architecture: any
+Depends: libnet-ip-perl
+Recommends: libtemplate-perl, libdbi-perl, libyaml-libyaml-perl, libdbd-pg-perl, libdbd-mysql-perl, libdbd-sqlite3-perl, libdbd-sybase-perl
+Description: FreeRADIUS Perl utilities
+ This package contains utilities for managing IP pools in SQL databases
 
 Package: libfreeradius4
 Architecture: any

--- a/debian/control.in
+++ b/debian/control.in
@@ -78,8 +78,8 @@ Package: freeradius-utils
 Architecture: any
 Replaces: freeradius (<< 3)
 Conflicts: radiusd-livingston, yardradius
-Depends: ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends}, freeradius-common, freeradius-config, libfreeradius4 (= ${binary:Version}), libtemplate-perl, libnet-ip-perl
-Recommends: libdbi-perl, libyaml-libyaml-perl, libdbd-pg-perl, libdbd-mysql-perl, libdbd-sqlite3-perl, libdbd-sybase-perl
+Depends: ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends}, freeradius-common, freeradius-config, libfreeradius4 (= ${binary:Version}), libnet-ip-perl
+Recommends: libtemplate-perl, libdbi-perl, libyaml-libyaml-perl, libdbd-pg-perl, libdbd-mysql-perl, libdbd-sqlite3-perl, libdbd-sybase-perl
 Description: FreeRADIUS client utilities
  This package contains various client programs and utilities from
  the FreeRADIUS Server project, including:

--- a/debian/freeradius-perl-util.install
+++ b/debian/freeradius-perl-util.install
@@ -1,0 +1,1 @@
+usr/bin/rlm_sqlippool_tool

--- a/debian/freeradius-utils.install
+++ b/debian/freeradius-utils.install
@@ -7,4 +7,3 @@ usr/bin/radtest
 usr/bin/radzap
 usr/bin/radsqlrelay
 usr/bin/radcrypt
-usr/bin/rlm_sqlippool_tool

--- a/man/man8/rlm_sqlippool_tool.8
+++ b/man/man8/rlm_sqlippool_tool.8
@@ -147,6 +147,13 @@ v6_pool_with_sparse_range:
 .ni
 .PP
 
+.SH PREREQUISITES
+
+To output formatted SQL, the Perl Template::Toolkit module is required.
+
+Direct connection to databases is done using Perl DBI.  The appropriate
+Perl DBD driver needs to be installed to enable this functionality.
+
 .SH SEE ALSO
 radiusd.conf(5), raddb/mods-available/sql
 .SH AUTHORS

--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -173,6 +173,15 @@ of the server, and let you decide if they satisfy your needs.
 Support for RFC and VSA Attributes Additional server configuration
 attributes Selecting a particular configuration Authentication methods
 
+%package perl-util
+Group: System Environment/Daemons
+Summary: FreeRADIUS Perl utilities
+Requires: perl-Net-IP
+
+%description perl-util
+This package provides Perl utilities for managing IP pools stored in
+SQL databases.
+
 %package json
 Summary: JSON support for FreeRADIUS
 Requires: %{name}%{?_isa} = %{version}-%{release}
@@ -798,7 +807,16 @@ fi
 
 %files utils
 %defattr(-,root,root)
-/usr/bin/*
+/usr/bin/smbencrypt
+/usr/bin/radclient
+/usr/bin/radwho
+/usr/bin/radsniff
+/usr/bin/radlast
+/usr/bin/radtest
+/usr/bin/radzap
+/usr/bin/radsqlrelay
+/usr/bin/radcrypt
+/usr/bin/rlm_redis_ippool_tool
 # man-pages
 %doc %{_mandir}/man1/radlast.1.gz
 %doc %{_mandir}/man1/radtest.1.gz
@@ -807,6 +825,11 @@ fi
 %doc %{_mandir}/man1/dhcpclient.1.gz
 %doc %{_mandir}/man8/radsqlrelay.8.gz
 %doc %{_mandir}/man8/rlm_redis_ippool_tool.8.gz
+
+%files perl-util
+%defattr(-,root,root)
+/usr/bin/rlm_sqlippool_tool
+#man-pages
 %doc %{_mandir}/man8/rlm_sqlippool_tool.8.gz
 
 %files json

--- a/scripts/dhcp/rlm_iscfixed2ippool
+++ b/scripts/dhcp/rlm_iscfixed2ippool
@@ -24,7 +24,6 @@
 
 use warnings;
 use strict;
-use Template;
 
 my $dns_available = 0;
 my $resolver;
@@ -197,8 +196,17 @@ unless (defined $template->{$opts->{dialect}}) {
 if ($opts->{radius_db}) {
 	&call_database($opts, $queries, @hosts);
 } else {
-	my $tt=Template->new();
-	$tt->process(\$template->{$opts->{dialect}}, {tablename => $opts->{table_name}, hosts => \@hosts}) || die $tt->error();
+	my $tt_available = 0;
+	eval {
+		require Template;
+		$tt_available = 1;
+	};
+	if ($tt_available) {
+		my $tt=Template->new();
+		$tt->process(\$template->{$opts->{dialect}}, {tablename => $opts->{table_name}, hosts => \@hosts}) || die $tt->error();
+	} else {
+		die "ERROR: Template Toolkit is not available. Install the Template Perl module.";
+	}
 }
 
 exit(0);

--- a/scripts/sql/rlm_sqlippool_tool
+++ b/scripts/sql/rlm_sqlippool_tool
@@ -17,6 +17,8 @@
 #
 #  Note: Direct connection to databases is done using Perl DBI.  You may need
 #        to install the appropriate Perl DBD driver to enable this functionality.
+#        Formatted SQL output is produced using Perl Template::Toolkit which
+#        will need to be installed if this output is required.
 #
 #
 #  Use with a single address range
@@ -163,7 +165,6 @@
 
 use strict;
 use Net::IP qw/ip_bintoip ip_iptobin ip_bincomp ip_binadd ip_is_ipv4 ip_is_ipv6/;
-use Template;
 
 #
 #  Option defaults
@@ -337,8 +338,7 @@ sub process_commandline {
 	if ($opts->{radius_db}) {
 		&call_database($opts, $queries, @entries);
 	} else {
-		my $tt=Template->new();
-		$tt->process(\$template->{$opts->{dialect}}, {ranges => [{pool_name => $opts->{pool_name}, ips => \@entries}], batchsize => 100, tablename => $opts->{table_name}}) || die $tt->error();
+		&output_sql($template->{$opts->{dialect}}, {ranges => [{pool_name => $opts->{pool_name}, ips => \@entries}], batchsize => 100, tablename => $opts->{table_name}});
 	}
 }
 
@@ -379,8 +379,24 @@ sub process_yaml_file {
 	if ($opts->{radius_db}) {
 		&call_database($opts, $queries, @entries);
 	} else {
+		&output_sql($template->{$opts->{dialect}}, {ranges => \@ranges, batchsize => 100, tablename => $opts->{table_name}});
+	}
+}
+
+sub output_sql {
+	my $template = shift();
+	my $vars = shift();
+
+	my $tt_available = 0;
+	eval {
+		require Template;
+		$tt_available = 1;
+	};
+	if ($tt_available) {
 		my $tt=Template->new();
-		$tt->process(\$template->{$opts->{dialect}}, {ranges => \@ranges, batchsize => 100, tablename => $opts->{table_name}}) || die $tt->error();
+		$tt->process(\$template, $vars) || die $tt->errors();
+	} else {
+		die "ERROR: Template Toolkit is not available. Install the Template Perl module.";
 	}
 }
 


### PR DESCRIPTION
Template Toolkit is only needed if the perl IP pool tools are to produce SQL output rather than directly operate on the database - so it is not a hard requirement.