### PR TITLE
v4: Add prepend operator for inserting attributes at the beginning of lists

### DIFF
--- a/doc/antora/modules/raddb/pages/mods-available/csv.adoc
+++ b/doc/antora/modules/raddb/pages/mods-available/csv.adoc
@@ -146,7 +146,7 @@ Where:
 | Parameter   | Description
 | <fr attr>   | Is the destination RADIUS attribute
                 with any valid list and request qualifiers.
-| <op>        | Is any assignment attribute (=, :=, +=, -=).
+| <op>        | Is any assignment attribute (=, :=, +=, ^=, -=).
 | <csv field> | Is the name of a field from the CSV file, as taken
                 from the `fields` configuration item.
 |===

--- a/doc/antora/modules/raddb/pages/mods-available/json.adoc
+++ b/doc/antora/modules/raddb/pages/mods-available/json.adoc
@@ -34,10 +34,12 @@ Selectors currently implemented are:
   * Automatic casting will occur between JSON and attribute types where possible.
   * Assignment of JSON objects/arrays to strings is supported, in which case the
   JSON serialized form of the object/array is used.
-  * If a jpath matches multiple nodes, unless the map includes the `+=` operator
-  * only the first node's value will be used.
-  * If the map uses `+=` then multiple instances of the attribute will be created,
-  each holding a different node value.
+  * If a jpath matches multiple nodes, unless the map includes the `+=` or `^=`
+  operator only the first node's value will be used.
+  * If the map uses `+=` or `^=` then multiple instances of the attribute will be
+  created, each holding a different node value.
+  * If the map uses `^=` then any new instances will be inserted at the head of
+  of the list.
 ====
 
 

--- a/doc/antora/modules/raddb/pages/mods-available/ldap.adoc
+++ b/doc/antora/modules/raddb/pages/mods-available/ldap.adoc
@@ -125,7 +125,7 @@ Where:
 | Parameter  | Description
 | <fr attr>  | Is the attribute you wish to create,
                with any valid list and request qualifiers.
-| <op>       | Is any assignment operator (`=`, `:=`, `+=`, `-=`).
+| <op>       | Is any assignment operator (`=`, `:=`, `+=`, `^=`, `-=`).
 | <value>    | Is the value to parse into the new attribute.
                If the value is wrapped in double quotes it
                will be xlat expanded.
@@ -163,7 +163,7 @@ Where:
 | Parameter   | Description
 | <fr attr>   | Is the destination RADIUS attribute
                 with any valid list and request qualifiers.
-| <op>        | Is any assignment attribute (=, :=, +=, -=).
+| <op>        | Is any assignment attribute (=, :=, +=, ^=, -=).
 | <ldap attr> | Is the attribute associated with user or
                 profile objects in the LDAP directory.
                 If the attribute name is wrapped in double quotes

--- a/doc/antora/modules/raddb/pages/mods-available/rest.adoc
+++ b/doc/antora/modules/raddb/pages/mods-available/rest.adoc
@@ -247,10 +247,7 @@ The response format adds three optional fields:
 | `is_json` | If `true`, any nested JSON data will be copied to the attribute
               in string form. Defaults to `true`.
 | `op`      | Controls how the attribute is inserted into the target list.
-              Defaults to `:=`. To create multiple attributes from multiple
-              values, this should be set to `+=`, otherwise only the last
-              value will be used, and it will be assigned to a single
-              attribute.
+              Defaults to `:=`.
 |===
 
 [source,json]

--- a/doc/antora/modules/reference/pages/unlang/update.adoc
+++ b/doc/antora/modules/reference/pages/unlang/update.adoc
@@ -81,6 +81,8 @@ name is already present in that list, its value is replaced with the
 value of the current attribute.
 | +=       | Add the attribute to the tail of the list, even if attributes
 of the same name are already present in the list.
+| ^=       | Add the attribute to the head of the list, even if attributes
+of the same name are already present in the list.
 | -=       | Remove all attributes from the list that match _<value>_.
 | !*       | Delete all occurances of the attribute, no matter what the value.
 |=====

--- a/man/man5/unlang.5
+++ b/man/man5/unlang.5
@@ -1046,6 +1046,11 @@ Add the attribute to the tail of the list, even if attributes of the
 same name are already present in the list. When the right hand side
 of the expression resolves to multiple values, it means add all values
 to the tail of the list.
+.IP ^=
+Add the attribute to the head of the list, even if attributes of the
+same name are already present in the list. When the right hand side
+of the expression resolves to multiple values, it means prepend all
+values to the head of the list.
 .RE
 .PP
 Filtering Operators

--- a/man/man5/users.5
+++ b/man/man5/users.5
@@ -94,10 +94,18 @@ Not allowed as a reply item.
 .TP 0.5i
 .B "Attribute += Value"
 Always matches as a check item, and adds the current attribute with
-value to the list of configuration items.
+value to the tail of the list of configuration items.
 .br
 As a reply item, it has an identical meaning, but the attribute is
-added to the reply items.
+added to the tail of the reply items list.
+
+.TP 0.5i
+.B "Attribute ^= Value"
+Always matches as a check item, and adds the current attribute with
+value to the head of the list of configuration items.
+.br
+As a reply item, it has an identical meaning, but the attribute is
+added to the head of the reply items list.
 
 .TP 0.5i
 .B "Attribute != Value"

--- a/scripts/ci/openresty/json-api.lua
+++ b/scripts/ci/openresty/json-api.lua
@@ -99,8 +99,12 @@ Api.endpoint('POST', '/user/<username>/mac/<client>',
             value = keyData.username
         }
         returnData["control.NAS-IP-Address"] = {
-            op = ":=",
+            op = "+=",
             value = body.NAS or body['NAS-IP-Address'].value
+        }
+        returnData["control.Tmp-String-2"] = {
+            op = "^=",
+            value = keyData.username
         }
         return ngx.say(cjson.encode(returnData))
     end
@@ -117,6 +121,10 @@ Api.endpoint('GET', '/user/<username>/mac/<client>',
         }
         returnData["control.User-Name"] = {
             op = ":=",
+            value = keyData.username
+        }
+        returnData["control.Tmp-String-2"] = {
+            op = "^=",
             value = keyData.username
         }
         return ngx.say(cjson.encode(returnData))

--- a/src/bin/radsniff.c
+++ b/src/bin/radsniff.c
@@ -1477,7 +1477,7 @@ static void rs_packet_process(uint64_t count, rs_event_t *event, struct pcap_pkt
 			 *	The delay is so we can detect retransmissions.
 			 */
 			original->linked = talloc_steal(original, packet);
-			fr_pair_list_move(&original->link_vps, &decoded);	/* Move the vps over */
+			fr_pair_list_move(&original->link_vps, &decoded, T_OP_ADD);	/* Move the vps over */
 			rs_tv_add_ms(&header->ts, conf->stats.timeout, &original->when);
 			if (fr_event_timer_at(NULL, event->list, &original->event,
 					      fr_time_from_timeval(&original->when), _rs_event, original) < 0) {
@@ -1670,7 +1670,7 @@ static void rs_packet_process(uint64_t count, rs_event_t *event, struct pcap_pkt
 			fr_pair_list_free(&original->packet_vps);
 			fr_radius_packet_free(&original->packet);
 			original->packet = talloc_steal(original, packet);
-			fr_pair_list_move(&original->packet_vps, &decoded);
+			fr_pair_list_move(&original->packet_vps, &decoded, T_OP_ADD);
 
 			/* Request may need to be reinserted as the 5 tuple of the response may of changed */
 			if (rs_packet_cmp(original, &search) != 0) {
@@ -1681,7 +1681,7 @@ static void rs_packet_process(uint64_t count, rs_event_t *event, struct pcap_pkt
 			fr_pair_list_free(&original->expect_vps);
 			fr_radius_packet_free(&original->expect);
 			original->expect = talloc_steal(original, search.expect);
-			fr_pair_list_move(&original->expect_vps, &search.expect_vps);
+			fr_pair_list_move(&original->expect_vps, &search.expect_vps, T_OP_ADD);
 
 			/* Disarm the timer for the cleanup event for the original request */
 			fr_event_timer_delete(&original->event);
@@ -1698,10 +1698,10 @@ static void rs_packet_process(uint64_t count, rs_event_t *event, struct pcap_pkt
 			original->capture_p = original->capture;
 
 			original->packet = talloc_steal(original, packet);
-			fr_pair_list_move(&original->packet_vps, &decoded);
+			fr_pair_list_move(&original->packet_vps, &decoded, T_OP_ADD);
 
 			original->expect = talloc_steal(original, search.expect);
-			fr_pair_list_move(&original->expect_vps, &search.expect_vps);
+			fr_pair_list_move(&original->expect_vps, &search.expect_vps, T_OP_ADD);
 
 			if (!fr_pair_list_empty(&search.link_vps)) {
 				bool ret;
@@ -1712,7 +1712,7 @@ static void rs_packet_process(uint64_t count, rs_event_t *event, struct pcap_pkt
 				     vp = fr_pair_list_next(&search.link_vps, vp)) {
 					fr_pair_steal(original, vp);
 				}
-				fr_pair_list_move(&original->link_vps, &search.link_vps);
+				fr_pair_list_move(&original->link_vps, &search.link_vps, T_OP_ADD);
 
 				/* We should never have conflicts */
 				ret = fr_rb_insert(link_tree, original);

--- a/src/lib/server/cf_file.c
+++ b/src/lib/server/cf_file.c
@@ -1812,6 +1812,7 @@ static int parse_input(cf_stack_t *stack)
 
 	case T_OP_EQ:
 	case T_OP_SET:
+	case T_OP_PREPEND:
 		fr_skip_whitespace(ptr);
 		op_token = name2_token;
 		break;

--- a/src/lib/server/cf_file.c
+++ b/src/lib/server/cf_file.c
@@ -1782,7 +1782,7 @@ static int parse_input(cf_stack_t *stack)
 	 *	so we check for them first.
 	 */
 	if (!((*ptr == '=') || (*ptr == '!') || (*ptr == '>') || (*ptr == '<') ||
-	      (*ptr == '-') || (*ptr == '+') || (*ptr == ':'))) {
+	      (*ptr == '-') || (*ptr == '+') || (*ptr == ':') || (*ptr == '^'))) {
 		ERROR("%s[%d]: Parse error at unexpected text: %s",
 		      frame->filename, frame->lineno, ptr);
 		return -1;

--- a/src/lib/server/map.c
+++ b/src/lib/server/map.c
@@ -1558,6 +1558,14 @@ int map_to_request(request_t *request, map_t const *map, radius_map_getvalue_t f
 		break;
 
 	/*
+	 *	^= - Prepend src_list attributes to the destination
+	 */
+	case T_OP_PREPEND:
+		fr_pair_list_prepend(list, &src_list);
+		fr_pair_list_free(&src_list);
+		break;
+
+	/*
 	 *	+= - Add all src_list attributes to the destination
 	 */
 	case T_OP_ADD:

--- a/src/lib/server/map.c
+++ b/src/lib/server/map.c
@@ -1335,9 +1335,14 @@ int map_to_request(request_t *request, map_t const *map, radius_map_getvalue_t f
 				FALL_THROUGH;
 
 		case T_OP_ADD:
-				fr_pair_list_move(list, &src_list);
+				fr_pair_list_move(list, &src_list, T_OP_ADD);
 				fr_pair_list_free(&src_list);
 			}
+			goto update;
+
+		case T_OP_PREPEND:
+			fr_pair_list_move(list, &src_list, map->op);
+			fr_pair_list_free(&src_list);
 			goto update;
 
 		default:

--- a/src/lib/server/map_async.c
+++ b/src/lib/server/map_async.c
@@ -1084,6 +1084,19 @@ int map_list_mod_apply(request_t *request, vp_list_mod_t const *vlm)
 		}
 			goto finish;
 
+		case T_OP_PREPEND:
+		{
+			fr_pair_list_t	vp_from;
+
+			fr_pair_list_init(&vp_from);
+			map_list_mod_to_vps(parent, &vp_from, vlm);
+			fr_assert(!fr_pair_list_empty(&vp_from));
+
+			fr_pair_list_prepend(vp_list, &vp_from);
+
+			goto finish;
+		}
+
 		default:
 			rcode = -1;
 			goto finish;
@@ -1200,6 +1213,19 @@ int map_list_mod_apply(request_t *request, vp_list_mod_t const *vlm)
 		fr_pair_list_append(vp_list, &vp_from);
 	}
 		goto finish;
+
+	case T_OP_PREPEND:
+	{
+		fr_pair_list_t	vp_from;
+
+		fr_pair_list_init(&vp_from);
+		map_list_mod_to_vps(parent, &vp_from, vlm);
+		fr_assert(!fr_pair_list_empty(&vp_from));
+
+		fr_pair_list_prepend(vp_list, &vp_from);
+
+		goto finish;
+	}
 
 	/*
 	 *	= - Set only if not already set

--- a/src/lib/unlang/compile.c
+++ b/src/lib/unlang/compile.c
@@ -907,7 +907,7 @@ int unlang_fixup_update(map_t *map, UNUSED void *ctx)
 		}
 
 		/*
-		 *	Only += and :=, and !* operators are supported
+		 *	Only += and :=, and !*, and ^= operators are supported
 		 *	for lists.
 		 */
 		switch (map->op) {
@@ -937,6 +937,14 @@ int unlang_fixup_update(map_t *map, UNUSED void *ctx)
 		case T_OP_EQ:
 			if (!tmpl_is_exec(map->rhs)) {
 				cf_log_err(map->ci, "Invalid source for list assignment '%s = ...'", map->lhs->name);
+				return -1;
+			}
+			break;
+
+		case T_OP_PREPEND:
+			if (!tmpl_is_list(map->rhs) &&
+			    !tmpl_is_exec(map->rhs)) {
+				cf_log_err(map->ci, "Invalid source for list assignment '%s ^= ...'", map->lhs->name);
 				return -1;
 			}
 			break;

--- a/src/lib/util/pair.c
+++ b/src/lib/util/pair.c
@@ -2526,6 +2526,16 @@ void fr_pair_list_append(fr_pair_list_t *dst, fr_pair_list_t *src)
 	fr_dlist_move(&dst->head, &src->head);
 }
 
+/** Move a list of fr_pair_t from a temporary list to the head of a destination list
+ *
+ * @param dst list to move pairs into
+ * @param src from which to take pairs
+ */
+void fr_pair_list_prepend(fr_pair_list_t *dst, fr_pair_list_t *src)
+{
+	fr_dlist_move_head(&dst->head, &src->head);
+}
+
 /** Evaluation function for matching if vp matches a given da
  *
  * Can be used as a filter function for fr_dcursor_filter_next()

--- a/src/lib/util/pair.h
+++ b/src/lib/util/pair.h
@@ -285,6 +285,7 @@ int		fr_pair_list_copy_by_ancestor(TALLOC_CTX *ctx, fr_pair_list_t *to,
 					      fr_pair_list_t *from, fr_dict_attr_t const *parent_da, unsigned int count);
 int		fr_pair_sublist_copy(TALLOC_CTX *ctx, fr_pair_list_t *to, fr_pair_list_t const *from, fr_pair_t *item);
 void		fr_pair_list_append(fr_pair_list_t *dst, fr_pair_list_t *src);
+void		fr_pair_list_prepend(fr_pair_list_t *dst, fr_pair_list_t *src);
 
 /** @hidecallergraph */
 void		*fr_pair_list_head(fr_pair_list_t const *list);

--- a/src/lib/util/pair_legacy.h
+++ b/src/lib/util/pair_legacy.h
@@ -44,7 +44,7 @@ fr_token_t	fr_pair_list_afrom_str(TALLOC_CTX *ctx, fr_dict_t const *dict,
 int		fr_pair_list_afrom_file(TALLOC_CTX *ctx, fr_dict_t const *dict,
 					fr_pair_list_t *out, FILE *fp, bool *pfiledone);
 
-void		fr_pair_list_move(fr_pair_list_t *to, fr_pair_list_t *from);
+void		fr_pair_list_move(fr_pair_list_t *to, fr_pair_list_t *from, fr_token_t op);
 
 #ifdef __cplusplus
 }

--- a/src/lib/util/pair_legacy_tests.c
+++ b/src/lib/util/pair_legacy_tests.c
@@ -226,8 +226,8 @@ static void test_fr_pair_list_move(void)
 	TEST_CHECK(fr_pair_list_afrom_file(autofree, test_dict, &old_list, fp, &pfiledone) == 0);
 	TEST_CHECK(pfiledone == true);
 
-	TEST_CASE("Move pair from 'old_list' to 'old_list' using fr_pair_list_move()");
-	fr_pair_list_move(&new_list, &old_list);
+	TEST_CASE("Move pair from 'old_list' to 'new_list' using fr_pair_list_move()");
+	fr_pair_list_move(&new_list, &old_list, T_OP_ADD);
 
 	TEST_CASE("Looking for Test-Uint32-0");
 	TEST_CHECK((vp = fr_pair_find_by_da(&new_list, fr_dict_attr_test_uint32, 0)) != NULL);

--- a/src/lib/util/token.c
+++ b/src/lib/util/token.c
@@ -47,6 +47,7 @@ fr_table_num_ordered_t const fr_tokens_table[] = {
 	{ L("=*"), 	T_OP_CMP_TRUE	},
 	{ L("!*"), 	T_OP_CMP_FALSE	},
 	{ L("=="),	T_OP_CMP_EQ	},
+	{ L("^="),	T_OP_PREPEND	},
 	{ L("="),	T_OP_EQ		},
 	{ L("!="),	T_OP_NE		},
 	{ L(">="),	T_OP_GE		},
@@ -94,6 +95,7 @@ char const *fr_tokens[] = {
 	"=*",
 	"!*",
 	"==",
+	"^=",
 	"#",
 	"<BARE-WORD>",
 	"<\"STRING\">",
@@ -132,9 +134,10 @@ const char fr_token_quote[] = {
 	'?',		/* =* 		20 */
 	'?',		/* !* */
 	'?',		/* == */
-	'?',				/* # */
-	'\0',		/* bare word */
-	'"',		/* "foo" 	25 */
+	'?',		/* ^= */
+	'?',		/* # */
+	'\0',		/* bare word 	25 */
+	'"',		/* "foo" */
 	'\'',		/* 'foo' */
 	'`',		/* `foo` */
 	'/',		/* /foo/ */
@@ -166,9 +169,10 @@ const bool fr_assignment_op[] = {
 	false,		/* =* 		20 */
 	false,		/* !* */
 	false,		/* == */
-	false,				/* # */
-	false,		/* bare word */
-	false,		/* "foo" 	25 */
+	true,		/* ^= */
+	false,		/* # */
+	false,		/* bare word 	25 */
+	false,		/* "foo" */
 	false,		/* 'foo' */
 	false,		/* `foo` */
 	false
@@ -199,9 +203,10 @@ const bool fr_equality_op[] = {
 	true,		/* =* 		20 */
 	true,		/* !* */
 	true,		/* == */
-	false,				/* # */
-	false,		/* bare word */
-	false,		/* "foo" 	25 */
+	false,		/* ^= */
+	false,		/* # */
+	false,		/* bare word 	25 */
+	false,		/* "foo" */
 	false,		/* 'foo' */
 	false,		/* `foo` */
 	false
@@ -232,9 +237,10 @@ const bool fr_str_tok[] = {
 	false,		/* =* 		20 */
 	false,		/* !* */
 	false,		/* == */
-	false,				/* # */
-	true,		/* bare word */
-	true,		/* "foo" 	25 */
+	false,		/* ^= */
+	false,		/* # */
+	true,		/* bare word 	25 */
+	true,		/* "foo" */
 	true,		/* 'foo' */
 	true,		/* `foo` */
 	false

--- a/src/lib/util/token.h
+++ b/src/lib/util/token.h
@@ -60,9 +60,10 @@ typedef enum fr_token {
 	T_OP_CMP_TRUE,			/* =* 		20 */
 	T_OP_CMP_FALSE,			/* !* */
 	T_OP_CMP_EQ,			/* == */
+	T_OP_PREPEND,			/* ^= */
 	T_HASH,				/* # */
-	T_BARE_WORD,			/* bare word */
-	T_DOUBLE_QUOTED_STRING,		/* "foo" 	25 */
+	T_BARE_WORD,			/* bare word 	25 */
+	T_DOUBLE_QUOTED_STRING,		/* "foo" */
 	T_SINGLE_QUOTED_STRING,		/* 'foo' */
 	T_BACK_QUOTED_STRING,		/* `foo` */
 	T_SOLIDUS_QUOTED_STRING,	/* /foo/ */
@@ -70,7 +71,7 @@ typedef enum fr_token {
 } fr_token_t;
 
 #define T_EQSTART	T_OP_ADD
-#define	T_EQEND		(T_OP_CMP_EQ + 1)
+#define	T_EQEND		(T_OP_PREPEND + 1)
 
 /** Macro to use as dflt
  *

--- a/src/modules/rlm_csv/rlm_csv.c
+++ b/src/modules/rlm_csv/rlm_csv.c
@@ -459,6 +459,7 @@ static int csv_map_verify(map_t *map, void *instance)
 	case T_OP_EQ:
 	case T_OP_SUB:
 	case T_OP_ADD:
+	case T_OP_PREPEND:
 	case T_OP_LT:
 	case T_OP_GT:
 	case T_OP_LE:

--- a/src/modules/rlm_dhcpv4/rlm_dhcpv4.c
+++ b/src/modules/rlm_dhcpv4/rlm_dhcpv4.c
@@ -118,7 +118,7 @@ static xlat_action_t dhcpv4_decode_xlat(TALLOC_CTX *ctx, fr_dcursor_t *out,
 		decoded++;
 	}
 
-	fr_pair_list_move(&request->request_pairs, &head);
+	fr_pair_list_move(&request->request_pairs, &head, T_OP_ADD);
 
 	/* Free any unmoved pairs */
 	fr_pair_list_free(&head);

--- a/src/modules/rlm_exec/rlm_exec.c
+++ b/src/modules/rlm_exec/rlm_exec.c
@@ -370,7 +370,7 @@ static unlang_action_t mod_exec_wait_resume(rlm_rcode_t *p_result, module_ctx_t 
 		ctx = tmpl_list_ctx(request, inst->output_list);
 
 		fr_pair_list_afrom_box(ctx, &vps, request->dict, box);
-		if (!fr_pair_list_empty(&vps)) fr_pair_list_move(output_pairs, &vps);
+		if (!fr_pair_list_empty(&vps)) fr_pair_list_move(output_pairs, &vps, T_OP_ADD);
 
 		fr_dlist_talloc_free(&m->box);	/* has been consumed */
 	}

--- a/src/modules/rlm_files/rlm_files.c
+++ b/src/modules/rlm_files/rlm_files.c
@@ -531,7 +531,7 @@ redo:
 		/*
 		 *	Move the control items over, too.
 		 */
-		fr_pair_list_move(&request->control_pairs, &list);
+		fr_pair_list_move(&request->control_pairs, &list, T_OP_ADD);
 		fr_pair_list_free(&list);
 
 		/* ctx may be reply */

--- a/src/tests/keywords/map-csv-prepend
+++ b/src/tests/keywords/map-csv-prepend
@@ -1,0 +1,25 @@
+#
+#  PRE: update map
+#
+
+update control {
+	&Tmp-String-0 := "fail"
+}
+
+map csv &User-Name {
+	&control.Tmp-String-0 ^= 'field3'
+}
+
+if ("%{control.Tmp-String-0[0]}" != 'success') {
+	test_fail
+}
+
+if ("%{control.Tmp-String-0[1]}" != "fail") {
+	test_fail
+}
+
+if ("%{control.Tmp-String-0[#]}" != 2) {
+	test_fail
+}
+
+success

--- a/src/tests/keywords/update-prepend
+++ b/src/tests/keywords/update-prepend
@@ -1,0 +1,83 @@
+#
+#  PRE: update
+#
+
+# Define initial test strings
+update control {
+	&Tmp-String-0 := 'foo'
+	&Tmp-String-0 += 'baz'
+}
+
+# Reset the request list and add the test strings
+# FIXME:
+# Temporary way to add multiple copies of an attribute - this should become
+# &request.Tmp-String-0 += &control.Tmp-String-0 when multi copies of attributes
+# are copied again.  Currently the desired syntax won't work due to tmpl_t only holding
+# a single value_box - so when mapt_to_list_mod() builds the list of value for the rhs
+# of the expression only the first one is copied to the tmpl_t.  See around line 780
+# of map_async.c
+update {
+	&request.Tmp-String-0 !* ANY
+	&request.Tmp-String-0 += &control.Tmp-String-0[0]
+	&request.Tmp-String-0 += &control.Tmp-String-0[1]
+}
+
+# Prepend a single value
+update request {
+	&Tmp-String-0 ^= 'boink'
+}
+
+# The prepended value should be first followd by the other two
+if (("%{Tmp-String-0[0]}" != 'boink') || ("%{Tmp-String-0[1]}" != 'foo') || ("%{Tmp-String-0[2]}" != 'baz')) {
+	test_fail
+}
+
+if ("%{Tmp-String-0[#]}" != 3) {
+	test_fail
+}
+
+# Add an extra element to the start of control
+update control {
+	&Tmp-String-0 ^= 'wibble'
+}
+
+# Prepend control to request
+update {
+	&request ^= &control
+}
+
+# The attributes should now be "wibble", "foo", "baz", "boink", "foo", "baz"
+if (("%{Tmp-String-0[0]}" != 'wibble') || ("%{Tmp-String-0[1]}" != 'foo') || ("%{Tmp-String-0[2]}" != 'baz') || ("%{Tmp-String-0[3]}" != 'boink') || ("%{Tmp-String-0[4]}" != 'foo') || ("%{Tmp-String-0[5]}" != 'baz')) {
+	test_fail
+}
+
+if ("%{Tmp-String-0[#]}" != 6) {
+	test_fail
+}
+
+# Set up an attribute in control with a single value
+update control {
+	&Tmp-String-0 := 'initial'
+}
+
+# Prepend the list of Tmp-String-0 from request to the new attribute
+#update {
+#	&control.Tmp-String-0 ^= &request.Tmp-String-0
+#}
+
+# (Temporary method to acheive the same - as per issue noted above)
+update {
+	&control ^= &request
+}
+
+# The control attributes should now be "wibble", "foo", "baz", "boink", "foo", "baz", "initial"
+if (("%{control.Tmp-String-0[0]}" != 'wibble') || ("%{control.Tmp-String-0[1]}" != 'foo') || ("%{control.Tmp-String-0[2]}" != 'baz') || ("%{control.Tmp-String-0[3]}" != 'boink') || ("%{control.Tmp-String-0[4]}" != 'foo') || ("%{control.Tmp-String-0[5]}" != 'baz') || ("%{control.Tmp-String-0[6]}" != 'initial')) {
+	test_fail
+}
+
+if ("%{control.Tmp-String-0[#]}" != 7) {
+	test_fail
+}
+
+
+success

--- a/src/tests/modules/json/eval.unlang
+++ b/src/tests/modules/json/eval.unlang
@@ -105,6 +105,28 @@ update request {
 	&Tmp-Integer-0 !* ANY
 }
 
+# 9a. All of the array
+map json &Tmp-String-0 {
+	&Tmp-Integer-0 += '$.my_array.*'
+}
+if ((&Tmp-Integer-0[0] != 0) || (&Tmp-Integer-0[1] != 1) || (&Tmp-Integer-0[2] != 2) || (&Tmp-Integer-0[3] != 3) || (&Tmp-Integer-0[4] != 4) || (&Tmp-Integer-0[5] != 5)) {
+	test_fail
+}
+
+update request {
+	&Tmp-Integer-0 := 9
+}
+# 9b. All of the array using prepend, places the array before the existing value
+map json &Tmp-String-0 {
+	&Tmp-Integer-0 ^= '$.my_array.*'
+}
+if ((&Tmp-Integer-0[0] != 0) || (&Tmp-Integer-0[1] != 1) || (&Tmp-Integer-0[2] != 2) || (&Tmp-Integer-0[3] != 3) || (&Tmp-Integer-0[4] != 4) || (&Tmp-Integer-0[5] != 5) || (&Tmp-Integer-0[6] != 9)) {
+	test_fail
+}
+update request {
+	&Tmp-Integer-0 !* ANY
+}
+
 # 10. End of the array
 map json &Tmp-String-0 {
 	&Tmp-Integer-0 := '$.my_array[5]'	# Past the end of the array (should be skipped)

--- a/src/tests/modules/rest/rest_module.unlang
+++ b/src/tests/modules/rest/rest_module.unlang
@@ -1,3 +1,8 @@
+# Pre-set Tmp-String-2 to check correct operator behaviour
+update control {
+	&Tmp-String-2 := "foo"
+}
+
 # Test "authorize" rest call.  Uses http to a GET end point
 rest
 
@@ -23,11 +28,21 @@ if (&control.User-Name != "Bob") {
 	test_fail
 }
 
+# The "op" for setting Tmp-String-2 is ^=
+if ((&control.Tmp-String-2[0] != "Bob") || (&control.Tmp-String-2[1] != "foo")) {
+	test_fail
+}
+
 # Reset control attributes
 update control {
 	&Tmp-String-0 !* ANY
 	&Tmp-String-1 !* ANY
 	&User-Name !* ANY
+}
+
+# Pre-fill NAS-IP-Address to check operator behaviour
+update control {
+	&NAS-IP-Address := "10.0.0.10"
 }
 
 # Test "accounting" rest call.  Uses https to a POST end point
@@ -53,8 +68,12 @@ if (&control.User-Name != "Bob") {
 	test_fail
 }
 
+if ((&control.Tmp-String-2[0] != "Bob") || (&control.Tmp-String-2[1] != "Bob") || (&control.Tmp-String-2[2] != "foo")) {
+	test_fail
+}
+
 # NAS IP Address is passed in body data
-if (&control.NAS-IP-Address != "192.168.1.1") {
+if ((&control.NAS-IP-Address[0] != "10.0.0.10") || (&control.NAS-IP-Address[1] != "192.168.1.1")) {
 	test_fail
 }
 

--- a/src/tests/modules/rest/rest_xlat.unlang
+++ b/src/tests/modules/rest/rest_xlat.unlang
@@ -54,6 +54,19 @@ if (&control.User-Name != "Bob") {
 }
 
 update control {
+	&Tmp-String-3 := 'dummy'
+}
+
+# Directly use json map and prepend the returned value
+map json "%{rest:GET http://%{Tmp-String-0}:%{Tmp-Integer-0}/user/%{User-Name}/mac/%{Called-Station-Id}}" {
+	&control.Tmp-String-3 ^= '$.control\.User-Name.value'
+}
+
+if ((&control.Tmp-String-3[0] != 'Bob') || (&control.Tmp-String-3[1] != 'dummy')) {
+	test_fail
+}
+
+update control {
 	&Tmp-String-2 = "%{json_encode:&request.NAS-IP-Address}"
 }
 

--- a/src/tests/modules/sql/map.unlang
+++ b/src/tests/modules/sql/map.unlang
@@ -167,6 +167,38 @@ update {
 	&control.Tmp-Integer-0 !* ANY
 }
 
+# Retrieve our test row(s) - With ^= we should get the values from the second row then the first
+map sql 'SELECT * FROM radusergroup WHERE priority = 0' {
+	&control.Tmp-String-0	^= 'username'
+	&control.Tmp-String-1	^= 'groupname'
+	&control.Tmp-Integer-0	^= 'priority'
+}
+
+if (!updated) {
+	test_fail
+}
+
+debug_control
+
+if ((&control.Tmp-String-0[0] != 'oof') || (&control.Tmp-String-0[1] != 'bob')) {
+	test_fail
+}
+
+if ((&control.Tmp-String-1[0] != 'rab') || (&control.Tmp-String-1[1] != 'bar')) {
+	test_fail
+}
+
+if ((&control.Tmp-Integer-0[0] != 0) || (&control.Tmp-Integer-0[1] != 0)) {
+	test_fail
+}
+
+# Clear the control list
+update {
+	&control.Tmp-String-0 !* ANY
+	&control.Tmp-String-1 !* ANY
+	&control.Tmp-Integer-0 !* ANY
+}
+
 # Retrieve our test row(s) - With += we should get the values from both rows
 map sql 'SELECT * FROM radusergroup WHERE priority = 0' {
 	&control.Tmp-String-0	+= 'username'
@@ -364,3 +396,4 @@ else {
 	test_fail
 }
 
+test_pass


### PR DESCRIPTION
Implement PR 3667 for FreeRADIUS v4

For DHCP, the sequence of a repeated attribute can be significant.

Adding a prepend operator ^= allows for policy to specifically add attributes at the beginning of a list to specify the sequence of a repeated attribute when returned to the client.