### PR TITLE
Rename parameters of fr_dbuff_in_bytes() and FR_DBUFF_IN_BYTES_RETURN()

### DIFF
--- a/src/lib/util/dbuff.h
+++ b/src/lib/util/dbuff.h
@@ -1271,22 +1271,22 @@ static inline size_t _fr_dbuff_in_memcpy_partial_dbuff(uint8_t **pos_p, fr_dbuff
 #define fr_dbuff_in_bytes_partial(_dbuff, ...) \
 	fr_dbuff_in_memcpy_partial(_dbuff, ((uint8_t []){ __VA_ARGS__ }), sizeof((uint8_t []){ __VA_ARGS__ }))
 
-/** Copy a byte sequence into a dbuff
+/** Copy a byte sequence into a dbuff or marker
  *
  * @copybrief fr_dbuff_in_memcpy
  *
- * @param[in] _dbuff	to copy byte sequence into.
- * @param[in] ...	bytes to copy.
+ * @param[in] _dbuff_or_marker	to copy byte sequence into.
+ * @param[in] ...		bytes to copy.
  */
-#define fr_dbuff_in_bytes(_dbuff, ...) \
-	fr_dbuff_in_memcpy(_dbuff, ((uint8_t []){ __VA_ARGS__ }), sizeof((uint8_t []){ __VA_ARGS__ }))
+#define fr_dbuff_in_bytes(_dbuff_or_marker, ...) \
+	fr_dbuff_in_memcpy(_dbuff_or_marker, ((uint8_t []){ __VA_ARGS__ }), sizeof((uint8_t []){ __VA_ARGS__ }))
 
-/** Copy a byte sequence into a dbuff returning if there's insufficient space
+/** Copy a byte sequence into a dbuff or marker returning if there's insufficient space
  *
  * @copydetails fr_dbuff_in_bytes
  */
-#define FR_DBUFF_IN_BYTES_RETURN(_dbuff, ...) \
-	FR_DBUFF_IN_MEMCPY_RETURN(_dbuff, ((uint8_t []){ __VA_ARGS__ }), sizeof((uint8_t []){ __VA_ARGS__ }))
+#define FR_DBUFF_IN_BYTES_RETURN(_dbuff_or_marker, ...) \
+	FR_DBUFF_IN_MEMCPY_RETURN(_dbuff_or_marker, ((uint8_t []){ __VA_ARGS__ }), sizeof((uint8_t []){ __VA_ARGS__ }))
 
 /** Internal function - do not call directly
  *
@@ -1370,9 +1370,9 @@ static inline ssize_t _fr_dbuff_in_double(uint8_t **pos_p, fr_dbuff_t *out, doub
 	return _fr_dbuff_in_uint64(pos_p, out, *(uint64_t *)(&num));
 }
 
-/** Copy data from a fixed sized C type into a dbuff
+/** Copy data from a fixed sized C type into a dbuff or marker
  *
- * @param[out] _out	dbuff to write to.  Integer types will be automatically
+ * @param[out] _out	dbuff or marker to write to.  Integer types will be automatically
  *			converted to big endian byte order.
  * @param[in] _in	Value to copy.
  * @return

--- a/src/lib/util/dbuff_tests.c
+++ b/src/lib/util/dbuff_tests.c
@@ -121,9 +121,12 @@ static void test_dbuff_net_encode(void)
 	TEST_CHECK(buff[1] == 0x34);
 
 	TEST_CASE("Generate wire format unsigned 16-bit value using marker");
+	fr_dbuff_set_to_start(&dbuff);
 	TEST_CHECK(fr_dbuff_in(&marker, u16val2) == sizeof(uint16_t));
 	TEST_CHECK(buff[0] == 0xcd);
 	TEST_CHECK(buff[1] == 0xef);
+	TEST_CHECK(fr_dbuff_used(&marker) == sizeof(uint16_t));
+	TEST_CHECK(fr_dbuff_used(&dbuff) == 0);
 
 	TEST_CASE("Generate wire format unsigned 32-bit value");
 	memset(buff, 0, sizeof(buff));
@@ -166,7 +169,6 @@ static void test_dbuff_net_encode(void)
 	TEST_CHECK(buff[1] == 0x00);
 	TEST_CHECK(buff[2] == 0xd3);
 	TEST_CHECK(buff[3] == 0x4d);
-
 
 	TEST_CASE("Generate wire format signed 64-bit value");
 	memset(buff, 0, sizeof(buff));
@@ -271,6 +273,21 @@ static void test_dbuff_net_encode(void)
 	fr_dbuff_init(&dbuff, buff, sizeof(uint32_t));
 
 	TEST_CHECK(fr_dbuff_in(&dbuff, u64val) == -(ssize_t)(sizeof(uint64_t) - sizeof(uint32_t)));
+
+	TEST_CASE("Input bytes using dbuff current position");
+	memset(buff, 0, sizeof(buff));
+	fr_dbuff_init(&dbuff, buff, sizeof(buff));
+	fr_dbuff_marker(&marker, &dbuff);
+	TEST_CHECK(fr_dbuff_in_bytes(&dbuff, 0xf0, 0xed, 0xcb) == 3);
+	TEST_CHECK(buff[0] == 0xf0);
+	TEST_CHECK(buff[1] == 0xed);
+	TEST_CHECK(buff[2] == 0xcb);
+	TEST_CHECK(fr_dbuff_used(&dbuff) == 3);
+	TEST_CASE("Input bytes using marker");
+	TEST_CHECK(fr_dbuff_in_bytes(&marker, 0x01, 0x23) == 2);
+	TEST_CHECK(buff[0] == 0x01);
+	TEST_CHECK(buff[1] == 0x23);
+	TEST_CHECK(fr_dbuff_used(&marker) == 2);
 }
 
 static void test_dbuff_no_advance(void)


### PR DESCRIPTION
Though they could be either dbufs or markers, the parameter names
suggested that only dbuffs would do. They now follow the convention
of "_dbuff_or_marker" to indicate their possible use. There was
already an fr_dbuff_in() call in dbuff_tests using a marker, but
none for fr_dbuff_in_bytes(), dbuff or marker; the latter is now
present, and both include tests to explicitly test cases in which
fr_dbuff_used(dbuff) and fr_dbuff_used(marker) differ.