### PR TITLE
FreeBSD build fixes and basic CI build with eapol_test checks

### DIFF
--- a/.github/workflows/ci-freebsd.yml
+++ b/.github/workflows/ci-freebsd.yml
@@ -1,0 +1,33 @@
+name: CI FreeBSD
+
+on:
+  push:
+    branches:
+      - packaging_test
+  schedule:
+    - cron: '0 20 * * *'
+
+jobs:
+  freebsd-build:
+
+    runs-on: macos-latest
+
+    name: "FreeBSD build"
+
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        path: freeradius
+
+    - name: Test using a FreeBSD VirtualBox VM
+      uses: vmactions/freebsd-vm@v0.0.9
+      with:
+        usesh: true
+        prepare: pkg install -y gmake talloc git
+        run: |
+          freebsd-version
+          cd freeradius
+          ./configure
+          gmake -j `sysctl -n hw.ncpu`
+          gmake test.eap

--- a/scripts/build/dlopen.c
+++ b/scripts/build/dlopen.c
@@ -36,7 +36,7 @@ RCSID("$Id$")
 
 #include "log.h"
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 #include <link.h>
 #endif
 

--- a/scripts/ci/eapol_test-build.sh
+++ b/scripts/ci/eapol_test-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /bin/sh
 
 #
 #  This program is is free software; you can redistribute it and/or modify
@@ -37,6 +37,7 @@ TMP_BUILD_DIR="${BUILD_DIR}"
 : ${HOSTAPD_GIT_TAG:="hostap_2_8"}
 : ${WPA_SUPPLICANT_DIR:="${HOSTAPD_DIR}/wpa_supplicant"}
 
+: ${MAKE:=make}
 : ${BUILD_CONF_DIR:="$(dirname $0)/eapol_test"}
 : ${EAPOL_TEST_PATH:="${BUILD_CONF_DIR}/eapol_test"}
 
@@ -53,27 +54,30 @@ if [ -z "${FORCE_BUILD}" ]; then
     fi
 fi
 
-case "$OSTYPE" in
-linux-gnu)
+OS="$(uname)"
+
+case "$OS" in
+linux-gnu|Linux)
     BUILD_CONF_FILE="${BUILD_CONF_DIR}/config_linux"
     ;;
 
-darwin*)
+darwin*|Darwin*)
     BUILD_CONF_FILE="${BUILD_CONF_DIR}/config_osx"
     ;;
 
-freebsd*)
+freebsd*|FreeBSD*)
     BUILD_CONF_FILE="${BUILD_CONF_DIR}/config_freebsd"
+    MAKE=gmake
     ;;
 
 *)
-    echo "Don't have specific eapol_test build config for OS $OSTYPE.  Using linux build config"
+    echo "Don't have specific eapol_test build config for OS $OS.  Using linux build config"
     BUILD_CONF_FILE="${BUILD_CONF_DIR}/linux"
     ;;
 esac
 
 if [ ! -e "${BUILD_CONF_FILE}" ]; then
-    echo "Missing build config file \"${BUILD_CONF_FILE}\" for OS $OSTYPE, please contribute one" 1>&2
+    echo "Missing build config file \"${BUILD_CONF_FILE}\" for OS $OS, please contribute one" 1>&2
     exit 1
 fi
 
@@ -86,7 +90,7 @@ fi
 
 cp "$BUILD_CONF_FILE" "$WPA_SUPPLICANT_DIR/.config"
 
-if ! make -C "${WPA_SUPPLICANT_DIR}" -j8 eapol_test 1>&2 || [ ! -e "${WPA_SUPPLICANT_DIR}/eapol_test" ]; then
+if ! ${MAKE} -C "${WPA_SUPPLICANT_DIR}" -j8 eapol_test 1>&2 || [ ! -e "${WPA_SUPPLICANT_DIR}/eapol_test" ]; then
     echo "Build error" 1>&2
     if [ -z "${BUILD_DIR}" ]; then rm -rf "$TMP_BUILD_DIR"; fi
     exit 1

--- a/scripts/ci/eapol_test/config_freebsd
+++ b/scripts/ci/eapol_test/config_freebsd
@@ -24,13 +24,13 @@ CFLAGS += -g3 -O0 -Wno-error=deprecated-declarations
 # replacement for WEXT and its use allows wpa_supplicant to properly control
 # the driver to improve existing functionality like roaming and to support new
 # functionality.
-CONFIG_DRIVER_WEXT=n
+CONFIG_DRIVER_WEXT=
 
 # Driver interface for Linux drivers using the nl80211 kernel interface
-CONFIG_DRIVER_NL80211=n
+CONFIG_DRIVER_NL80211=
 
 # QCA vendor extensions to nl80211
-CONFIG_DRIVER_NL80211_QCA=n
+CONFIG_DRIVER_NL80211_QCA=
 
 # driver_nl80211.c requires libnl. If you are compiling it yourself
 # you may need to point hostapd to your version of libnl.
@@ -113,7 +113,7 @@ CONFIG_EAP_GTC=y
 CONFIG_EAP_OTP=y
 
 # EAP-SIM (enable CONFIG_PCSC, if EAP-SIM is used)
-#CONFIG_EAP_SIM=y
+CONFIG_EAP_SIM=y
 
 # EAP-PSK (experimental; this is _not_ needed for WPA-PSK)
 CONFIG_EAP_PSK=y
@@ -125,7 +125,7 @@ CONFIG_EAP_PWD=y
 CONFIG_EAP_PAX=y
 
 # LEAP
-CONFIG_EAP_LEAP=n
+CONFIG_EAP_LEAP=
 
 # EAP-AKA (enable CONFIG_PCSC, if EAP-AKA is used)
 CONFIG_EAP_AKA=y

--- a/scripts/ci/eapol_test/config_linux
+++ b/scripts/ci/eapol_test/config_linux
@@ -24,13 +24,13 @@ CFLAGS += -g3 -O0 -Wno-error=deprecated-declarations
 # replacement for WEXT and its use allows wpa_supplicant to properly control
 # the driver to improve existing functionality like roaming and to support new
 # functionality.
-CONFIG_DRIVER_WEXT=n
+CONFIG_DRIVER_WEXT=
 
 # Driver interface for Linux drivers using the nl80211 kernel interface
-CONFIG_DRIVER_NL80211=n
+CONFIG_DRIVER_NL80211=
 
 # QCA vendor extensions to nl80211
-CONFIG_DRIVER_NL80211_QCA=n
+CONFIG_DRIVER_NL80211_QCA=
 
 # driver_nl80211.c requires libnl. If you are compiling it yourself
 # you may need to point hostapd to your version of libnl.
@@ -125,7 +125,7 @@ CONFIG_EAP_PWD=y
 CONFIG_EAP_PAX=y
 
 # LEAP
-CONFIG_EAP_LEAP=n
+CONFIG_EAP_LEAP=
 
 # EAP-AKA (enable CONFIG_PCSC, if EAP-AKA is used)
 CONFIG_EAP_AKA=y

--- a/scripts/ci/eapol_test/config_osx
+++ b/scripts/ci/eapol_test/config_osx
@@ -24,13 +24,13 @@ LIBS += -L/usr/local/opt/openssl/lib -L/usr/local/lib
 # replacement for WEXT and its use allows wpa_supplicant to properly control
 # the driver to improve existing functionality like roaming and to support new
 # functionality.
-CONFIG_DRIVER_WEXT=n
+CONFIG_DRIVER_WEXT=
 
 # Driver interface for Linux drivers using the nl80211 kernel interface
-CONFIG_DRIVER_NL80211=n
+CONFIG_DRIVER_NL80211=
 
 # QCA vendor extensions to nl80211
-CONFIG_DRIVER_NL80211_QCA=n
+CONFIG_DRIVER_NL80211_QCA=
 
 # driver_nl80211.c requires libnl. If you are compiling it yourself
 # you may need to point hostapd to your version of libnl.
@@ -125,7 +125,7 @@ CONFIG_EAP_PWD=y
 CONFIG_EAP_PAX=y
 
 # LEAP
-CONFIG_EAP_LEAP=n
+CONFIG_EAP_LEAP=
 
 # EAP-AKA (enable CONFIG_PCSC, if EAP-AKA is used)
 CONFIG_EAP_AKA=y

--- a/src/lib/unlang/tmpl.c
+++ b/src/lib/unlang/tmpl.c
@@ -32,7 +32,7 @@ RCSID("$Id$")
 #include "tmpl_priv.h"
 #include <signal.h>
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 #include <sys/wait.h>
 #endif
 


### PR DESCRIPTION
Some minor fixes for building with FreeBSD.

Run CI checks within FreeBSD as a VM on MacOS X:
 * This is a scheduled workflow since VM startup time is slow.
 * At this stage the build is slim.
 * Full tests explode (segfault during trunk tests) which needs to be investigated, so for time being we perform only the eapol_test based checks.