### PR TITLE
rlm_redis: Add new 'logfile' option for rlm_redis. Closes #1114

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -52,6 +52,7 @@ FreeRADIUS 3.0.22 Tue 24 Mar 2020 12:00:00 EDT urgency=low
 	* Add rlm_rest support for HTTP/2.
 	* Add REST-HTTP-Status-Code attribute holding HTTP status code.
 	* Add option to set http_negotiation in rlm_rest.  Fixes #2821.
+	* Add new 'logfile' rlm_redis option to redirect all REDIS queries to a logfile. Closes #1114
 
 	Bug fixes
 	* Respect the "log_reject" configuration item in more places.

--- a/raddb/mods-available/redis
+++ b/raddb/mods-available/redis
@@ -25,6 +25,10 @@ redis {
 	#  Set connection and query timeout for rlm_redis
 	query_timeout = 5
 
+	# Write REDIS queries to a logfile. This is potentially useful for tracing
+	# issues with authorization queries.
+#	logfile = ${logdir}/redis.log
+
 	#
 	#  Information for the connection pool.  The configuration items
 	#  below are the same for all modules which use the new

--- a/src/modules/rlm_redis/rlm_redis.h
+++ b/src/modules/rlm_redis/rlm_redis.h
@@ -30,6 +30,8 @@ RCSIDH(rlm_redis_h, "$Id$")
 #include <pthread.h>
 #endif
 
+#include <freeradius-devel/exfile.h>
+
 #include <freeradius-devel/modpriv.h>
 #include <hiredis/hiredis.h>
 
@@ -42,7 +44,6 @@ typedef struct rlm_redis_t REDIS_INST;
 
 typedef struct rlm_redis_t {
 	char const		*xlat_name;
-
 	char const		*hostname;
 	uint16_t		port;
 	uint32_t		database;
@@ -50,12 +51,17 @@ typedef struct rlm_redis_t {
 	uint16_t		query_timeout;
 	fr_connection_pool_t	*pool;
 
+	char const 		*logfile;
+	exfile_t		*ef;
+
 	int (*redis_query)(REDISSOCK **dissocket_p, REDIS_INST *inst, char const *query, REQUEST *request);
 	int (*redis_finish_query)(REDISSOCK *dissocket);
 } rlm_redis_t;
 
 #define MAX_QUERY_LEN			4096
 #define MAX_REDIS_ARGS			32
+
+void rlm_redis_query_log(REDIS_INST *inst, REQUEST *request, char const *query);
 
 int rlm_redis_query(REDISSOCK **dissocket_p, REDIS_INST *inst,
 		    char const *query, REQUEST *request);


### PR DESCRIPTION
It allows the user to redirect all REDIS queries to a logfile.