### PR TITLE
rlm_python: Improve error messages

### DIFF
--- a/raddb/mods-available/python
+++ b/raddb/mods-available/python
@@ -19,47 +19,47 @@ python {
 
 	# Pass all VPS lists as a 6-tuple to the callbacks
 	# (request, reply, config, state, proxy_req, proxy_reply)
-	# pass_all_vps = no
+#	pass_all_vps = no
 
 	# Pass all VPS lists as a dictionary to the callbacks
 	# Keys: "request", "reply", "config", "session-state", "proxy-request",
 	#       "proxy-reply"
 	# This option prevales over "pass_all_vps"
-	# pass_all_vps_dict = no
+#	pass_all_vps_dict = no
 
-	mod_instantiate = ${.module}
+#	mod_instantiate = ${.module}
 #	func_instantiate = instantiate
 
-	mod_detach = ${.module}
+#	mod_detach = ${.module}
 #	func_detach = detach
 
-	mod_authorize = ${.module}
+#	mod_authorize = ${.module}
 #	func_authorize = authorize
 
-	mod_authenticate = ${.module}
+#	mod_authenticate = ${.module}
 #	func_authenticate = authenticate
 
-	mod_preacct = ${.module}
+#	mod_preacct = ${.module}
 #	func_preacct = preacct
 
-	mod_accounting = ${.module}
+#	mod_accounting = ${.module}
 #	func_accounting = accounting
 
-	mod_checksimul = ${.module}
+#	mod_checksimul = ${.module}
 #	func_checksimul = checksimul
 
-	mod_pre_proxy = ${.module}
+#	mod_pre_proxy = ${.module}
 #	func_pre_proxy = pre_proxy
 
-	mod_post_proxy = ${.module}
+#	mod_post_proxy = ${.module}
 #	func_post_proxy = post_proxy
 
-	mod_post_auth = ${.module}
+#	mod_post_auth = ${.module}
 #	func_post_auth = post_auth
 
-	mod_recv_coa = ${.module}
+#	mod_recv_coa = ${.module}
 #	func_recv_coa = recv_coa
 
-	mod_send_coa = ${.module}
+#	mod_send_coa = ${.module}
 #	func_send_coa = send_coa
 }

--- a/raddb/mods-available/python3
+++ b/raddb/mods-available/python3
@@ -19,47 +19,47 @@ python3 {
 
 	# Pass all VPS lists as a 6-tuple to the callbacks
 	# (request, reply, config, state, proxy_req, proxy_reply)
-	# pass_all_vps = no
+#	pass_all_vps = no
 
 	# Pass all VPS lists as a dictionary to the callbacks
 	# Keys: "request", "reply", "config", "session-state", "proxy-request",
 	#       "proxy-reply"
 	# This option prevales over "pass_all_vps"
-	# pass_all_vps_dict = no
+#	pass_all_vps_dict = no
 
-	mod_instantiate = ${.module}
+#	mod_instantiate = ${.module}
 #	func_instantiate = instantiate
 
-	mod_detach = ${.module}
+#	mod_detach = ${.module}
 #	func_detach = detach
 
-	mod_authorize = ${.module}
+#	mod_authorize = ${.module}
 #	func_authorize = authorize
 
-	mod_authenticate = ${.module}
+#	mod_authenticate = ${.module}
 #	func_authenticate = authenticate
 
-	mod_preacct = ${.module}
+#	mod_preacct = ${.module}
 #	func_preacct = preacct
 
-	mod_accounting = ${.module}
+#	mod_accounting = ${.module}
 #	func_accounting = accounting
 
-	mod_checksimul = ${.module}
+#	mod_checksimul = ${.module}
 #	func_checksimul = checksimul
 
-	mod_pre_proxy = ${.module}
+#	mod_pre_proxy = ${.module}
 #	func_pre_proxy = pre_proxy
 
-	mod_post_proxy = ${.module}
+#	mod_post_proxy = ${.module}
 #	func_post_proxy = post_proxy
 
-	mod_post_auth = ${.module}
+#	mod_post_auth = ${.module}
 #	func_post_auth = post_auth
 
-	mod_recv_coa = ${.module}
+#	mod_recv_coa = ${.module}
 #	func_recv_coa = recv_coa
 
-	mod_send_coa = ${.module}
+#	mod_send_coa = ${.module}
 #	func_send_coa = send_coa
 }

--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -114,7 +114,7 @@ typedef struct python_thread_state {
  */
 static CONF_PARSER module_config[] = {
 
-#define A(x) { "mod_" #x, FR_CONF_OFFSET(PW_TYPE_STRING, rlm_python_t, x.module_name), "${.module}" }, \
+#define A(x) { "mod_" #x, FR_CONF_OFFSET(PW_TYPE_STRING, rlm_python_t, x.module_name), NULL }, \
 	{ "func_" #x, FR_CONF_OFFSET(PW_TYPE_STRING, rlm_python_t, x.function_name), NULL },
 
 	A(instantiate)
@@ -810,20 +810,30 @@ static void python_function_destroy(python_func_def_t *def)
 /** Import a user module and load a function from it
  *
  */
-static int python_function_load(python_func_def_t *def)
+static int python_function_load(char const *name, python_func_def_t *def)
 {
-	char const *funcname = "python_function_load";
+	if (!def->module_name && !def->function_name) return 0; /* Just not set, it's fine */
 
-	if (def->module_name == NULL || def->function_name == NULL) return 0;
+	if (!def->module_name) {
+		ERROR("Once you have set the 'func_%s = %s', you should set 'mod_%s = ...' too.",
+					name, def->function_name, name);
+		return -1;
+	}
+
+	if (!def->function_name) {
+		ERROR("Once you have set the 'mod_%s = %s', you should set 'func_%s = ...' too.",
+					name, def->module_name, name);
+		return -1;
+	}
 
 	def->module = PyImport_ImportModule(def->module_name);
 	if (!def->module) {
-		ERROR("%s - Module '%s' not found", funcname, def->module_name);
+		ERROR("%s - Module '%s' not found", __func__, def->module_name);
 
 	error:
 		python_error_log();
 		ERROR("%s - Failed to import python function '%s.%s'",
-		      funcname, def->module_name, def->function_name);
+		      __func__, def->module_name, def->function_name);
 		Py_XDECREF(def->function);
 		def->function = NULL;
 		Py_XDECREF(def->module);
@@ -834,12 +844,12 @@ static int python_function_load(python_func_def_t *def)
 
 	def->function = PyObject_GetAttrString(def->module, def->function_name);
 	if (!def->function) {
-		ERROR("%s - Function '%s.%s' is not found", funcname, def->module_name, def->function_name);
+		ERROR("%s - Function '%s.%s' is not found", __func__, def->module_name, def->function_name);
 		goto error;
 	}
 
 	if (!PyCallable_Check(def->function)) {
-		ERROR("%s - Function '%s.%s' is not callable", funcname, def->module_name, def->function_name);
+		ERROR("%s - Function '%s.%s' is not callable", __func__, def->module_name, def->function_name);
 		goto error;
 	}
 
@@ -1151,7 +1161,7 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 	/*
 	 *	Process the various sections
 	 */
-#define PYTHON_FUNC_LOAD(_x) if (python_function_load(&inst->_x) < 0) goto error
+#define PYTHON_FUNC_LOAD(_x) if (python_function_load(#_x, &inst->_x) < 0) goto error
 	PYTHON_FUNC_LOAD(instantiate);
 	PYTHON_FUNC_LOAD(authenticate);
 	PYTHON_FUNC_LOAD(authorize);
@@ -1168,14 +1178,16 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 	PYTHON_FUNC_LOAD(detach);
 
 	/*
-	 *	Call the instantiate function.
+	 *	Call the instantiate function only if the function and module is set.
 	 */
-	code = do_python_single(NULL, inst->instantiate.function, "instantiate", inst->pass_all_vps, inst->pass_all_vps_dict);
-	if (code == RLM_MODULE_FAIL) {
-	error:
-		python_error_log();	/* Needs valid thread with GIL */
-		PyEval_SaveThread();
-		return -1;
+	if (inst->instantiate.module_name && inst->instantiate.function_name) {
+		code = do_python_single(NULL, inst->instantiate.function, "instantiate", inst->pass_all_vps, inst->pass_all_vps_dict);
+		if (code == RLM_MODULE_FAIL) {
+		error:
+			python_error_log();	/* Needs valid thread with GIL */
+			PyEval_SaveThread();
+			return -1;
+		}
 	}
 	PyEval_SaveThread();
 


### PR DESCRIPTION
We should allow the user to know when we are missing to set the func_$foo
or mod_$foo. even we shouldn't set any default value hardcode with
'${.module}' directly in the source code just because we are setting
that through the raddb/mods-available/python

Therefore, it should help A LOT the user to know when they are doing
something wrong as described internally in the support ticket #5076