### PR TITLE
Propagate shifted from parent to child

### DIFF
--- a/src/lib/util/dbuff.h
+++ b/src/lib/util/dbuff.h
@@ -200,6 +200,7 @@ do { \
 	.p		= (_dbuff)->p, \
 	.is_const 	= (_dbuff)->is_const, \
 	.adv_parent 	= false, \
+	.shifted	= (_dbuff)->shifted, \
 	.extend		= (_dbuff)->extend, \
 	.uctx		= (_dbuff)->uctx, \
 	.parent 	= (_dbuff) \
@@ -221,6 +222,7 @@ do { \
 	.p		= (_dbuff)->p, \
 	.is_const	= (_dbuff)->is_const, \
 	.adv_parent	= _adv_parent, \
+	.shifted	= (_dbuff)->shifted, \
 	.extend		= NULL, \
 	.uctx		= NULL, \
 	.parent		= (_dbuff) \


### PR DESCRIPTION
Just as with sbuffs, child dbuffs should inherit shifted. This will become important when we add FR_DBUFF_COPY() analogous to FR_SBUFF_COPY(), and if/when FR_DBUFF_MAX() is changed to take advantage of extensible dbuffs.