### PR TITLE
DHCP: Dedicated rlm_sql instance to support option lookup

### DIFF
--- a/raddb/mods-available/dhcp_sql
+++ b/raddb/mods-available/dhcp_sql
@@ -1,0 +1,92 @@
+# -*- text -*-
+##
+## mods-available/sql -- SQL modules
+##
+##	$Id$
+
+######################################################################
+#
+#  Configuration for the DHCP-specific instance of the SQL module
+#
+#  The database schemas and queries are located in subdirectories:
+#
+#	sql/dhcp/<DB>/schema.sql	Schema
+#	sql/dhcp/<DB>/queries.conf	Reply options lookup queries
+#
+#  Where "DB" is mysql, mssql, oracle, or postgresql.
+#
+
+#
+#  See raddb/mods-available/sql for a description of the configuration items
+#  for the sql module.
+#
+sql dhcp_sql {
+	dialect = "sqlite"
+	driver = "rlm_sql_null"
+#	driver = "rlm_sql_${dialect}"
+
+	sqlite {
+		filename = "/tmp/freeradius.db"
+		busy_timeout = 200
+		bootstrap = "${modconfdir}/${..:name}/dhcp/sqlite/schema.sql"
+	}
+
+	mysql {
+		tls {
+			ca_file = "/etc/ssl/certs/my_ca.crt"
+			ca_path = "/etc/ssl/certs/"
+			certificate_file = "/etc/ssl/certs/private/client.crt"
+			private_key_file = "/etc/ssl/certs/private/client.key"
+			cipher = "DHE-RSA-AES256-SHA:AES128-SHA"
+
+			tls_required = yes
+			tls_check_cert = no
+			tls_check_cert_cn = no
+		}
+		warnings = auto
+	}
+
+	postgresql {
+		send_application_name = yes
+	}
+
+	mongo {
+		appname = "freeradius"
+		tls {
+			certificate_file = /path/to/file
+			certificate_password = "password"
+			ca_file = /path/to/file
+			ca_dir = /path/to/directory
+			crl_file = /path/to/file
+			weak_cert_validation = false
+			allow_invalid_hostname = false
+		}
+	}
+
+#       server = "localhost"
+#       port = 3306
+#       login = "radius"
+#       password = "radpass"
+
+	radius_db = "radius"
+
+	dhcpreply_table = "dhcpreply"
+	groupreply_table = "dhcpgroupreply"
+	dhcpgroup_table = "dhcpgroup"
+	read_groups = no
+
+	pool {
+		start = ${thread[pool].start_servers}
+		min = ${thread[pool].min_spare_servers}
+		max = ${thread[pool].max_servers}
+		spare = ${thread[pool].max_spare_servers}
+		uses = 0
+		retry_delay = 30
+		lifetime = 0
+		idle_timeout = 60
+	}
+
+	group_attribute = "${.:instance}-SQL-Group"
+
+	$INCLUDE ${modconfdir}/${.:name}/dhcp/${dialect}/queries.conf
+}

--- a/raddb/mods-available/dhcp_sqlippool
+++ b/raddb/mods-available/dhcp_sqlippool
@@ -19,7 +19,7 @@ sqlippool dhcp_sqlippool {
 	#
 	#  If you have multiple sql instances, such as "sql sql1 {...}",
 	#  use the *instance* name here: sql1.
-	sql_module_instance = "sql"
+	sql_module_instance = "dhcp_sql"
 
 	#  This is duplicative of info available in the SQL module, but
 	#  we have to list it here as we do not yet support nested

--- a/raddb/mods-config/sql/dhcp/mssql/queries.conf
+++ b/raddb/mods-config/sql/dhcp/mssql/queries.conf
@@ -1,0 +1,52 @@
+# -*- text -*-
+#
+#  dhcp/mssql/queries.conf -- MSSQL configuration for DHCP schema (schema.sql)
+#
+#  $Id$
+
+# Safe characters list for sql queries. Everything else is replaced
+# with their mime-encoded equivalents.
+# The default list should be ok
+# safe_characters = "@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_: /"
+
+#######################################################################
+#  Query config:  Identifier
+#######################################################################
+# This is the identifier that will get substituted, escaped, and added
+# as attribute 'SQL-User-Name'.  '%{SQL-User-Name}' should be used
+# below everywhere an identifier substitution is needed so you you can
+# be sure the identifier passed from the client is escaped properly.
+#
+sql_user_name = "%{control:DHCP-SQL-Option-Identifier}"
+
+#######################################################################
+#  Attribute Lookup Queries
+#######################################################################
+#  These queries setup the reply items in ${dhcpreply_table} and
+#  ${group_reply_query}.  You can use any query/tables you want, but
+#  the return data for each row MUST be in the following order:
+#
+#  0. Row ID (currently unused)
+#  1. Identifier
+#  2. Item Attr Name
+#  3. Item Attr Value
+#  4. Item Attr Operation
+#######################################################################
+
+authorize_reply_query = "\
+	SELECT id, Identifier, Attribute, Value, op \
+	FROM ${dhcpreply_table} \
+	WHERE Identifier = '%{SQL-User-Name}' AND Context = '%{control:DHCP-SQL-Option-Context}' \
+	ORDER BY id"
+
+authorize_group_reply_query = "\
+	SELECT id, GroupName, Attribute, Value, op \
+	FROM ${groupreply_table} \
+	WHERE GroupName = '%{${group_attribute}}' AND Context = '%{control:DHCP-SQL-Option-Context}' \
+	ORDER BY id"
+
+group_membership_query = "\
+	SELECT GroupName \
+	FROM ${dhcpgroup_table} \
+	WHERE Identifier='%{SQL-User-Name}' AND Context = '%{control:DHCP-SQL-Option-Context}' \
+	ORDER BY priority"

--- a/raddb/mods-config/sql/dhcp/mssql/schema.sql
+++ b/raddb/mods-config/sql/dhcp/mssql/schema.sql
@@ -1,0 +1,91 @@
+-- $Id$
+--
+-- MSSQL schema for DHCP for FreeRADIUS
+--
+-- To load:
+--  isql -S db_ip_addr -d db_name -U db_login -P db_passwd -i schema.sql
+
+--
+-- Table structure for table 'dhcpgroupreply'
+--
+CREATE TABLE [dhcpgroupreply] (
+	[id] [int] IDENTITY (1, 1) NOT NULL,
+	[GroupName] [varchar] (64) NOT NULL,
+	[Attribute] [varchar] (32) NOT NULL,
+	[Value] [varchar] (253) NOT NULL,
+	[op] [char] (2) NULL,
+	[prio] [int] NOT NULL,
+	[Context] [varchar] (16) NOT NULL
+) ON [PRIMARY]
+GO
+
+ALTER TABLE [dhcpgroupreply] WITH NOCHECK ADD
+	CONSTRAINT [DF_dhcpgroupreply_GroupName] DEFAULT ('') FOR [GroupName],
+	CONSTRAINT [DF_dhcpgroupreply_Attribute] DEFAULT ('') FOR [Attribute],
+	CONSTRAINT [DF_dhcpgroupreply_Value] DEFAULT ('') FOR [Value],
+	CONSTRAINT [DF_dhcpgroupreply_op] DEFAULT (null) FOR [op],
+	CONSTRAINT [DF_dhcpgroupreply_prio] DEFAULT (0) FOR [prio],
+	CONSTRAINT [DF_dhcpgroupreply_context] DEFAULT ('') FOR [Context],
+	CONSTRAINT [PK_dhcpgroupreply] PRIMARY KEY NONCLUSTERED
+	(
+		[id]
+	) ON [PRIMARY]
+GO
+
+CREATE INDEX [GroupName] ON [dhcpgroupreply]([Context],[GroupName]) ON [PRIMARY]
+GO
+
+
+--
+-- Table structure for table 'dhcpreply'
+--
+CREATE TABLE [dhcpreply] (
+	[id] [int] IDENTITY (1, 1) NOT NULL,
+	[Identifier] [varchar] (64) NOT NULL,
+	[Attribute] [varchar] (32) NOT NULL,
+	[Value] [varchar] (253) NOT NULL,
+	[op] [char] (2) NULL,
+	[Context] [varchar] (16) NOT NULL
+) ON [PRIMARY]
+GO
+
+ALTER TABLE [dhcpreply] WITH NOCHECK ADD
+	CONSTRAINT [DF_dhcpreply_Identifier] DEFAULT ('') FOR [Identifier],
+	CONSTRAINT [DF_dhcpreply_Attribute] DEFAULT ('') FOR [Attribute],
+	CONSTRAINT [DF_dhcpreply_Value] DEFAULT ('') FOR [Value],
+	CONSTRAINT [DF_dhcpreply_op] DEFAULT (null) FOR [op],
+	CONSTRAINT [DF_dhcpreply_Context] DEFAULT ('') FOR [Context],
+	CONSTRAINT [PK_dhcpreply] PRIMARY KEY NONCLUSTERED
+	(
+		[id]
+	) ON [PRIMARY]
+GO
+
+CREATE INDEX [Identifier] ON [dhcpreply]([Context],[Identifier]) ON [PRIMARY]
+GO
+
+
+--
+-- Table structure for table 'dhcpgroup'
+--
+CREATE TABLE [dhcpgroup] (
+	[id] [int] IDENTITY (1, 1) NOT NULL,
+	[Identifier] [varchar] (64) NOT NULL,
+	[GroupName] [varchar] (64) NULL,
+	[Priority] [int] NULL,
+	[Context] [varchar] (16) NULL
+) ON [PRIMARY]
+GO
+
+ALTER TABLE [dhcpgroup] WITH NOCHECK ADD
+	CONSTRAINT [DF_dhcpgroup_Identifier] DEFAULT ('') FOR [Identifier],
+	CONSTRAINT [DF_dhcpgroup_GroupName] DEFAULT ('') FOR [GroupName],
+	CONSTRAINT [DF_dhcpgroup_Context] DEFAULT ('') FOR [Context],
+	CONSTRAINT [PK_dhcpgroup] PRIMARY KEY NONCLUSTERED
+	(
+		[id]
+	) ON [PRIMARY]
+GO
+
+CREATE INDEX [Identifier] ON [dhcpgroup]([Context],[Identifier]) ON [PRIMARY]
+GO

--- a/raddb/mods-config/sql/dhcp/mysql/queries.conf
+++ b/raddb/mods-config/sql/dhcp/mysql/queries.conf
@@ -1,0 +1,75 @@
+# -*- text -*-
+#
+#  dhcp/mysql/queries.conf -- MySQL configuration for DHCP schema (schema.sql)
+#
+#  $Id$
+
+# Use the driver specific SQL escape method.
+#
+# If you enable this configuration item, the "safe_characters"
+# configuration is ignored.  FreeRADIUS then uses the PostgreSQL escape
+# functions to escape input strings.  The only downside to making this
+# change is that the PostgreSQL escaping method is not the same the one
+# used by FreeRADIUS.  So characters which are NOT in the
+# "safe_characters" list will now be stored differently in the database.
+#
+#auto_escape = yes
+
+# Safe characters list for sql queries. Everything else is replaced
+# with their mime-encoded equivalents.
+# The default list should be ok
+# Using 'auto_escape' is preferred
+safe_characters = "@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_: /"
+
+#######################################################################
+#  Connection config
+#######################################################################
+# The character set is not configurable. The default character set of
+# the mysql client library is used. To control the character set,
+# create/edit my.cnf (typically in /etc/mysql/my.cnf or /etc/my.cnf)
+# and enter
+# [client]
+# default-character-set = utf8
+#
+
+#######################################################################
+#  Query config:  Identifier
+#######################################################################
+# This is the identifier that will get substituted, escaped, and added
+# as attribute 'SQL-User-Name'.  '%{SQL-User-Name}' should be used
+# below everywhere an identifier substitution is needed so you you can
+# be sure the identifier passed from the client is escaped properly.
+#
+sql_user_name = "%{control:DHCP-SQL-Option-Identifier}"
+
+#######################################################################
+#  Attribute Lookup Queries
+#######################################################################
+#  These queries setup the reply items in ${dhcpreply_table} and
+#  ${group_reply_query}.  You can use any query/tables you want, but
+#  the return data for each row MUST be in the following order:
+#
+#  0. Row ID (currently unused)
+#  1. Identifier
+#  2. Item Attr Name
+#  3. Item Attr Value
+#  4. Item Attr Operation
+#######################################################################
+
+authorize_reply_query = "\
+	SELECT id, identifier, attribute, value, Op \
+	FROM ${dhcpreply_table} \
+	WHERE identifier = '%{SQL-User-Name}' AND context = '%{control:DHCP-SQL-Option-Context}' \
+	ORDER BY id"
+
+authorize_group_reply_query = "\
+	SELECT id, groupname, attribute, value, op \
+	FROM ${groupreply_table} \
+	WHERE groupname = '%{${group_attribute}}' AND context = '%{control:DHCP-SQL-Option-Context}' \
+	ORDER BY id"
+
+group_membership_query = "\
+	SELECT groupnme \
+	FROM ${dhcpgroup_table} \
+	WHERE identifier='%{SQL-User-Name}' AND context = '%{control:DHCP-SQL-Option-Context}' \
+	ORDER BY priority"

--- a/raddb/mods-config/sql/dhcp/mysql/schema.sql
+++ b/raddb/mods-config/sql/dhcp/mysql/schema.sql
@@ -1,0 +1,47 @@
+#
+# $Id$
+#
+# PostgreSQL schema for DHCP for FreeRADIUS
+#
+#
+
+#
+# Table structure for table 'dhcpgroupreply'
+#
+CREATE TABLE IF NOT EXISTS dhcpgroupreply (
+  id int(11) unsigned NOT NULL auto_increment,
+  groupname varchar(64) NOT NULL default '',
+  attribute varchar(64) NOT NULL default '',
+  op char(2) NOT NULL DEFAULT '=',
+  value varchar(253) NOT NULL default '',
+  context varchar(16) NOT NULL default '',
+  PRIMARY KEY (id),
+  KEY groupname (context,groupname(32))
+);
+
+#
+# Table structure for table 'dhcpreply'
+#
+CREATE TABLE IF NOT EXISTS dhcpreply (
+  id int(11) unsigned NOT NULL auto_increment,
+  identifier varchar(253) NOT NULL default '',
+  attribute varchar(64) NOT NULL default '',
+  op char(2) NOT NULL DEFAULT '=',
+  value varchar(253) NOT NULL default '',
+  context varchar(16) NOT NULL default '',
+  PRIMARY KEY (id),
+  KEY identifier (context,identifier(32))
+);
+
+#
+# Table structure for table 'dhcpgroup'
+#
+CREATE TABLE IF NOT EXISTS dhcpgroup (
+  id int(11) unsigned NOT NULL auto_increment,
+  identifier varchar(253) NOT NULL default '',
+  groupname varchar(64) NOT NULL default '',
+  priority int(11) NOT NULL default '1',
+  context varchar(16) NOT NULL default '',
+  PRIMARY KEY (id),
+  KEY identifier (context,identifier(32))
+);

--- a/raddb/mods-config/sql/dhcp/mysql/setup.sql
+++ b/raddb/mods-config/sql/dhcp/mysql/setup.sql
@@ -1,0 +1,21 @@
+/*
+ * setup.sql -- MySQL commands for creating the RADIUS user.
+ *
+ *	WARNING: You should change 'localhost' and 'radpass'
+ *		 to something else.  Also update raddb/mods-available/sql
+ *		 with the new RADIUS password.
+ *
+ *	WARNING: This example file is untested.  Use at your own risk.
+ *		 Please send any bug fixes to the mailing list.
+ *
+ *	$Id$
+ */
+
+/*
+ *  Create default administrator for RADIUS
+ */
+CREATE USER 'radius'@'localhost' IDENTIFIED BY 'radpass';
+
+GRANT SELECT ON radius.dhcpreply TO 'radius'@'localhost';
+GRANT SELECT ON radius.dhcpgroupreply TO 'radius'@'localhost';
+GRANT SELECT ON radius.dhcpgroup TO 'radius'@'localhost';

--- a/raddb/mods-config/sql/dhcp/oracle/queries.conf
+++ b/raddb/mods-config/sql/dhcp/oracle/queries.conf
@@ -1,0 +1,47 @@
+# -*- text -*-
+#
+#  dhcp/oracle/queries.conf -- Oracle configuration for DHCP schema (schema.sql)
+#
+#  $Id$
+
+#######################################################################
+#  Query config:  Identifier
+#######################################################################
+# This is the identifier that will get substituted, escaped, and added
+# as attribute 'SQL-User-Name'.  '%{SQL-User-Name}' should be used
+# below everywhere an identifier substitution is needed so you you can
+# be sure the identifier passed from the client is escaped properly.
+#
+sql_user_name = "%{control:DHCP-SQL-Option-Identifier}"
+
+#######################################################################
+#  Attribute Lookup Queries
+#######################################################################
+#  These queries setup the reply items in ${dhcpreply_table} and
+#  ${group_reply_query}.  You can use any query/tables you want, but
+#  the return data for each row MUST be in the following order:
+#
+#  0. Row ID (currently unused)
+#  1. Identifier
+#  2. Item Attr Name
+#  3. Item Attr Value
+#  4. Item Attr Operation
+#######################################################################
+
+authorize_reply_query = "\
+	SELECT id, identifier, attribute, value, op \
+	FROM ${dhcpreply_table} \
+	WHERE identifier = '%{SQL-User-Name}' AND context = '%{control:DHCP-SQL-Option-Context}' \
+	ORDER BY id"
+
+authorize_group_reply_query = "\
+	SELECT id, groupname, attribute, value, op \
+	FROM ${groupreply_table} \
+	WHERE groupname = '%{${group_attribute}}' AND context = '%{control:DHCP-SQL-Option-Context}' \
+	ORDER BY id"
+
+group_membership_query = "\
+	SELECT groupname \
+	FROM ${dhcpgroup_table} \
+	WHERE identifier='%{SQL-User-Name}' AND context = '%{control:DHCP-SQL-Option-Context}' \
+	ORDER BY priority"

--- a/raddb/mods-config/sql/dhcp/oracle/schema.sql
+++ b/raddb/mods-config/sql/dhcp/oracle/schema.sql
@@ -1,0 +1,81 @@
+/*
+ * $Id$
+ *
+ * Oracle schema for DHCP for FreeRADIUS
+ *
+ */
+
+/*
+ * Table structure for table 'dhcpgroupreply'
+ */
+CREATE TABLE dhcpgroupreply (
+	id		INT PRIMARY KEY,
+	groupname	VARCHAR(64) NOT NULL,
+	attribute	VARCHAR(64) NOT NULL,
+	op		CHAR(2) NOT NULL,
+	value		VARCHAR(253) NOT NULL,
+	context		VARCHAR(16) NOT NULL
+);
+CREATE INDEX dhcpgroupreply_idx1 ON dhcpgroupreply(context,groupname);
+CREATE SEQUENCE dhcpgroupreply_seq START WITH 1 INCREMENT BY 1;
+
+/* Trigger to emulate a serial # on the primary key */
+CREATE OR REPLACE TRIGGER dhcpgroupreply_serialnumber
+	BEFORE INSERT OR UPDATE OF id ON dhcpgroupreply
+	FOR EACH ROW
+	BEGIN
+		if ( :new.id = 0 or :new.id is null ) then
+			SELECT dhcpgroupreply_seq.nextval into :new.id from dual;
+		end if;
+	END;
+/
+
+/*
+ * Table structure for table 'dhcpreply'
+ */
+CREATE TABLE dhcpreply (
+	id		INT PRIMARY KEY,
+	identifier	VARCHAR(253) NOT NULL,
+	attribute	VARCHAR(64) NOT NULL,
+	op		CHAR(2) NOT NULL,
+	value		VARCHAR(253) NOT NULL,
+	context		VARCHAR(16) NOT NULL
+);
+CREATE INDEX dhcpreply_idx1 ON dhcpreply(context,identifier);
+CREATE SEQUENCE dhcpreply_seq START WITH 1 INCREMENT BY 1;
+
+/* Trigger to emulate a serial # on the primary key */
+CREATE OR REPLACE TRIGGER dhcpreply_serialnumber
+	BEFORE INSERT OR UPDATE OF id ON dhcpreply
+	FOR EACH ROW
+	BEGIN
+		if ( :new.id = 0 or :new.id is null ) then
+			SELECT dhcpreply_seq.nextval into :new.id from dual;
+		end if;
+	END;
+/
+
+/*
+ * Table structure for table 'dhcpgroup'
+ */
+CREATE TABLE dhcpgroup (
+	id		INT PRIMARY KEY,
+	identifier	VARCHAR(253) NOT NULL,
+	groupname	VARCHAR(64) NOT NULL,
+	priority	INT NOT NULL,
+	context		VARCHAR(16) NOT NULL
+);
+CREATE INDEX dhcpgroup_idx1 ON dhcpgroup(context,identifier);
+CREATE SEQUENCE dhcpgroup_seq START WITH 1 INCREMENT BY 1;
+
+/* Trigger to emulate a serial # on the primary key */
+CREATE OR REPLACE TRIGGER dhcpgroup_serialnumber
+	BEFORE INSERT OR UPDATE OF id ON dhcpgroup
+	FOR EACH ROW
+	BEGIN
+		if ( :new.id = 0 or :new.id is null ) then
+			SELECT dhcpgroup_seq.nextval into :new.id from dual;
+		end if;
+	END;
+/
+

--- a/raddb/mods-config/sql/dhcp/postgresql/queries.conf
+++ b/raddb/mods-config/sql/dhcp/postgresql/queries.conf
@@ -1,0 +1,76 @@
+# -*- text -*-
+#
+#  dhcp/postgresql/queries.conf -- PostgreSQL configuration for DHCP schema (schema.sql)
+#
+#  $Id$
+
+# Use the driver specific SQL escape method.
+#
+# If you enable this configuration item, the "safe_characters"
+# configuration is ignored.  FreeRADIUS then uses the PostgreSQL escape
+# functions to escape input strings.  The only downside to making this
+# change is that the PostgreSQL escaping method is not the same the one
+# used by FreeRADIUS.  So characters which are NOT in the
+# "safe_characters" list will now be stored differently in the database.
+#
+#auto_escape = yes
+
+# Safe characters list for sql queries. Everything else is replaced
+# with their mime-encoded equivalents.
+# The default list should be ok
+# Using 'auto_escape' is preferred
+# safe_characters = "@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_: /"
+
+#######################################################################
+#  Query config:  Identifier
+#######################################################################
+# This is the identifier that will get substituted, escaped, and added
+# as attribute 'SQL-User-Name'.  '%{SQL-User-Name}' should be used
+# below everywhere an identifier substitution is needed so you you can
+# be sure the identifier passed from the client is escaped properly.
+#
+sql_user_name = "%{control:DHCP-SQL-Option-Identifier}"
+
+#######################################################################
+#  Open Query
+#######################################################################
+# This query is run whenever a new connection is opened.
+# It is commented out by default.
+#
+# If you have issues with connections hanging for too long, uncomment
+# the next line, and set the timeout in milliseconds.  As a general
+# rule, if the queries take longer than a second, something is wrong
+# with the database.
+#open_query = "set statement_timeout to 1000"
+
+#######################################################################
+#  Attribute Lookup Queries
+#######################################################################
+#  These queries setup the reply items in ${dhcpreply_table} and
+#  ${group_reply_query}.  You can use any query/tables you want, but
+#  the return data for each row MUST be in the following order:
+#
+#  0. Row ID (currently unused)
+#  1. Identifier
+#  2. Item Attr Name
+#  3. Item Attr Value
+#  4. Item Attr Operation
+#######################################################################
+
+authorize_reply_query = "\
+	SELECT id, Identifier, Attribute, Value, Op \
+	FROM ${dhcpreply_table} \
+	WHERE Identifier = '%{SQL-User-Name}' AND Context = '%{control:DHCP-SQL-Option-Context}' \
+	ORDER BY id"
+
+authorize_group_reply_query = "\
+	SELECT id, GroupName, Attribute, Value, op \
+	FROM ${groupreply_table} \
+	WHERE GroupName = '%{${group_attribute}}' AND Context = '%{control:DHCP-SQL-Option-Context}' \
+	ORDER BY id"
+
+group_membership_query = "\
+	SELECT GroupName \
+	FROM ${dhcpgroup_table} \
+	WHERE Identifier='%{SQL-User-Name}' AND Context = '%{control:DHCP-SQL-Option-Context}' \
+	ORDER BY priority"

--- a/raddb/mods-config/sql/dhcp/postgresql/schema.sql
+++ b/raddb/mods-config/sql/dhcp/postgresql/schema.sql
@@ -1,0 +1,44 @@
+/*
+ * $Id$
+ *
+ * PostgreSQL schema for DHCP for FreeRADIUS
+ *
+ */
+
+/*
+ * Table structure for table 'dhcpgroupreply'
+ */
+CREATE TABLE IF NOT EXISTS dhcpgroupreply (
+	id			serial PRIMARY KEY,
+	GroupName		text NOT NULL DEFAULT '',
+	Attribute		text NOT NULL DEFAULT '',
+	op			VARCHAR(2) NOT NULL DEFAULT '=',
+	Value			text NOT NULL DEFAULT '',
+	Context			text NOT NULL DEFAULT ''
+);
+CREATE INDEX dhcpgroupreply_GroupName ON dhcpgroupreply (Context,GroupName,Attribute);
+
+/*
+ * Table structure for table 'dhcpreply'
+ */
+CREATE TABLE IF NOT EXISTS dhcpreply (
+	id			serial PRIMARY KEY,
+	Identifier		text NOT NULL DEFAULT '',
+	Attribute		text NOT NULL DEFAULT '',
+	op			VARCHAR(2) NOT NULL DEFAULT '=',
+	Value			text NOT NULL DEFAULT '',
+	Context			text NOT NULL DEFAULT ''
+);
+CREATE INDEX dhcpreply_Identifier ON dhcpreply (Context,Identifier,Attribute);
+
+/*
+ * Table structure for table 'dhcpgroup'
+ */
+CREATE TABLE IF NOT EXISTS dhcpgroup (
+	id			serial PRIMARY KEY,
+	Identifier		text NOT NULL DEFAULT '',
+	GroupName		text NOT NULL DEFAULT '',
+	Priority		integer NOT NULL DEFAULT 0,
+	Context			text NOT NULL DEFAULT ''
+);
+CREATE INDEX dhcpgroup_Identifier ON dhcpgroup (Context,Identifier);

--- a/raddb/mods-config/sql/dhcp/postgresql/setup.sql
+++ b/raddb/mods-config/sql/dhcp/postgresql/setup.sql
@@ -1,0 +1,28 @@
+/*
+ * admin.sql -- PostgreSQL commands for creating the RADIUS user.
+ *
+ *	WARNING: You should change 'localhost' and 'radpass'
+ *		 to something else.  Also update raddb/mods-available/sql
+ *		 with the new RADIUS password.
+ *
+ *	WARNING: This example file is untested.  Use at your own risk.
+ *		 Please send any bug fixes to the mailing list.
+ *
+ *	$Id$
+ */
+
+/*
+ *  Create default administrator for RADIUS
+ */
+CREATE USER radius WITH PASSWORD 'radpass';
+
+/*
+ * The server can read any table in SQL
+ */
+GRANT SELECT ON dhcpreply TO radius;
+GRANT SELECT ON dhcpgroupreply TO radius;
+GRANT SELECT ON dhcpgroup TO radius;
+
+GRANT USAGE, SELECT ON SEQUENCE dhcpgroupreply_id_seq TO radius;
+GRANT USAGE, SELECT ON SEQUENCE dhcpreply_id_seq TO radius;
+GRANT USAGE, SELECT ON SEQUENCE dhcpgroup_id_seq TO radius;

--- a/raddb/mods-config/sql/dhcp/sqlite/queries.conf
+++ b/raddb/mods-config/sql/dhcp/sqlite/queries.conf
@@ -1,0 +1,52 @@
+# -*- text -*-
+#
+#  dhcp/sqlite/queries.conf -- SQLite configuration for DHCP schema (schema.sql)
+#
+#  $Id$
+
+# Safe characters list for sql queries. Everything else is replaced
+# with their mime-encoded equivalents.
+# The default list should be ok
+# safe_characters = "@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_: /"
+
+#######################################################################
+#  Query config:  Identifier
+#######################################################################
+# This is the identifier that will get substituted, escaped, and added
+# as attribute 'SQL-User-Name'.  '%{SQL-User-Name}' should be used
+# below everywhere an identifier substitution is needed so you you can
+# be sure the identifier passed from the client is escaped properly.
+#
+sql_user_name = "%{control:DHCP-SQL-Option-Identifier}"
+
+#######################################################################
+#  Attribute Lookup Queries
+#######################################################################
+#  These queries setup the reply items in ${dhcpreply_table} and
+#  ${group_reply_query}.  You can use any query/tables you want, but
+#  the return data for each row MUST be in the following order:
+#
+#  0. Row ID (currently unused)
+#  1. Identifier
+#  2. Item Attr Name
+#  3. Item Attr Value
+#  4. Item Attr Operation
+#######################################################################
+
+authorize_reply_query = "\
+	SELECT id, identifier, attribute, value, op \
+	FROM ${dhcpreply_table} \
+	WHERE identifier = '%{SQL-User-Name}' AND context = '%{control:DHCP-SQL-Option-Context}' \
+	ORDER BY id"
+
+authorize_group_reply_query = "\
+	SELECT id, groupname, attribute, value, op \
+	FROM ${groupreply_table} \
+	WHERE groupname = '%{${group_attribute}}' AND context = '%{control:DHCP-SQL-Option-Context}' \
+	ORDER BY id"
+
+group_membership_query = "\
+	SELECT groupname \
+	FROM ${dhcpgroup_table} \
+	WHERE identifier='%{SQL-User-Name}' AND context = '%{control:DHCP-SQL-Option-Context}' \
+	ORDER BY priority"

--- a/raddb/mods-config/sql/dhcp/sqlite/schema.sql
+++ b/raddb/mods-config/sql/dhcp/sqlite/schema.sql
@@ -1,0 +1,46 @@
+-----------------------------------------------------------------------------
+-- $Id$                 ␉····   --
+--                                                                         --
+--  schema.sql                       rlm_sql - FreeRADIUS SQLite Module    --
+--                                                                         --
+--     Database schema for SQLite rlm_sql module for DHCP                  --
+--                                                                         --
+-----------------------------------------------------------------------------
+
+--
+-- Table structure for table 'dhcpgroupreply'
+--
+CREATE TABLE IF NOT EXISTS dhcpgroupreply (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	groupname varchar(64) NOT NULL default '',
+	attribute varchar(64) NOT NULL default '',
+	op char(2) NOT NULL DEFAULT '=',
+	value varchar(253) NOT NULL default '',
+	context varchar(16) NOT NULL default ''
+);
+CREATE INDEX dhcpgroupreply_groupname ON dhcpgroupreply(context,groupname);
+
+--
+-- Table structure for table 'dhcpreply'
+--
+CREATE TABLE IF NOT EXISTS dhcpreply (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	identifier varchar(253) NOT NULL default '',
+	attribute varchar(64) NOT NULL default '',
+	op char(2) NOT NULL DEFAULT '=',
+	value varchar(253) NOT NULL default '',
+	context varchar(16) NOT NULL default ''
+);
+CREATE INDEX dhcpreply_identifier ON dhcpreply(context,identifier);
+
+--
+-- Table structure for table 'dhcpgroup'
+--
+CREATE TABLE IF NOT EXISTS dhcpgroup (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	identifier varchar(253) NOT NULL default '',
+	groupname varchar(64) NOT NULL default '',
+	priority int(11) NOT NULL default '1',
+	context varchar(16) NOT NULL default ''
+);
+CREATE INDEX dhcpgroup_identifier ON dhcpgroup(context,identifier);

--- a/raddb/policy.d/dhcp
+++ b/raddb/policy.d/dhcp
@@ -138,3 +138,190 @@ dhcp_sqlippool_decline {
 
 }
 
+#  Example policy for fetching option data from SQL
+dhcp_policy_sql {
+
+	#
+	#  Network-specific options
+	#
+
+	#
+	#  We want to lookup the Layer 2 network specific DHCP options to
+	#  include in the reply. For this we need a stable identifier for the
+	#  network from which the request is originating (based on
+	#  DHCP-Network-Subnet) which can be used as the lookup key
+	#  (DHCP-SQL-Option-Identifier) for the network options.
+	#
+	#  Here we fabricate an example for the purpose of placing all
+	#  configuration elements into SQL. We use a PostgreSQL query that
+	#  returns the network identifier in the row containing the smallest
+	#  enclosing CIDR, which assumes a schema such as the following:
+	#
+	#    CREATE TABLE fr_network_to_identifier (network CIDR, network_id TEXT)
+	#
+	#  Note: An rlm_files based lookup of the network_identifier (as per
+	#  the examples in the dhcp virtual server) may be preferable to an ad
+	#  hoc SQL query assuming that the network topology does not change
+	#  frequently.
+	#
+#	update control {
+#		&control:Tmp-String-0 := "%{dhcp_sql:SELECT network_id \
+#		    FROM fr_network_to_identifier \
+#		    WHERE '%{DHCP-Network-Subnet}'::inet << network \
+#		    ORDER BY MASKLEN(network) DESC LIMIT 1;}"
+#	}
+
+	#
+	#  Use the network identifer to lookup the options specific to the
+	#  originating network, using "network" context.  Common network
+	#  settings can be placed into a group and shared, with individual
+	#  networks mapped to one or more option groups.
+	#
+	#    - Place network-specific options in the dhcpreply table with
+	#      "context = 'network'".
+	#    - Add "Fall-Through := Yes" to the network options in the dhcpreply
+	#      table to trigger group lookups for the network, which are
+	#      disabled by default.
+	#    - Place "identifier = <network_id>, groupname = <group>,
+	#      priority = <priority>, context = 'network'" in the dhcpgroup
+	#      table to map a network to a shared set of network options.
+	#    - Place group-specific options in the dhcpgroupreply table with
+	#      "context = 'network'".
+	#
+	#  Note: In "shared-network" or "multinet" topologies you can instead
+	#  just set all of the network options once in the subnet-specific
+	#  options (after obtaining an IP address), below.
+	#
+#	update control {
+#		&DHCP-SQL-Option-Context := "network"
+#		&DHCP-SQL-Option-Identifier := &control:Tmp-String-0
+#	}
+#	dhcp_sql.authorize
+
+
+	#
+	#  Allocate IPs from the DHCP pool in SQL.
+	#
+	#  Here we simply reuse the network_id (obtained previously) as the
+	#  Pool-Name.
+	#
+#	update control {
+#		&Pool-Name := &control:Tmp-String-0
+#	}
+#	dhcp_sqlippool
+
+
+	#
+	#  Subnet-specific options
+	#
+
+	#
+	#  In "shared-network" or "multinet" topologies (in which a Layer 2
+	#  network has a single pool that contains addresses from multiple
+	#  subnets) it is necessary to set subnet-specific options based on the
+	#  address that has just been allocated.
+	#
+	#  Again, for this we need to derive a stable identifier for the subnet
+	#  to which the IP address we are issuing belongs that will serve as a
+	#  lookup key for the network options.
+	#
+	#  Continuing our previous example, we can use a PostgreSQL query to
+	#  find the subnet identifer in the row with the closest enclosing
+	#  CIDR, which assumes a schema such as the following:
+	#
+	#      CREATE TABLE fr_subnet_to_identifier (subnet CIDR, subnet_id TEXT)
+	#
+	#  Note: An rlm_files based lookup of the subnet_identifier (as per the
+	#  examples in the dhcp virtual server) is preferable to an ad hoc SQL
+	#  query assuming that the network topology does not change frequently.
+	#
+#	update control {
+#		&control:Tmp-String-0 := "%{dhcp_sql:SELECT subnet_id \
+#		    FROM fr_subnet_to_identifier \
+#		    WHERE '%{reply:DHCP-Your-IP-Address}'::inet << subnet \
+#		    ORDER BY MASKLEN(subnet) DESC LIMIT 1;}"
+#	}
+
+	#
+	#  Use the subnet identifer to lookup the options specific to the
+	#  subnet for the IP we are allocating, using "subnet" context.  Common
+	#  subnet settings can be placed into a group and shared, with
+	#  individual subnets mapped to one or more option groups.
+	#
+	#    - Place subnet-specific options in the dhcpreply table with
+	#      "context = 'subnet'".
+	#    - Add "Fall-Through := Yes" to the subnet options in the dhcpreply
+	#      table to trigger group lookups for the subnet, which are
+	#      disabled by default.
+	#    - Place "identifier = <subnet_id>, groupname = <group>,
+	#      priority = <priority>, context = 'subnet'" in the dhcpgroup
+	#      table to map a subnet to a shared set of subnet options.
+	#    - Place group-specific options in the dhcpgroupreply table with
+	#      "context = 'subnet'".
+	#
+#	update control {
+#		&DHCP-SQL-Option-Context := "subnet"
+#		&DHCP-SQL-Option-Identifier := &control:Tmp-String-0
+#	}
+#	dhcp_sql.authorize
+
+
+	#
+	#  Host-specific and group-specific options
+	#
+
+	#  "Groups" conventionally differentiate devices based on manual
+	#  groupings using a device-specific identifier such as the MAC
+	#  address.
+	#
+	#    - Place host-specific options in the dhcpreply table with
+	#      "context = 'group'".
+	#    - Add "Fall-Through := Yes" to the device options in the dhcpreply
+	#      table to trigger group lookups, which are disabled by default.
+	#    - Place "identifier = <MAC-Address>, groupname = <group>,
+	#      priority = <priority>, context='group'" in the dhcpgroup table
+	#      to map a device to its groups.
+	#    - Place group-specific options in the dhcpgroupreply table with
+	#      "context = 'group'".
+	#
+#	update control {
+#		&DHCP-SQL-Option-Context := "group"
+#		&DHCP-SQL-Option-Identifier := &request:DHCP-Client-Hardware-Address
+#	}
+#	dhcp_sql.authorize
+
+
+	#
+	#  Class/subclass-specific options
+	#
+
+	#
+	#  "Classes" conventionally differentiate devices based on all or part
+	#  of one or more DHCP request options, or any combination of
+	#  information that is available in the request or has already looked
+	#  up from some datastore.
+	#
+	#  Create multiple instances of the following block, one for each
+	#  class. Differentiate between classes by setting
+	#  DHCP-SQL-Option-Context uniquely.
+	#
+	#    - Place "subclass"-specific options (i.e. each member of a class)
+	#      in the dhcpreply table with "context = <class-name>".
+	#    - For class-level options common to every member of a class,
+	#      either:
+	#        - Duplicate the options for each member of the subclass.
+	#      or:
+	#        - Add "Fall-Through := Yes" to each members options to trigger
+	#          group lookups, which are disabled by default.
+	#        - Map each member of the class to a group in the dhcpgroup
+	#          table with context = '<class-name>';
+	#        - Create the corresponding class in the dhcpgroupreply table
+	#          with "context = '<class-name>'".
+	#
+#	update control {
+#		&DHCP-SQL-Option-Context := "class-vci-substring"
+#		&DHCP-SQL-Option-Identifier := "%{substring %{request:DHCP-Vendor-Class-Identifier} 5 4}"
+#	}
+#	dhcp_sql.authorize
+
+}

--- a/raddb/sites-available/dhcp
+++ b/raddb/sites-available/dhcp
@@ -224,6 +224,12 @@ dhcp DHCP-Discover {
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_hosts
 
+	#  As an alternative or complement to configuration files based lookup
+	#  for options data you can instead use an SQL database. Example
+	#  configuration is found in dhcp_policy_sql in policy.d/dhcp which
+	#  will need to be adapted to your requirements.
+	#dhcp_policy_sql
+
 	#  Set the type of packet to send in reply.
 	#
 	#  The server will look at the DHCP-Message-Type attribute to
@@ -329,6 +335,12 @@ dhcp DHCP-Request {
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_hosts
 
+	#  As an alternative or complement to configuration files based lookup
+	#  for options data you can instead use an SQL database. Example
+	#  configuration is found in dhcp_policy_sql in policy.d/dhcp which
+	#  will need to be adapted to your requirements.
+	#dhcp_policy_sql
+
 	#  If DHCP-Message-Type is not set, returning "ok" or
 	#  "updated" from this section will respond with a DHCP-Ack
 	#  packet.
@@ -361,6 +373,9 @@ dhcp DHCP-Decline {
 	#  Enable mods-available/dhcp_files to use this
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_network
+
+	#  Use a policy that set options from data stored in an SQL database
+	#dhcp_policy_sql
 
 	#  If using IPs from a DHCP pool in SQL then you may need to set the
 	#  pool name here if you haven't set it elsewhere and release the IP.
@@ -414,6 +429,9 @@ dhcp DHCP-Inform {
 	#  Enable mods-available/dhcp_files to use this
 	#  Options are set in mods-config/files/dhcp
 	#dhcp_hosts
+
+	#  Use a policy that set options from data stored in an SQL database
+	#dhcp_policy_sql
 
 	ok
 }

--- a/share/dictionary.dhcp
+++ b/share/dictionary.dhcp
@@ -64,9 +64,14 @@ ATTRIBUTE	DHCP-Relay-IP-Address			272	ipaddr
 # the subnet which the client belongs to.  Stored as an ipv4prefix
 # to allow closest subnet matching in rlm_files
 ATTRIBUTE	DHCP-Network-Subnet			274	ipv4prefix
+
 # This is a name for the group a client belongs to then used for
 # looking up of options
 ATTRIBUTE	DHCP-Group-Name				275	string
+
+# These are for controlling option lookups
+ATTRIBUTE	DHCP-SQL-Option-Identifier		276	string
+ATTRIBUTE	DHCP-SQL-Option-Context			277	string
 
 VALUE	DHCP-Flags			Broadcast		0x8000
 


### PR DESCRIPTION
New dhcp_sql instance of rlm_sql for use with DHCP:

  - Separate queries.conf and schema.sql, etc. for DHCP vs RADIUS.
  - Group lookup is disabled by default and there are no check queries provided
    to reduce query load for typical use cases.
  - No accounting-related configuration items and queries.

The schema provides dhcpreply, dhcpgroupreply and dhcpgroup (née "usergroup")
tables as per corresponding RADIUS authorize schema, except:

  - Rename column Username -> Identifier since the lookup key varies based on
    "contexts". There will typically be multiple option merges from different
    context to set network-specific options, device-specific options, classes,
    etc.
    - Set Identifier for lookup using the DHCP-SQL-Option-Identifier internal
      attribute (which gets escaped into SQL-User-Name, as usual).
  - Add a Context column ("network", "subnet", "group", "class-abc", etc.) to
    support lookups using the same tables but with the options data partitioned
    between contexts.
    - Set current Context using the DHCP-SQL-Option-Context internal attribute.
      This is not SQL escaped, however it is not set from tainted data.

Example policy for performing SQL options lookup from SQL provided in
policy.d/dhcp.