### PR TITLE
CI: Use CI- and distro-provided compiler packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,17 +166,13 @@ jobs:
     - name: Install LLVM 10
       if: ${{ matrix.env.CC == 'clang' && runner.os != 'macOS' }}
       run: |
-        . /etc/os-release
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add
-        sudo apt-add-repository "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-10 main"
         sudo apt-get install -y --no-install-recommends clang-10 llvm-10 gdb
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 60 && sudo update-alternatives --set clang /usr/bin/clang-10
         sudo update-alternatives --install /usr/bin/llvm-symbolizer llvm-symbolizer /usr/bin/llvm-symbolizer-10 60 && sudo update-alternatives --set llvm-symbolizer /usr/bin/llvm-symbolizer-10
 
-    - name: Install GCC 10
+    - name: Set compiler to GCC 10
       if: ${{ matrix.env.CC == 'gcc' }}
       run: |
-        sudo apt-get install -y --no-install-recommends gcc-10 gccgo-10 gdb
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60 && sudo update-alternatives --set gcc /usr/bin/gcc-10
 
     #


### PR DESCRIPTION
GCC 10 is already pre-installed in the environment.

Clang 10 is available in the local boinic-updates repo, so no need to download from often slow LLVM repo.