### PR TITLE
v4: Replace fr_pair_t * with fr_pair_list_t in structures

### DIFF
--- a/src/bin/radclient.c
+++ b/src/bin/radclient.c
@@ -386,6 +386,8 @@ static int radclient_init(TALLOC_CTX *ctx, rc_file_pair_t *files)
 		request->packet->id = last_used_id;
 		request->num = num++;
 
+		fr_pair_list_init(&request->filter);
+
 		/*
 		 *	Read the request VP's.
 		 */

--- a/src/bin/radclient.h
+++ b/src/bin/radclient.h
@@ -79,7 +79,7 @@ struct rc_request {
 
 	fr_radius_packet_t	*packet;	//!< The outgoing request.
 	fr_radius_packet_t	*reply;		//!< The incoming response.
-	fr_pair_t	*filter;	//!< If the reply passes the filter, then the request passes.
+	fr_pair_list_t	filter;		//!< If the reply passes the filter, then the request passes.
 	FR_CODE		filter_code;	//!< Expected code of the response packet.
 
 	int		resend;

--- a/src/bin/radsniff.c
+++ b/src/bin/radsniff.c
@@ -1076,6 +1076,7 @@ static void rs_packet_cleanup(rs_request_t *request)
 static void _rs_event(UNUSED fr_event_list_t *el, UNUSED fr_time_t now, void *ctx)
 {
 	rs_request_t *request = talloc_get_type_abort(ctx, rs_request_t);
+
 	request->event = NULL;
 	rs_packet_cleanup(request);
 }
@@ -1212,6 +1213,7 @@ static void rs_packet_process(uint64_t count, rs_event_t *event, struct pcap_pkt
 	rs_request_t		search;
 
 	memset(&search, 0, sizeof(search));
+	fr_pair_list_init(&search.link_vps);
 
 	if (!start_pcap.tv_sec) {
 		start_pcap = header->ts;
@@ -1656,6 +1658,7 @@ static void rs_packet_process(uint64_t count, rs_event_t *event, struct pcap_pkt
 		} else {
 			original = talloc_zero(conf, rs_request_t);
 			talloc_set_destructor(original, _request_free);
+			fr_pair_list_init(&original->link_vps);
 
 			original->id = count;
 			original->in = event->in;

--- a/src/bin/radsniff.c
+++ b/src/bin/radsniff.c
@@ -2240,6 +2240,8 @@ int main(int argc, char *argv[])
 
 	conf = talloc_zero(autofree, rs_t);
 	RS_ASSERT(conf);
+	fr_pair_list_init(&conf->filter_request_vps);
+	fr_pair_list_init(&conf->filter_response_vps);
 
 	stats = talloc_zero(conf, rs_stats_t);
 

--- a/src/bin/radsniff.h
+++ b/src/bin/radsniff.h
@@ -287,8 +287,8 @@ struct rs {
 	char const		*filter_request;	//!< Raw request filter string.
 	char const		*filter_response;	//!< Raw response filter string.
 
-	fr_pair_t 		*filter_request_vps;	//!< Sorted filter vps.
-	fr_pair_t 		*filter_response_vps;	//!< Sorted filter vps.
+	fr_pair_list_t 		filter_request_vps;	//!< Sorted filter vps.
+	fr_pair_list_t 		filter_response_vps;	//!< Sorted filter vps.
 	FR_CODE			filter_request_code;	//!< Filter request packets by code.
 	FR_CODE			filter_response_code;	//!< Filter response packets by code.
 

--- a/src/bin/radsniff.h
+++ b/src/bin/radsniff.h
@@ -208,7 +208,7 @@ typedef struct {
 	bool			silent_cleanup;		//!< Cleanup was forced before normal expiry period,
 							//!< ignore stats about packet loss.
 
-	fr_pair_t		*link_vps;		//!< fr_pair_ts used to link retransmissions.
+	fr_pair_list_t		link_vps;		//!< fr_pair_ts used to link retransmissions.
 
 	bool			in_request_tree;	//!< Whether the request is currently in the request tree.
 	bool			in_link_tree;		//!< Whether the request is currently in the linked tree.

--- a/src/lib/redis/cluster.c
+++ b/src/lib/redis/cluster.c
@@ -238,7 +238,7 @@ struct fr_redis_cluster_key_slot_s {
 struct fr_redis_cluster {
 	char const		*log_prefix;		//!< What to prepend to log messages.
 	char const		*trigger_prefix;	//!< Trigger path.
-	fr_pair_t		*trigger_args;		//!< Arguments to pass to triggers.
+	fr_pair_list_t		trigger_args;		//!< Arguments to pass to triggers.
 	bool			triggers_enabled;	//!< Whether triggers are enabled.
 
 	bool			remapping;		//!< True when cluster is being remapped.
@@ -2273,6 +2273,7 @@ fr_redis_cluster_t *fr_redis_cluster_alloc(TALLOC_CTX *ctx,
 		ERROR("%s - Out of memory", log_prefix);
 		return NULL;
 	}
+	fr_pair_list_init(&cluster->trigger_args);
 
 	cs_name1 = cf_section_name1(module);
 	cs_name2 = cf_section_name2(module);

--- a/src/lib/server/exfile.c
+++ b/src/lib/server/exfile.c
@@ -51,7 +51,7 @@ struct exfile_s {
 	bool			locking;
 	CONF_SECTION		*conf;			//!< Conf section to search for triggers.
 	char const		*trigger_prefix;	//!< Trigger path in the global trigger section.
-	fr_pair_t		*trigger_args;		//!< Arguments to pass to trigger.
+	fr_pair_list_t		trigger_args;		//!< Arguments to pass to trigger.
 };
 
 #define MAX_TRY_LOCK 4			//!< How many times we attempt to acquire a lock
@@ -151,6 +151,7 @@ exfile_t *exfile_init(TALLOC_CTX *ctx, uint32_t max_entries, uint32_t max_idle, 
 
 	ef = talloc_zero(NULL, exfile_t);
 	if (!ef) return NULL;
+	fr_pair_list_init(&ef->trigger_args);
 
 	talloc_link_ctx(ctx, ef);
 

--- a/src/lib/server/listen.h
+++ b/src/lib/server/listen.h
@@ -159,7 +159,7 @@ typedef struct {
 #if 0
 	fr_tls_session_t		*tls_session;
 	request_t			*request; /* horrible hacks */
-	fr_pair_t		*cert_vps;
+	fr_pair_list_t		cert_vps;
 	pthread_mutex_t		mutex;
 	uint8_t			*data;
 	size_t			partial;

--- a/src/lib/server/pool.c
+++ b/src/lib/server/pool.c
@@ -133,7 +133,7 @@ struct fr_pool_s {
 
 	char const	*trigger_prefix;	//!< Prefix to prepend to names of all triggers
 						//!< fired by the connection pool code.
-	fr_pair_t	*trigger_args;		//!< Arguments to make available in connection pool triggers.
+	fr_pair_list_t	trigger_args;		//!< Arguments to make available in connection pool triggers.
 
 	fr_time_delta_t	held_trigger_min;	//!< If a connection is held for less than the specified
 						//!< period, fire a trigger.
@@ -949,6 +949,7 @@ fr_pool_t *fr_pool_init(TALLOC_CTX *ctx,
 	 *	beneath the pool.
 	 */
 	MEM(pool = talloc_zero(NULL, fr_pool_t));
+	fr_pair_list_init(&pool->trigger_args);
 
 	/*
 	 *	Ensure the pool is freed at the same time

--- a/src/lib/server/request.c
+++ b/src/lib/server/request.c
@@ -104,6 +104,12 @@ static void request_init(char const *file, int line, request_t *request)
 	request->alloc_line = line;
 
 	fr_dlist_entry_init(&request->free_entry);	/* Needs to be initialised properly, else bad things happen */
+
+	/*
+	 *	Initialise pair value lists
+	 */
+	fr_pair_list_init(&request->control);
+	fr_pair_list_init(&request->state);
 }
 
 /** Callback for freeing a request struct

--- a/src/lib/server/request.h
+++ b/src/lib/server/request.h
@@ -103,13 +103,13 @@ struct request_s {
 	fr_radius_packet_t		*packet;	//!< Incoming request.
 	fr_radius_packet_t		*reply;		//!< Outgoing response.
 
-	fr_pair_t		*control;	//!< #fr_pair_t (s) used to set per request parameters
+	fr_pair_list_t		control;	//!< #fr_pair_t list used to set per request parameters
 						//!< for modules and the server core at runtime.
 
 	uint64_t		seq_start;	//!< State sequence ID.  Stable identifier for a sequence of requests
 						//!< and responses.
 	TALLOC_CTX		*state_ctx;	//!< for request->state
-	fr_pair_t		*state;		//!< #fr_pair_t (s) available over the lifetime of the authentication
+	fr_pair_list_t		state;		//!< #fr_pair_t list available over the lifetime of the authentication
 						//!< attempt. Useful where the attempt involves a sequence of
 						//!< many request/challenge packets, like OTP, and EAP.
 

--- a/src/lib/server/tmpl.h
+++ b/src/lib/server/tmpl.h
@@ -503,7 +503,7 @@ struct tmpl_cursor_nested_s {
 		} group;
 
 		struct {
-			fr_pair_t		**list_head;		//!< Head of the list we're currently
+			fr_pair_list_t		*list_head;		//!< Head of the list we're currently
 									///< iterating over.
 		} leaf;
 	};
@@ -518,7 +518,7 @@ struct tmpl_cursor_ctx_s {
 	tmpl_t const		*vpt;		//!< tmpl we're evaluating.
 
 	request_t		*request;	//!< Result of following the request references.
-	fr_pair_t		**list;		//!< List within the request.
+	fr_pair_list_t		*list;		//!< List within the request.
 
 	tmpl_cursor_nested_t	leaf;		//!< Pre-allocated leaf state.  We always need
 						///< one of these so it doesn't make sense to
@@ -544,7 +544,7 @@ typedef struct {
 
 	TALLOC_CTX		*list_ctx;	//!< Where to allocate new attributes if building
 						///< out from the current extents of the tree.X
-	fr_pair_t		**list;		//!< List that we tried to evaluate ar in and failed.
+	fr_pair_list_t		*list;		//!< List that we tried to evaluate ar in and failed.
 						///< Or if ar is NULL, the list that represents the
 						///< deepest grouping or TLV attribute the chain of
 						///< ars referenced.
@@ -741,7 +741,7 @@ void tmpl_verify(char const *file, int line, tmpl_t const *vpt);
  * Example:
  @code{.c}
    TALLOC_CTX *ctx;
-   fr_pair_t **head;
+   fr_pair_list_t *head;
    fr_value_box_t value;
 
    RADIUS_LIST_AND_CTX(ctx, head, request, CURRENT_REQUEST, PAIR_LIST_REQUEST);

--- a/src/lib/server/trigger.c
+++ b/src/lib/server/trigger.c
@@ -188,7 +188,7 @@ bool trigger_enabled(void)
 typedef struct {
 	char		*name;
 	xlat_exp_t	*xlat;
-	fr_pair_t	*vps;
+	fr_pair_list_t	vps;
 	fr_value_box_t	*box;
 	bool		expanded;
 } fr_trigger_t;
@@ -401,6 +401,7 @@ int trigger_exec(request_t *request, CONF_SECTION const *cs, char const *name, b
 	}
 
 	MEM(ctx = talloc_zero(fake, fr_trigger_t));
+	fr_pair_list_init(&ctx->vps);
 	ctx->name = talloc_strdup(ctx, value);
 
 	if (request) {

--- a/src/lib/server/users_file.c
+++ b/src/lib/server/users_file.c
@@ -122,6 +122,8 @@ int pairlist_read(TALLOC_CTX *ctx, fr_dict_t const *dict, char const *file, PAIR
 	 *	Allocate the structure for one entry.
 	 */
 	MEM(t = talloc_zero(ctx, PAIR_LIST));
+	fr_pair_list_init(&t->check);
+	fr_pair_list_init(&t->reply);
 
 	/*
 	 *	Read the entire file into memory for speed.
@@ -329,6 +331,8 @@ parse_again:
 		 *	Allocate another one, just in case it's needed.
 		 */
 		MEM(t = talloc_zero(ctx, PAIR_LIST));
+		fr_pair_list_init(&t->check);
+		fr_pair_list_init(&t->reply);
 
 		/*
 		 *	Look for a name.  If we came here because

--- a/src/lib/server/users_file.h
+++ b/src/lib/server/users_file.h
@@ -36,8 +36,8 @@ extern "C" {
 
 typedef struct pair_list {
 	char const		*name;
-	fr_pair_t		*check;
-	fr_pair_t		*reply;
+	fr_pair_list_t		check;
+	fr_pair_list_t		reply;
 	int			order;
 	int			lineno;
 	struct pair_list	*next;

--- a/src/lib/unlang/foreach.c
+++ b/src/lib/unlang/foreach.c
@@ -47,10 +47,10 @@ static int xlat_foreach_inst[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };	/* up to 10 f
  *
  */
 typedef struct {
-	request_t			*request;			//!< The current request.
+	request_t		*request;			//!< The current request.
 	fr_cursor_t		cursor;				//!< Used to track our place in the list
 								///< we're iterating over.
-	fr_pair_t 		*vps;				//!< List containing the attribute(s) we're
+	fr_pair_list_t 		vps;				//!< List containing the attribute(s) we're
 								///< iterating over.
 	fr_pair_t		*variable;			//!< Attribute we update the value of.
 	int			depth;				//!< Level of nesting of this foreach loop.
@@ -167,6 +167,7 @@ static unlang_action_t unlang_foreach(rlm_rcode_t *p_result, request_t *request)
 	}
 
 	MEM(frame->state = foreach = talloc_zero(stack, unlang_frame_state_foreach_t));
+	fr_pair_list_init(&foreach->vps);
 
 	/*
 	 *	Copy the VPs from the original request, this ensures deterministic

--- a/src/lib/unlang/tmpl_priv.h
+++ b/src/lib/unlang/tmpl_priv.h
@@ -49,7 +49,7 @@ typedef struct {
 	fr_event_timer_t const		*ev;		//!< for timing out the child
 	fr_event_pid_t const   		*ev_pid;	//!< for cleaning up the process
 
-	fr_pair_t			*vps;		//!< input VPs
+	fr_pair_list_t			vps;		//!< input VPs
 	char				*buffer;	//!< for reading the answer
 	char				*ptr;		//!< where in the buffer we are writing to
 	int				status;		//!< return code of the program

--- a/src/lib/util/packet.c
+++ b/src/lib/util/packet.c
@@ -43,6 +43,7 @@ fr_radius_packet_t *fr_radius_alloc(TALLOC_CTX *ctx, bool new_vector)
 	fr_radius_packet_t	*rp;
 
 	rp = talloc_zero(ctx, fr_radius_packet_t);
+	fr_pair_list_init(&rp->vps);
 	if (!rp) {
 		fr_strerror_printf("out of memory");
 		return NULL;

--- a/src/lib/util/packet.h
+++ b/src/lib/util/packet.h
@@ -65,7 +65,7 @@ typedef struct {
 	fr_time_t		timestamp;		//!< When we received the packet.
 	uint8_t			*data;			//!< Packet data (body).
 	size_t			data_len;		//!< Length of packet data.
-	fr_pair_t		*vps;			//!< Result of decoding the packet into fr_pair_ts.
+	fr_pair_list_t		vps;			//!< Result of decoding the packet into fr_pair_t list.
 
 	uint32_t       		rounds;			//!< for State[0]
 

--- a/src/modules/proto_bfd/proto_bfd.c
+++ b/src/modules/proto_bfd/proto_bfd.c
@@ -387,6 +387,8 @@ static const char *bfd_state[] = {
 static void bfd_request(bfd_state_t *session, request_t *request, fr_radius_packet_t *packet)
 {
 	memset(request, 0, sizeof(*request));
+	fr_pair_list_init(&request->control);
+	fr_pair_list_init(&request->state);
 	memset(packet, 0, sizeof(*packet));
 
 	request->packet = packet;

--- a/src/modules/proto_bfd/proto_bfd.c
+++ b/src/modules/proto_bfd/proto_bfd.c
@@ -390,6 +390,7 @@ static void bfd_request(bfd_state_t *session, request_t *request, fr_radius_pack
 	fr_pair_list_init(&request->control);
 	fr_pair_list_init(&request->state);
 	memset(packet, 0, sizeof(*packet));
+	fr_pair_list_init(&packet->vps);
 
 	request->packet = packet;
 	request->server_cs = session->server_cs;

--- a/src/modules/rlm_eap/types/rlm_eap_mschapv2/eap_mschapv2.h
+++ b/src/modules/rlm_eap/types/rlm_eap_mschapv2/eap_mschapv2.h
@@ -44,6 +44,6 @@ typedef struct {
 	bool		has_peer_challenge;
 	uint8_t		auth_challenge[MSCHAPV2_CHALLENGE_LEN];
 	uint8_t		peer_challenge[MSCHAPV2_CHALLENGE_LEN];
-	fr_pair_t	*mppe_keys;
-	fr_pair_t	*reply;
+	fr_pair_list_t	mppe_keys;
+	fr_pair_list_t	reply;
 } mschapv2_opaque_t;

--- a/src/modules/rlm_eap/types/rlm_eap_mschapv2/rlm_eap_mschapv2.c
+++ b/src/modules/rlm_eap/types/rlm_eap_mschapv2/rlm_eap_mschapv2.c
@@ -829,14 +829,16 @@ static unlang_action_t mod_session_init(rlm_rcode_t *p_result, module_ctx_t cons
 	 */
 	data = talloc_zero(eap_session, mschapv2_opaque_t);
 	fr_assert(data != NULL);
+	fr_pair_list_init(&data->mppe_keys);
+	fr_pair_list_init(&data->reply);
 
 	/*
 	 *	We're at the stage where we're challenging the user.
 	 */
 	data->code = FR_EAP_MSCHAPV2_CHALLENGE;
 	memcpy(data->auth_challenge, auth_challenge->vp_octets, MSCHAPV2_CHALLENGE_LEN);
-	data->mppe_keys = NULL;
-	data->reply = NULL;
+	fr_pair_list_init(&data->mppe_keys);
+	fr_pair_list_init(&data->reply);
 
 	if (peer_challenge) {
 		data->has_peer_challenge = true;

--- a/src/modules/rlm_eap/types/rlm_eap_peap/eap_peap.h
+++ b/src/modules/rlm_eap/types/rlm_eap_peap/eap_peap.h
@@ -52,7 +52,7 @@ typedef struct {
 	char const	*virtual_server;
 	bool		soh;
 	char const	*soh_virtual_server;
-	fr_pair_t	*soh_reply_vps;
+	fr_pair_list_t	soh_reply_vps;
 	peap_resumption	session_resumption_state;
 } peap_tunnel_t;
 

--- a/src/modules/rlm_eap/types/rlm_eap_peap/rlm_eap_peap.c
+++ b/src/modules/rlm_eap/types/rlm_eap_peap/rlm_eap_peap.c
@@ -117,6 +117,7 @@ static peap_tunnel_t *peap_alloc(TALLOC_CTX *ctx, rlm_eap_peap_t *inst)
 	t->soh = inst->soh;
 	t->soh_virtual_server = inst->soh_virtual_server;
 	t->session_resumption_state = PEAP_RESUMPTION_MAYBE;
+	fr_pair_list_init(&t->soh_reply_vps);
 
 	return t;
 }

--- a/src/modules/rlm_files/rlm_files.c
+++ b/src/modules/rlm_files/rlm_files.c
@@ -304,6 +304,9 @@ static unlang_action_t file_common(rlm_rcode_t *p_result, rlm_files_t const *ins
 
 	fr_pair_list_init(&check_tmp);
 	fr_pair_list_init(&reply_tmp);
+	fr_pair_list_init(&my_pl.check);
+	fr_pair_list_init(&my_pl.reply);
+
 	if (tmpl_expand(&name, buffer, sizeof(buffer), request, inst->key, NULL, NULL) < 0) {
 		REDEBUG("Failed expanding key %s", inst->key->name);
 		RETURN_MODULE_FAIL;

--- a/src/modules/rlm_isc_dhcp/rlm_isc_dhcp.c
+++ b/src/modules/rlm_isc_dhcp/rlm_isc_dhcp.c
@@ -194,7 +194,7 @@ struct rlm_isc_dhcp_info_s {
 	 */
 	fr_hash_table_t		*hosts_by_ether;  //!< by MAC address
 	fr_hash_table_t		*hosts_by_uid;	//!< by client identifier
-	fr_pair_t		*options;	//!< DHCP options
+	fr_pair_list_t		options;	//!< DHCP options
 	fr_trie_t		*subnets;
 	rlm_isc_dhcp_info_t	*child;
 	rlm_isc_dhcp_info_t	**last;		//!< pointer to last child
@@ -1284,6 +1284,7 @@ static int match_keyword(rlm_isc_dhcp_info_t *parent, rlm_isc_dhcp_tokenizer_t *
 	DDEBUG("... TOKEN %.*s ", state->token_len, state->token);
 
 	info = talloc_zero(parent, rlm_isc_dhcp_info_t);
+	fr_pair_list_init(&info->options);
 	if (tokens[half].max_argc) {
 		info->argv = talloc_zero_array(info, fr_value_box_t *, tokens[half].max_argc);
 	}
@@ -2204,6 +2205,7 @@ static int mod_instantiate(void *instance, CONF_SECTION *conf)
 	if (!inst->name) inst->name = cf_section_name1(conf);
 
 	inst->head = info = talloc_zero(inst, rlm_isc_dhcp_info_t);
+	fr_pair_list_init(&info->options);
 	info->last = &(info->child);
 
 	inst->hosts_by_ether = fr_hash_table_create(inst, host_ether_hash, host_ether_cmp, NULL);

--- a/src/modules/rlm_radius/rlm_radius_udp.c
+++ b/src/modules/rlm_radius/rlm_radius_udp.c
@@ -150,7 +150,7 @@ struct udp_request_s {
 	bool			can_retransmit;		//!< can we retransmit this packet?
 	bool			status_check;		//!< is this packet a status check?
 
-	fr_pair_t		*extra;			//!< VPs for debugging, like Proxy-State.
+	fr_pair_list_t		extra;			//!< VPs for debugging, like Proxy-State.
 
 	uint8_t			code;			//!< Packet code.
 	uint8_t			id;			//!< Last ID assigned to this packet.
@@ -343,6 +343,7 @@ static void CC_HINT(nonnull) status_check_alloc(fr_event_list_t *el, udp_handle_
 	fr_assert(!h->status_u && !h->status_r && !h->status_request);
 
 	u = talloc_zero(h, udp_request_t);
+	fr_pair_list_init(&u->extra);
 
 	/*
 	 *	Status checks are prioritized over any other packet


### PR DESCRIPTION
Where fr_pair_t * is used for a list in data structures, replace it with fr_pair_list_t and add explicit initialisation calls for the new list headers.