### PR TITLE
Add support for timezone on alpine

### DIFF
--- a/scripts/docker/alpine/Dockerfile
+++ b/scripts/docker/alpine/Dockerfile
@@ -57,7 +57,7 @@ COPY --from=build /opt /opt
 # These are needed for the server to start
 #
 RUN apk update \
-    && apk add talloc libressl pcre libwbclient \
+    && apk add talloc libressl pcre libwbclient tzdata \
     \
 #
 #  Libraries that are needed dependent on which modules are used


### PR DESCRIPTION
It would be great to have support for timezone on the alpine using environment variable `TZ`, e.g. `TZ=Europe/Zurich`.

```yml
version: '3.8'

services:
  freeradius:
    image: docker.io/freeradius/freeradius-server:3.0.21-alpine
    volumes:
      - ./raddb:/etc/raddb
    ports:
      - 1812:1812
      - 1813:1813
    environment:
      - TZ=Europe/Zurich
    networks:
      - default

networks:
  default:
```

Which will result in

```sh
[user@docker freeradius]$ docker exec freeradius date
Thu Jan 21 14:13:56 CET 2021
```

instead of

```sh
[user@docker freeradius]$ docker exec freeradius date
Thu Jan 21 12:13:56 UTC 2021
```