### PR TITLE
talloc: Add fr_talloc_autofree_context()

### DIFF
--- a/src/bin/radclient.c
+++ b/src/bin/radclient.c
@@ -1151,7 +1151,7 @@ int main(int argc, char **argv)
 	 */
 	fr_thread_local_atexit_setup();
 
-	autofree = talloc_autofree_context();
+	autofree = fr_talloc_autofree_context();
 
 #ifndef NDEBUG
 	if (fr_fault_setup(autofree, getenv("PANIC_ACTION"), argv[0]) < 0) {
@@ -1217,7 +1217,7 @@ int main(int argc, char **argv)
 			char const *p;
 			rc_file_pair_t *files;
 
-			files = talloc(talloc_autofree_context(), rc_file_pair_t);
+			files = talloc(fr_talloc_autofree_context(), rc_file_pair_t);
 			if (!files) goto oom;
 
 			p = strchr(optarg, ':');
@@ -1416,7 +1416,7 @@ int main(int argc, char **argv)
 	if (rbtree_num_elements(filename_tree) == 0) {
 		rc_file_pair_t *files;
 
-		files = talloc_zero(talloc_autofree_context(), rc_file_pair_t);
+		files = talloc_zero(fr_talloc_autofree_context(), rc_file_pair_t);
 		files->packets = "-";
 		if (radclient_init(files, files) < 0) fr_exit_now(1);
 	}

--- a/src/bin/radict.c
+++ b/src/bin/radict.c
@@ -246,7 +246,7 @@ int main(int argc, char *argv[])
 	 */
 	fr_thread_local_atexit_setup();
 
-	autofree = talloc_autofree_context();
+	autofree = fr_talloc_autofree_context();
 
 #ifndef NDEBUG
 	if (fr_fault_setup(autofree, getenv("PANIC_ACTION"), argv[0]) < 0) {

--- a/src/bin/radiusd.c
+++ b/src/bin/radiusd.c
@@ -250,11 +250,11 @@ int main(int argc, char *argv[])
 			 *	config to exist in.  We mprotect() this later to
 			 *	catch any stray writes.
 			 */
-			global_ctx = talloc_page_aligned_pool(talloc_autofree_context(),
+			global_ctx = talloc_page_aligned_pool(fr_talloc_autofree_context(),
 							      &pool_page_start, &pool_page_end, pool_size);
 			do_mprotect = true;
 		} else {
-	 		global_ctx = talloc_new(talloc_autofree_context());
+	 		global_ctx = talloc_new(fr_talloc_autofree_context());
 	 		do_mprotect = false;
 		}
 

--- a/src/bin/radsniff.c
+++ b/src/bin/radsniff.c
@@ -2270,7 +2270,7 @@ int main(int argc, char *argv[])
 	 */
 	fr_thread_local_atexit_setup();
 
-	autofree = talloc_autofree_context();
+	autofree = fr_talloc_autofree_context();
 
 	/*
 	 *	Useful if using radsniff as a long running stats daemon

--- a/src/bin/radsnmp.c
+++ b/src/bin/radsnmp.c
@@ -911,7 +911,7 @@ int main(int argc, char **argv)
 	 */
 	fr_thread_local_atexit_setup();
 
-	autofree = talloc_autofree_context();
+	autofree = fr_talloc_autofree_context();
 	conf = talloc_zero(autofree, radsnmp_conf_t);
 	conf->proto = IPPROTO_UDP;
 	conf->dict_dir = DICTDIR;

--- a/src/bin/radwho.c
+++ b/src/bin/radwho.c
@@ -207,7 +207,7 @@ int main(int argc, char **argv)
 	 */
 	fr_thread_local_atexit_setup();
 
-	autofree = talloc_autofree_context();
+	autofree = fr_talloc_autofree_context();
 
 #ifndef NDEBUG
 	if (fr_fault_setup(autofree, getenv("PANIC_ACTION"), argv[0]) < 0) {

--- a/src/bin/unit_test_attribute.c
+++ b/src/bin/unit_test_attribute.c
@@ -2992,7 +2992,7 @@ int main(int argc, char *argv[])
 	 */
 	fr_thread_local_atexit_setup();
 
-	autofree = talloc_autofree_context();
+	autofree = fr_talloc_autofree_context();
 
 #ifndef NDEBUG
 	if (fr_fault_setup(autofree, getenv("PANIC_ACTION"), argv[0]) < 0) {

--- a/src/bin/unit_test_map.c
+++ b/src/bin/unit_test_map.c
@@ -169,7 +169,7 @@ int main(int argc, char *argv[])
 	 */
 	fr_thread_local_atexit_setup();
 
-	autofree = talloc_autofree_context();
+	autofree = fr_talloc_autofree_context();
 
 #ifndef NDEBUG
 	if (fr_fault_setup(autofree, getenv("PANIC_ACTION"), argv[0]) < 0) {

--- a/src/bin/unit_test_module.c
+++ b/src/bin/unit_test_module.c
@@ -605,7 +605,7 @@ int main(int argc, char *argv[])
 	 */
 	fr_thread_local_atexit_setup();
 
-	autofree = talloc_autofree_context();
+	autofree = fr_talloc_autofree_context();
 	thread_ctx = talloc_new(autofree);
 
 	config = main_config_alloc(autofree);

--- a/src/lib/server/pair_server_tests.c
+++ b/src/lib/server/pair_server_tests.c
@@ -157,7 +157,7 @@ static int init_adhoc_attrs(fr_dict_adhoc_attr_t *dict_adhoc)
 
 static void pair_tests_init(void)
 {
-	autofree = talloc_autofree_context();
+	autofree = fr_talloc_autofree_context();
 	if (!autofree) {
 	error:
 		fr_perror("pair_tests");

--- a/src/lib/util/pair_legacy_tests.c
+++ b/src/lib/util/pair_legacy_tests.c
@@ -165,7 +165,7 @@ static void pair_tests_init(void)
 {
 	printf("Setup %s\n", __func__);
 
-	autofree = talloc_autofree_context();
+	autofree = fr_talloc_autofree_context();
 	if (!autofree) {
 	error:
 		fr_perror("pair_tests");

--- a/src/lib/util/pair_tests.c
+++ b/src/lib/util/pair_tests.c
@@ -175,7 +175,7 @@ static int init_adhoc_attrs(fr_dict_adhoc_attr_t *dict_adhoc)
 
 static void pair_tests_init(void)
 {
-	autofree = talloc_autofree_context();
+	autofree = fr_talloc_autofree_context();
 	if (!autofree) {
 	error:
 		fr_perror("pair_tests");

--- a/src/lib/util/talloc.h
+++ b/src/lib/util/talloc.h
@@ -247,6 +247,12 @@ typedef struct talloc_child_ctx_s TALLOC_CHILD_CTX;
 TALLOC_CHILD_CTX	*talloc_child_ctx_init(TALLOC_CTX *ctx);
 TALLOC_CHILD_CTX	*talloc_child_ctx_alloc(TALLOC_CHILD_CTX *parent) CC_HINT(nonnull);
 
+/*
+ *	The talloc_autofree_context() is marked as deprecated since libtalloc > 2.1.15,
+ *	but we need that.
+ */
+void *fr_talloc_autofree_context(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/modules/proto_control/radmin.c
+++ b/src/modules/proto_control/radmin.c
@@ -858,7 +858,7 @@ int main(int argc, char **argv)
 	 */
 	fr_thread_local_atexit_setup();
 
-	autofree = talloc_autofree_context();
+	autofree = fr_talloc_autofree_context();
 
 #ifndef NDEBUG
 	if (fr_fault_setup(autofree, getenv("PANIC_ACTION"), argv[0]) < 0) {

--- a/src/modules/proto_dhcpv4/dhcpclient.c
+++ b/src/modules/proto_dhcpv4/dhcpclient.c
@@ -580,7 +580,7 @@ int main(int argc, char **argv)
 	 */
 	fr_thread_local_atexit_setup();
 
-	autofree = talloc_autofree_context();
+	autofree = fr_talloc_autofree_context();
 
 	fr_debug_lvl = 1;
 

--- a/src/tests/util/atomic_queue_test.c
+++ b/src/tests/util/atomic_queue_test.c
@@ -27,6 +27,7 @@ RCSID("$Id$")
 #include <string.h>
 #include <sys/time.h>
 #include <freeradius-devel/util/debug.h>
+#include <freeradius-devel/util/talloc.h>
 
 #ifdef HAVE_GETOPT_H
 #	include <getopt.h>
@@ -70,7 +71,7 @@ int main(int argc, char *argv[])
 	intptr_t		val;
 	void			*data;
 	fr_atomic_queue_t	*aq;
-	TALLOC_CTX		*autofree = talloc_autofree_context();
+	TALLOC_CTX		*autofree = fr_talloc_autofree_context();
 
 	size = 4;
 

--- a/src/tests/util/channel_test.c
+++ b/src/tests/util/channel_test.c
@@ -489,7 +489,7 @@ int main(int argc, char *argv[])
 {
 	int			c;
 	fr_channel_t		*channel;
-	TALLOC_CTX		*autofree = talloc_autofree_context();
+	TALLOC_CTX		*autofree = fr_talloc_autofree_context();
 	pthread_attr_t		attr;
 	pthread_t		master_id, worker_id;
 

--- a/src/tests/util/control_test.c
+++ b/src/tests/util/control_test.c
@@ -180,7 +180,7 @@ retry:
 int main(int argc, char *argv[])
 {
 	int 			c;
-	TALLOC_CTX		*autofree = talloc_autofree_context();
+	TALLOC_CTX		*autofree = fr_talloc_autofree_context();
 	pthread_attr_t		attr;
 	pthread_t		master_id, worker_id;
 

--- a/src/tests/util/message_set_test.c
+++ b/src/tests/util/message_set_test.c
@@ -197,7 +197,7 @@ int main(int argc, char *argv[])
 	fr_message_set_t	*ms;
 	uint32_t		seed;
 
-	TALLOC_CTX		*autofree = talloc_autofree_context();
+	TALLOC_CTX		*autofree = fr_talloc_autofree_context();
 
 	memset(array, 0, sizeof(array));
 	memset(messages, 0, sizeof(messages));

--- a/src/tests/util/radius1_test.c
+++ b/src/tests/util/radius1_test.c
@@ -522,7 +522,7 @@ static void sig_ignore(int sig)
 int main(int argc, char *argv[])
 {
 	int		c;
-	TALLOC_CTX	*autofree = talloc_autofree_context();
+	TALLOC_CTX	*autofree = fr_talloc_autofree_context();
 	uint16_t	port16 = 0;
 
 	fr_time_start();

--- a/src/tests/util/radius_schedule_test.c
+++ b/src/tests/util/radius_schedule_test.c
@@ -219,7 +219,7 @@ int main(int argc, char *argv[])
 	int			num_networks = 1;
 	int			num_workers = 2;
 	uint16_t		port16 = 0;
-	TALLOC_CTX		*autofree = talloc_autofree_context();
+	TALLOC_CTX		*autofree = fr_talloc_autofree_context();
 	fr_schedule_t		*sched;
 	fr_listen_t		listen = { .app_io = &app_io, .app = &test_app };
 	fr_listen_test_t	*app_io_inst;

--- a/src/tests/util/ring_buffer_test.c
+++ b/src/tests/util/ring_buffer_test.c
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
 	fr_ring_buffer_t *rb;
 	uint32_t	seed;
 
-	TALLOC_CTX	*autofree = talloc_autofree_context();
+	TALLOC_CTX	*autofree = fr_talloc_autofree_context();
 
 	while ((c = getopt(argc, argv, "hl:s:x")) != -1) switch (c) {
 		case 'l':

--- a/src/tests/util/schedule_test.c
+++ b/src/tests/util/schedule_test.c
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
 	int c;
 	int num_networks = 1;
 	int num_workers = 2;
-	TALLOC_CTX	*autofree = talloc_autofree_context();
+	TALLOC_CTX	*autofree = fr_talloc_autofree_context();
 	fr_schedule_t	*sched;
 
 	fr_time_start();

--- a/src/tests/util/worker_test.c
+++ b/src/tests/util/worker_test.c
@@ -480,7 +480,7 @@ static void sig_ignore(int sig)
 int main(int argc, char *argv[])
 {
 	int c;
-	TALLOC_CTX	*autofree = talloc_autofree_context();
+	TALLOC_CTX	*autofree = fr_talloc_autofree_context();
 
 	if (fr_time_start() < 0) {
 		fprintf(stderr, "Failed to start time: %s\n", fr_syserror(errno));


### PR DESCRIPTION
Due to talloc_autofree_context() be marked as deprecated. We are
backporting for our own API.