### PR TITLE
Add tests to exercise fr_dbuff_out() with marker as source

### DIFF
--- a/src/lib/util/dbuff.h
+++ b/src/lib/util/dbuff.h
@@ -1202,14 +1202,14 @@ FR_DBUFF_OUT_DEF(int64)
  */
 #define fr_dbuff_out(_out, _in) \
 	_Generic((_out), \
-		uint8_t *	: _fr_dbuff_memcpy_out((uint8_t *)(_out), _fr_dbuff_current_ptr(_in), _in, 1), \
-		uint16_t *	: _fr_dbuff_uint16_out((uint16_t *)(_out), _fr_dbuff_current_ptr(_in), _in), \
-		uint32_t *	: _fr_dbuff_uint32_out((uint32_t *)(_out), _fr_dbuff_current_ptr(_in), _in), \
-		uint64_t *	: _fr_dbuff_uint64_out((uint64_t *)(_out), _fr_dbuff_current_ptr(_in), _in), \
-		int8_t *	: _fr_dbuff_memcpy_out((uint8_t *)(_out), _fr_dbuff_current_ptr(_in), _in, 1), \
-		int16_t *	: _fr_dbuff_int16_out((int16_t *)(_out), _fr_dbuff_current_ptr(_in), _in), \
-		int32_t *	: _fr_dbuff_int32_out((int32_t *)(_out), _fr_dbuff_current_ptr(_in), _in), \
-		int64_t *	: _fr_dbuff_int64_out((int64_t *)(_out), _fr_dbuff_current_ptr(_in), _in) \
+		uint8_t *	: _fr_dbuff_memcpy_out((uint8_t *)(_out), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in), 1), \
+		uint16_t *	: _fr_dbuff_uint16_out((uint16_t *)(_out), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in)), \
+		uint32_t *	: _fr_dbuff_uint32_out((uint32_t *)(_out), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in)), \
+		uint64_t *	: _fr_dbuff_uint64_out((uint64_t *)(_out), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in)), \
+		int8_t *	: _fr_dbuff_memcpy_out((uint8_t *)(_out), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in), 1), \
+		int16_t *	: _fr_dbuff_int16_out((int16_t *)(_out), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in)), \
+		int32_t *	: _fr_dbuff_int32_out((int32_t *)(_out), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in)), \
+		int64_t *	: _fr_dbuff_int64_out((int64_t *)(_out), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in)) \
 	)
 #define FR_DBUFF_OUT_RETURN(_out, _in) FR_DBUFF_RETURN(fr_dbuff_out, _out, _in)
 


### PR DESCRIPTION
We also include the correction that the added tests turned up.