### PR TITLE
docs: fix simple typo, mininum -> minimum

### DIFF
--- a/src/modules/rlm_radius/rlm_radius_udp.c
+++ b/src/modules/rlm_radius/rlm_radius_udp.c
@@ -1344,7 +1344,7 @@ static int encode(rlm_radius_udp_t const *inst, request_t *request, udp_request_
 	}
 
 	/*
-	 *	We should have at mininum 64-byte packets, so don't
+	 *	We should have at minimum 64-byte packets, so don't
 	 *	bother doing run-time checks here.
 	 */
 	fr_assert(u->packet_len >= (size_t) (RADIUS_HEADER_LENGTH + proxy_state + message_authenticator));


### PR DESCRIPTION
There is a small typo in src/modules/rlm_radius/rlm_radius_udp.c.

Should read `minimum` rather than `mininum`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md