### PR TITLE
rlm_sql_map: Add 'multiple_rows' option

### DIFF
--- a/raddb/mods-available/sql_map
+++ b/raddb/mods-available/sql_map
@@ -43,4 +43,7 @@ sql_map {
 #		reply:Tunnel-Medium-Type	:= 5
 #		reply:Tunnel-Private-Group-ID	:= 6
 	}
+
+	# If the 'query' results in multiple rows, it creates the <radius attr>[*] array entry.
+#	multiple_rows = yes
 }


### PR DESCRIPTION
It allows the user to configure the module to enable/disable processing of
multiple rows.