### PR TITLE
Minor tweaks to eapol_test-build.sh; Disable shellcheck SC2223

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,6 @@
+#
+#  SC2223: This default assignment may cause DoS due to globbing. Quote it.
+#
+#  Easy to trigger and rarely a concern.
+#
+disable=SC2223

--- a/scripts/ci/eapol_test-build.sh
+++ b/scripts/ci/eapol_test-build.sh
@@ -38,7 +38,7 @@ TMP_BUILD_DIR="${BUILD_DIR}"
 : ${WPA_SUPPLICANT_DIR:="${HOSTAPD_DIR}/wpa_supplicant"}
 
 : ${MAKE:=make}
-: ${BUILD_CONF_DIR:="$(dirname $0)/eapol_test"}
+: ${BUILD_CONF_DIR:="$(dirname "$0")/eapol_test"}
 : ${EAPOL_TEST_PATH:="${BUILD_CONF_DIR}/eapol_test"}
 
 if [ -z "${FORCE_BUILD}" ]; then
@@ -48,7 +48,7 @@ if [ -z "${FORCE_BUILD}" ]; then
     fi
 
     WHICH_EAPOL_TEST="$(which eapol_test)"
-    if [ ! -z "${WHICH_EAPOL_TEST}" ]; then
+    if [ -n "${WHICH_EAPOL_TEST}" ]; then
         echo "${WHICH_EAPOL_TEST}"
         exit 0
     fi


### PR DESCRIPTION
Fixes for issues SC2086 and SC2236 from Super Linter output:

```
In scripts/ci/eapol_test-build.sh line 41:
: ${BUILD_CONF_DIR:="$(dirname $0)/eapol_test"}
  ^-- SC2223: This default assignment may cause DoS due to globbing. Quote it.
                               ^-- SC2086: Double quote to prevent globbing and word splitting.

In scripts/ci/eapol_test-build.sh line 51:
    if [ ! -z "${WHICH_EAPOL_TEST}" ]; then
         ^-- SC2236: Use -n instead of ! -z.
```

Disable SC2223: "This default assignment may cause DoS due to globbing. Quote it" since this is easy to trigger and rarely a concern.