### PR TITLE
sqlcounter: fixed configuration for PostgreSQL

### DIFF
--- a/doc/modules/rlm_sqlcounter
+++ b/doc/modules/rlm_sqlcounter
@@ -65,10 +65,10 @@ sqlcounter monthlycounter {
 The respective lines for postgresql are:
 
 query = "SELECT SUM(AcctSessionTime) FROM radacct WHERE UserName='%{%k}'"
-query = "SELECT SUM(AcctSessionTime - GREATER((%b - AcctStartTime::ABSTIME::INT4), 0)) FROM radacct WHERE UserName='%{%k}' AND AcctStartTime::ABSTIME::INT4 + AcctSessionTime > '%b'"
-query = "SELECT SUM(AcctSessionTime - GREATER((%b - AcctStartTime::ABSTIME::INT4), 0)) FROM radacct WHERE UserName='%{%k}' AND AcctStartTime::ABSTIME::INT4 + AcctSessionTime > '%b'"
+query = "SELECT SUM(AcctSessionTime - GREATEST((%b - EXTRACT(epoch FROM AcctStartTime)), 0)) FROM radacct WHERE UserName='%{%k}' AND EXTRACT(epoch FROM AcctStartTime) + AcctSessionTime > '%b'"
+query = "SELECT SUM(AcctSessionTime - GREATEST((%b - EXTRACT(epoch FROM AcctStartTime)), 0)) FROM radacct WHERE UserName='%{%k}' AND EXTRACT(epoch FROM AcctStartTime) + AcctSessionTime > '%b'"
 
-If you are running postgres 7.x, you may not have a GREATER function.
+If you are running postgres 7.x, you may not have a GREATEST function.
 
 An example of one is:
 
@@ -180,4 +180,3 @@ definied in sqlcounter.conf
 
 VERY IMPORTANT:
 Accounting must be done via sql or this will not work.
-

--- a/raddb/mods-config/sql/counter/postgresql/dailycounter.conf
+++ b/raddb/mods-config/sql/counter/postgresql/dailycounter.conf
@@ -5,10 +5,10 @@
 #  below
 #
 query = "\
-	SELECT SUM(AcctSessionTime - GREATER((%%b - AcctStartTime::ABSTIME::INT4), 0)) \
+	SELECT SUM(AcctSessionTime - GREATEST((%%b - EXTRACT(epoch FROM AcctStartTime)), 0)) \
 	FROM radacct \
 	WHERE UserName='%{${key}}' \
-	AND AcctStartTime::ABSTIME::INT4 + AcctSessionTime > '%%b'"
+	AND EXTRACT(epoch FROM AcctStartTime) + AcctSessionTime > '%%b'"
 
 #
 #  This query ignores calls that started in a previous
@@ -19,7 +19,7 @@ query = "\
 #	SELECT SUM(AcctSessionTime) \
 #	FROM radacct \
 #	WHERE UserName='%{${key}}' \
-#	AND AcctStartTime::ABSTIME::INT4 > '%%b'"
+#	AND EXTRACT(epoch FROM AcctStartTime) > '%%b'"
 
 #
 #  This query is the same as above, but demonstrates an
@@ -30,5 +30,5 @@ query = "\
 #	SELECT SUM(AcctSessionTime) \
 #	FROM radacct \
 #	WHERE UserName='%{${key}}' \
-#	AND AcctStartTime::ABSTIME::INT4 BETWEEN '%%b' \
+#	AND EXTRACT(epoch FROM AcctStartTime) BETWEEN '%%b' \
 #	AND '%%e'"

--- a/raddb/mods-config/sql/counter/postgresql/monthlycounter.conf
+++ b/raddb/mods-config/sql/counter/postgresql/monthlycounter.conf
@@ -3,10 +3,10 @@
 #  involves more work for the SQL server than those
 #  below
 query = "\
-	SELECT SUM(AcctSessionTime - GREATER((%%b - AcctStartTime::ABSTIME::INT4), 0)) \
+	SELECT SUM(AcctSessionTime - GREATEST((%%b - EXTRACT(epoch FROM AcctStartTime)), 0)) \
 	FROM radacct \
 	WHERE UserName='%{${key}}' \
-	AND AcctStartTime::ABSTIME::INT4 + AcctSessionTime > '%%b'"
+	AND EXTRACT(epoch FROM AcctStartTime) + AcctSessionTime > '%%b'"
 
 #
 #  This query ignores calls that started in a previous
@@ -17,7 +17,7 @@ query = "\
 #	SELECT SUM(AcctSessionTime) \
 #	FROM radacct \
 #	WHERE UserName='%{${key}}' \
-#	AND AcctStartTime::ABSTIME::INT4 > '%%b'"
+#	AND EXTRACT(epoch FROM AcctStartTime) > '%%b'"
 
 #
 #  This query is the same as above, but demonstrates an
@@ -28,4 +28,4 @@ query = "\
 #	SELECT SUM(AcctSessionTime) \
 #	FROM radacct \
 #	WHERE UserName='%{${key}}' \
-#	AND AcctStartTime::ABSTIME::INT4 BETWEEN '%%b' AND '%%e'"
+#	AND EXTRACT(epoch FROM AcctStartTime) BETWEEN '%%b' AND '%%e'"


### PR DESCRIPTION
`ABSTIME` is deprecated since PostgreSQL 7.0 and removed in PostgreSQL 12.
`GREATER` doesn't seem to be documented, but `GREATEST` is available since PostgreSQL 9.

Fixes #3867.