### PR TITLE
Add fr_dbuff_uint64v_out(), and float/double options for fr_dbuff_out()

### DIFF
--- a/src/lib/util/dbuff.h
+++ b/src/lib/util/dbuff.h
@@ -1209,9 +1209,43 @@ FR_DBUFF_OUT_DEF(int64)
 		int8_t *	: _fr_dbuff_memcpy_out((uint8_t *)(_out), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in), 1), \
 		int16_t *	: _fr_dbuff_int16_out((int16_t *)(_out), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in)), \
 		int32_t *	: _fr_dbuff_int32_out((int32_t *)(_out), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in)), \
-		int64_t *	: _fr_dbuff_int64_out((int64_t *)(_out), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in)) \
+		int64_t *	: _fr_dbuff_int64_out((int64_t *)(_out), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in)), \
+		float *		: _fr_dbuff_uint32_out((uint32_t *)(_out), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in)), \
+		double *	: _fr_dbuff_uint64_out((uint64_t *)(_out), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in)) \
 	)
 #define FR_DBUFF_OUT_RETURN(_out, _in) FR_DBUFF_RETURN(fr_dbuff_out, _out, _in)
+
+/** Read bytes from a dbuff or marker and interpret them as a network order unsigned integer
+ * @param[in] _num		points to a uint64_t to store the integer in
+ * @param[in] _dbuff_or_marker	data to copy bytes from
+ * @param[in] _length		number of bytes to read (must be positive and less than eight)
+ *
+ * @return
+ *	- 0	no data read.
+ *	- >0	the number of bytes read.
+ *	- <0	the number of bytes we would have needed
+ *		to complete the read operation.
+ */
+#define fr_dbuff_uint64v_out(_num, _dbuff_or_marker, _length) \
+	_fr_dbuff_uint64v_out(_num, _fr_dbuff_current_ptr(_dbuff_or_marker), fr_dbuff_ptr(_dbuff_or_marker), _length)
+
+/** Internal function - do not call directly
+ */
+static inline ssize_t _fr_dbuff_uint64v_out(uint64_t *num, uint8_t **pos_p, fr_dbuff_t *dbuff, size_t length)
+{
+	ssize_t		slen;
+
+	fr_assert(length > 0 && length <= sizeof(uint64_t));
+
+	*num = 0;
+	slen = _fr_dbuff_memcpy_out(((uint8_t *) num) + (8 - length), pos_p, dbuff, length);
+	if (slen <= 0) return slen;
+
+	*num = fr_net_to_uint64((uint8_t const *)num);
+	return length;
+}
+
+#define FR_DBUFF_UINT64V_OUT_RETURN(_num, _dbuff, _length) FR_DBUFF_RETURN(fr_dbuff_uint64v_out, _num, _dbuff, _length)
 
 /** @} */
 

--- a/src/lib/util/dbuff_tests.c
+++ b/src/lib/util/dbuff_tests.c
@@ -375,22 +375,28 @@ static void test_dbuff_out(void)
 	fr_dbuff_t	dbuff1;
 	fr_dbuff_t	dbuff2;
 	fr_dbuff_marker_t	marker1;
+	uint8_t		u8val = 0;
 	uint16_t	u16val = 0;
 	uint32_t	u32val = 0;
 	uint64_t	u64val = 0;
 	uint64_t	u64val2 = 0;
+	int8_t		i8val = 0;
 	int16_t		i16val = 0;
 	int32_t		i32val = 0;
 	int64_t		i64val = 0;
+	float		fval1 = 1.5, fval2 = 0;
+	double		dval1 = 2048.0625, dval2 = 0;
 
 	fr_dbuff_init(&dbuff1, buff1, sizeof(buff1));
 	fr_dbuff_init(&dbuff2, buff2, sizeof(buff2));
 
 	TEST_CASE("Check dbuff reads of unsigned integers");
+	TEST_CHECK(fr_dbuff_out(&u8val, &dbuff1) == 1);
+	TEST_CHECK(u8val == 0x01);
 	TEST_CHECK(fr_dbuff_out(&u16val, &dbuff1) == 2);
-	TEST_CHECK(u16val == 0x0123);
+	TEST_CHECK(u16val == 0x2345);
 	TEST_CHECK(fr_dbuff_out(&u32val, &dbuff1) == 4);
-	TEST_CHECK(u32val == 0x456789ab);
+	TEST_CHECK(u32val == 0x6789abcd);
 	fr_dbuff_set_to_start(&dbuff1);
 	TEST_CHECK(fr_dbuff_out(&u64val, &dbuff1) == 8);
 	TEST_CHECK(u64val == 0x0123456789abcdef);
@@ -408,16 +414,40 @@ static void test_dbuff_out(void)
 
 	TEST_CASE("Check dbuff reads of signed integers");
 	fr_dbuff_set_to_start(&dbuff1);
+	TEST_CHECK(fr_dbuff_out(&i8val, &dbuff1) == 1);
+	TEST_CHECK(i8val == 0x01);
 	TEST_CHECK(fr_dbuff_out(&i16val, &dbuff1) == 2);
-	TEST_CHECK(i16val == 0x0123);
+	TEST_CHECK(i16val == 0x2345);
 	TEST_CHECK(fr_dbuff_out(&i32val, &dbuff1) == 4);
-	TEST_CHECK(i32val == 0x456789ab);
+	TEST_CHECK(i32val == 0x6789abcd);
 	fr_dbuff_set_to_start(&dbuff1);
 	TEST_CHECK(fr_dbuff_out(&i64val, &dbuff1) == 8);
 	TEST_CHECK(i64val == 0x0123456789abcdef);
 
+	TEST_CASE("Check dbuff reads of floating point values");
+	TEST_CHECK(fr_dbuff_in(&dbuff2, *(uint32_t *)&fval1) == 4);
+	fr_dbuff_set_to_start(&dbuff2);
+	TEST_CHECK(fr_dbuff_out(&fval2, &dbuff2) == 4);
+	TEST_CHECK(fval1 == fval2);
+	fr_dbuff_set_to_start(&dbuff2);
+	TEST_CHECK(fr_dbuff_in(&dbuff2, *(uint64_t *)&dval1) == 8);
+	fr_dbuff_set_to_start(&dbuff2);
+	TEST_CHECK(fr_dbuff_out(&dval2, &dbuff2) == 8);
+	TEST_CHECK(dval1 == dval2);
+
+	TEST_CASE("Check variable length uint64_t read");
+	fr_dbuff_set_to_start(&dbuff1);
+	TEST_CHECK(fr_dbuff_uint64v_out(&u64val, &dbuff1, 2) == 2);
+	TEST_CHECK(u64val == 0x0123);
+	TEST_CHECK(fr_dbuff_uint64v_out(&u64val, &dbuff1, 4) == 4);
+	TEST_CHECK(u64val == 0x456789ab);
+	fr_dbuff_set_to_start(&dbuff1);
+	TEST_CHECK(fr_dbuff_uint64v_out(&u64val, &dbuff1, 8) == 8);
+	TEST_CHECK(u64val == 0x0123456789abcdef);
+
 	TEST_CASE("fr_dbuff_memcpy_out");
 	fr_dbuff_set_to_start(&dbuff1);
+	fr_dbuff_set_to_start(&dbuff2);
 	fr_dbuff_marker(&marker1, &dbuff1);
 	memset(buff3, 0, sizeof(buff3));
 	TEST_CHECK(fr_dbuff_memcpy_out(buff3, &dbuff1, 7) == 7);
@@ -427,8 +457,10 @@ static void test_dbuff_out(void)
 	TEST_CHECK(fr_dbuff_memcpy_out(&dbuff2, &dbuff1, 4) == 4);
 	fr_dbuff_set_to_start(&dbuff1);
 	fr_dbuff_advance(&dbuff1, 3);
+	fr_dbuff_advance(&dbuff2, 2);
 	TEST_CHECK(fr_dbuff_memcpy_out(&dbuff2, &dbuff1, 4) == 4);
-	TEST_CHECK(memcmp(fr_dbuff_start(&dbuff2), fr_dbuff_start(&dbuff1) + 3, 4) == 0);
+	TEST_CHECK(memcmp(fr_dbuff_start(&dbuff2), fr_dbuff_start(&dbuff1), 2) == 0 &&
+		   memcmp(fr_dbuff_start(&dbuff2) + 2, fr_dbuff_start(&dbuff1) + 3, 4) == 0);
 }
 
 TEST_LIST = {


### PR DESCRIPTION
Unlike fr_dbuff_uint64v_in(), one must pass a length between 1 and 8
inclusive to specify the number of bytes to read, as well as a dbuff
or marker and a pointer to a uint64_t. Bytes read are interpreted as
an unsigned integer in network order, converted to host order, and
stored in the pointed-at uint64_t.