### PR TITLE
CI: Cache hostapd build directory to avoid unnecessary rebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ env:
   FR_GLOBAL_POOL: 4M
   TEST_CERTS: yes
   DO_BUILD: yes
+  HOSTAPD_BUILD_DIR: /tmp/hostapd.ci
+  HOSTAPD_GIT_TAG: hostap_2_8
   CI: 1
   GH_ACTIONS: 1
 
@@ -100,6 +102,14 @@ jobs:
     # Now the LFS pull will be local if we hit the cache, or remote otherwise
     - name: Git LFS pull
       run: git lfs pull
+
+    - name: Restore eapol_test build directory from cache
+      uses: actions/cache@v2
+      id: hostapd-cache
+      with:
+        path: ${{ env.HOSTAPD_BUILD_DIR }}
+        key: hostapd-${{ runner.os }}-${{ env.HOSTAPD_GIT_TAG }}-v3
+      if: ${{ matrix.env.TEST_TYPE != 'fuzzing' }}
 
     - name: Package manager performance improvements
       if: ${{ runner.os != 'macOS' }}

--- a/scripts/ci/eapol_test-build.sh
+++ b/scripts/ci/eapol_test-build.sh
@@ -31,6 +31,7 @@
 #  FORCE_BUILD=1 in the environment.
 #
 
+: ${BUILD_DIR:="${HOSTAPD_BUILD_DIR}"}
 TMP_BUILD_DIR="${BUILD_DIR}"
 : ${TMP_BUILD_DIR:="$(mktemp -d -t eapol_test.XXXXX)"}
 : ${HOSTAPD_DIR:="${TMP_BUILD_DIR}/hostapd"}
@@ -88,7 +89,7 @@ if ! [ -e "${HOSTAPD_DIR}/.git" ] && ! git clone --branch "${HOSTAPD_GIT_TAG}" -
     exit 1
 fi
 
-cp "$BUILD_CONF_FILE" "$WPA_SUPPLICANT_DIR/.config"
+cp -n "$BUILD_CONF_FILE" "$WPA_SUPPLICANT_DIR/.config"
 
 if ! ${MAKE} -C "${WPA_SUPPLICANT_DIR}" -j8 eapol_test 1>&2 || [ ! -e "${WPA_SUPPLICANT_DIR}/eapol_test" ]; then
     echo "Build error" 1>&2


### PR DESCRIPTION
Saves bandwidth and some build time in CI.