### PR TITLE
Remove the NUL termination from fr_sbuff_extend_file().

### DIFF
--- a/src/lib/util/sbuff.c
+++ b/src/lib/util/sbuff.c
@@ -252,7 +252,6 @@ size_t fr_sbuff_extend_file(fr_sbuff_t *sbuff, size_t extension)
 
 	read = fread(sbuff->end, 1, available, fctx->file);
 	sbuff->end += read;	/* Advance end, which increases fr_sbuff_remaining() */
-	*sbuff->end = '\0';	/* Terminate sbuff */
 
 	/** Check for errors
 	 */

--- a/src/lib/util/sbuff_tests.c
+++ b/src/lib/util/sbuff_tests.c
@@ -23,7 +23,7 @@
 #include <freeradius-devel/util/acutest.h>
 #include <freeradius-devel/util/acutest_helpers.h>
 
-#include "sbuff.c"
+#include "sbuff.h"
 
 //#include <gperftools/profiler.h>
 
@@ -909,6 +909,7 @@ static void test_file_extend(void)
 	FILE		*fp;
 	char		buff[16];
 	char		fbuff[] = "                        xyzzy";
+	char		*post_ws;
 
 	TEST_CASE("Initialization");
 	fp = fmemopen(fbuff, sizeof(fbuff) - 1, "r");
@@ -918,7 +919,9 @@ static void test_file_extend(void)
 	TEST_CASE("Advance past whitespace, which will require shift/extend");
 	TEST_CHECK_LEN(sizeof(fbuff) - 6, fr_sbuff_adv_past_whitespace(&sbuff, SIZE_MAX));
 	TEST_CASE("Verify that we passed all and only whitespace");
-	TEST_CHECK_STRCMP(sbuff.p, "xyzzy");
+	(void) fr_sbuff_out_abstrncpy(NULL, &post_ws, &sbuff, 24);
+	TEST_CHECK_STRCMP(post_ws, "xyzzy");
+	talloc_free(post_ws);
 	fclose(fp);
 }
 


### PR DESCRIPTION
This entails a change to test_file_extend() in sbuff_tests. You can't simply
strcmp() with the buffer contents, but must instead use sbuff routines, since
they honor the buffer end pointer and ignore trailing leftovers.