### PR TITLE
Convert remaining fr_pair_t ** to fr_pair_list_t * where they are list headers

### DIFF
--- a/src/lib/server/tmpl.h
+++ b/src/lib/server/tmpl.h
@@ -844,7 +844,7 @@ typedef enum {
 
 void			tmpl_debug(tmpl_t const *vpt);
 
-fr_pair_t		**radius_list(request_t *request, pair_list_t list);
+fr_pair_list_t		*radius_list(request_t *request, pair_list_t list);
 
 fr_radius_packet_t	*radius_packet(request_t *request, pair_list_t list_name);
 
@@ -989,10 +989,10 @@ fr_pair_t		*tmpl_cursor_init(int *err, TALLOC_CTX *ctx, tmpl_cursor_ctx_t *cc,
 
 void			tmpl_cursor_clear(tmpl_cursor_ctx_t *cc);
 
-int			tmpl_copy_pairs(TALLOC_CTX *ctx, fr_pair_t **out,
+int			tmpl_copy_pairs(TALLOC_CTX *ctx, fr_pair_list_t *out,
 					request_t *request, tmpl_t const *vpt);
 
-int			tmpl_copy_pair_children(TALLOC_CTX *ctx, fr_pair_t **out,
+int			tmpl_copy_pair_children(TALLOC_CTX *ctx, fr_pair_list_t *out,
 						request_t *request, tmpl_t const *vpt);
 
 int			tmpl_find_vp(fr_pair_t **out, request_t *request, tmpl_t const *vpt);

--- a/src/lib/server/tmpl_eval.c
+++ b/src/lib/server/tmpl_eval.c
@@ -990,7 +990,7 @@ static fr_pair_t *_tmpl_cursor_list_eval(UNUSED fr_pair_t **prev, fr_pair_t *cur
 }
 
 static inline CC_HINT(always_inline)
-void _tmpl_cursor_list_init(TALLOC_CTX *list_ctx, fr_pair_t **list, tmpl_attr_t const *ar, tmpl_cursor_ctx_t *cc)
+void _tmpl_cursor_list_init(TALLOC_CTX *list_ctx, fr_pair_list_t *list, tmpl_attr_t const *ar, tmpl_cursor_ctx_t *cc)
 {
 	tmpl_cursor_nested_t *ns;
 


### PR DESCRIPTION
a couple of outstanding changes missed in the previous round of conversion.