### PR TITLE
CI package tests: Run bleeding-edge distro builds for RPM and DEB on push

### DIFF
--- a/.github/workflows/ci-deb.yml
+++ b/.github/workflows/ci-deb.yml
@@ -2,9 +2,6 @@ name: CI DEB
 
 on:
   push:
-    branches:
-      - packaging_test
-      - ci-debug
   schedule:
     - cron: '0 20 * * *'
 
@@ -12,17 +9,58 @@ env:
   DEBIAN_FRONTEND: noninteractive
 
 jobs:
+
+  #
+  #  We don't want to consume many workers on each push so we only build the
+  #  full suite of distros during the scheduled or ci-debug run and just the
+  #  "bleeding-edge" distro on each push.
+  #
+  #  This job builds the matrix based on the event that trigger this run which
+  #  the next job consumes.
+  #
+  set-matrix:
+    name: Setup build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - id: set-matrix
+      name: Setup the matrix
+      run: |
+        if [ "$GITHUB_EVENT_NAME" = "schedule" -o "$GITHUB_REF" = "refs/heads/ci-debug" ]; then
+          M=$(cat <<EOF
+          {
+            "env": [
+              { "NAME": "ubuntu-16.04", "OS": "ubuntu:16.04"   },
+              { "NAME": "ubuntu-18.04", "OS": "ubuntu:18.04"   },
+              { "NAME": "ubuntu-20.04", "OS": "ubuntu:20.04"   },
+              { "NAME": "debian-9",     "OS": "debian:stretch" },
+              { "NAME": "debian-10",    "OS": "debian:buster"  },
+              { "NAME": "debian-sid",   "OS": "debian:sid"     }
+            ]
+          }
+        EOF
+          )
+        else
+          M=$(cat <<EOF
+          {
+            "env": [
+              { "NAME": "debian-sid",   "OS": "debian:sid"     }
+            ]
+          }
+        EOF
+          )
+        fi
+        echo ::set-output name=matrix::$M
+
+
   deb-build:
 
+    needs:
+      - set-matrix
+
     strategy:
-      matrix:
-        env:
-          - { NAME: "ubuntu-16.04", OS: "ubuntu:16.04" }
-          - { NAME: "ubuntu-18.04", OS: "ubuntu:18.04" }
-          - { NAME: "ubuntu-20.04", OS: "ubuntu:20.04" }
-          - { NAME: "debian-9",     OS: "debian:stretch" }
-          - { NAME: "debian-10",    OS: "debian:buster" }
-          - { NAME: "debian-sid",   OS: "debian:sid" }
+      matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
       fail-fast: false
 
     runs-on: ubuntu-latest
@@ -125,17 +163,11 @@ jobs:
   deb-test:
 
     needs:
+      - set-matrix
       - deb-build
 
     strategy:
-      matrix:
-        env:
-          - { NAME: "ubuntu-16.04", OS: "ubuntu:16.04" }
-          - { NAME: "ubuntu-18.04", OS: "ubuntu:18.04" }
-          - { NAME: "ubuntu-20.04", OS: "ubuntu:20.04" }
-          - { NAME: "debian-9", OS: "debian:stretch" }
-          - { NAME: "debian-10", OS: "debian:buster" }
-          - { NAME: "debian-sid", OS: "debian:sid" }
+      matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
       fail-fast: false
 
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-rpm.yml
+++ b/.github/workflows/ci-rpm.yml
@@ -2,21 +2,59 @@ name: CI RPM
 
 on:
   push:
-    branches:
-      - packaging_test
-      - ci-debug
   schedule:
     - cron: '0 20 * * *'
 
 jobs:
+
+  #
+  #  We don't want to consume many workers on each push so we only build the
+  #  full suite of distros during the scheduled or ci-debug run and just the
+  #  "bleeding-edge" distro on each push.
+  #
+  #  This job builds the matrix based on the event that trigger this run which
+  #  the next job consumes.
+  #
+  set-matrix:
+    name: Setup build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+    - id: set-matrix
+      name: Setup the matrix
+      run: |
+        if [ "$GITHUB_EVENT_NAME" = "schedule" -o "$GITHUB_REF" = "refs/heads/ci-debug" ]; then
+          M=$(cat <<EOF
+          {
+            "env": [
+              { "NAME": "centos-7", "OS": "centos:7"             },
+              { "NAME": "centos-8", "OS": "centos:8"             },
+              { "NAME": "fedora-rawhide", "OS": "fedora:rawhide" }
+            ]
+          }
+        EOF
+          )
+        else
+          M=$(cat <<EOF
+          {
+            "env": [
+              { "NAME": "fedora-rawhide", "OS": "fedora:rawhide" }
+            ]
+          }
+        EOF
+          )
+        fi
+        echo ::set-output name=matrix::$M
+
+
   rpm-build:
 
+    needs:
+      - set-matrix
+
     strategy:
-      matrix:
-        env:
-          - { NAME: "centos-7",  OS: "centos:7" }
-          - { NAME: "centos-8",  OS: "centos:8" }
-          - { NAME: "fedora-rawhide", OS: "fedora:rawhide" }
+      matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
       fail-fast: false
 
     runs-on: ubuntu-latest
@@ -153,14 +191,11 @@ jobs:
   rpm-test:
 
     needs:
+      - set-matrix
       - rpm-build
 
     strategy:
-      matrix:
-        env:
-          - { NAME: "centos-7", OS: "centos:7" }
-          - { NAME: "centos-8", OS: "centos:8" }
-          - { NAME: "fedora-rawhide", OS: "fedora:rawhide" }
+      matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
       fail-fast: false
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
GH now lets you build the matrix from job output so we can execute different plans on push vs on schedule.

This lets us perform package testing on each push without consuming lots of workers.

Typically all DEB or RPM distros either succeed together or fail together, so on push we just run a job for each of DEB and RPM using a bleeding-edge distro.