### PR TITLE
Build: Always build with Python 3 on CentOS

### DIFF
--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -276,10 +276,8 @@ This plugin provides Perl support for the FreeRADIUS server project.
 Summary: Python support for FreeRADIUS
 Group: System Environment/Daemons
 Requires: %{name}%{?_isa} = %{version}-%{release}
-%{!?el8:Requires: python}
-%{?el8:Requires: python3}
-%{!?el8:BuildRequires: python-devel}
-%{?el8:BuildRequires: python3-devel}
+Requires: python3
+BuildRequires: python3-devel
 
 %description python
 This plugin provides Python support for the FreeRADIUS server project.


### PR DESCRIPTION
Since we're saying goodbye to Python 2 with
04f6485155ecdcaaca0d8fff6cc2fe7bee94c391.