### PR TITLE
Correct issues turned up by clang address sanitizer

### DIFF
--- a/src/lib/util/dbuff_tests.c
+++ b/src/lib/util/dbuff_tests.c
@@ -356,6 +356,9 @@ static void test_dbuff_talloc_extend(void)
 	/*
 	 * @todo: the analogous test for extensible source.
 	 */
+
+	talloc_free(dbuff1.buff);
+	talloc_free(dbuff2.buff);
 }
 
 static void test_dbuff_talloc_extend_multi_level(void)
@@ -382,6 +385,8 @@ static void test_dbuff_talloc_extend_multi_level(void)
 	TEST_CHECK(fr_dbuff_used(&dbuff2) == 0);
 	TEST_CHECK(fr_dbuff_remaining(&dbuff2) == 0);
 	TEST_CHECK(fr_dbuff_in(&dbuff2, (uint64_t) 0x123456789abcdef0) == -8);
+
+	talloc_free(dbuff1.buff);
 }
 
 static void test_dbuff_fd(void)

--- a/src/lib/util/sbuff.c
+++ b/src/lib/util/sbuff.c
@@ -184,7 +184,7 @@ size_t fr_sbuff_shift(fr_sbuff_t *sbuff, size_t shift)
 	 *	then assume we need to re-terminate
 	 *	later.
 	 */
-	reterminate = (*sbuff->p == '\0') && !sbuff->is_const;
+	reterminate = (sbuff->p < sbuff->end) && (*sbuff->p == '\0') && !sbuff->is_const;
 
 	/*
 	 *	Determine the maximum shift amount.

--- a/src/lib/util/sbuff_tests.c
+++ b/src/lib/util/sbuff_tests.c
@@ -823,6 +823,8 @@ static void test_talloc_extend(void)
 	TEST_CHECK(strcmp(fr_sbuff_start(&sbuff), "01234567890123456789012345678901234ABCDEFGHIJKLMNO") == 0);
 	TEST_SBUFF_USED(&sbuff, 50);
 	TEST_SBUFF_LEN(&sbuff, 51);
+
+	talloc_free(sbuff.buff);
 }
 
 static void test_talloc_extend_init_zero(void)
@@ -852,6 +854,8 @@ static void test_talloc_extend_init_zero(void)
 	TEST_CHECK(strcmp(fr_sbuff_start(&sbuff), "ABCD") == 0);
 	TEST_SBUFF_USED(&sbuff, 4);
 	TEST_SBUFF_LEN(&sbuff, 7);
+
+	talloc_free(sbuff.buff);
 }
 
 static void test_talloc_extend_multi_level(void)
@@ -883,6 +887,8 @@ static void test_talloc_extend_multi_level(void)
 	TEST_CHECK(sbuff_0.start == sbuff_1.start);
 	TEST_CHECK(sbuff_0.end == sbuff_1.end);
 	TEST_CHECK(sbuff_0.p == sbuff_1.p);
+
+	talloc_free(sbuff_0.buff);
 }
 
 static void test_talloc_extend_with_marker(void)
@@ -930,6 +936,8 @@ static void test_talloc_extend_with_marker(void)
 	TEST_CHECK((marker_1.p - sbuff_0.start) == 2);
 	TEST_SBUFF_USED(&sbuff_0, 3);
 	TEST_SBUFF_LEN(&sbuff_0, 5);
+
+	talloc_free(sbuff_0.buff);
 }
 
 static void test_file_extend(void)


### PR DESCRIPTION
These fell into two classes:
* not freeing buffers created by fr_[sd]buff_init_talloc() in tests,
* trying to reterminate sbuffs in fr_sbuff_shift() by
  putting a '\0' past the end