### PR TITLE
talloc: Fix missing _talloc_pooled_object() configure check

### DIFF
--- a/configure
+++ b/configure
@@ -8061,6 +8061,20 @@ $as_echo "$as_me: WARNING: talloc library not found. Use --with-talloc-lib-dir=<
   as_fn_error $? "FreeRADIUS requires libtalloc.  Please read doc/developers/dependencies.adoc for further instructions." "$LINENO" 5
 fi
 
+for ac_func in _talloc_pooled_object
+
+do :
+  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+_ACEOF
+
+fi
+done
+
+
 TALLOC_LIBS="${smart_lib}"
 TALLOC_LDFLAGS="${smart_ldflags}"
 

--- a/configure.ac
+++ b/configure.ac
@@ -943,6 +943,15 @@ if test "x$ac_cv_lib_talloc__talloc" != "xyes"; then
   AC_MSG_ERROR([FreeRADIUS requires libtalloc.  Please read doc/developers/dependencies.adoc for further instructions.])
 fi
 
+dnl #
+dnl # Check for talloc_set_memlimit
+dnl # This was only included in version 2.0.8
+dnl # Needs to be done here with the talloc linker flags set
+dnl #
+AC_CHECK_FUNCS(
+  _talloc_pooled_object
+)
+
 TALLOC_LIBS="${smart_lib}"
 TALLOC_LDFLAGS="${smart_ldflags}"
 AC_SUBST(TALLOC_LIBS)


### PR DESCRIPTION
It fixes the typo in _talloc_pooled_object 762c3a72100e079d5918f140d0c516c406495672