### PR TITLE
CI tests for build and install of DEBs and RPMs

### DIFF
--- a/.github/workflows/ci-deb.yml
+++ b/.github/workflows/ci-deb.yml
@@ -1,0 +1,109 @@
+name: CI DEB
+
+on:
+  push:
+    branches-ignore:
+      - coverity_scan
+  pull_request:
+
+env:
+  CI: 1
+  GH_ACTIONS: 1
+  DEBIAN_FRONTEND: noninteractive
+
+jobs:
+  deb-build:
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: debian:buster
+
+    name: "DEB build"
+
+    steps:
+
+    - name: Package manager performance improvements
+      run: |
+        echo force-unsafe-io > /etc/dpkg/dpkg.cfg.d/02speedup
+        echo 'man-db man-db/auto-update boolean false' | debconf-set-selections
+
+    - name: Install recent git
+      run: |
+        apt-get update
+        apt-get install -y git
+
+    - uses: actions/checkout@v2
+      with:
+        repository: mheily/libkqueue
+        path: libkqueue
+
+    - name: Install build tools
+      run: |
+        apt-get install -y cmake make gcc file
+
+    - name: Build libkqueue
+      run: |
+        cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=lib ./
+        make
+        cpack -G DEB
+        dpkg -i --force-all ./libkqueue*.deb
+      working-directory: libkqueue
+
+    - uses: actions/checkout@v2
+      with:
+        path: freeradius
+
+    - name: Install build dependencies
+      run: |
+        apt-get install -y build-essential devscripts quilt
+        debian/rules debian/control
+        mk-build-deps -irt"apt-get -y" debian/control ;
+      working-directory: freeradius
+
+    - name: Build DEBs
+      run: |
+        make deb
+        mkdir debs
+      working-directory: freeradius
+
+    - name: Collect DEBs
+      run: |
+        mkdir debs
+        mv libkqueue/*.deb debs
+        mv *.deb debs
+
+    - name: Store DEBs
+      uses: actions/upload-artifact@v2
+      with:
+        name: debs
+        path: debs
+
+  deb-test:
+
+    needs:
+      - deb-build
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: debian:buster
+
+    name: "DEB install test"
+
+    steps:
+
+    - name: Load DEBs
+      uses: actions/download-artifact@v2
+      with:
+        name: debs
+
+    - name: Install DEBs
+      run: |
+        apt-get update
+        find . -maxdepth 1 -name '*.deb' | xargs apt-get install -y
+
+    - name: Startup test
+      run: |
+        freeradius -XC
+

--- a/.github/workflows/ci-rpm.yml
+++ b/.github/workflows/ci-rpm.yml
@@ -1,0 +1,129 @@
+name: CI RPM
+
+on:
+  push:
+    branches-ignore:
+      - coverity_scan
+  pull_request:
+
+env:
+  CI: 1
+  GH_ACTIONS: 1
+
+jobs:
+  rpm-build:
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: centos:8
+
+    name: "RPM build"
+
+    steps:
+
+    - name: Install recent git
+      run: |
+        yum install -y git
+
+    - uses: actions/checkout@v2
+      with:
+        repository: mheily/libkqueue
+        path: libkqueue
+
+    - name: Install build tools
+      run: |
+        yum install -y cmake make gcc rpm-build
+
+    - name: Build libkqueue
+      run: |
+        cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=lib ./
+        make
+        cpack -G RPM
+        yum localinstall -y *.rpm
+      working-directory: libkqueue
+
+    - uses: actions/checkout@v2
+      with:
+        path: freeradius
+
+    - name: Extra repos
+      run: |
+        echo '[ltb-project]' >> /etc/yum.repos.d/ltb-project.repo
+        echo 'name=LTB project packages' >> /etc/yum.repos.d/ltb-project.repo
+        echo 'baseurl=https://ltb-project.org/rpm/$releasever/$basearch' >> /etc/yum.repos.d/ltb-project.repo
+        echo 'enabled=1' >> /etc/yum.repos.d/ltb-project.repo
+        echo 'gpgcheck=1' >> /etc/yum.repos.d/ltb-project.repo
+        echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-LTB-project' >> /etc/yum.repos.d/ltb-project.repo
+        rpm --import https://ltb-project.org/lib/RPM-GPG-KEY-LTB-project
+        yum install -y epel-release yum-utils
+        yum config-manager --enable PowerTools
+
+    - name: Install build dependencies
+      run: |
+        yum install -y \
+          bzip2 \
+          gcc \
+          libcurl-devel \
+          make \
+          perl \
+          rpm-build \
+          yum-utils
+        yum-builddep -y freeradius/redhat/freeradius.spec
+
+    - name: Build RPMs
+      run: |
+        make rpm
+      working-directory: freeradius
+
+    - name: Collect RPMs
+      run: |
+        mkdir rpms
+        mv libkqueue/*.rpm rpms
+        mv freeradius/rpmbuild/RPMS/x86_64/*.rpm rpms
+
+    - name: Store RPMs
+      uses: actions/upload-artifact@v2
+      with:
+        name: rpms
+        path: rpms
+
+  rpm-test:
+
+    needs:
+      - rpm-build
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: centos:8
+
+    name: "RPM install test"
+
+    steps:
+
+    - name: Extra repos
+      run: |
+        echo '[ltb-project]' >> /etc/yum.repos.d/ltb-project.repo
+        echo 'name=LTB project packages' >> /etc/yum.repos.d/ltb-project.repo
+        echo 'baseurl=https://ltb-project.org/rpm/$releasever/$basearch' >> /etc/yum.repos.d/ltb-project.repo
+        echo 'enabled=1' >> /etc/yum.repos.d/ltb-project.repo
+        echo 'gpgcheck=1' >> /etc/yum.repos.d/ltb-project.repo
+        echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-LTB-project' >> /etc/yum.repos.d/ltb-project.repo
+        rpm --import https://ltb-project.org/lib/RPM-GPG-KEY-LTB-project
+        yum install -y epel-release yum-utils
+        yum config-manager --enable PowerTools
+
+    - name: Load RPMs
+      uses: actions/download-artifact@v2
+      with:
+        name: rpms
+
+    - name: Install RPMs
+      run: |
+        yum install -y *.rpm
+
+    - name: Startup test
+      run: |
+        radiusd -XC
+

--- a/debian/freeradius-config.postinst
+++ b/debian/freeradius-config.postinst
@@ -33,11 +33,11 @@ case "$1" in
 	  done
 
           # Create links for default modules
-          for mod in always attr_filter cache_eap chap \
-              detail detail.log digest dynamic_clients eap \
+          for mod in always attr_filter cache_eap chap client \
+              delay detail detail.log dhcpv4 digest eap \
               eap_inner echo exec expiration expr files linelog logintime \
-              mschap ntlm_auth pap pam passwd radutmp realm \
-              replicate soh sradutmp unix unpack utf8 ; do
+              mschap ntlm_auth pap pam passwd radutmp \
+              soh sradutmp stats unix unpack utf8 ; do
             if test ! -h /etc/freeradius/mods-enabled/$mod && \
                test ! -e /etc/freeradius/mods-enabled/$mod; then
               ln -s ../mods-available/$mod /etc/freeradius/mods-enabled/$mod

--- a/debian/freeradius-dhcp.install
+++ b/debian/freeradius-dhcp.install
@@ -1,4 +1,4 @@
 usr/lib/freeradius/rlm_dhcp*.so
 usr/lib/freeradius/proto_dhcp*.so
-usr/lib/freeradius/libfreeradius-dhcp.so
+usr/lib/freeradius/libfreeradius-dhcp*.so
 usr/bin/dhcpclient

--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -148,6 +148,7 @@ Adds support for rlm_memcached as a cache driver.
 Group: System Environment/Daemons
 Summary: FreeRADIUS config files
 Provides: freeradius-config
+Requires: make
 
 %description config
 FreeRADIUS default config files
@@ -213,8 +214,8 @@ Requires: freeradius-libfreeradius-util = %{version}-%{release}
 
 %description libfreeradius-curl
 Integrates libcurl with FreeRADIUS' internal event loop.
-Requires: libcurl >= 7.45.0
-BuildRequires: libcurl-devel >= 7.45.0
+Requires: libcurl >= 7.24.0
+BuildRequires: libcurl-devel >= 7.24.0
 
 %package libfreeradius-util
 Summary: Utility library used by all other FreeRADIUS libraries
@@ -715,6 +716,7 @@ fi
 %config(noreplace) %{_sysconfdir}/raddb/users
 %dir %attr(770,root,radiusd) %{_sysconfdir}/raddb/certs
 %attr(640,root,radiusd) %config(noreplace) %{_sysconfdir}/raddb/certs/*
+%attr(755,root,radiusd) %{_sysconfdir}/raddb/certs/bootstrap
 %dir %attr(750,root,radiusd) %{_sysconfdir}/raddb/sites-available
 %attr(640,root,radiusd) %config(noreplace) %{_sysconfdir}/raddb/sites-available/*
 %dir %attr(750,root,radiusd) %{_sysconfdir}/raddb/sites-enabled


### PR DESCRIPTION
Build RPM/DEB packages -> Reset the environment -> Install them -> Run radiusd -XC

NOTE: RPM and DEB packages are broken post-install so don't pull this now if we want to keep the CI clean.

Might eventually want to consider scheduling this rather than running it on push.