### PR TITLE
CI: Expand FreeBSD build and tests

### DIFF
--- a/.github/workflows/ci-freebsd.yml
+++ b/.github/workflows/ci-freebsd.yml
@@ -16,18 +16,68 @@ jobs:
 
     steps:
 
+    # Checkout, but defer pulling LFS objects until we've restored the cache
     - uses: actions/checkout@v2
       with:
+        lfs: false
         path: freeradius
+
+    - name: Create LFS file list as cache key
+      run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
+      working-directory: freeradius
+
+    - name: Restore LFS cache
+      uses: actions/cache@v2
+      id: lfs-cache
+      with:
+        path: .git/lfs
+        key: freebsd-lfs-${{ hashFiles('freeradius/.lfs-assets-id') }}-v1
+
+    # Now the LFS pull will be local if we hit the cache, or remote otherwise
+    - name: Git LFS pull
+      run: git lfs pull
+      working-directory: freeradius
 
     - name: Test using a FreeBSD VirtualBox VM
       uses: vmactions/freebsd-vm@v0.0.9
       with:
         usesh: true
-        prepare: pkg install -y gmake talloc git
+        prepare: |
+          pkg install -y         \
+            curl                 \
+            cyrus-sasl           \
+            firebird25-client    \
+            freetds              \
+            git                  \
+            git-lfs              \
+            gmake                \
+            google-perftools     \
+            hiredis              \
+            json-c               \
+            libidn               \
+            libmemcached         \
+            libpcap              \
+            lua52                \
+            luajit               \
+            mysql80-client       \
+            net-snmp             \
+            openldap-client      \
+            python3              \
+            py37-pip             \
+            postgresql12-client  \
+            talloc               \
+            unixODBC
+          pip install tacacs_plus
         run: |
           freebsd-version
           cd freeradius
           ./configure
           gmake -j `sysctl -n hw.ncpu`
-          gmake test.eap
+          # Disable some tests that are currently broken on FreeBSD
+          # Failing with: talloc type issue
+          echo                   > src/lib/server/trunk_tests.mk
+          # Failing with: Failed to send packet for ID 123: udp_send failed: EINVAL: Invalid argument
+          echo 'test.radclient:' > src/tests/radclient/all.mk
+          echo 'test.digest:'    > src/tests/digest/all.mk
+          echo 'test.radmin:'    > src/tests/radmin/all.mk
+          gmake test

--- a/src/tests/modules/exec/async.unlang
+++ b/src/tests/modules/exec/async.unlang
@@ -3,7 +3,7 @@
 #  because we don't wait for the response.
 #
 update request {
-	&Tmp-String-0 := "%{exec_async:/bin/bash -c 'echo hello'}"
+	&Tmp-String-0 := "%{exec_async:/bin/sh -c 'echo hello'}"
 }
 if (&Tmp-String-0 != '') {
 	test_fail
@@ -15,7 +15,7 @@ if (&Tmp-String-0 != '') {
 #  Async calls should not have their output added to the request
 #
 update request {
-	&Tmp-String-0 := "%{exec_async:/bin/bash -c \"echo 'reply.Reply-Message = \'hello\''\"}"
+	&Tmp-String-0 := "%{exec_async:/bin/sh -c \"echo 'reply.Reply-Message = \'hello\''\"}"
 }
 
 if (&reply.Reply-Message == 'hello') {

--- a/src/tests/modules/exec/backticks_list.unlang
+++ b/src/tests/modules/exec/backticks_list.unlang
@@ -3,7 +3,7 @@
 #  because we don't wait for the response.
 #
 update request {
-	&Tmp-String-0 := `/bin/bash -c 'echo hello'`
+	&Tmp-String-0 := `/bin/sh -c 'echo hello'`
 }
 if (&Tmp-String-0 != 'hello') {
 	test_fail
@@ -15,7 +15,7 @@ if (&Tmp-String-0 != 'hello') {
 #  Test default list override
 #
 #update request {
-#	control: += `/bin/bash -c "echo reply.Reply-Message = \'hello\'"`
+#	control: += `/bin/sh -c "echo reply.Reply-Message = \'hello\'"`
 #}
 
 #if (&reply.Reply-Message != 'hello') {

--- a/src/tests/modules/exec/sync.unlang
+++ b/src/tests/modules/exec/sync.unlang
@@ -3,7 +3,7 @@
 #  because we don't wait for the response.
 #
 update request {
-	&Tmp-String-0 := "%{exec_sync:/bin/bash -c 'echo hello'}"
+	&Tmp-String-0 := "%{exec_sync:/bin/sh -c 'echo hello'}"
 }
 if (&Tmp-String-0 != 'hello') {
 	test_fail
@@ -15,7 +15,7 @@ if (&Tmp-String-0 != 'hello') {
 #  Sync calls should have their output added to the request
 #
 update request {
-	&Tmp-String-0 := "%{exec_sync:/bin/bash -c 'echo \"reply.Reply-Message = \'hello\'\"'}"
+	&Tmp-String-0 := "%{exec_sync:/bin/sh -c 'echo \"reply.Reply-Message = \'hello\'\"'}"
 }
 
 if (&reply.Reply-Message != 'hello') {


### PR DESCRIPTION
Update `exec` tests to use /bin/sh rather than /bin/bash, since this path is more stable between OSs.

Expand build for FreeBSD to enable all modules whose dependencies can be satisfied from standard Ports packages.

Perform `make test` for FreeBSD build, for the time being disabling tests that currently fail.

CI results based on last successful build:
https://github.com/terryburton/freeradius-server/actions/runs/490932807
https://github.com/terryburton/freeradius-server/actions/runs/490932806