### PR TITLE
autoconf: The talloc_set_memlimit() is no longer needed

### DIFF
--- a/src/include/autoconf.h.in
+++ b/src/include/autoconf.h.in
@@ -521,9 +521,6 @@
 /* Define to 1 if you have the <sys/wait.h> header file. */
 #undef HAVE_SYS_WAIT_H
 
-/* Define to 1 if you have the `talloc_set_memlimit' function. */
-#undef HAVE_TALLOC_SET_MEMLIMIT
-
 /* 128 bit unsigned integer */
 #undef HAVE_UINT128_T
 


### PR DESCRIPTION
Such call is deprecated since libtalloc > 2.1.15