### PR TITLE
CI RPMs: Remove workaround for scomp filter bug with faccessat2

### DIFF
--- a/.github/workflows/ci-rpm.yml
+++ b/.github/workflows/ci-rpm.yml
@@ -26,28 +26,6 @@ jobs:
 
     steps:
 
-    #
-    #  The secomp filters used by GitHub Action's Docker do not allow
-    #  faccessat2, as used by glibc >= 2.32.9000-16.
-    #
-    #      https://bugzilla.redhat.com/show_bug.cgi?id=1869030
-    #
-    #  It may take a while for GH to upgrade Docker so for now we downgrade
-    #  and/or pin glibc.
-    #
-    - name: Downgrade/pin glibc on Rawhide
-      if: ${{ matrix.env.NAME == 'fedora-rawhide' }}
-      run: |
-        yum install -y \
-             https://kojipkgs.fedoraproject.org/packages/glibc/2.32.9000/15.fc34/x86_64/glibc-devel-2.32.9000-15.fc34.x86_64.rpm \
-             https://kojipkgs.fedoraproject.org/packages/glibc/2.32.9000/15.fc34/x86_64/glibc-2.32.9000-15.fc34.x86_64.rpm \
-             https://kojipkgs.fedoraproject.org/packages/glibc/2.32.9000/15.fc34/x86_64/glibc-common-2.32.9000-15.fc34.x86_64.rpm \
-             https://kojipkgs.fedoraproject.org/packages/glibc/2.32.9000/15.fc34/noarch/glibc-headers-x86-2.32.9000-15.fc34.noarch.rpm \
-             https://kojipkgs.fedoraproject.org/packages/glibc/2.32.9000/15.fc34/x86_64/glibc-langpack-en-2.32.9000-15.fc34.x86_64.rpm \
-             https://kojipkgs.fedoraproject.org/packages/glibc/2.32.9000/15.fc34/x86_64/glibc-minimal-langpack-2.32.9000-15.fc34.x86_64.rpm \
-             yum-plugin-versionlock
-        yum versionlock glibc*
-
     # Required so that the checkout action uses git protocol rather than the GitHub REST API.
     # make rpm requires the FR directory to be a git repository.
     - name: Install recent git for CentOS 7
@@ -171,22 +149,6 @@ jobs:
     name: "RPM install test"
 
     steps:
-
-    #
-    #  See corresponding comment in the build job
-    #
-    - name: Downgrade glibc on Rawhide
-      if: ${{ matrix.env.NAME == 'fedora-rawhide' }}
-      run: |
-        yum install -y \
-             https://kojipkgs.fedoraproject.org/packages/glibc/2.32.9000/15.fc34/x86_64/glibc-devel-2.32.9000-15.fc34.x86_64.rpm \
-             https://kojipkgs.fedoraproject.org/packages/glibc/2.32.9000/15.fc34/x86_64/glibc-2.32.9000-15.fc34.x86_64.rpm \
-             https://kojipkgs.fedoraproject.org/packages/glibc/2.32.9000/15.fc34/x86_64/glibc-common-2.32.9000-15.fc34.x86_64.rpm \
-             https://kojipkgs.fedoraproject.org/packages/glibc/2.32.9000/15.fc34/noarch/glibc-headers-x86-2.32.9000-15.fc34.noarch.rpm \
-             https://kojipkgs.fedoraproject.org/packages/glibc/2.32.9000/15.fc34/x86_64/glibc-langpack-en-2.32.9000-15.fc34.x86_64.rpm \
-             https://kojipkgs.fedoraproject.org/packages/glibc/2.32.9000/15.fc34/x86_64/glibc-minimal-langpack-2.32.9000-15.fc34.x86_64.rpm \
-             yum-plugin-versionlock
-        yum versionlock glibc*
 
     - name: Extra repos for CentOS
       if: ${{ startsWith(matrix.env.NAME, 'centos-') }}


### PR DESCRIPTION
No longer required and now results in other issues.