### PR TITLE
Give access to type size info without explicit use of dict_attr_sizes[]

### DIFF
--- a/src/lib/util/dict.h
+++ b/src/lib/util/dict.h
@@ -111,6 +111,14 @@ enum {
 
 extern const size_t dict_attr_sizes[FR_TYPE_MAX + 1][2];
 
+#define min_size(_type) (dict_attr_sizes[_type][0])
+#define max_size(_type) (dict_attr_sizes[_type][1])
+
+static inline bool is_fixed_size(fr_type_t type)
+{
+	return min_size(type) == max_size(type);
+}
+
 /** Extension identifier
  *
  * @note New extension structures should also be added to the to the appropriate table in dict_ext.c

--- a/src/lib/util/dict_validate.c
+++ b/src/lib/util/dict_validate.c
@@ -506,7 +506,7 @@ bool dict_attr_flags_valid(fr_dict_t *dict, fr_dict_attr_t const *parent,
 			 *	@todo - allow dns_label encoding as
 			 *	the first member.
 			 */
-			if ((dict_attr_sizes[sibling->type][1] == ~(size_t) 0) &&
+			if ((max_size(sibling->type) == ~(size_t) 0) &&
 			    (sibling->flags.length == 0)) {
 				fr_strerror_const("Only the last child of a 'struct' attribute can have variable length");
 				return false;

--- a/src/lib/util/value.c
+++ b/src/lib/util/value.c
@@ -4209,7 +4209,7 @@ int fr_value_box_from_str(TALLOC_CTX *ctx, fr_value_box_t *dst,
 	/*
 	 *	Set size for all fixed length attributes.
 	 */
-	ret = dict_attr_sizes[*dst_type][1];	/* Max length */
+	ret = max_size(*dst_type);
 
 	/*
 	 *	Lookup any names before continuing
@@ -4501,13 +4501,13 @@ parse:
 		if (fr_inet_pton(&dst->vb_ip, in, inlen, AF_UNSPEC, fr_hostname_lookups, true) < 0) return -1;
 		switch (dst->vb_ip.af) {
 		case AF_INET:
-			ret = dict_attr_sizes[FR_TYPE_COMBO_IP_ADDR][0]; /* size of IPv4 address */
+			ret = min_size(FR_TYPE_COMBO_IP_ADDR); /* size of IPv4 address */
 			*dst_type = FR_TYPE_IPV4_ADDR;
 			break;
 
 		case AF_INET6:
 			*dst_type = FR_TYPE_IPV6_ADDR;
-			ret = dict_attr_sizes[FR_TYPE_COMBO_IP_ADDR][1]; /* size of IPv6 address */
+			ret = max_size(FR_TYPE_COMBO_IP_ADDR); /* size of IPv6 address */
 			break;
 
 		default:

--- a/src/modules/rlm_unpack/rlm_unpack.c
+++ b/src/modules/rlm_unpack/rlm_unpack.c
@@ -162,13 +162,12 @@ static ssize_t unpack_xlat(UNUSED TALLOC_CTX *ctx, char **out, size_t outlen,
 	/*
 	 *	Output must be a non-zero limited size.
 	 */
-	if ((dict_attr_sizes[type][0] ==  0) ||
-	    (dict_attr_sizes[type][0] != dict_attr_sizes[type][1])) {
+	if ((min_size(type) ==  0) || !is_fixed_size(type)) {
 		REDEBUG("unpack requires fixed-size output type, not '%s'", data_type);
 		goto nothing;
 	}
 
-	if (input_len < (offset + dict_attr_sizes[type][0])) {
+	if (input_len < (offset + min_size(type))) {
 		REDEBUG("Insufficient data to unpack '%s' from '%s'", data_type, data_name);
 		goto nothing;
 	}
@@ -181,7 +180,7 @@ static ssize_t unpack_xlat(UNUSED TALLOC_CTX *ctx, char **out, size_t outlen,
 
 	MEM(cast = fr_pair_afrom_da(request, da));
 
-	memcpy(&(cast->data), input + offset, dict_attr_sizes[type][0]);
+	memcpy(&(cast->data), input + offset, min_size(type));
 
 	/*
 	 *	Hacks

--- a/src/protocols/dhcpv4/encode.c
+++ b/src/protocols/dhcpv4/encode.c
@@ -212,8 +212,8 @@ static ssize_t encode_rfc_hdr(fr_dbuff_t *dbuff,
 		 *	then don't encode this VP.
 		 */
 		if (hdr[1] && vp->da->flags.array &&
-		    (dict_attr_sizes[vp->da->type][0] == dict_attr_sizes[vp->da->type][1]) &&
-		    (hdr[1] + dict_attr_sizes[vp->da->type][0]) > 255) {
+		    is_fixed_size(vp->da->type) &&
+		    (hdr[1] + min_size(vp->da->type)) > 255) {
 			break;
 		}
 


### PR DESCRIPTION
The change provides min_size() and max_size() macros and a Boolean
function, is_fixed_size(). All take an fr_type_t value and do the
subscripting of dict_attr_sizes for the user. References to
dict_attr_sizes[] other than definition and initialization have
been changed to use these, to exercise them and I believe make
the intent of the rewritten code clearer.