### PR TITLE
Extend timeout on SMTP delivery tests

### DIFF
--- a/src/tests/modules/smtp/smtp_crln/tls_crln.unlang
+++ b/src/tests/modules/smtp/smtp_crln/tls_crln.unlang
@@ -13,13 +13,13 @@ update request {
 smtp.authorize
 
 #
-# Wait up to a tenth second for exim to deliver the email
+# Wait up to half a second for exim to deliver the email
 # Then confirm it was delivered
 #
 if (`/bin/sh -c "for i in 1 2 3 4 5 ; \
 do if [ -e build/ci/exim4/mail/crln_test_receiver ] ;\
 then break; \
-fi; sleep .02;\
+fi; sleep .1;\
 done ; \
 test -f build/ci/exim4/mail/crln_test_receiver ;\
 echo $?"` == "1") {

--- a/src/tests/modules/smtp/smtp_stringparse/tls_stringparse.unlang
+++ b/src/tests/modules/smtp/smtp_stringparse/tls_stringparse.unlang
@@ -10,13 +10,13 @@ update request {
 smtp.authorize
 
 #
-# Wait up to a tenth second for exim to deliver the email
+# Wait up to half a second for exim to deliver the email
 # Then confirm it was delivered
 #
 if (`/bin/sh -c "for i in 1 2 3 4 5 ; \
 do if [ -e build/ci/exim4/mail/stringparse_test_receiver ] ;\
 then break; \
-fi; sleep .02;\
+fi; sleep .1;\
 done ; \
 test -f build/ci/exim4/mail/stringparse_test_receiver ;\
 echo $?"` == "1") {

--- a/src/tests/modules/smtp/tls_delivery.unlang
+++ b/src/tests/modules/smtp/tls_delivery.unlang
@@ -16,13 +16,13 @@ update request {
 smtp.authorize
 
 #
-# Wait up to a tenth second for exim to deliver the email
+# Wait up to half a second for exim to deliver the email
 # Then confirm it was delivered
 #
 if (`/bin/sh -c "for i in 1 2 3 4 5 ; \
 do if [ -e build/ci/exim4/mail/smtp_delivery_receiver ] ;\
 then break; \
-fi; sleep .02;\
+fi; sleep .1;\
 done ; \
 test -f build/ci/exim4/mail/smtp_delivery_receiver ;\
 echo $?"` == "1") {


### PR DESCRIPTION
to allow for slower exim performance when CI hosts are under load