### PR TITLE
radiusd: Remove 'talloc_memory_limit' option

### DIFF
--- a/src/bin/radiusd.c
+++ b/src/bin/radiusd.c
@@ -96,15 +96,14 @@ static void sig_hup (int);
 static int talloc_config_set(main_config_t *config)
 {
 	if (config->spawn_workers) {
-		if (config->talloc_memory_limit || config->talloc_memory_report) {
-			fr_strerror_printf("talloc_memory_limit and talloc_memory_report "
-					   "require single threaded mode (-s | -X)");
+		if (config->talloc_memory_report) {
+			fr_strerror_printf("talloc_memory_report require single threaded mode (-s | -X)");
 			return 1;
 		}
 		return 0;
 	}
 
-	if (!config->talloc_memory_limit && !config->talloc_memory_report) {
+	if (!config->talloc_memory_report) {
 		talloc_disable_null_tracking();
 		return 0;
 	}
@@ -334,7 +333,7 @@ int main(int argc, char *argv[])
 	}
 
 	/*  Process the options.  */
-	while ((c = getopt(argc, argv, "Cd:D:e:fhi:l:L:Mn:p:PrstTvxX")) != -1) switch (c) {
+	while ((c = getopt(argc, argv, "Cd:D:e:fhi:l:Mn:p:PrstTvxX")) != -1) switch (c) {
 		case 'C':
 			check_config = true;
 			config->spawn_workers = false;
@@ -376,24 +375,6 @@ int main(int argc, char *argv[])
 					config->name, config->log_file, fr_syserror(errno));
 				EXIT_WITH_FAILURE;
 			}
-			break;
-
-		case 'L':
-		{
-			size_t limit;
-
-			if (fr_size_from_str(&limit, optarg) < 0) {
-				fr_perror("%s: Invalid memory limit", config->name);
-				EXIT_WITH_FAILURE;
-			}
-
-			if ((limit > (((size_t)((1024 * 1024) * 1024)) * 16) || (limit < ((1024 * 1024) * 10)))) {
-				fprintf(stderr, "%s: Memory limit must be between 10M-16G\n", config->name);
-				EXIT_WITH_FAILURE;
-			}
-
-			config->talloc_memory_limit = limit;
-		}
 			break;
 
 		case 'n':

--- a/src/lib/server/main_config.c
+++ b/src/lib/server/main_config.c
@@ -80,7 +80,6 @@ static int num_networks_parse(TALLOC_CTX *ctx, void *out, void *parent, CONF_ITE
 static int num_workers_parse(TALLOC_CTX *ctx, void *out, void *parent, CONF_ITEM *ci, CONF_PARSER const *rule);
 static int lib_dir_parse(TALLOC_CTX *ctx, void *out, void *parent, CONF_ITEM *ci, CONF_PARSER const *rule);
 
-static int talloc_memory_limit_parse(TALLOC_CTX *ctx, void *out, void *parent, CONF_ITEM *ci, CONF_PARSER const *rule);
 static int talloc_pool_size_parse(TALLOC_CTX *ctx, void *out, void *parent, CONF_ITEM *ci, CONF_PARSER const *rule);
 
 static int max_request_time_parse(TALLOC_CTX *ctx, void *out, void *parent, CONF_ITEM *ci, CONF_PARSER const *rule);
@@ -153,7 +152,6 @@ static const CONF_PARSER resources[] = {
 	 *	it exists.
 	 */
 	{ FR_CONF_OFFSET("talloc_pool_size", FR_TYPE_SIZE | FR_TYPE_HIDDEN, main_config_t, talloc_pool_size), .func = talloc_pool_size_parse },			/* DO NOT SET DEFAULT */
-	{ FR_CONF_OFFSET("talloc_memory_limit", FR_TYPE_SIZE | FR_TYPE_HIDDEN, main_config_t, talloc_memory_limit), .func = talloc_memory_limit_parse },		/* DO NOT SET DEFAULT */
 	{ FR_CONF_OFFSET("talloc_memory_report", FR_TYPE_BOOL | FR_TYPE_HIDDEN, main_config_t, talloc_memory_report) },						/* DO NOT SET DEFAULT */
 	CONF_PARSER_TERMINATOR
 };
@@ -277,29 +275,6 @@ static int hostname_lookups_parse(TALLOC_CTX *ctx, void *out, void *parent,
 	if ((ret = cf_pair_parse_value(ctx, out, parent, ci, rule)) < 0) return ret;
 
 	memcpy(&fr_hostname_lookups, out, sizeof(fr_hostname_lookups));
-
-	return 0;
-}
-
-static int talloc_memory_limit_parse(TALLOC_CTX *ctx, void *out, void *parent,
-				     CONF_ITEM *ci, CONF_PARSER const *rule)
-{
-	int	ret;
-	size_t	value;
-
-	if ((ret = cf_pair_parse_value(ctx, out, parent, ci, rule)) < 0) return ret;
-
-	memcpy(&value, out, sizeof(value));
-
-	if (value) {
-		FR_SIZE_BOUND_CHECK("resources.talloc_memory_limit", value, >=,
-				    (size_t)1024 * 1024 * 10);
-
-		FR_SIZE_BOUND_CHECK("resources.talloc_memory_limit", value, <=,
-				    ((((size_t)1024) * 1024 * 1024) * 16));
-	}
-
-	memcpy(out, &value, sizeof(value));
 
 	return 0;
 }

--- a/src/lib/server/main_config.h
+++ b/src/lib/server/main_config.h
@@ -133,8 +133,6 @@ struct main_config_s {
 							//!< Can only be used when the server is running in single
 							//!< threaded mode.
 
-	size_t		talloc_memory_limit;		//!< Limit the amount of talloced memory the server uses.
-							//!< Only applicable in single threaded mode.
 	uint32_t	max_networks;			//!< for the scheduler
 	uint32_t	max_workers;			//!< for the scheduler
 	fr_time_delta_t	stats_interval;			//!< for the scheduler


### PR DESCRIPTION
As the talloc_set_memlimit() is marked as deprecated. We no longer
needed that.