### PR TITLE
rlm_redis_ippool_tool: Link OpenSSL

### DIFF
--- a/src/modules/rlm_redis_ippool/rlm_redis_ippool_tool.mk
+++ b/src/modules/rlm_redis_ippool/rlm_redis_ippool_tool.mk
@@ -13,6 +13,6 @@ SOURCES		:= $(TARGETNAME).c
 SRC_CFLAGS	+= -I$(top_builddir)/src/lib/redis
 
 TGT_PREREQS	:= $(LIBFREERADIUS_SERVER) libfreeradius-redis.a libfreeradius-util.a
-TGT_LDLIBS	+= $(TALLOC_LIBS)
+TGT_LDLIBS	+= $(TALLOC_LIBS) $(OPENSSL_LIBS)
 
 MAN		:= rlm_redis_ippool_tool.8


### PR DESCRIPTION
FreeBSD build failing with:

```
LINK /home/vagrant/freeradius/build/bin/rlm_redis_ippool_tool
ld: error: /home/vagrant/freeradius/build/lib/.libs/libfreeradius-unlang.so: undefined reference to EVP_blake2b512
ld: error: /home/vagrant/freeradius/build/lib/.libs/libfreeradius-unlang.so: undefined reference to EVP_blake2s256
ld: error: /home/vagrant/freeradius/build/lib/.libs/libfreeradius-unlang.so: undefined reference to EVP_sha224
ld: error: /home/vagrant/freeradius/build/lib/.libs/libfreeradius-unlang.so: undefined reference to EVP_sha384
ld: error: /home/vagrant/freeradius/build/lib/.libs/libfreeradius-unlang.so: undefined reference to EVP_sha3_224
ld: error: /home/vagrant/freeradius/build/lib/.libs/libfreeradius-unlang.so: undefined reference to EVP_sha3_256
ld: error: /home/vagrant/freeradius/build/lib/.libs/libfreeradius-unlang.so: undefined reference to EVP_sha3_384
ld: error: /home/vagrant/freeradius/build/lib/.libs/libfreeradius-unlang.so: undefined reference to EVP_sha3_512
ld: error: /home/vagrant/freeradius/build/lib/.libs/libfreeradius-unlang.so: undefined reference to EVP_sha512
cc: error: linker command failed with exit code 1 (use -v to see invocation)
gmake: *** [scripts/boiler.mk:701: /home/vagrant/freeradius/build/bin/rlm_redis_ippool_tool] Error 1
gmake: *** Waiting for unfinished jobs....
```