### PR TITLE
Just return NULL at the detection of padding

### DIFF
--- a/src/protocols/dhcpv4/packet.c
+++ b/src/protocols/dhcpv4/packet.c
@@ -51,10 +51,7 @@ uint8_t const *fr_dhcpv4_packet_get_option(dhcp_packet_t const *packet, size_t p
 	data = &packet->options[where];
 
 	while (where < size) {
-		if (data[0] == 0) { /* padding */
-			where++;
-			continue;
-		}
+		if (data[0] == 0) return NULL; /* padding */
 
 		if (data[0] == 255) { /* end of options */
 			if ((field == DHCP_OPTION_FIELD) && (overload & DHCP_FILE_FIELD)) {


### PR DESCRIPTION
As written, it incremented where and continued. That makes sure it
leaves the loop, but since *only* where is changed, data[0] is still
0 the next time through, so it's an O(size) way to return NULL.
Might as well just return NULL.