### PR TITLE
CI: Add GitHub Super-Linter workflow

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,27 @@
+name: Super-Linter
+
+on:
+  push:
+    branches-ignore:
+      - coverity_scan
+  pull_request:
+
+jobs:
+
+  lint:
+    name: Super-Linter. ${{ fromJSON('["Changes-only", "Full"]')[github.ref == 'refs/heads/linter'] }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Lint
+        uses: github/super-linter@v3
+        env:
+          DEFAULT_BRANCH: master
+          FILTER_REGEX_EXCLUDE: .*/(configure|config\.sub|config\.guess|missing|install-sh|freeradius\.css|toc_focus\.js|asciidoc/sass/.*\.scss)
+          VALIDATE_ALL_CODEBASE: ${{ github.ref == 'refs/heads/linter' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a workflow that runs Super-Linter, which runs a battery of linters over the codebase: https://github.com/github/super-linter

The output of some of the linters (e.g. ShellCheck) is somewhat vexatious but there is some stuff in there that should be cleaned up, so I haven't silenced any of the checks for now.

To keep the noise down it is configured to ordinarily perform a lint of only changed files. However, all files will be linted on push to the "linter" branch so that we can see cleanup progress.