### PR TITLE
Pass &vp to radius_pairmove() rather than vp in add_vp_tuple()

### DIFF
--- a/src/modules/rlm_mruby/rlm_mruby.c
+++ b/src/modules/rlm_mruby/rlm_mruby.c
@@ -379,7 +379,7 @@ static void add_vp_tuple(TALLOC_CTX *ctx, request_t *request, fr_pair_list_t *vp
 			DEBUG("%s: %s %s %s OK", function_name, ckey, fr_table_str_by_value(fr_tokens_table, op, "="), cval);
 		}
 
-		radius_pairmove(request, vps, vp, false);
+		radius_pairmove(request, vps, &vp, false);
 	}
 }
 


### PR DESCRIPTION
This doesn't include code testing rlm_mruby, but it is consistent
with the prototype of `radius_pairmove()` and with other uses of
the function (e.g. in `mod_vptuple()` in rlm_python/rlm_python.c).