### PR TITLE
Make 'utc = yes' works for converting strings into unix timestamp as well

### DIFF
--- a/src/modules/rlm_date/rlm_date.c
+++ b/src/modules/rlm_date/rlm_date.c
@@ -95,7 +95,11 @@ static ssize_t xlat_date_convert(void *instance, REQUEST *request, char const *f
 			goto error;
 		}
 
-		date = mktime(&tminfo);
+		if (!inst->utc) {
+			date = mktime(&tminfo);
+		} else {
+			date = timegm(&tminfo);
+		}
 		if (date < 0) {
 			REDEBUG("Failed converting parsed time into unix time");
 


### PR DESCRIPTION
Please note that no changes needed in ```raddb/mods-available/date``` as comment will now work just fine. :)

Give me a hint if you need a separate PR for master branch.