### PR TITLE
Allow fr_dbuff_in_memcpy() from marker to uint8_t *

### DIFF
--- a/src/lib/util/dbuff.h
+++ b/src/lib/util/dbuff.h
@@ -1507,7 +1507,7 @@ static inline ssize_t _fr_dbuff_out_memcpy_dbuff(uint8_t **out_p, fr_dbuff_t *ou
  */
 #define fr_dbuff_out_memcpy(_out, _in, _outlen) \
 	_Generic((_out), \
-		 uint8_t *		: _fr_dbuff_out_memcpy((uint8_t *)(_out), _fr_dbuff_current_ptr(_in), _in, _outlen), \
+		 uint8_t *		: _fr_dbuff_out_memcpy((uint8_t *)(_out), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in), _outlen), \
 		 fr_dbuff_t *		: _fr_dbuff_out_memcpy_dbuff(_fr_dbuff_current_ptr((fr_dbuff_t *)_out), fr_dbuff_ptr((fr_dbuff_t *)(_out)), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in), _outlen), \
 		 fr_dbuff_marker_t *	: _fr_dbuff_out_memcpy_dbuff(_fr_dbuff_current_ptr((fr_dbuff_marker_t *)_out), fr_dbuff_ptr((fr_dbuff_marker_t *)(_out)), _fr_dbuff_current_ptr(_in), fr_dbuff_ptr(_in), _outlen) \
 	)

--- a/src/lib/util/dbuff_tests.c
+++ b/src/lib/util/dbuff_tests.c
@@ -525,6 +525,11 @@ static void test_dbuff_out(void)
 	TEST_CHECK(fr_dbuff_out_memcpy(&dbuff2, &dbuff1, 4) == 4);
 	TEST_CHECK(memcmp(fr_dbuff_start(&dbuff2), fr_dbuff_start(&dbuff1), 2) == 0 &&
 		   memcmp(fr_dbuff_start(&dbuff2) + 2, fr_dbuff_start(&dbuff1) + 3, 4) == 0);
+	memset(buff3, 0, sizeof(buff3));
+	fr_dbuff_set_to_start(&marker1);
+	TEST_CHECK(fr_dbuff_out_memcpy(buff3, &marker1, 4) == 4);
+	TEST_CHECK(memcmp(buff3, buff1, 4) == 0);
+	TEST_CHECK(fr_dbuff_current(&marker1) - fr_dbuff_start(&dbuff1) == 4);
 }
 
 TEST_LIST = {


### PR DESCRIPTION
(and add a corresponding check in dbuff_tests)