### PR TITLE
v4: Add a "substring" xlat keyword

### DIFF
--- a/raddb/mods-available/unpack
+++ b/raddb/mods-available/unpack
@@ -7,17 +7,22 @@
 #
 #  = Unpack Module
 #
-#  The `unpack` module unpacks binary data from octets type attributes
+#  The `unpack` module provides two xlat functions:
+#
+#  `unpack` unpacks binary data from octets type attributes
 #  into individual attributes.
 #
 #  It is used when vendors put multiple fields into one attribute
 #  of type "octets".
 #
+#  `substring` returns a substring from either the string representation
+#  of an attribute or a literal string
+#
 #  NOTE: The module is useful only for `xlat`.
 #
 
 #
-#  ## Syntax
+#  ## Unpack Syntax
 #
 #  To use it, add it to the `raddb/mods-enabled/` directory.  Then,
 #  use it on the right-hand side of a variable assignment.
@@ -43,13 +48,50 @@
 #
 
 #
-#  ## Sample
+#  ## Unpack Sample
 #
 #  if we have `Class = 0x00000001020304`, then
 #
 #    %{unpack:&Class 4 uint16}
 #
 #  will unpack octets `4` and `5` as a `uint16`, which has value `0x0304`.
+#
+
+#
+#  ## Substring Syntax
+#
+#  `substring` is for use on the right-hand side of variable assignment.
+#
+#    %{substring:<data> <start> <len>}
+#
+#  The arguments are three fields:
+#
+#  data::
+#
+#  Either `&Attribute-Name` the name of an attribute to express as a string
+#  or literal `string` data.
+#
+#  start::
+#
+#  The offset into the expanded string from which the substring is copied.  The
+#  offset starts at zero.  Values of `start` less than zero are counted in from
+#  the end of the string.
+#
+#  len::
+#
+#  The length of the substring to return.  If the requested length is greater
+#  than the available string then the returned length will be reduced.  Negative
+#  values for `len` remove that many characters from the end of the string.
+#
+
+#
+#  ## Substring Sample
+#
+#  if we have `Tmp-String-0 = "foo bar"`, then
+#
+#    %{substring:&Tmp-String-0 2 3}
+#
+#  will return "o b"
 #
 
 #

--- a/src/modules/rlm_unpack/rlm_unpack.c
+++ b/src/modules/rlm_unpack/rlm_unpack.c
@@ -351,7 +351,7 @@ static ssize_t substring_xlat(UNUSED TALLOC_CTX *ctx, char **out, size_t outlen,
 	}
 
 	if (start > slen) {
-		*out = '\0';
+		*out[0] = '\0';
 		talloc_free(buffer);
 		WARN("Start position %li is after end of string length of %li", start, slen);
 		return 0;

--- a/src/tests/keywords/substring
+++ b/src/tests/keywords/substring
@@ -1,0 +1,312 @@
+#
+# PRE: update
+#
+#  Check substring xlat works correctly
+#
+update {
+	&control.Cleartext-Password := 'hello'
+	&reply.Filter-Id := 'filter'
+}
+
+update request {
+	&Tmp-String-0      := 'foo bar'
+	&Tmp-Integer-0     := 54786512
+	&Tmp-IP-Address-0  := 192.168.56.34
+	&Tmp-Ethernet-0    := 01:23:45:67:89:ab
+}
+
+update request {
+	&Tmp-String-1 := "%{substring:&Tmp-String-0 2 3}"
+	&Tmp-String-2 := "%{substring:&Tmp-String-0 -3 3}"
+	&Tmp-String-3 := "%{substring:&Tmp-String-0 1 -3}"
+	&Tmp-String-4 := "%{substring:&Tmp-String-0 -4 -1}"
+	&Tmp-String-5 := "%{substring:&Tmp-String-0 8 5}"
+	&Tmp-String-6 := "%{substring:&Tmp-String-0 4 -10}"
+	&Tmp-String-7 := "%{substring:&Tmp-String-0 0 7}"
+	&Tmp-String-8 := "%{substring:&Tmp-String-0 3 0}"
+	&Tmp-String-9 := "%{substring:&Tmp-String-0 4 8}"
+}
+
+if (&Tmp-String-1 != 'o b') {
+	test_fail
+}
+
+if (&Tmp-String-2 != 'bar') {
+	test_fail
+}
+
+if (&Tmp-String-3 != 'oo ') {
+	test_fail
+}
+
+if (&Tmp-String-4 != ' ba') {
+	test_fail
+}
+
+if (&Tmp-String-5 != '') {
+	test_fail
+}
+
+if (&Tmp-String-6 != '') {
+	test_fail
+}
+
+if (&Tmp-String-7 != 'foo bar') {
+	test_fail
+}
+
+if (&Tmp-String-8 != '') {
+	test_fail
+}
+
+if (&Tmp-String-9 != 'bar') {
+	test_fail
+}
+
+update request {
+	&Tmp-String-0      := ' foo bar '
+}
+
+update request {
+	&Tmp-String-1 := "%{substring: &Tmp-String-0 2 3}"
+	&Tmp-String-2 := "%{substring:&Tmp-String-0 -3 3}"
+	&Tmp-String-3 := "%{substring:&Tmp-String-0 1 -3}"
+	&Tmp-String-4 := "%{substring:&Tmp-String-0 -4 -1}"
+	&Tmp-String-5 := "%{substring:&Tmp-String-0 10 5}"
+	&Tmp-String-6 := "%{substring:&Tmp-String-0 4 -10}"
+	&Tmp-String-7 := "%{substring:&Tmp-String-0 0 9}"
+	&Tmp-String-8 := "%{substring:&Tmp-String-0 3 0}"
+	&Tmp-String-9 := "%{substring:&Tmp-String-0 4 10}"
+}
+
+if (&Tmp-String-1 != 'oo ') {
+	test_fail
+}
+
+if (&Tmp-String-2 != 'ar ') {
+	test_fail
+}
+
+if (&Tmp-String-3 != 'foo b') {
+	test_fail
+}
+
+if (&Tmp-String-4 != 'bar') {
+	test_fail
+}
+
+if (&Tmp-String-5 != '') {
+	test_fail
+}
+
+if (&Tmp-String-6 != '') {
+	test_fail
+}
+
+if (&Tmp-String-7 != ' foo bar ') {
+	test_fail
+}
+
+if (&Tmp-String-8 != '') {
+	test_fail
+}
+
+if (&Tmp-String-9 != ' bar ') {
+	test_fail
+}
+
+update request {
+	&Tmp-String-1 := "%{substring:&Tmp-Integer-0 2 3}"
+	&Tmp-String-2 := "%{substring:&Tmp-Integer-0 -3 3}"
+	&Tmp-String-3 := "%{substring:&Tmp-Integer-0 1 -3}"
+	&Tmp-String-4 := "%{substring:&Tmp-Integer-0 -4 -1}"
+	&Tmp-String-5 := "%{substring:&Tmp-Integer-0 8 5}"
+	&Tmp-String-6 := "%{substring:&Tmp-Integer-0 4 -10}"
+	&Tmp-String-7 := "%{substring:&Tmp-Integer-0 0 8}"
+	&Tmp-String-8 := "%{substring:&Tmp-Integer-0 5 0}"
+	&Tmp-String-9 := "%{substring:&Tmp-Integer-0 4 10}"
+}
+
+if (&Tmp-String-1 != '786') {
+	test_fail
+}
+
+if (&Tmp-String-2 != '512') {
+	test_fail
+}
+
+if (&Tmp-String-3 != '4786') {
+	test_fail
+}
+
+if (&Tmp-String-4 != '651') {
+	test_fail
+}
+
+if (&Tmp-String-5 != '') {
+	test_fail
+}
+
+if (&Tmp-String-6 != '') {
+	test_fail
+}
+
+if (&Tmp-String-7 != '54786512') {
+	test_fail
+}
+
+if (&Tmp-String-8 != '') {
+	test_fail
+}
+
+if (&Tmp-String-9 != '6512') {
+	test_fail
+}
+
+update request {
+	&Tmp-String-1 := "%{substring:&Tmp-IP-Address-0 2 3}"
+	&Tmp-String-2 := "%{substring:&Tmp-IP-Address-0 -3 3}"
+	&Tmp-String-3 := "%{substring:&Tmp-IP-Address-0 1 -3}"
+	&Tmp-String-4 := "%{substring:&Tmp-IP-Address-0 -4 -1}"
+	&Tmp-String-5 := "%{substring:&Tmp-IP-Address-0 15 5}"
+	&Tmp-String-6 := "%{substring:&Tmp-IP-Address-0 4 -20}"
+	&Tmp-String-7 := "%{substring:&Tmp-IP-Address-0 0 13}"
+	&Tmp-String-8 := "%{substring:&Tmp-IP-Address-0 6 0}"
+	&Tmp-String-9 := "%{substring:&Tmp-IP-Address-0 8 12}"
+}
+
+if (&Tmp-String-1 != '2.1') {
+	test_fail
+}
+
+if (&Tmp-String-2 != '.34') {
+	test_fail
+}
+
+if (&Tmp-String-3 != '92.168.56') {
+	test_fail
+}
+
+if (&Tmp-String-4 != '6.3') {
+	test_fail
+}
+
+if (&Tmp-String-5 != '') {
+	test_fail
+}
+
+if (&Tmp-String-6 != '') {
+	test_fail
+}
+
+if (&Tmp-String-7 != '192.168.56.34') {
+	test_fail
+}
+
+if (&Tmp-String-8 != '') {
+	test_fail
+}
+
+if (&Tmp-String-9 != '56.34') {
+	test_fail
+}
+
+update request {
+	&Tmp-String-1 := "%{substring:&Tmp-Ethernet-0 2 3}"
+	&Tmp-String-2 := "%{substring:&Tmp-Ethernet-0 -3 3}"
+	&Tmp-String-3 := "%{substring:&Tmp-Ethernet-0 1 -3}"
+	&Tmp-String-4 := "%{substring:&Tmp-Ethernet-0 -4 -1}"
+	&Tmp-String-5 := "%{substring:&Tmp-Ethernet-0 20 5}"
+	&Tmp-String-6 := "%{substring:&Tmp-Ethernet-0 4 -20}"
+	&Tmp-String-7 := "%{substring:&Tmp-Ethernet-0 0 17}"
+	&Tmp-String-8 := "%{substring:&Tmp-Ethernet-0 8 0}"
+	&Tmp-String-9 := "%{substring:&Tmp-Ethernet-0 9 12}"
+}
+
+if (&Tmp-String-1 != ':23') {
+	test_fail
+}
+
+if (&Tmp-String-2 != ':ab') {
+	test_fail
+}
+
+if (&Tmp-String-3 != '1:23:45:67:89') {
+	test_fail
+}
+
+if (&Tmp-String-4 != '9:a') {
+	test_fail
+}
+
+if (&Tmp-String-5 != '') {
+	test_fail
+}
+
+if (&Tmp-String-6 != '') {
+	test_fail
+}
+
+if (&Tmp-String-7 != '01:23:45:67:89:ab') {
+	test_fail
+}
+
+if (&Tmp-String-8 != '') {
+	test_fail
+}
+
+if (&Tmp-String-9 != '67:89:ab') {
+	test_fail
+}
+
+update request {
+	&Tmp-String-1 := "%{substring:foo bar 2 3}"
+	&Tmp-String-2 := "%{substring:foo bar -3 3}"
+	&Tmp-String-3 := "%{substring:foo bar 1 -3}"
+	&Tmp-String-4 := "%{substring:foo bar -4 -1}"
+	&Tmp-String-5 := "%{substring:foo bar 8 5}"
+	&Tmp-String-6 := "%{substring:foo bar 4 -10}"
+	&Tmp-String-7 := "%{substring: foo bar  0 9}"
+	&Tmp-String-8 := "%{substring: foo bar  5 0}"
+	&Tmp-String-9 := "%{substring: foo bar  4 10}"
+}
+
+debug_request
+
+if (&Tmp-String-1 != 'o b') {
+	test_fail
+}
+
+if (&Tmp-String-2 != 'bar') {
+	test_fail
+}
+
+if (&Tmp-String-3 != 'oo ') {
+	test_fail
+}
+
+if (&Tmp-String-4 != ' ba') {
+	test_fail
+}
+
+if (&Tmp-String-5 != '') {
+	test_fail
+}
+
+if (&Tmp-String-6 != '') {
+	test_fail
+}
+
+if (&Tmp-String-7 != ' foo bar ') {
+	test_fail
+}
+
+if (&Tmp-String-8 != '') {
+	test_fail
+}
+
+if (&Tmp-String-9 != ' bar ') {
+	test_fail
+}
+
+success

--- a/src/tests/keywords/unit_test_module.conf
+++ b/src/tests/keywords/unit_test_module.conf
@@ -22,6 +22,8 @@ modules {
 
 	$INCLUDE ${raddb}/mods-enabled/escape
 
+	$INCLUDE ${raddb}/mods-enabled/unpack
+
 	delay reschedule {
 		force_reschedule = yes
 	}


### PR DESCRIPTION
Add an xlat substring keyword with the syntax
 `"%{substring:<attribute | string> <start> <len>}"`

Follows normal substring behaviour where `start` and `len` can be negative to count from the end of the string.

Particularly useful in conditional work for DHCP - e.g. extracting a vendor prefix from a hardware address.