### PR TITLE
Add Key Identifier extensions to server.cnf

### DIFF
--- a/raddb/certs/server.cnf
+++ b/raddb/certs/server.cnf
@@ -56,6 +56,8 @@ emailAddress		= admin@example.org
 commonName		= "Example Server Certificate"
 
 [ v3_radius ]
+subjectKeyIdentifier	= hash
+authorityKeyIdentifier	= keyid:always,issuer:always
 basicConstraints	= CA:FALSE
 keyUsage		= nonRepudiation, digitalSignature, keyEncipherment
 


### PR DESCRIPTION
The Intel Wireless Daemon (iwd, alternative to wpa_supplicant) heavily
relies on Linux kernel interfaces for all its crypto, but the Linux
kernel doesn't seem to accept certificates without these extensions and
hence TLS will fail without them.