### PR TITLE
v4: Change fr_pair_list_afrom_box() to work on externally created list

### DIFF
--- a/src/lib/server/map_async.c
+++ b/src/lib/server/map_async.c
@@ -659,9 +659,10 @@ int map_to_list_mod(TALLOC_CTX *ctx, vp_list_mod_t **out,
 	{
 		fr_cursor_t	to;
 		fr_dcursor_t	from;
-		fr_pair_list_t	*vp_head = NULL;
+		fr_pair_list_t	vp_head;
 		fr_pair_t	*vp;
 
+		fr_pair_list_init(&vp_head);
 		/*
 		 *	If the LHS is an attribute, we just do the
 		 *	same thing as an xlat expansion.
@@ -700,14 +701,14 @@ int map_to_list_mod(TALLOC_CTX *ctx, vp_list_mod_t **out,
 		/*
 		 *	Parse the VPs from the RHS.
 		 */
-		vp_head = fr_pair_list_afrom_box(ctx, request->dict, *rhs_result);
-		if (fr_pair_list_empty(vp_head)) {
+		fr_pair_list_afrom_box(ctx, &vp_head, request->dict, *rhs_result);
+		if (fr_pair_list_empty(&vp_head)) {
 			talloc_free(n);
 			RDEBUG2("No pairs returned by exec");
 			return 0;	/* No pairs returned */
 		}
 
-		(void)fr_dcursor_init(&from, vp_head);
+		(void)fr_dcursor_init(&from, &vp_head);
 		while ((vp = fr_dcursor_remove(&from))) {
 			map_t *mod;
 			tmpl_rules_t rules;

--- a/src/lib/util/pair.c
+++ b/src/lib/util/pair.c
@@ -2554,14 +2554,17 @@ void fr_pair_list_tainted(fr_pair_list_t *list)
 }
 
 
-/*
- *	Parse a set of VPs from a value box.
+/** Parse a list of VPs from a value box.
+ *
+ * @param[in] ctx	to allocate new VPs in
+ * @param[out] out	list to add new pairs to
+ * @param[in] dict	to use in parsing
+ * @param[in] box	whose value is to be parsed
  */
-fr_pair_list_t *fr_pair_list_afrom_box(TALLOC_CTX *ctx, fr_dict_t const *dict, fr_value_box_t *box)
+void fr_pair_list_afrom_box(TALLOC_CTX *ctx, fr_pair_list_t *out, fr_dict_t const *dict, fr_value_box_t *box)
 {
 	int comma = 0;
 	char *p, *end, *last_comma = NULL;
-	fr_pair_list_t *vps;
 
 	fr_assert(box->type == FR_TYPE_STRING);
 
@@ -2611,17 +2614,14 @@ fr_pair_list_t *fr_pair_list_afrom_box(TALLOC_CTX *ctx, fr_dict_t const *dict, f
 	 */
 	if (last_comma) *last_comma = '\0';
 
-	vps = fr_pair_list_alloc(ctx);
-	if (fr_pair_list_afrom_str(ctx, dict, box->vb_strvalue, vps) == T_INVALID) {
-		fr_pair_list_free(vps);
-		return vps;
+	if (fr_pair_list_afrom_str(ctx, dict, box->vb_strvalue, out) == T_INVALID) {
+		return;
 	}
 
 	/*
 	 *	Mark the attributes as tainted.
 	 */
-	fr_pair_list_tainted(vps);
-	return vps;
+	fr_pair_list_tainted(out);
 }
 
 /** Move a list of fr_pair_t from a temporary list to a destination list

--- a/src/lib/util/pair.h
+++ b/src/lib/util/pair.h
@@ -396,7 +396,7 @@ void			fr_pair_list_debug(fr_pair_list_t const *list);
 /** @} */
 
 void			fr_pair_list_tainted(fr_pair_list_t *vps);
-fr_pair_list_t		*fr_pair_list_afrom_box(TALLOC_CTX *ctx, fr_dict_t const *dict, fr_value_box_t *box);
+void			fr_pair_list_afrom_box(TALLOC_CTX *ctx, fr_pair_list_t *out, fr_dict_t const *dict, fr_value_box_t *box);
 
 /* Tokenization */
 typedef struct {

--- a/src/modules/rlm_exec/rlm_exec.c
+++ b/src/modules/rlm_exec/rlm_exec.c
@@ -358,17 +358,18 @@ static unlang_action_t mod_exec_wait_resume(rlm_rcode_t *p_result, module_ctx_t 
 
 	if (inst->output && m->box) {
 		TALLOC_CTX *ctx;
-		fr_pair_list_t *vps, *output_pairs;
+		fr_pair_list_t vps, *output_pairs;
 
 		RDEBUG("EXEC GOT -- %pV", m->box);
 
+		fr_pair_list_init(&vps);
 		output_pairs = tmpl_list_head(request, inst->output_list);
 		fr_assert(output_pairs != NULL);
 
 		ctx = tmpl_list_ctx(request, inst->output_list);
 
-		vps = fr_pair_list_afrom_box(ctx, request->dict, m->box);
-		if (!fr_pair_list_empty(vps)) fr_pair_list_move(output_pairs, vps);
+		fr_pair_list_afrom_box(ctx, &vps, request->dict, m->box);
+		if (!fr_pair_list_empty(&vps)) fr_pair_list_move(output_pairs, &vps);
 
 		m->box = NULL;	/* has been consumed */
 	}


### PR DESCRIPTION
fr_pair_list_afrom_box() was previously allocating a list head and returning that, even though the use cases were only temporary lists, potentially leaving a list header not freed.