### PR TITLE
Accept pkcs11: URIs for EAP certificates and private keys

### DIFF
--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -235,6 +235,9 @@ eap {
 			#  root CAs, instead of putting them in
 			#  `certificate_file`.
 			#
+			#  This field may contain a PKCS #11 URI instead of a filename
+			#  if OpenSSL is using the libp11 "pkcs11" ENGINE plugin.
+			#
 			certificate_file = ${certdir}/rsa/server.pem
 
 			#
@@ -248,6 +251,9 @@ eap {
 			#  only one `certificate_file` to the clients.  The main use for multiple
 			#  `ca_file` entries is to permit the use of EAP-TLS with client certificates
 			#  from multiple Root CAs.
+			#
+			#  This field may contain a PKCS #11 URI instead of a filename
+			#  if OpenSSL is using the libp11 "pkcs11" ENGINE plugin.
 			#
 			ca_file = ${certdir}/rsa/ca.pem
 
@@ -264,6 +270,9 @@ eap {
 			#  If the Private key & Certificate are located in the same file,
 			#  then `private_key_file` & `certificate_file` must contain the
 			#  same file name.
+			#
+			#  This field may contain a PKCS #11 URI instead of a filename
+			#  if OpenSSL is using the libp11 "pkcs11" ENGINE plugin.
 			#
 			private_key_file = ${certdir}/rsa/server.key
 

--- a/src/lib/tls/base-h
+++ b/src/lib/tls/base-h
@@ -341,6 +341,8 @@ extern CONF_PARSER fr_tls_client_config[];
  */
 extern _Thread_local TALLOC_CTX *ssl_talloc_ctx;
 
+extern ENGINE *pkcs11_engine;
+
 /** Bind any memory allocated by an OpenSSL function to the object it created
  *
  * This is a horrible workaround for OpenSSL memory leaks.  But should always


### PR DESCRIPTION
On systems where the libp11 "pkcs11" [OpenSSL ENGINE plugin](https://github.com/OpenSC/libp11) is installed, allow the user to request keys and certs from an HSM or smartcard instead of storing them in the clear on disk.

This is useful because revoking a leaked EAP server certificate can be highly disruptive, especially if there are many deployed devices and IoT gadgets that connect to the network exclusively via 802.1x.  Storing the private key on a smartcard ensures that it cannot be extracted if the RADIUS server is compromised.

Performance-wise, I see penalties ranging from ~90ms per TLS handshake (ECC256) to 160ms (RSA2048) on a YubiKey 4.  I would expect that higher-grade HSM hardware would be much faster, but I don't have access to it for testing.

To test this on Ubuntu 20.04 with a YubiKey, I set up a local installation with an on-disk private key, tested it with `radiusd -X`, and then moved it to the smartcard:

```
sudo apt install -y opensc opensc-pkcs11 libengine-pkcs11-openssl yubico-piv-tool
yubico-piv-tool --pin=123456 --action=import-key --slot=9a < radius.key
yubico-piv-tool --pin=123456 --action=import-certificate --slot=9a < radius.pem
```

(I had to use `yubico-piv-tool` instead of the standard `pkcs11-tool` because `C_CreateObject` is apparently unsupported.)

Then I edited the `mods-enabled/eap` file to add a PKCS#11 URI with the `pin-value` property set:

```
    #private_key_file = ${certdir}/rsa/radius.key
    private_key_file = "pkcs11:model=PKCS%2315%20emulated;id=%01;pin-value=123456;type=private"
```

I then restarted `radiusd -X` and used a test client / `eapol_test` to verify that the server still worked correctly.

I don't really expect most users to set things up so that interactive PIN entry is required, but I did test that case.  When running `radiusd -X` from the command line, OpenSSL will prompt for a PIN; without `-X` the daemon will log an appropriate error and exit.

The one thing I wasn't able to figure out is how to import the entire certificate chain into the YubiKey's X.509 certificate slot (if such a thing is even possible).  So I suspect that loading `certificate_file` from PKCS#11 is mainly useful if the server certificate is self-signed.

Also, I didn't test this against old versions of OpenSSL, and I didn't test the case where OpenSSL is missing ENGINE support (which I suspect will already break the existing `fr_openssl_init()` code).