### PR TITLE
In fr_sbuff_extend_file(), don't NUL terminate if the read fills the …

### DIFF
--- a/src/lib/util/sbuff.c
+++ b/src/lib/util/sbuff.c
@@ -252,7 +252,7 @@ size_t fr_sbuff_extend_file(fr_sbuff_t *sbuff, size_t extension)
 
 	read = fread(sbuff->end, 1, available, fctx->file);
 	sbuff->end += read;	/* Advance end, which increases fr_sbuff_remaining() */
-	*sbuff->end = '\0';	/* Terminate sbuff */
+	if (sbuff->end < fctx->buff_end) *sbuff->end = '\0';	/* Terminate sbuff */
 
 	/** Check for errors
 	 */


### PR DESCRIPTION
…buffer.