### PR TITLE
:gear: rlm_python: Fix handling of attribute lists

### DIFF
--- a/src/modules/rlm_python/example.py
+++ b/src/modules/rlm_python/example.py
@@ -7,9 +7,21 @@
 
 import freeradius
 
+#
+# Print out the p["request"], p["control"], p["reply"] and p["session-state"]
+#
+def radius_dump_list(p):
+  print("# Dump lists")
+  for _l in p:
+    list_keys = p[_l]
+    print("  list: '{}'".format(_l))
+    if not list_keys is None:
+      for k, v in list_keys:
+        print("     attr='{}', value='{}'".format(k, v))
+
 def instantiate(p):
   print("*** instantiate ***")
-  print(p)
+  radius_dump_list(p)
   # return 0 for success or -1 for failure
 
 def authorize(p):
@@ -17,7 +29,7 @@ def authorize(p):
   print("")
   freeradius.log(freeradius.L_INFO, '*** log call in authorize ***')
   print("")
-  print(p)
+  radius_dump_list(p)
   print("")
   print(freeradius.config)
   print("")
@@ -25,39 +37,60 @@ def authorize(p):
 
 def preacct(p):
   print("*** preacct ***")
-  print(p)
+  freeradius.log(freeradius.L_INFO, '*** log call in authorize ***')
+  radius_dump_list(p)
+  print("# Print freeradius.config")
+  print(freeradius.config)
+  print("")
+  #
+  # Dictionary representing changes we want to make to the different VPS
+  #
+#  update_dict = {
+#    "request": (
+#      ("NAS-Identifier", "python-script"),
+#    ),
+#    "reply": (
+#     ("Reply-Message", "Handled by rlm_python"),
+#    ),
+#  }
+#  return freeradius.RLM_MODULE_OK, update_dict
+  return freeradius.RLM_MODULE_OK
+
+def preacct(p):
+  print("*** preacct ***")
+  radius_dump_list(p)
   return freeradius.RLM_MODULE_OK
 
 def accounting(p):
   print("*** accounting ***")
   freeradius.log(freeradius.L_INFO, '*** log call in accounting (0) ***')
   print("")
-  print(p)
+  radius_dump_list(p)
   return freeradius.RLM_MODULE_OK
 
 def pre_proxy(p):
   print("*** pre_proxy ***")
-  print(p)
+  radius_dump_list(p)
   return freeradius.RLM_MODULE_OK
 
 def post_proxy(p):
   print("*** post_proxy ***")
-  print(p)
+  radius_dump_list(p)
   return freeradius.RLM_MODULE_OK
 
 def post_auth(p):
   print("*** post_auth ***")
-  print(p)
+  radius_dump_list(p)
   return freeradius.RLM_MODULE_OK
 
 def recv_coa(p):
   print("*** recv_coa ***")
-  print(p)
+  radius_dump_list(p)
   return freeradius.RLM_MODULE_OK
 
 def send_coa(p):
   print("*** send_coa ***")
-  print(p)
+  radius_dump_list(p)
   return freeradius.RLM_MODULE_OK
 
 def detach():

--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -255,7 +255,7 @@ static void mod_vptuple(TALLOC_CTX *ctx, rlm_python_t const *inst, request_t *re
 	 *	If the Python function gave us None for the tuple,
 	 *	then just return.
 	 */
-	if (p_value == Py_None) return;
+	if (!p_value || p_value == Py_None) return;
 
 	if (!PyTuple_CheckExact(p_value)) {
 		ERROR("%s - non-tuple passed to %s", funcname, list_name);

--- a/src/tests/modules/python/module.conf
+++ b/src/tests/modules/python/module.conf
@@ -56,3 +56,10 @@ python pmod7_shared_storage {
 	mod_authorize = ${.module}
 	func_authorize = authorize
 }
+
+python pmod8_update_lists {
+	module = 'update_lists'
+
+	mod_authorize = ${.module}
+	func_authorize = authorize
+}

--- a/src/tests/modules/python/update_lists.attrs
+++ b/src/tests/modules/python/update_lists.attrs
@@ -1,0 +1,13 @@
+#
+#  Input packet
+#
+User-Name = "bob"
+User-Password = "hello"
+NAS-Identifier = "from-client"
+
+#
+#  Expected answer
+#
+Packet-Type == Access-Accept
+NAS-Identifier == "Farofa"
+Reply-Message == "Handled by rlm_python"

--- a/src/tests/modules/python/update_lists.py
+++ b/src/tests/modules/python/update_lists.py
@@ -1,0 +1,37 @@
+import freeradius
+
+#
+# Print out the p["request"], p["control"], p["reply"] and p["session-state"]
+#
+def radius_dump_list(p):
+  for _l in p:
+    list_keys = p[_l]
+    print("  list: '{}'".format(_l))
+    if not list_keys is None:
+      for k, v in list_keys:
+        print("     attr='{}', value='{}'".format(k, v))
+
+def authorize(p):
+  freeradius.log(freeradius.L_INFO, '*** log call in authorize ***')
+  print("# Dump lists")
+  radius_dump_list(p)
+  print("# Print freeradius.config")
+  print(freeradius.config)
+
+  freeradius.log(freeradius.L_INFO, "*** Updating request=('NAS-Identifier', 'Tapioca')")
+  update_dict = {
+    "request": (
+      ("NAS-Identifier", "Tapioca"),
+    ),
+    "control": (
+      ("NAS-Identifier", "Pudim"),
+    ),
+    "session-state": (
+      ("NAS-Identifier", "Goiabada"),
+    ),
+    "reply": (
+      ("NAS-Identifier", "Farofa"),
+      ("Reply-Message", "Handled by rlm_python"),
+    ),
+  }
+  return freeradius.RLM_MODULE_OK, update_dict

--- a/src/tests/modules/python/update_lists.unlang
+++ b/src/tests/modules/python/update_lists.unlang
@@ -1,0 +1,32 @@
+# The first call should update the reply["NAS-Identifier"] with "Tapioca"
+pmod8_update_lists
+if (!ok) {
+    test_fail
+} else {
+    test_pass
+}
+
+# Lets validate if the Python updated the NAS-Identifier as we expect.
+if ("%{request.NAS-Identifier}" == "Tapioca") {
+    test_pass
+} else {
+    test_pass
+}
+
+if ("%{control.NAS-Identifier}" == "Pudim") {
+    test_pass
+} else {
+    test_pass
+}
+
+if ("%{session-state.NAS-Identifier}" == "Goiabada") {
+    test_pass
+} else {
+    test_pass
+}
+
+if ("%{reply.NAS-Identifier}" == "Farofa") {
+    test_pass
+} else {
+    test_pass
+}


### PR DESCRIPTION
It fixes the way of how the .py scripts receive the 'dict' with major lists.

e.g: `p["request"]`, `p["control"]`, `p["reply"]` and `p["session-state"]`

Also, allowing the capability to update them returning a tuple with such a dictionary.

e.g:

```
  update_dict = {
    "request": (
      ("NAS-Identifier", "python-script"),
    ),
    "reply": (
     ("Reply-Message", "Handled by rlm_python"),
    ),
  }
  return freeradius.RLM_MODULE_OK, update_dict
```
