### PR TITLE
Restrict deletion during iteration to in-order.

### DIFF
--- a/src/lib/util/rbtree.c
+++ b/src/lib/util/rbtree.c
@@ -876,7 +876,7 @@ void *rbtree_node2data(UNUSED rbtree_t *tree, fr_rb_node_t *node)
  *	- The first node.  Mutex will be held.
  *	- NULL if the tree is empty.
  */
-void *rbtree_iter_init_inorder(fr_rb_tree_iter_t *iter, rbtree_t *tree)
+void *rbtree_iter_init_inorder(fr_rb_tree_iter_inorder_t *iter, rbtree_t *tree)
 {
 	fr_rb_node_t *x = tree->root;
 
@@ -889,7 +889,7 @@ void *rbtree_iter_init_inorder(fr_rb_tree_iter_t *iter, rbtree_t *tree)
 	 */
 	while (x->left != NIL) x = x->left;
 
-	*iter = (fr_rb_tree_iter_t){
+	*iter = (fr_rb_tree_iter_inorder_t){
 		.tree = tree,
 		.node = x
 	};
@@ -906,7 +906,7 @@ void *rbtree_iter_init_inorder(fr_rb_tree_iter_t *iter, rbtree_t *tree)
  *	- The next node.
  *	- NULL if no more nodes remain.
  */
-void *rbtree_iter_next_inorder(fr_rb_tree_iter_t *iter)
+void *rbtree_iter_next_inorder(fr_rb_tree_iter_inorder_t *iter)
 {
 	fr_rb_node_t *x = iter->node, *y;
 
@@ -1137,9 +1137,9 @@ void *rbtree_iter_next_postorder(fr_rb_tree_iter_t *iter)
  *
  * @note Only makes sense for in-order traversals.
  *
- * @param[in] iter	previously initialised with #rbtree_iter_init
+ * @param[in] iter	previously initialised with #rbtree_iter_inorder_init
  */
-void rbtree_iter_delete(fr_rb_tree_iter_t *iter)
+void rbtree_iter_inorder_delete(fr_rb_tree_iter_inorder_t *iter)
 {
 	fr_rb_node_t *x = iter->node;
 
@@ -1148,15 +1148,4 @@ void rbtree_iter_delete(fr_rb_tree_iter_t *iter)
 	iter->next = iter->node;
 	iter->node = NULL;
 	rbtree_delete_internal(iter->tree, x, true);
-}
-
-/** Explicitly unlock the tree
- *
- * @note Must be called if iterating over the tree ends early.
- *
- * @param[in] iter	previously initialised with #rbtree_iter_init
- */
-void rbtree_iter_done(fr_rb_tree_iter_t *iter)
-{
-	if (iter->tree->lock) pthread_mutex_unlock(&iter->tree->mutex);
 }

--- a/src/lib/util/rbtree_tests.c
+++ b/src/lib/util/rbtree_tests.c
@@ -46,7 +46,7 @@ static void test_rbtree_iter_inorder(void)
 	fr_rb_test_node_t	sorted[MAXSIZE];
 	fr_rb_test_node_t	*p;
 	size_t			n, i;
-	fr_rb_tree_iter_t	iter;
+	fr_rb_tree_iter_inorder_t	iter;
 
 	TEST_CASE("in-order iterator");
 	t = rbtree_alloc(NULL, fr_rb_test_node_t, node, fr_rb_test_cmp, NULL, RBTREE_FLAG_LOCK);
@@ -178,10 +178,10 @@ uint32_t	non_primes[] = { 1,  4,  6,  8,  9, 10, 12, 14, 15, 16, 18, 20, 21, 22,
 
 static void test_rbtree_iter_delete(void)
 {
-	rbtree_t 		*t;
-	size_t			i;
-	fr_rb_test_node_t	*p;
-	fr_rb_tree_iter_t	iter;
+	rbtree_t 			*t;
+	size_t				i;
+	fr_rb_test_node_t		*p;
+	fr_rb_tree_iter_inorder_t	iter;
 
 	t = rbtree_alloc(NULL, fr_rb_test_node_t, node, fr_rb_test_cmp, NULL, RBTREE_FLAG_LOCK);
 	TEST_CHECK(t != NULL);
@@ -202,7 +202,7 @@ static void test_rbtree_iter_delete(void)
 	for (p = rbtree_iter_init_inorder(&iter, t);
 	     p;
 	     p = rbtree_iter_next_inorder(&iter)) {
-		if (is_prime(p->num)) rbtree_iter_delete(&iter);
+		if (is_prime(p->num)) rbtree_iter_inorder_delete(&iter);
 	}
 
 	/*


### PR DESCRIPTION
This requires different iterator structures for inorder traversal,
but it does enforce the constraint at compile time.

rbtree_iter_done() is now a macro using _Generic(), so at least that
doesn't have to change.