### PR TITLE
rlm_sql: Use the non-xlat escape function to expand the group membership query

### DIFF
--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -573,7 +573,7 @@ static int sql_get_grouplist(rlm_sql_t *inst, rlm_sql_handle_t **handle, REQUEST
 
 	if (!inst->config->groupmemb_query) return 0;
 
-	if (radius_axlat(&expanded, request, inst->config->groupmemb_query, sql_escape_for_xlat_func, inst) < 0) return -1;
+	if (radius_axlat(&expanded, request, inst->config->groupmemb_query, sql_escape_func, *handle) < 0) return -1;
 
 	ret = rlm_sql_select_query(inst, request, handle, expanded);
 	talloc_free(expanded);


### PR DESCRIPTION
Use the basic sql_escape_func when expanding the group membership query that
uses our existing SQL handle.

If we use sql_escape_for_xlat_func, which reserves a connection, then when the
connection pool is exhausted we erroneously conclude that the user is not a
member of any groups.