### PR TITLE
add HW-Ext-Specific RADIUS attribute for bounce port using CoA

### DIFF
--- a/share/dictionary/radius/dictionary.huawei
+++ b/share/dictionary/radius/dictionary.huawei
@@ -226,6 +226,7 @@ ATTRIBUTE	Application-Scene			221	octets
 ATTRIBUTE	MS-Maximum-MAC-Study-Number		222	octets # ether??
 ATTRIBUTE	GGSN-Vendor				232	string
 ATTRIBUTE	GGSN-Version				233	string
+ATTRIBUTE	Ext-Specific				238	string
 ATTRIBUTE	Web-URL					253	string
 ATTRIBUTE	Version					254	string
 ATTRIBUTE	Product-ID				255	string


### PR DESCRIPTION
Hello,

I would like to use `HW-Ext-Specific` RADIUS attribute as described in [Huawei's documentation](https://support.huawei.com/hedex/hdx.do?lib=EDOC1100101074AEI08211&docid=EDOC1100101074&lang=en&v=05&tocLib=EDOC1100101074AEI08211&tocV=05&id=EN-US_CLIREF_0176366782&tocURL=resources%2525252Fdc%2525252Fradius-server_authorization_hw-ext-specific_command_bounce-port_disable.html&p=t&fe=1&ui=3&keyword=radius-server%25252Bauthorization%25252Bhw-ext-specific%25252Bcommand%25252Bbounce-port%25252Bdisable) in order to bounce a port using a CoA message.

According to documentation, RADIUS attribute identifier is `HW-Ext-Specific` and not `Huawei-Ext-Specific`. I've noticed a changed between FreeRADIUS master and v3.0 branch where vendor name is not added anymore before each RADIUS attribute in dictionnary. I'm not sure my PR is correct and how to handle a vendor which has two aliases: 
- Huawei
- HW

Thanks in advance