### PR TITLE
CI: Set explicit retention days for uploaded assets; name fixes

### DIFF
--- a/.github/workflows/ci-deb.yml
+++ b/.github/workflows/ci-deb.yml
@@ -102,6 +102,7 @@ jobs:
       with:
         name: debs-${{ matrix.env.NAME }}
         path: debs
+        retention-days: 1
 
   deb-test:
 
@@ -179,7 +180,9 @@ jobs:
       if: ${{ failure() }}
       uses: actions/upload-artifact@v2
       with:
-        name: radius-logs-${{ matrix.env.NAME }}.tgz
+        name: radius-logs-${{ matrix.env.NAME }}
         path: |
           /var/log/freeradius
           freeradius/build/tests/eapol_test
+        retention-days: 30
+

--- a/.github/workflows/ci-rpm.yml
+++ b/.github/workflows/ci-rpm.yml
@@ -151,6 +151,7 @@ jobs:
       with:
         name: rpms-${{ matrix.env.NAME }}
         path: rpms
+        retention-days: 1
 
   rpm-test:
 
@@ -255,7 +256,8 @@ jobs:
       if: ${{ failure() }}
       uses: actions/upload-artifact@v2
       with:
-        name: radius-logs-${{ matrix.env.NAME }}.tgz
+        name: radius-logs-${{ matrix.env.NAME }}
         path: |
           /var/log/radius
           freeradius/build/tests/eapol_test
+        retention-days: 30

--- a/.github/workflows/ci-scheduled-fuzzing.yml
+++ b/.github/workflows/ci-scheduled-fuzzing.yml
@@ -144,4 +144,5 @@ jobs:
       with:
         name: fuzzer-${{ matrix.env.PROTOCOL }}-${{ steps.pick_commit.outputs.commit_id }}
         path: build/fuzzer
+        retention_days: 30
       if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,7 @@ jobs:
       with:
         name: clang-scan.tgz
         path: build/plist/**/*.html
+        retention-days: 30
       if: ${{ matrix.env.CC == 'clang' && failure() }}
 
     - name: Install fixture (redis)
@@ -336,6 +337,7 @@ jobs:
       with:
         name: clang-fuzzer
         path: build/fuzzer
+        retention-days: 30
       if: ${{ matrix.env.TEST_TYPE == 'fuzzing' && failure() }}
 
     #


### PR DESCRIPTION
Default retention period is 90 days which is excessive for large
artifacts, especially now that this can be controlled.

Do not retain the packages built for post-install testing. We limit to
the minimum of 1 day. These assets are large and we don't want people to
use them.