### PR TITLE
CI: Add MacOS build to the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,27 +50,25 @@ jobs:
 #        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 #
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.env.OS }}
 
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-18.04
-#          - ubuntu-20.04
         env:
-          - { CC: gcc,   TEST_CERTS: yes, DO_BUILD: yes, LIBS_OPTIONAL: no,  LIBS_SHARED: yes, BUILD_CFLAGS: "-DWITH_EVAL_DEBUG" }
-          - { CC: gcc,   TEST_CERTS: yes, DO_BUILD: yes, LIBS_OPTIONAL: yes, LIBS_SHARED: yes, BUILD_CFLAGS: "-DWITH_EVAL_DEBUG" }
-          - { CC: gcc,   TEST_CERTS: yes, DO_BUILD: yes, LIBS_OPTIONAL: yes, LIBS_SHARED: yes, BUILD_CFLAGS: "-DWITH_EVAL_DEBUG -O2 -g3" }
-          - { CC: gcc,   TEST_CERTS: yes, DO_BUILD: yes, LIBS_OPTIONAL: yes, LIBS_SHARED: yes, BUILD_CFLAGS: "-DNDEBUG" }
-          - { CC: clang, TEST_CERTS: yes, DO_BUILD: yes, LIBS_OPTIONAL: no,  LIBS_SHARED: yes, BUILD_CFLAGS: "-DWITH_EVAL_DEBUG" }
-          - { CC: clang, TEST_CERTS: yes, DO_BUILD: yes, LIBS_OPTIONAL: yes, LIBS_SHARED: yes, BUILD_CFLAGS: "-DWITH_EVAL_DEBUG" }
-          - { CC: clang, TEST_CERTS: yes, DO_BUILD: yes, LIBS_OPTIONAL: yes, LIBS_SHARED: yes, BUILD_CFLAGS: "-DWITH_EVAL_DEBUG -O2 -g3" }
-          - { CC: clang, TEST_CERTS: yes, DO_BUILD: yes, LIBS_OPTIONAL: yes, LIBS_SHARED: yes, BUILD_CFLAGS: "-DNDEBUG" }
+          - { OS: ubuntu-18.04, CC: gcc,   TEST_CERTS: yes, DO_BUILD: yes, LIBS_OPTIONAL: no,  LIBS_SHARED: yes, BUILD_CFLAGS: "-DWITH_EVAL_DEBUG" }
+          - { OS: ubuntu-18.04, CC: gcc,   TEST_CERTS: yes, DO_BUILD: yes, LIBS_OPTIONAL: yes, LIBS_SHARED: yes, BUILD_CFLAGS: "-DWITH_EVAL_DEBUG" }
+          - { OS: ubuntu-18.04, CC: gcc,   TEST_CERTS: yes, DO_BUILD: yes, LIBS_OPTIONAL: yes, LIBS_SHARED: yes, BUILD_CFLAGS: "-DWITH_EVAL_DEBUG -O2 -g3" }
+          - { OS: ubuntu-18.04, CC: gcc,   TEST_CERTS: yes, DO_BUILD: yes, LIBS_OPTIONAL: yes, LIBS_SHARED: yes, BUILD_CFLAGS: "-DNDEBUG" }
+          - { OS: ubuntu-18.04, CC: clang, TEST_CERTS: yes, DO_BUILD: yes, LIBS_OPTIONAL: no,  LIBS_SHARED: yes, BUILD_CFLAGS: "-DWITH_EVAL_DEBUG" }
+          - { OS: ubuntu-18.04, CC: clang, TEST_CERTS: yes, DO_BUILD: yes, LIBS_OPTIONAL: yes, LIBS_SHARED: yes, BUILD_CFLAGS: "-DWITH_EVAL_DEBUG" }
+          - { OS: ubuntu-18.04, CC: clang, TEST_CERTS: yes, DO_BUILD: yes, LIBS_OPTIONAL: yes, LIBS_SHARED: yes, BUILD_CFLAGS: "-DWITH_EVAL_DEBUG -O2 -g3" }
+          - { OS: ubuntu-18.04, CC: clang, TEST_CERTS: yes, DO_BUILD: yes, LIBS_OPTIONAL: yes, LIBS_SHARED: yes, BUILD_CFLAGS: "-DNDEBUG" }
+          - { OS: macos-10.15,  CC: clang, TEST_CERTS: yes, DO_BUILD: yes, LIBS_OPTIONAL: yes, LIBS_SHARED: yes, BUILD_CFLAGS: "-DWITH_EVAL_DEBUG" }
 
     env: ${{ matrix.env }}
 
-    name: "${{ matrix.os }} ${{ matrix.env.CC }} ${{ toJson(matrix.env) }}"
+    name: "${{ matrix.env.OS }} ${{ matrix.env.CC }} ${{ toJson(matrix.env) }}"
 
     steps:
 
@@ -94,6 +92,7 @@ jobs:
       run: git lfs pull
 
     - name: Package manager performance improvements
+      if: ${{ runner.os != 'macOS' }}
       run: |
         sudo sh -c 'echo force-unsafe-io > /etc/dpkg/dpkg.cfg.d/02speedup'
         echo 'man-db man-db/auto-update boolean false' | sudo debconf-set-selections
@@ -102,32 +101,38 @@ jobs:
     - uses: actions/setup-ruby@v1
 
     - name: Freshen APT repo metadata
+      if: ${{ runner.os != 'macOS' }}
       run: |
         sudo apt-get update
 
     - name: Install fixture (redis)
+      if: ${{ runner.os != 'macOS' }}
       run: |
         sudo apt-get install -y --no-install-recommends redis-server redis-tools
         sudo systemctl start redis-server
 
     - name: Install fixture (openldap)
+      if: ${{ runner.os != 'macOS' }}
       run: |
         sudo apt-get install -y --no-install-recommends slapd ldap-utils apparmor-utils
         sudo systemctl stop slapd
         sudo aa-complain /usr/sbin/slapd
 
     - name: Install fixture (dovecot imapd)
+      if: ${{ runner.os != 'macOS' }}
       run: |
         sudo apt-get install -y --no-install-recommends dovecot-imapd
         sudo systemctl stop dovecot
         sudo aa-complain /usr/sbin/dovecot
 
     - name: Install fixture (exim)
+      if: ${{ runner.os != 'macOS' }}
       run: |
         sudo apt-get install -y --no-install-recommends exim4
         sudo systemctl stop exim4
 
     - name: Configure fixture (PostgreSQL)
+      if: ${{ runner.os != 'macOS' }}
       run: |
         export PG_VER=13
         sudo sh -c "echo host  all all 127.0.0.1/32 trust >  /etc/postgresql/$PG_VER/main/pg_hba.conf"
@@ -135,15 +140,17 @@ jobs:
         sudo systemctl start postgresql
 
     - name: Configure fixture (MySQL)
+      if: ${{ runner.os != 'macOS' }}
       run: |
         sudo systemctl start mysql
         mysql -h 127.0.0.1 -uroot -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '';";
 
     - name: Install cassandra driver (not yet available on 20.04)
-      if: ${{ matrix.os != 'ubuntu-20.04' }}
+      if: ${{ runner.os != 'macOS' && matrix.env.OS != 'ubuntu-20.04' }}
       run: sudo ./scripts/ci/cassandra-install.sh
 
     - name: Install common build dependencies
+      if: ${{ runner.os != 'macOS' }}
       run: |
         sudo apt-get install -y --no-install-recommends \
         autoconf \
@@ -197,19 +204,43 @@ jobs:
         quilt
 
     - name: Install JSON build deps for 18.04
-      if: ${{ matrix.os == 'ubuntu-18.04' }}
+      if: ${{ matrix.env.OS == 'ubuntu-18.04' }}
       run: sudo apt-get install -y --no-install-recommends libjson-c3
 
     - name: Install JSON build deps for 20.04
-      if: ${{ matrix.os == 'ubuntu-20.04' }}
+      if: ${{ matrix.env.OS == 'ubuntu-20.04' }}
       run: sudo apt-get install -y --no-install-recommends libjson-c4
+
+    - name: Install dependencies (MacOS)
+      if: ${{ runner.os == 'macOS' }}
+      run: |
+        brew install \
+          cassandra-cpp-driver \
+          gperftools \
+          hiredis \
+          json-c \
+          libidn \
+          libmemcached \
+          luajit \
+          mariadb \
+          make \
+          mruby \
+          talloc
+        ln -s `brew --prefix`/opt/make/bin/gmake /usr/local/bin/make
+        echo "#! /bin/sh"               >> /usr/local/bin/nproc
+        echo "sysctl -n hw.physicalcpu" >> /usr/local/bin/nproc
+        chmod +x /usr/local/bin/nproc
+      env:
+        HOMEBREW_NO_AUTO_UPDATE: 1
+        HOMEBREW_NO_INSTALL_CLEANUP: 1
+        HOMEBREW_CLEANUP_PERIODIC_FULL_DAYS: 3650
 
     - name: Install tacacs_plus
       run: |
         pip3 install tacacs_plus
 
     - name: Install LLVM 10 for 18.04
-      if: ${{ matrix.os == 'ubuntu-18.04' && matrix.env.CC == 'clang' }}
+      if: ${{ matrix.env.OS == 'ubuntu-18.04' && matrix.env.CC == 'clang' }}
       run: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add
         sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
@@ -218,13 +249,13 @@ jobs:
         sudo update-alternatives --install /usr/bin/llvm-symbolizer llvm-symbolizer /usr/bin/llvm-symbolizer-10 60 && sudo update-alternatives --set llvm-symbolizer /usr/bin/llvm-symbolizer-10
 
     - name: Install GCC 10 for 18.04
-      if: ${{ matrix.os == 'ubuntu-18.04' && matrix.env.CC == 'gcc' }}
+      if: ${{ matrix.env.OS == 'ubuntu-18.04' && matrix.env.CC == 'gcc' }}
       run: |
         sudo apt-get install -y --no-install-recommends gcc-10 gccgo-10 gdb
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 && sudo update-alternatives --set gcc /usr/bin/gcc-10
 
     - name: Install LLVM 10 for 20.04
-      if: ${{ matrix.os == 'ubuntu-20.04' && matrix.env.CC == 'clang' }}
+      if: ${{ matrix.env.OS == 'ubuntu-20.04' && matrix.env.CC == 'clang' }}
       run: |
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add
         sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main"
@@ -233,7 +264,7 @@ jobs:
         sudo update-alternatives --install /usr/bin/llvm-symbolizer llvm-symbolizer /usr/bin/llvm-symbolizer-10 60 && sudo update-alternatives --set llvm-symbolizer /usr/bin/llvm-symbolizer-10
 
     - name: Install GCC 10 for 20.04
-      if: ${{ matrix.os == 'ubuntu-20.04' && matrix.env.CC == 'gcc' }}
+      if: ${{ matrix.env.OS == 'ubuntu-20.04' && matrix.env.CC == 'gcc' }}
       run: |
         sudo apt-get install -y --no-install-recommends gcc-10 gccgo-10 gdb
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 && sudo update-alternatives --set gcc /usr/bin/gcc-10
@@ -243,6 +274,25 @@ jobs:
         $CC --version
         make --version
 
+    - name: Hacks to silence clang-12 warnings in talloc and json-c (MacOS)
+      if: ${{ runner.os == 'macOS' }}
+      run: |
+        sed -i '' '1i\
+        #pragma clang diagnostic ignored "-Wdocumentation"
+        ' /usr/local/include/talloc.h
+        sed -i '' '1i\
+        #pragma clang diagnostic ignored "-Wdocumentation-deprecated-sync"
+        ' /usr/local/include/json-c/json_tokener.h
+        sed -i '' '1i\
+        #pragma clang diagnostic ignored "-Wdocumentation-deprecated-sync"
+        ' /usr/local/include/json-c/arraylist.h
+        sed -i '' '1i\
+        #pragma clang diagnostic ignored "-Wdocumentation-deprecated-sync"
+        ' /usr/local/include/json-c/json_util.h
+        sed -i '' '1i\
+        #pragma clang diagnostic ignored "-Wstrict-prototypes"
+        ' /usr/local/include/cassandra.h
+
     - name: Minimal configure
       run: ./configure -C --without-modules
       if: ${{ matrix.env.DO_BUILD == 'no' }}
@@ -251,13 +301,22 @@ jobs:
       run: |
         if $CC -v 2>&1 | grep clang > /dev/null; then
             echo "Enabling llvm sanitizers"
-            enable_llvm_sanitizers="--enable-llvm-address-sanitizer --enable-llvm-leak-sanitizer --enable-llvm-undefined-behaviour-sanitizer"
+            enable_llvm_sanitizers="--enable-llvm-address-sanitizer --enable-llvm-undefined-behaviour-sanitizer"
+            if [ "`uname`" != "Darwin" ]; then
+                enable_llvm_sanitizers="$enable_llvm_sanitizers --enable-llvm-leak-sanitizer"
+            fi
         else
             enable_llvm_sanitizers=""
+        fi
+        if [ "`uname`" = "Darwin" ]; then
+            build_paths="--with-libfreeradius-ldap-lib-dir=`brew --prefix`/opt/openldap/lib --with-libfreeradius-ldap-include-dir=`brew --prefix`/opt/openldap/include --with-openssl-lib-dir=`brew --prefix`/opt/openssl/lib --with-openssl-include-dir=`brew --prefix`/opt/openssl/include --with-unixodbc-lib-dir=`brew --prefix`/opt/unixodbc/lib --with-unixodbc-include-dir=`brew --prefix`/opt/unixodbc/include"
+        else
+            build_paths=""
         fi
         CFLAGS="${BUILD_CFLAGS}" ./configure -C \
             --enable-werror \
             $enable_llvm_sanitizers \
+            $build_paths \
             --prefix=$HOME/freeradius \
             --with-shared-libs=$LIBS_SHARED \
             --with-threads=$LIBS_OPTIONAL \
@@ -274,10 +333,11 @@ jobs:
         make -j `nproc`
       if: ${{ matrix.env.DO_BUILD != 'no' }}
 
+    # Disabled on MacOS to reduce the runtime
     - name: Clang Static Analyzer
+      if: ${{ runner.os != 'macOS' && matrix.env.DO_BUILD != 'no' && matrix.env.CC == 'clang' }}
       run: |
         make -j `nproc` scan && [ "$(find build/plist/ -name *.html)" = '' ];
-      if: ${{ matrix.env.DO_BUILD != 'no' && matrix.env.CC == 'clang' }}
 
     - name: "Clang Static Analyzer: Store assets on failure"
       uses: actions/upload-artifact@v2
@@ -286,7 +346,8 @@ jobs:
         path: build/plist/**/*.html
       if: ${{ matrix.env.DO_BUILD != 'no' && matrix.env.CC == 'clang' && failure() }}
 
-    - name: Setup fixtures
+    - name: Setup fixtures and run full CI tests
+      if: ${{ runner.os != 'macOS' && matrix.env.DO_BUILD != 'no' }}
       run: |
         for i in \
             postgresql-setup.sh \
@@ -300,7 +361,14 @@ jobs:
             echo "Calling $i"
             $script
         done
-      if: ${{ matrix.env.DO_BUILD != 'no' }}
+        make ci-test
 
-    - name: Test
-      run: make ci-test
+    # Includes hack to disable trunk tests on MacOS which are currently broken
+    # Also, no detect_leaks support for ASAN
+    - name: Run basic tests (MacOS)
+      if: ${{ runner.os == 'macOS' }}
+      run: |
+        : > src/lib/server/trunk_tests.mk
+        make test
+      env:
+        ASAN_OPTIONS: symbolize=1 detect_stack_use_after_return=1


### PR DESCRIPTION
No fixtures, just ordinary "make test" for now.

We disable clang static analysis scan to keep the runtime within that of the other jobs.

Trunk tests disabled on MacOS for the moment because they are known to fail.