### PR TITLE
Bring back the rbtree_iter_done() function, and add an inorder flavor

### DIFF
--- a/src/lib/util/rbtree.c
+++ b/src/lib/util/rbtree.c
@@ -1149,3 +1149,25 @@ void rbtree_iter_inorder_delete(fr_rb_tree_iter_inorder_t *iter)
 	iter->node = NULL;
 	rbtree_delete_internal(iter->tree, x, true);
 }
+
+/** Explicitly unlock the tree
+ *
+ * @note Must be called if iterating over the tree ends early.
+ *
+ * @param[in] iter	previously initialised with #rbtree_iter_init
+ */
+void rbtree_iter_done(fr_rb_tree_iter_t *iter)
+{
+	if (iter->tree->lock) pthread_mutex_unlock(&iter->tree->mutex);
+}
+
+/** Explicitly unlock the tree
+ *
+ * @note Must be called if iterating over the tree ends early.
+ *
+ * @param[in] iter	previously initialised with #rbtree_iter_inorder_init
+ */
+void rbtree_iter_inorder_done(fr_rb_tree_iter_inorder_t *iter)
+{
+	if (iter->tree->lock) pthread_mutex_unlock(&iter->tree->mutex);
+}

--- a/src/lib/util/rbtree.h
+++ b/src/lib/util/rbtree.h
@@ -195,19 +195,9 @@ void		*rbtree_iter_next_postorder(fr_rb_tree_iter_t *iter) CC_HINT(nonnull);
 
 void		rbtree_iter_inorder_delete(fr_rb_tree_iter_inorder_t *iter);
 
-/** Explicitly unlock the tree
- *
- * @note Must be called if iterating over the tree ends early.
- *
- * @param[in] iter	previously initialised with #rbtree_iter_init
- */
-#define rbtree_iter_done(_iter) \
-	(_Generic(_iter), \
-		(fr_rb_tree_iter_t *)		: (void) (((fr_rb_tree_iter_t *)(_iter)->lock) ? \
-							pthread_mutex_unlock((fr_rb_tree_iter_t *)(_iter)->lock) : 0),  \
-		(fr_rb_tree_iter_inorder_t *)	: (void) (((fr_rb_tree_iter_inorder_t *)(_iter)->lock) ? \
-							pthread_mutex_unlock((fr_rb_tree_iter_inorder_t *)(_iter)->lock) : 0),  \
-	)
+void		rbtree_iter_done(fr_rb_tree_iter_t *iter);
+
+void		rbtree_iter_inorder_done(fr_rb_tree_iter_inorder_t *iter);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
rbtree_t is only complete within rbtree.c, so a macro in rbtree.h
doesn't have the information to do what the rbtree_iter_done()
function in rbtree.c could do. So we'll bring back that function
and add rbtree_iter_inorder_done() that of course takes an
fr_rb_tree_iter_inorder_t *.