### PR TITLE
radclient: Fix 'invalid attribute' test

### DIFF
--- a/src/tests/radclient/all.mk
+++ b/src/tests/radclient/all.mk
@@ -59,6 +59,12 @@ $(OUTPUT)/%: $(DIR)/% | $(TEST).radiusd_kill $(TEST).radiusd_start
 #
 	$(Q)if [ "$$(uname -s)" = "Darwin" ]; then sed -i .bak 's/via lo0/via lo/g' $(FOUND); fi
 #
+#	Remove all entries with "^_EXIT.*CALLED .*/"
+#	It is necessary to match all builds with/without -DNDEBUG
+#
+	$(Q)mv -f $(FOUND) $(FOUND).bak
+	$(Q)sed '/^_EXIT.*CALLED .*/d' $(FOUND).bak > $(FOUND)
+#
 #	Checking.
 #
 #	1. diff between src/test/radclient/$test.out & build/test/radclient/$test.out

--- a/src/tests/radclient/auth_invalid_attr_5.out
+++ b/src/tests/radclient/auth_invalid_attr_5.out
@@ -1,3 +1,2 @@
 (0) Error parsing "src/tests/radclient/auth_invalid_attr_5.txt": Unknown attribute  "This-Is-Invalid-Attribute" for parent "RADIUS"
 radclient: Failed parsing input files
-_EXIT(1) CALLED src/bin/radclient.c[1429]


### PR DESCRIPTION
It is necessary to match the output files built with/without -NDEBUG