### PR TITLE
Minor CI improvements

### DIFF
--- a/.github/workflows/ci-deb.yml
+++ b/.github/workflows/ci-deb.yml
@@ -36,8 +36,11 @@ jobs:
 
     - name: Package manager performance improvements
       run: |
+        sed -i 's/deb.debian.org/debian-archive.trafficmanager.net/' /etc/apt/sources.list
+        sed -i 's/archive.ubuntu.com/azure.archive.ubuntu.com/' /etc/apt/sources.list
         echo force-unsafe-io > /etc/dpkg/dpkg.cfg.d/02speedup
         echo 'man-db man-db/auto-update boolean false' | debconf-set-selections
+        apt-get update
 
     #
     #  Required so that the checkout action uses git protocol rather than the GitHub REST API.
@@ -45,7 +48,6 @@ jobs:
     #
     - name: Install recent git
       run: |
-        apt-get update
         apt-get install -y --no-install-recommends git-core ca-certificates
 
     - uses: actions/checkout@v2
@@ -147,12 +149,6 @@ jobs:
 
     steps:
 
-    # For pkill
-    - name: Install procps
-      run: |
-        apt-get update
-        apt-get install -y --no-install-recommends procps
-
     - name: Load DEBs
       uses: actions/download-artifact@v2
       with:
@@ -160,8 +156,16 @@ jobs:
 
     - name: Package manager performance improvements
       run: |
+        sed -i 's/deb.debian.org/debian-archive.trafficmanager.net/' /etc/apt/sources.list
+        sed -i 's/archive.ubuntu.com/azure.archive.ubuntu.com/' /etc/apt/sources.list
         echo force-unsafe-io > /etc/dpkg/dpkg.cfg.d/02speedup
         echo 'man-db man-db/auto-update boolean false' | debconf-set-selections
+        apt-get update
+
+    # For pkill
+    - name: Install procps
+      run: |
+        apt-get install -y --no-install-recommends procps
 
     - name: Install DEBs
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,25 +190,6 @@ jobs:
         pcre-config --libs-posix --version 2>/dev/null || :
         pcre2-config --libs-posix --version 2>/dev/null || :
 
-    - name: Hacks to silence clang-12 warnings in talloc and json-c (MacOS)
-      if: ${{ runner.os == 'macOS' }}
-      run: |
-        sed -i '' '1i\
-        #pragma clang diagnostic ignored "-Wdocumentation"
-        ' /usr/local/include/talloc.h
-        sed -i '' '1i\
-        #pragma clang diagnostic ignored "-Wdocumentation-deprecated-sync"
-        ' /usr/local/include/json-c/json_tokener.h
-        sed -i '' '1i\
-        #pragma clang diagnostic ignored "-Wdocumentation-deprecated-sync"
-        ' /usr/local/include/json-c/arraylist.h
-        sed -i '' '1i\
-        #pragma clang diagnostic ignored "-Wdocumentation-deprecated-sync"
-        ' /usr/local/include/json-c/json_util.h
-        sed -i '' '1i\
-        #pragma clang diagnostic ignored "-Wstrict-prototypes"
-        ' /usr/local/include/cassandra.h
-
     - name: Configure
       run: |
         if $CC -v 2>&1 | grep clang > /dev/null; then

--- a/src/modules/rlm_sql/drivers/rlm_sql_cassandra/rlm_sql_cassandra.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_cassandra/rlm_sql_cassandra.c
@@ -38,7 +38,15 @@
 #include <freeradius-devel/server/base.h>
 #include <freeradius-devel/util/debug.h>
 
+#ifdef HAVE_WDOCUMENTATION
+DIAG_OFF(documentation)
+#endif
+DIAG_OFF(strict-prototypes)  /* Seen with homebrew cassandra-cpp-driver 2.15.3 */
 #include <cassandra.h>
+DIAG_ON(strict-prototypes)
+#ifdef HAVE_WDOCUMENTATION
+DIAG_ON(documentation)
+#endif
 
 #include "rlm_sql.h"
 


### PR DESCRIPTION
Replace CI hacks with DIAG_{ON,OFF} pragmas to address MacOS build errors.
Use Azure mirrors for the DEB container builds. Likely to be more reliable and very slightly faster.