### PR TITLE
Changed the vector member of fr_radius_ctx_t from pointer to array

### DIFF
--- a/src/modules/rlm_radius/rlm_radius_udp.c
+++ b/src/modules/rlm_radius/rlm_radius_udp.c
@@ -1240,7 +1240,7 @@ static decode_fail_t decode(TALLOC_CTX *ctx, VALUE_PAIR **reply, uint8_t *respon
 	 *	or if we run out of memory.
 	 */
 	fr_cursor_init(&cursor, reply);
-	if (fr_radius_decode(ctx, data, packet_len, original,
+	if (fr_radius_decode(ctx, data, packet_len, &original[4],
 			     inst->secret, talloc_array_length(inst->secret) - 1, &cursor) < 0) {
 		REDEBUG("Failed decoding attributes for packet");
 		fr_pair_list_free(reply);

--- a/src/protocols/radius/decode.c
+++ b/src/protocols/radius/decode.c
@@ -1718,7 +1718,7 @@ static int decode_test_ctx(void **out, TALLOC_CTX *ctx)
 
 	test_ctx = talloc_zero(ctx, fr_radius_ctx_t);
 	test_ctx->secret = talloc_strdup(test_ctx, "testing123");
-	test_ctx->vector = vector;
+	memcpy(test_ctx->vector, vector, RADIUS_AUTH_VECTOR_LENGTH);
 	test_ctx->tmp_ctx = talloc_zero(ctx, uint8_t);
 	talloc_set_destructor(test_ctx, _test_ctx_free);
 
@@ -1762,7 +1762,7 @@ static ssize_t fr_radius_decode_proto(TALLOC_CTX *ctx, VALUE_PAIR **vps, uint8_t
 	fr_cursor_append(&cursor, vp);
 	(void) fr_cursor_tail(&cursor);
 
-	return fr_radius_decode(ctx, data, packet_len, test_ctx->vector - 4, /* decode adds 4 to this */
+	return fr_radius_decode(ctx, data, packet_len, test_ctx->vector,
 				test_ctx->secret, talloc_array_length(test_ctx->secret) - 1, &cursor);
 }
 

--- a/src/protocols/radius/encode.c
+++ b/src/protocols/radius/encode.c
@@ -1488,7 +1488,7 @@ static int encode_test_ctx(void **out, TALLOC_CTX *ctx)
 	if (!test_ctx) return -1;
 
 	test_ctx->secret = talloc_strdup(test_ctx, "testing123");
-	test_ctx->vector = vector;
+	memcpy(test_ctx->vector, vector, RADIUS_AUTH_VECTOR_LENGTH);
 	test_ctx->rand_ctx.a = 6809;
 	test_ctx->rand_ctx.b = 2112;
 	talloc_set_destructor(test_ctx, _test_ctx_free);

--- a/src/protocols/radius/packet.c
+++ b/src/protocols/radius/packet.c
@@ -121,9 +121,10 @@ int fr_radius_packet_decode(RADIUS_PACKET *packet, RADIUS_PACKET *original,
 	fr_cursor_t		cursor, out;
 	fr_radius_ctx_t		packet_ctx = {
 					.secret = secret,
-					.vector = packet->vector,
 					.tunnel_password_zeros = tunnel_password_zeros
 				};
+
+	memcpy(packet_ctx.vector, packet->vector, RADIUS_AUTH_VECTOR_LENGTH);
 
 #ifndef NDEBUG
 	if (fr_debug_lvl >= L_DBG_LVL_4) fr_radius_packet_log_hex(&default_log, packet);
@@ -146,19 +147,22 @@ int fr_radius_packet_decode(RADIUS_PACKET *packet, RADIUS_PACKET *original,
 		 *	radsniff doesn't always have a response
 		 */
 		if (original) {
- 			packet_ctx.vector = original->vector;
+ 			memcpy(packet_ctx.vector, original->vector, RADIUS_AUTH_VECTOR_LENGTH);
 		} else {
 			memset(packet->vector, 0, sizeof(packet->vector));
+			memset(packet_ctx.vector, 0, RADIUS_AUTH_VECTOR_LENGTH);
 		}
 		break;
 
 	case FR_CODE_ACCOUNTING_REQUEST:
 		memset(packet->vector, 0, sizeof(packet->vector));
+		memset(packet_ctx.vector, 0, RADIUS_AUTH_VECTOR_LENGTH);
 		break;
 
 	case FR_CODE_COA_REQUEST:
 	case FR_CODE_DISCONNECT_REQUEST:
 		memset(packet->vector, 0, sizeof(packet->vector));
+		memset(packet_ctx.vector, 0, RADIUS_AUTH_VECTOR_LENGTH);
 		break;
 
 	default:

--- a/src/protocols/radius/radius.h
+++ b/src/protocols/radius/radius.h
@@ -127,7 +127,8 @@ ssize_t		fr_radius_recv_header(int sockfd, fr_ipaddr_t *src_ipaddr, uint16_t *sr
 ssize_t		fr_radius_encode(uint8_t *packet, size_t packet_len, uint8_t const *original,
 				 char const *secret, UNUSED size_t secret_len, int code, int id, VALUE_PAIR *vps);
 
-ssize_t		fr_radius_decode(TALLOC_CTX *ctx, uint8_t const *packet, size_t packet_len, uint8_t const *original,
+ssize_t		fr_radius_decode(TALLOC_CTX *ctx, uint8_t const *packet, size_t packet_len,
+				 uint8_t const *original_auth_vector,
 				 char const *secret, UNUSED size_t secret_len, fr_cursor_t *cursor) CC_HINT(nonnull(1,2,5,7));
 
 int		fr_radius_init(void);
@@ -165,7 +166,7 @@ typedef struct {
 
 typedef struct {
 	TALLOC_CTX		*tmp_ctx;		//!< for temporary things cleaned up during decoding
-	uint8_t const		*vector;		//!< vector for encryption / decryption of data
+	uint8_t			vector[RADIUS_AUTH_VECTOR_LENGTH];	//!< vector for encryption / decryption of data
 	char const		*secret;		//!< shared secret.  MUST be talloc'd
 	fr_fast_rand_t		rand_ctx;		//!< for tunnel passwords
 	int			salt_offset;		//!< for tunnel passwords


### PR DESCRIPTION
This avoids possible issues with pointers changing out from
underneath the context if a dbuff version of, for example,
fr_radius_encode(), decides to use extensible dbuffs.