### PR TITLE
eapol_test: Fix OSX build using clang >= 11

### DIFF
--- a/scripts/ci/eapol_test/config_osx
+++ b/scripts/ci/eapol_test/config_osx
@@ -9,7 +9,7 @@
 # be modified from here. In most cases, these lines should use += in order not
 # to override previous values of the variables.
 
-CFLAGS += -g3 -O0 -Wno-error=deprecated-declarations
+CFLAGS += -g3 -O0 -Wno-error=deprecated-declarations -Wno-error=void-pointer-to-enum-cast
 CFLAGS += -I /usr/local/opt/openssl/include -I/usr/local/include/openssl
 LIBS += -L/usr/local/opt/openssl/lib -L/usr/local/lib
 


### PR DESCRIPTION
Fixes the eapol_test build using clang >= 11

```
../src/radius/radius_client.c:817:24: error: cast to smaller integer type 'RadiusType' from 'void *' [-Werror,-Wvoid-pointer-to-enum-cast]
        RadiusType msg_type = (RadiusType) sock_ctx;
```

