### PR TITLE
Make the underlying dbuff version of fr_dhcpv4_encode_option() visible

### DIFF
--- a/src/protocols/dhcpv4/dhcpv4.h
+++ b/src/protocols/dhcpv4/dhcpv4.h
@@ -163,6 +163,7 @@ ssize_t		fr_dhcpv4_decode_option(TALLOC_CTX *ctx, fr_cursor_t *cursor, fr_dict_t
  */
 ssize_t		fr_dhcpv4_encode_option(uint8_t *out, size_t outlen,
 					fr_cursor_t *cursor, void *encoder_ctx);
+ssize_t		fr_dhcpv4_encode_option_dbuff(fr_dbuff_t *dbuff, fr_cursor_t *cursor, void *encoder_ctx);
 
 /*
  *	packet.c

--- a/src/protocols/dhcpv4/encode.c
+++ b/src/protocols/dhcpv4/encode.c
@@ -35,8 +35,6 @@
 #include "dhcpv4.h"
 #include "attrs.h"
 
-static ssize_t encode_option_dbuff(fr_dbuff_t *dbuff, fr_cursor_t *cursor, void *encoder_ctx);
-
 /** Write DHCP option value into buffer
  *
  * Does not include DHCP option length or number.
@@ -506,10 +504,10 @@ static ssize_t encode_vsio_hdr(fr_dbuff_t *dbuff,
  */
 ssize_t fr_dhcpv4_encode_option(uint8_t *out, size_t outlen, fr_cursor_t *cursor, void *encoder_ctx)
 {
-	return encode_option_dbuff(&FR_DBUFF_TMP(out, outlen), cursor, encoder_ctx);
+	return fr_dhcpv4_encode_option_dbuff(&FR_DBUFF_TMP(out, outlen), cursor, encoder_ctx);
 }
 
-static ssize_t encode_option_dbuff(fr_dbuff_t *dbuff, fr_cursor_t *cursor, void *encoder_ctx)
+ssize_t fr_dhcpv4_encode_option_dbuff(fr_dbuff_t *dbuff, fr_cursor_t *cursor, void *encoder_ctx)
 {
 	VALUE_PAIR		*vp;
 	unsigned int		depth = 0;


### PR DESCRIPTION
This makes it possible to switch users of fr_dhcpv4_encode_option()
ver to dbuffs individually rather than all at once.