### PR TITLE
update debian/ubuntu systemd service

### DIFF
--- a/debian/freeradius.service
+++ b/debian/freeradius.service
@@ -31,10 +31,10 @@ RuntimeDirectoryMode=0775
 User=freerad
 Group=freerad
 # This does not work on Ubuntu Bionic:
-ExecStartPre=/bin/chown freerad:freerad /var/run/freeradius
+ExecStartPre=/bin/chown -R freerad:freerad /run/radiusd/
 
-ExecStartPre=/usr/sbin/freeradius $FREERADIUS_OPTIONS -Cx -lstdout
-ExecStart=/usr/sbin/freeradius -f $FREERADIUS_OPTIONS
+ExecStartPre=/usr/local/sbin/radiusd $FREERADIUS_OPTIONS -Cx -lstdout
+ExecStart=/usr/local/sbin/radiusd -f $FREERADIUS_OPTIONS
 Restart=on-failure
 RestartSec=5
 
@@ -58,12 +58,14 @@ ProtectKernelTunables=true
 
 # Only allow native system calls
 SystemCallArchitectures=native
-
 # We shouldn't be writing to the configuration directory
-ReadOnlyDirectories=/etc/freeradius/
+ReadOnlyDirectories=/usr/local/etc/raddb/
 
 # We can read and write to the log directory.
 ReadWriteDirectories=/var/log/freeradius/
+
+StandardOutput=file:/var/log/freeradius/standard.log
+StandardError=file:/var/log/freeradius/error.log
 
 [Install]
 WantedBy=multi-user.target

--- a/raddb/radiusd.conf.in
+++ b/raddb/radiusd.conf.in
@@ -56,7 +56,7 @@
 prefix = @prefix@
 exec_prefix = @exec_prefix@
 sysconfdir = @sysconfdir@
-localstatedir = @localstatedir@
+localstatedir = "" # this places the PID in /run which is the correct path in systemd.
 sbindir = @sbindir@
 logdir = @logdir@
 raddbdir = @raddbdir@


### PR DESCRIPTION
After hours of struggling with getting this right, I thought I would post this config as the default one since the current one is wrong, or at least doesn't work.

When building from source, the paths are wrong. Also, systemd PID shouldn't be run in `/var/run` (`usr/local/var/run`), it should be run in `/run/folder`.

This PR solves all that so that the paths are correct, and the actual PID is run from the correct directory.

Also added logging for systemd instead of logging to syslog.