### PR TITLE
module_instance_read_only(): The talloc_set_memlimit() is no longer n…

### DIFF
--- a/src/lib/server/module.c
+++ b/src/lib/server/module.c
@@ -631,26 +631,6 @@ bool module_section_type_set(request_t *request, fr_dict_attr_t const *type_da, 
 	}
 }
 
-/** Mark module instance data as being read only
- *
- * This still allows memory to be modified, but not allocated
- */
-int module_instance_read_only(void *inst, char const *name)
-{
-	int	rcode;
-	size_t	size;
-
-	size = talloc_total_size(inst);
-	rcode = talloc_set_memlimit(inst, size);
-	if (rcode < 0) {
-		ERROR("Failed setting memory limit for module %s", name);
-	} else {
-		DEBUG3("Memory limit for module %s is set to %zd bytes", name, size);
-	}
-
-	return rcode;
-}
-
 /** Find an existing module instance by its name and parent
  *
  * @param[in] parent		to qualify search with.
@@ -1349,10 +1329,6 @@ static int _module_instantiate(void *instance, UNUSED void *ctx)
 		 */
 		pthread_mutex_init(mi->mutex, NULL);
 	}
-
-#ifndef NDEBUG
-	if (mi->dl_inst->data) module_instance_read_only(mi->dl_inst->data, mi->name);
-#endif
 
 	mi->instantiated = true;
 

--- a/src/lib/server/module.h
+++ b/src/lib/server/module.h
@@ -295,8 +295,6 @@ char const	*module_state_method_to_str(module_state_func_table_t const *table,
 
 bool		module_section_type_set(request_t *request, fr_dict_attr_t const *type_da, fr_dict_enum_t const *enumv);
 
-int		module_instance_read_only(TALLOC_CTX *ctx, char const *name);
-
 /** @} */
 
 /** @name Module and module thread lookup

--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -1035,9 +1035,6 @@ static int mod_bootstrap(void *instance, CONF_SECTION *conf)
 		TALLOC_FREE(inst->driver_inst);
 		return -1;
 	}
-#ifndef NDEBUG
-	module_instance_read_only(inst->driver_inst, inst->driver->name);
-#endif
 
 	/*
 	 *	@fixme Inst should be passed to all driver callbacks


### PR DESCRIPTION
…eeded

Such call is deprecated since libtalloc > 2.1.15