### PR TITLE
rlm_rest - Add option to set http version

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -54,6 +54,7 @@ FreeRADIUS 3.0.22 Tue 24 Mar 2020 12:00:00 EDT urgency=low
 	  Fixes #3801. Patches from Benjamin Thompson.
 	* Add rlm_rest support for HTTP/2.
 	* Add REST-HTTP-Status-Code attribute holding HTTP status code.
+	* Add option to set http_negotiation in rlm_rest.  Fixes #2821.
 
 	Bug fixes
 	* Respect the "log_reject" configuration item in more places.

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -53,6 +53,7 @@ FreeRADIUS 3.0.22 Tue 24 Mar 2020 12:00:00 EDT urgency=low
 	* Add support for EAPS-AKA authentication to rlm_wimax.
 	  Fixes #3801. Patches from Benjamin Thompson.
 	* Add rlm_rest support for HTTP/2.
+	* Add REST-HTTP-Status-Code attribute holding HTTP status code.
 
 	Bug fixes
 	* Respect the "log_reject" configuration item in more places.

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -52,6 +52,7 @@ FreeRADIUS 3.0.22 Tue 24 Mar 2020 12:00:00 EDT urgency=low
 	  more information about each client.
 	* Add support for EAPS-AKA authentication to rlm_wimax.
 	  Fixes #3801. Patches from Benjamin Thompson.
+	* Add rlm_rest support for HTTP/2.
 
 	Bug fixes
 	* Respect the "log_reject" configuration item in more places.

--- a/raddb/mods-available/rest
+++ b/raddb/mods-available/rest
@@ -169,6 +169,9 @@ rest {
 	#  2xx    successful    yes           ok/updated
 	#  5xx    server error  no            fail
 	#  xxx    -             no            invalid
+	#
+	#  The status code is held in %{reply:REST-HTTP-Status-Code}.
+	#
 	authorize {
 		uri = "${..connect_uri}/user/%{User-Name}/mac/%{Called-Station-ID}?action=authorize"
 		method = 'get'

--- a/raddb/mods-available/rest
+++ b/raddb/mods-available/rest
@@ -54,6 +54,12 @@ rest {
 #	connect_timeout = 4.0
 
 	#
+	# Specify HTTP protocol version to use. one of '1.0', '1.1', '2.0', '2.0+auto',
+	# '2.0+tls' or 'default'. (libcurl option CURLOPT_HTTP_VERSION)
+	#
+#	http_negotiation = 1.1
+
+	#
 	#  The following config items can be used in each of the sections.
 	#  The sections themselves reflect the sections in the server.
 	#  For example if you list rest in the authorize section of a virtual server,
@@ -94,7 +100,6 @@ rest {
 	#  (i.e. deleted) after each call to the rest module, and each
 	#  %{rest:} expansion.  This is so that headers from one REST
 	#  call do not affect headers from a different REST call.
-
 	#
 	#  Body encodings are the same for requests and responses
 	#

--- a/share/dictionary.freeradius.internal
+++ b/share/dictionary.freeradius.internal
@@ -254,6 +254,7 @@ ATTRIBUTE	FreeRADIUS-Response-Delay-USec		1155	integer
 
 ATTRIBUTE	REST-HTTP-Header			1160	string
 ATTRIBUTE	REST-HTTP-Body				1161	string
+ATTRIBUTE	REST-HTTP-Status-Code			1162	integer
 
 ATTRIBUTE	Cache-Expires				1170	date
 ATTRIBUTE	Cache-Created				1171	date

--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -115,6 +115,15 @@ do {\
 	}\
 } while (0)
 
+/*
+ * that macro is originally declared in include/curl/curlver.h
+ * We have to use this as curl uses lots of enums
+ */
+#ifndef CURL_AT_LEAST_VERSION
+#  define CURL_VERSION_BITS(x, y, z) ((x) << 16 | (y) << 8 | (z))
+#  define CURL_AT_LEAST_VERSION(x, y, z) (LIBCURL_VERSION_NUM >= CURL_VERSION_BITS(x, y, z))
+#endif
+
 const unsigned long http_curl_auth[HTTP_AUTH_NUM_ENTRIES] = {
 	0,			// HTTP_AUTH_UNKNOWN
 	0,			// HTTP_AUTH_NONE
@@ -219,6 +228,40 @@ const FR_NAME_NUMBER http_content_type_table[] = {
 	{ "application/x-yaml",			HTTP_BODY_YAML		},
 
 	{  NULL , -1 }
+};
+
+/** Conversion table for "HTTP" protocol version to use.
+ *
+ * Used by rlm_rest_t for specify the http client version.
+ *
+ * Values we expect to use in curl_easy_setopt()
+ *
+ * @see fr_str2int
+ * @see fr_int2str
+ */
+const FR_NAME_NUMBER http_negotiation_table[] = {
+
+	{ "1.0", 	CURL_HTTP_VERSION_1_0 },		//!< Enforce HTTP 1.0 requests.
+	{ "1.1",	CURL_HTTP_VERSION_1_1 },		//!< Enforce HTTP 1.1 requests.
+/*
+ *	These are all enum values
+ */
+#if CURL_AT_LEAST_VERSION(7,49,0)
+	{ "2.0", 	CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE },	//!< Enforce HTTP 2.0 requests.
+#endif
+#if CURL_AT_LEAST_VERSION(7,33,0)
+	{ "2.0+auto",	CURL_HTTP_VERSION_2_0 },		//!< Attempt HTTP 2 requests. libcurl will fall back
+								///< to HTTP 1.1 if HTTP 2 can't be negotiated with the
+								///< server. (Added in 7.33.0)
+#endif
+#if CURL_AT_LEAST_VERSION(7,47,0)
+	{ "2.0+tls",	CURL_HTTP_VERSION_2TLS },		//!< Attempt HTTP 2 over TLS (HTTPS) only.
+								///< libcurl will fall back to HTTP 1.1 if HTTP 2
+								///< can't be negotiated with the HTTPS server.
+								///< For clear text HTTP servers, libcurl will use 1.1.
+#endif
+	{ "default", 	CURL_HTTP_VERSION_NONE }		//!< We don't care about what version the library uses.
+								///< libcurl will use whatever it thinks fit.
 };
 
 /*
@@ -2012,6 +2055,16 @@ int rest_request_config(rlm_rest_t *instance, rlm_rest_section_t *section,
 	SET_OPTION(CURLOPT_URL, uri);
 	SET_OPTION(CURLOPT_NOSIGNAL, 1);
 	SET_OPTION(CURLOPT_USERAGENT, "FreeRADIUS " RADIUSD_VERSION_STRING);
+
+	/*
+	 *	As described in https://curl.se/libcurl/c/CURLOPT_HTTP_VERSION.html,
+	 *	The libcurl decides which http version should be
+	 *  used by default accoring by library version.
+	 */
+	if (instance->http_negotiation != CURL_HTTP_VERSION_NONE) {
+		RDEBUG3("Set HTTP negotiation for %s", instance->http_negotiation_str);
+		SET_OPTION(CURLOPT_HTTP_VERSION, instance->http_negotiation);
+	}
 
 	content_type = fr_int2str(http_content_type_table, type, section->body_str);
 	snprintf(buffer, sizeof(buffer), "Content-Type: %s", content_type);

--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -2339,6 +2339,7 @@ int rest_request_perform(UNUSED rlm_rest_t *instance, UNUSED rlm_rest_section_t 
 	rlm_rest_handle_t	*randle = handle;
 	CURL			*candle = randle->handle;
 	CURLcode		ret;
+	VALUE_PAIR 		*vp;
 
 	ret = curl_easy_perform(candle);
 	if (ret != CURLE_OK) {
@@ -2346,6 +2347,14 @@ int rest_request_perform(UNUSED rlm_rest_t *instance, UNUSED rlm_rest_section_t 
 
 		return -1;
 	}
+
+	/*
+	 *  Save the HTTP return status code.
+	 */
+	vp = pair_make_reply("REST-HTTP-Status-Code", NULL, T_OP_SET);
+	vp->vp_integer = rest_get_handle_code(handle);
+
+	RDEBUG2("Adding reply:REST-HTTP-Status-Code += \"%d\"", vp->vp_integer);
 
 	return 0;
 }

--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -1589,8 +1589,9 @@ static size_t rest_response_header(void *in, size_t size, size_t nmemb, void *us
 		 *  HTTP/<version> <reason_code>[ <reason_phrase>]\r\n
 		 *
 		 *  "HTTP/1.1 " (8) + "100 " (4) + "\r\n" (2) = 14
+		 *  "HTTP/2 " (8) + "100 " (4) + "\r\n" (2) = 12
 		 */
-		if (s < 14) {
+		if (s < 12) {
 			REDEBUG("Malformed HTTP header: Status line too short");
 			goto malformed;
 		}
@@ -1628,8 +1629,10 @@ static size_t rest_response_header(void *in, size_t size, size_t nmemb, void *us
 		p++;
 		s--;
 
-		/*  Char after reason code must be a space, or \r */
-		if (!((p[3] == ' ') || (p[3] == '\r'))) goto malformed;
+		/*
+		 *  "xxx( |\r)" status code and terminator.
+		 */
+		if (!isdigit(p[0]) || !isdigit(p[1]) || !isdigit(p[2]) || !((p[3] == ' ') || (p[3] == '\r'))) goto malformed;
 
 		ctx->code = atoi(p);
 

--- a/src/modules/rlm_rest/rest.h
+++ b/src/modules/rlm_rest/rest.h
@@ -110,6 +110,8 @@ extern const FR_NAME_NUMBER http_body_type_table[];
 
 extern const FR_NAME_NUMBER http_content_type_table[];
 
+extern const FR_NAME_NUMBER http_negotiation_table[];
+
 /*
  *	Structure for section configuration
  */
@@ -164,6 +166,9 @@ typedef struct rlm_rest_t {
 
 	struct timeval		connect_timeout_tv;	//!< Connection timeout timeval.
 	long			connect_timeout;	//!< Connection timeout ms.
+
+	char const		*http_negotiation_str;	//!< The string version of the http_negotiation
+	long			http_negotiation;	//!< The HTTP protocol version to use
 
 	fr_connection_pool_t	*pool;		//!< Pointer to the connection pool.
 

--- a/src/modules/rlm_rest/rlm_rest.c
+++ b/src/modules/rlm_rest/rlm_rest.c
@@ -83,6 +83,8 @@ static const CONF_PARSER section_config[] = {
 static const CONF_PARSER module_config[] = {
 	{ "connect_uri", FR_CONF_OFFSET(PW_TYPE_STRING, rlm_rest_t, connect_uri), NULL },
 	{ "connect_timeout", FR_CONF_OFFSET(PW_TYPE_TIMEVAL, rlm_rest_t, connect_timeout_tv), "4.0" },
+	{ "http_negotiation", FR_CONF_OFFSET(PW_TYPE_STRING, rlm_rest_t, http_negotiation_str), "default" },
+
 	CONF_PARSER_TERMINATOR
 };
 
@@ -927,6 +929,12 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 /*		(parse_sub_section(conf, &inst->checksimul, MOD_SESSION) < 0) || */
 		(parse_sub_section(conf, &inst->post_auth, MOD_POST_AUTH) < 0))
 	{
+		return -1;
+	}
+
+	inst->http_negotiation = fr_str2int(http_negotiation_table, inst->http_negotiation_str, -1);
+	if (inst->http_negotiation == -1) {
+		cf_log_err_cs(conf, "Unsupported HTTP version \"%s\".", inst->http_negotiation_str);
 		return -1;
 	}
 


### PR DESCRIPTION
This adds enough moving parts to allow direct Okta integration.

1. Option to set the HTTP negotiation version.
2. Get the response status code.