### PR TITLE
Satisfy clang static analysis

### DIFF
--- a/src/protocols/radius/decode.c
+++ b/src/protocols/radius/decode.c
@@ -1760,7 +1760,7 @@ static ssize_t fr_radius_decode_proto(TALLOC_CTX *ctx, VALUE_PAIR **vps, uint8_t
 	}
 	(void) fr_pair_value_memdup(vp, data + 4, 16, true);
 	fr_cursor_append(&cursor, vp);
-	vp = fr_cursor_tail(&cursor);
+	(void) fr_cursor_tail(&cursor);
 
 	return fr_radius_decode(ctx, data, packet_len, test_ctx->vector - 4, /* decode adds 4 to this */
 				test_ctx->secret, talloc_array_length(test_ctx->secret) - 1, &cursor);


### PR DESCRIPTION
Got rid of assignment to a not-thereafter-used variable,
turning it into a cast of RHS to void.