### PR TITLE
dict_util: The talloc_set_memlimit() is no longer needed

### DIFF
--- a/src/lib/util/dict_util.c
+++ b/src/lib/util/dict_util.c
@@ -3387,16 +3387,12 @@ void fr_dict_global_read_only(void)
 	     dict;
 	     dict = fr_hash_table_iter_next(dict_gctx->protocol_by_num, &iter)) {
 	     	dict_hash_tables_finalise(dict);
-		talloc_set_memlimit(dict, talloc_get_size(dict));
 		dict->read_only = true;
 	}
 
 	dict = dict_gctx->internal;
 	dict_hash_tables_finalise(dict);
-	talloc_set_memlimit(dict, talloc_get_size(dict));
 	dict->read_only = true;
-
-	talloc_set_memlimit(dict_gctx, talloc_get_size(dict_gctx));
 	dict_gctx->read_only = true;
 }
 


### PR DESCRIPTION
Such call is deprecated since libtalloc > 2.1.15