### PR TITLE
Add Vendor Centec

### DIFF
--- a/share/dictionary/radius/dictionary
+++ b/share/dictionary/radius/dictionary
@@ -165,6 +165,7 @@ $INCLUDE dictionary.bt
 $INCLUDE dictionary.cablelabs
 $INCLUDE dictionary.cabletron
 $INCLUDE dictionary.camiant
+$INCLUDE dictionary.centec
 $INCLUDE dictionary.checkpoint
 $INCLUDE dictionary.chillispot
 $INCLUDE dictionary.cisco
@@ -324,5 +325,6 @@ $INCLUDE dictionary.yubico
 $INCLUDE dictionary.zeus
 $INCLUDE dictionary.zte
 $INCLUDE dictionary.zyxel
+
 
 END-PROTOCOL RADIUS

--- a/share/dictionary/radius/dictionary.centec
+++ b/share/dictionary/radius/dictionary.centec
@@ -1,0 +1,18 @@
+# Copyright (C) 2019 The FreeRADIUS Server project and contributors
+# This work is licensed under CC-BY version 4.0 https://creativecommons.org/licenses/by/4.0
+#
+## Centec Packet RADIUS Dictionary
+#
+# http://www.centecnetworks.com
+#
+#
+
+VENDOR		Centec				27975
+BEGIN-VENDOR	Centec
+
+#
+# Centec Privilege Attributes
+#
+ATTRIBUTE	Centec-Exec-Privilege				1	integer
+
+END-VENDOR      Centec


### PR DESCRIPTION
Test：
root@6ea3cc76b3a0:/etc/freeradius/3.0# freeradius -X
FreeRADIUS Version 3.0.20
Copyright (C) 1999-2019 The FreeRADIUS server project and contributors
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE
You may redistribute copies of FreeRADIUS under the terms of the
GNU General Public License
For more information about these matters, see the file named COPYRIGHT
Starting - reading configuration files ...
including dictionary file /usr/share/freeradius/dictionary
including dictionary file /usr/share/freeradius/dictionary.dhcp
including dictionary file /usr/share/freeradius/dictionary.vqp
including dictionary file /etc/freeradius/3.0/dictionary
including configuration file /etc/freeradius/3.0/radiusd.conf
including configuration file /etc/freeradius/3.0/proxy.conf
including configuration file /etc/freeradius/3.0/clients.conf
including files in directory /etc/freeradius/3.0/mods-enabled/
including configuration file /etc/freeradius/3.0/mods-enabled/chap
including configuration file /etc/freeradius/3.0/mods-enabled/pap
including configuration file /etc/freeradius/3.0/mods-enabled/cache_eap
including configuration file /etc/freeradius/3.0/mods-enabled/utf8
including configuration file /etc/freeradius/3.0/mods-enabled/replicate
including configuration file /etc/freeradius/3.0/mods-enabled/logintime
including configuration file /etc/freeradius/3.0/mods-enabled/mschap
including configuration file /etc/freeradius/3.0/mods-enabled/detail
including configuration file /etc/freeradius/3.0/mods-enabled/always
including configuration file /etc/freeradius/3.0/mods-enabled/ntlm_auth
including configuration file /etc/freeradius/3.0/mods-enabled/echo
including configuration file /etc/freeradius/3.0/mods-enabled/soh
including configuration file /etc/freeradius/3.0/mods-enabled/unix
including configuration file /etc/freeradius/3.0/mods-enabled/exec
including configuration file /etc/freeradius/3.0/mods-enabled/dynamic_clients
including configuration file /etc/freeradius/3.0/mods-enabled/unpack
including configuration file /etc/freeradius/3.0/mods-enabled/passwd
including configuration file /etc/freeradius/3.0/mods-enabled/attr_filter
including configuration file /etc/freeradius/3.0/mods-enabled/sradutmp
including configuration file /etc/freeradius/3.0/mods-enabled/realm
including configuration file /etc/freeradius/3.0/mods-enabled/detail.log
including configuration file /etc/freeradius/3.0/mods-enabled/expiration
including configuration file /etc/freeradius/3.0/mods-enabled/radutmp
including configuration file /etc/freeradius/3.0/mods-enabled/linelog
including configuration file /etc/freeradius/3.0/mods-enabled/preprocess
including configuration file /etc/freeradius/3.0/mods-enabled/files
including configuration file /etc/freeradius/3.0/mods-enabled/expr
including configuration file /etc/freeradius/3.0/mods-enabled/digest
including configuration file /etc/freeradius/3.0/mods-enabled/eap
including files in directory /etc/freeradius/3.0/policy.d/
including configuration file /etc/freeradius/3.0/policy.d/abfab-tr
including configuration file /etc/freeradius/3.0/policy.d/moonshot-targeted-ids
including configuration file /etc/freeradius/3.0/policy.d/debug
including configuration file /etc/freeradius/3.0/policy.d/canonicalization
including configuration file /etc/freeradius/3.0/policy.d/filter
including configuration file /etc/freeradius/3.0/policy.d/cui
including configuration file /etc/freeradius/3.0/policy.d/rfc7542
including configuration file /etc/freeradius/3.0/policy.d/operator-name
including configuration file /etc/freeradius/3.0/policy.d/accounting
including configuration file /etc/freeradius/3.0/policy.d/dhcp
including configuration file /etc/freeradius/3.0/policy.d/control
including configuration file /etc/freeradius/3.0/policy.d/eap
including files in directory /etc/freeradius/3.0/sites-enabled/
including configuration file /etc/freeradius/3.0/sites-enabled/inner-tunnel
including configuration file /etc/freeradius/3.0/sites-enabled/default
main {
 security {
        user = "freerad"
        group = "freerad"
        allow_core_dumps = no
 }
        name = "freeradius"
        prefix = "/usr"
        localstatedir = "/var"
        logdir = "/var/log/freeradius"
        run_dir = "/var/run/freeradius"
}
main {
        name = "freeradius"
        prefix = "/usr"
        localstatedir = "/var"
        sbindir = "/usr/sbin"
        logdir = "/var/log/freeradius"
        run_dir = "/var/run/freeradius"
        libdir = "/usr/lib/freeradius"
        radacctdir = "/var/log/freeradius/radacct"
        hostname_lookups = no
        max_request_time = 30
        cleanup_delay = 5
        max_requests = 16384
        pidfile = "/var/run/freeradius/freeradius.pid"
        checkrad = "/usr/sbin/checkrad"
        debug_level = 0
        proxy_requests = yes
 log {
        stripped_names = no
        auth = no
        auth_badpass = no
        auth_goodpass = no
        colourise = yes
        msg_denied = "You are already logged in - access denied"
 }
 resources {
 }
 security {
        max_attributes = 200
        reject_delay = 1.000000
        status_server = yes
 }
}
radiusd: #### Loading Realms and Home Servers ####
 proxy server {
        retry_delay = 5
        retry_count = 3
        default_fallback = no
        dead_time = 120
        wake_all_if_all_dead = no
 }
 home_server localhost {
        ipaddr = 127.0.0.1
        port = 1812
        type = "auth"
        secret = <<< secret >>>
        response_window = 20.000000
        response_timeouts = 1
        max_outstanding = 65536
        zombie_period = 40
        status_check = "status-server"
        ping_interval = 30
        check_interval = 30
        check_timeout = 4
        num_answers_to_alive = 3
        revive_interval = 120
  limit {
        max_connections = 16
        max_requests = 0
        lifetime = 0
        idle_timeout = 0
  }
  coa {
        irt = 2
        mrt = 16
        mrc = 5
        mrd = 30
  }
 }
 home_server_pool my_auth_failover {
        type = fail-over
        home_server = localhost
 }
 realm example.com {
        auth_pool = my_auth_failover
 }
 realm LOCAL {
 }
radiusd: #### Loading Clients ####
 client localhost {
        ipaddr = 127.0.0.1
        require_message_authenticator = no
        secret = <<< secret >>>
        nas_type = "other"
        proto = "*"
  limit {
        max_connections = 16
        lifetime = 0
        idle_timeout = 30
  }
 }
 client localhost_ipv6 {
        ipv6addr = ::1
        require_message_authenticator = no
        secret = <<< secret >>>
  limit {
        max_connections = 16
        lifetime = 0
        idle_timeout = 30
  }
 }
Debug state unknown (cap_sys_ptrace capability not set)
systemd watchdog is disabled
 # Creating Auth-Type = mschap
 # Creating Auth-Type = eap
 # Creating Auth-Type = PAP
 # Creating Auth-Type = CHAP
 # Creating Auth-Type = MS-CHAP
 # Creating Auth-Type = digest
radiusd: #### Instantiating modules ####
 modules {
  # Loaded module rlm_chap
  # Loading module "chap" from file /etc/freeradius/3.0/mods-enabled/chap
  # Loaded module rlm_pap
  # Loading module "pap" from file /etc/freeradius/3.0/mods-enabled/pap
  pap {
        normalise = yes
  }
  # Loaded module rlm_cache
  # Loading module "cache_eap" from file /etc/freeradius/3.0/mods-enabled/cache_eap
  cache cache_eap {
        driver = "rlm_cache_rbtree"
        key = "%{%{control:State}:-%{%{reply:State}:-%{State}}}"
        ttl = 15
        max_entries = 0
        epoch = 0
        add_stats = no
  }
  # Loaded module rlm_utf8
  # Loading module "utf8" from file /etc/freeradius/3.0/mods-enabled/utf8
  # Loaded module rlm_replicate
  # Loading module "replicate" from file /etc/freeradius/3.0/mods-enabled/replicate
  # Loaded module rlm_logintime
  # Loading module "logintime" from file /etc/freeradius/3.0/mods-enabled/logintime
  logintime {
        minimum_timeout = 60
  }
  # Loaded module rlm_mschap
  # Loading module "mschap" from file /etc/freeradius/3.0/mods-enabled/mschap
  mschap {
        use_mppe = yes
        require_encryption = no
        require_strong = no
        with_ntdomain_hack = yes
   passchange {
   }
        allow_retry = yes
        winbind_retry_with_normalised_username = no
  }
  # Loaded module rlm_detail
  # Loading module "detail" from file /etc/freeradius/3.0/mods-enabled/detail
  detail {
        filename = "/var/log/freeradius/radacct/%{%{Packet-Src-IP-Address}:-%{Packet-Src-IPv6-Address}}/detail-%Y%m%d"
        header = "%t"
        permissions = 384
        locking = no
        escape_filenames = no
        log_packet_header = no
  }
  # Loaded module rlm_always
  # Loading module "reject" from file /etc/freeradius/3.0/mods-enabled/always
  always reject {
        rcode = "reject"
        simulcount = 0
        mpp = no
  }
  # Loading module "fail" from file /etc/freeradius/3.0/mods-enabled/always
  always fail {
        rcode = "fail"
        simulcount = 0
        mpp = no
  }
  # Loading module "ok" from file /etc/freeradius/3.0/mods-enabled/always
  always ok {
        rcode = "ok"
        simulcount = 0
        mpp = no
  }
  # Loading module "handled" from file /etc/freeradius/3.0/mods-enabled/always
  always handled {
        rcode = "handled"
        simulcount = 0
        mpp = no
  }
  # Loading module "invalid" from file /etc/freeradius/3.0/mods-enabled/always
  always invalid {
        rcode = "invalid"
        simulcount = 0
        mpp = no
  }
  # Loading module "userlock" from file /etc/freeradius/3.0/mods-enabled/always
  always userlock {
        rcode = "userlock"
        simulcount = 0
        mpp = no
  }
  # Loading module "notfound" from file /etc/freeradius/3.0/mods-enabled/always
  always notfound {
        rcode = "notfound"
        simulcount = 0
        mpp = no
  }
  # Loading module "noop" from file /etc/freeradius/3.0/mods-enabled/always
  always noop {
        rcode = "noop"
        simulcount = 0
        mpp = no
  }
  # Loading module "updated" from file /etc/freeradius/3.0/mods-enabled/always
  always updated {
        rcode = "updated"
        simulcount = 0
        mpp = no
  }
  # Loaded module rlm_exec
  # Loading module "ntlm_auth" from file /etc/freeradius/3.0/mods-enabled/ntlm_auth
  exec ntlm_auth {
        wait = yes
        program = "/path/to/ntlm_auth --request-nt-key --domain=MYDOMAIN --username=%{mschap:User-Name} --password=%{User-Password}"
        shell_escape = yes
  }
  # Loading module "echo" from file /etc/freeradius/3.0/mods-enabled/echo
  exec echo {
        wait = yes
        program = "/bin/echo %{User-Name}"
        input_pairs = "request"
        output_pairs = "reply"
        shell_escape = yes
  }
  # Loaded module rlm_soh
  # Loading module "soh" from file /etc/freeradius/3.0/mods-enabled/soh
  soh {
        dhcp = yes
  }
  # Loaded module rlm_unix
  # Loading module "unix" from file /etc/freeradius/3.0/mods-enabled/unix
  unix {
        radwtmp = "/var/log/freeradius/radwtmp"
  }
Creating attribute Unix-Group
  # Loading module "exec" from file /etc/freeradius/3.0/mods-enabled/exec
  exec {
        wait = no
        input_pairs = "request"
        shell_escape = yes
        timeout = 10
  }
  # Loaded module rlm_dynamic_clients
  # Loading module "dynamic_clients" from file /etc/freeradius/3.0/mods-enabled/dynamic_clients
  # Loaded module rlm_unpack
  # Loading module "unpack" from file /etc/freeradius/3.0/mods-enabled/unpack
  # Loaded module rlm_passwd
  # Loading module "etc_passwd" from file /etc/freeradius/3.0/mods-enabled/passwd
  passwd etc_passwd {
        filename = "/etc/passwd"
        format = "*User-Name:Crypt-Password:"
        delimiter = ":"
        ignore_nislike = no
        ignore_empty = yes
        allow_multiple_keys = no
        hash_size = 100
  }
  # Loaded module rlm_attr_filter
  # Loading module "attr_filter.post-proxy" from file /etc/freeradius/3.0/mods-enabled/attr_filter
  attr_filter attr_filter.post-proxy {
        filename = "/etc/freeradius/3.0/mods-config/attr_filter/post-proxy"
        key = "%{Realm}"
        relaxed = no
  }
  # Loading module "attr_filter.pre-proxy" from file /etc/freeradius/3.0/mods-enabled/attr_filter
  attr_filter attr_filter.pre-proxy {
        filename = "/etc/freeradius/3.0/mods-config/attr_filter/pre-proxy"
        key = "%{Realm}"
        relaxed = no
  }
  # Loading module "attr_filter.access_reject" from file /etc/freeradius/3.0/mods-enabled/attr_filter
  attr_filter attr_filter.access_reject {
        filename = "/etc/freeradius/3.0/mods-config/attr_filter/access_reject"
        key = "%{User-Name}"
        relaxed = no
  }
  # Loading module "attr_filter.access_challenge" from file /etc/freeradius/3.0/mods-enabled/attr_filter
  attr_filter attr_filter.access_challenge {
        filename = "/etc/freeradius/3.0/mods-config/attr_filter/access_challenge"
        key = "%{User-Name}"
        relaxed = no
  }
  # Loading module "attr_filter.accounting_response" from file /etc/freeradius/3.0/mods-enabled/attr_filter
  attr_filter attr_filter.accounting_response {
        filename = "/etc/freeradius/3.0/mods-config/attr_filter/accounting_response"
        key = "%{User-Name}"
        relaxed = no
  }
  # Loaded module rlm_radutmp
  # Loading module "sradutmp" from file /etc/freeradius/3.0/mods-enabled/sradutmp
  radutmp sradutmp {
        filename = "/var/log/freeradius/sradutmp"
        username = "%{User-Name}"
        case_sensitive = yes
        check_with_nas = yes
        permissions = 420
        caller_id = no
  }
  # Loaded module rlm_realm
  # Loading module "IPASS" from file /etc/freeradius/3.0/mods-enabled/realm
  realm IPASS {
        format = "prefix"
        delimiter = "/"
        ignore_default = no
        ignore_null = no
  }
  # Loading module "suffix" from file /etc/freeradius/3.0/mods-enabled/realm
  realm suffix {
        format = "suffix"
        delimiter = "@"
        ignore_default = no
        ignore_null = no
  }
  # Loading module "bangpath" from file /etc/freeradius/3.0/mods-enabled/realm
  realm bangpath {
        format = "prefix"
        delimiter = "!"
        ignore_default = no
        ignore_null = no
  }
  # Loading module "realmpercent" from file /etc/freeradius/3.0/mods-enabled/realm
  realm realmpercent {
        format = "suffix"
        delimiter = "%"
        ignore_default = no
        ignore_null = no
  }
  # Loading module "ntdomain" from file /etc/freeradius/3.0/mods-enabled/realm
  realm ntdomain {
        format = "prefix"
        delimiter = "\\"
        ignore_default = no
        ignore_null = no
  }
  # Loading module "auth_log" from file /etc/freeradius/3.0/mods-enabled/detail.log
  detail auth_log {
        filename = "/var/log/freeradius/radacct/%{%{Packet-Src-IP-Address}:-%{Packet-Src-IPv6-Address}}/auth-detail-%Y%m%d"
        header = "%t"
        permissions = 384
        locking = no
        escape_filenames = no
        log_packet_header = no
  }
  # Loading module "reply_log" from file /etc/freeradius/3.0/mods-enabled/detail.log
  detail reply_log {
        filename = "/var/log/freeradius/radacct/%{%{Packet-Src-IP-Address}:-%{Packet-Src-IPv6-Address}}/reply-detail-%Y%m%d"
        header = "%t"
        permissions = 384
        locking = no
        escape_filenames = no
        log_packet_header = no
  }
  # Loading module "pre_proxy_log" from file /etc/freeradius/3.0/mods-enabled/detail.log
  detail pre_proxy_log {
        filename = "/var/log/freeradius/radacct/%{%{Packet-Src-IP-Address}:-%{Packet-Src-IPv6-Address}}/pre-proxy-detail-%Y%m%d"
        header = "%t"
        permissions = 384
        locking = no
        escape_filenames = no
        log_packet_header = no
  }
  # Loading module "post_proxy_log" from file /etc/freeradius/3.0/mods-enabled/detail.log
  detail post_proxy_log {
        filename = "/var/log/freeradius/radacct/%{%{Packet-Src-IP-Address}:-%{Packet-Src-IPv6-Address}}/post-proxy-detail-%Y%m%d"
        header = "%t"
        permissions = 384
        locking = no
        escape_filenames = no
        log_packet_header = no
  }
  # Loaded module rlm_expiration
  # Loading module "expiration" from file /etc/freeradius/3.0/mods-enabled/expiration
  # Loading module "radutmp" from file /etc/freeradius/3.0/mods-enabled/radutmp
  radutmp {
        filename = "/var/log/freeradius/radutmp"
        username = "%{User-Name}"
        case_sensitive = yes
        check_with_nas = yes
        permissions = 384
        caller_id = yes
  }
  # Loaded module rlm_linelog
  # Loading module "linelog" from file /etc/freeradius/3.0/mods-enabled/linelog
  linelog {
        filename = "/var/log/freeradius/linelog"
        escape_filenames = no
        syslog_severity = "info"
        permissions = 384
        format = "This is a log message for %{User-Name}"
        reference = "messages.%{%{reply:Packet-Type}:-default}"
  }
  # Loading module "log_accounting" from file /etc/freeradius/3.0/mods-enabled/linelog
  linelog log_accounting {
        filename = "/var/log/freeradius/linelog-accounting"
        escape_filenames = no
        syslog_severity = "info"
        permissions = 384
        format = ""
        reference = "Accounting-Request.%{%{Acct-Status-Type}:-unknown}"
  }
  # Loaded module rlm_preprocess
  # Loading module "preprocess" from file /etc/freeradius/3.0/mods-enabled/preprocess
  preprocess {
        huntgroups = "/etc/freeradius/3.0/mods-config/preprocess/huntgroups"
        hints = "/etc/freeradius/3.0/mods-config/preprocess/hints"
        with_ascend_hack = no
        ascend_channels_per_line = 23
        with_ntdomain_hack = no
        with_specialix_jetstream_hack = no
        with_cisco_vsa_hack = no
        with_alvarion_vsa_hack = no
  }
  # Loaded module rlm_files
  # Loading module "files" from file /etc/freeradius/3.0/mods-enabled/files
  files {
        filename = "/etc/freeradius/3.0/mods-config/files/authorize"
        acctusersfile = "/etc/freeradius/3.0/mods-config/files/accounting"
        preproxy_usersfile = "/etc/freeradius/3.0/mods-config/files/pre-proxy"
  }
  # Loaded module rlm_expr
  # Loading module "expr" from file /etc/freeradius/3.0/mods-enabled/expr
  expr {
        safe_characters = "@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_: /äéöüàâæçèéêëîïôœùûüaÿÄÉÖÜßÀÂÆÇÈÉÊËÎÏÔŒÙÛÜŸ"
  }
  # Loaded module rlm_digest
  # Loading module "digest" from file /etc/freeradius/3.0/mods-enabled/digest
  # Loaded module rlm_eap
  # Loading module "eap" from file /etc/freeradius/3.0/mods-enabled/eap
  eap {
        default_eap_type = "md5"
        timer_expire = 60
        ignore_unknown_eap_types = no
        cisco_accounting_username_bug = no
        max_sessions = 16384
  }
  instantiate {
  }
  # Instantiating module "pap" from file /etc/freeradius/3.0/mods-enabled/pap
  # Instantiating module "cache_eap" from file /etc/freeradius/3.0/mods-enabled/cache_eap
rlm_cache (cache_eap): Driver rlm_cache_rbtree (module rlm_cache_rbtree) loaded and linked
  # Instantiating module "logintime" from file /etc/freeradius/3.0/mods-enabled/logintime
  # Instantiating module "mschap" from file /etc/freeradius/3.0/mods-enabled/mschap
rlm_mschap (mschap): using internal authentication
  # Instantiating module "detail" from file /etc/freeradius/3.0/mods-enabled/detail
  # Instantiating module "reject" from file /etc/freeradius/3.0/mods-enabled/always
  # Instantiating module "fail" from file /etc/freeradius/3.0/mods-enabled/always
  # Instantiating module "ok" from file /etc/freeradius/3.0/mods-enabled/always
  # Instantiating module "handled" from file /etc/freeradius/3.0/mods-enabled/always
  # Instantiating module "invalid" from file /etc/freeradius/3.0/mods-enabled/always
  # Instantiating module "userlock" from file /etc/freeradius/3.0/mods-enabled/always
  # Instantiating module "notfound" from file /etc/freeradius/3.0/mods-enabled/always
  # Instantiating module "noop" from file /etc/freeradius/3.0/mods-enabled/always
  # Instantiating module "updated" from file /etc/freeradius/3.0/mods-enabled/always
  # Instantiating module "etc_passwd" from file /etc/freeradius/3.0/mods-enabled/passwd
rlm_passwd: nfields: 3 keyfield 0(User-Name) listable: no
  # Instantiating module "attr_filter.post-proxy" from file /etc/freeradius/3.0/mods-enabled/attr_filter
reading pairlist file /etc/freeradius/3.0/mods-config/attr_filter/post-proxy
  # Instantiating module "attr_filter.pre-proxy" from file /etc/freeradius/3.0/mods-enabled/attr_filter
reading pairlist file /etc/freeradius/3.0/mods-config/attr_filter/pre-proxy
  # Instantiating module "attr_filter.access_reject" from file /etc/freeradius/3.0/mods-enabled/attr_filter
reading pairlist file /etc/freeradius/3.0/mods-config/attr_filter/access_reject
  # Instantiating module "attr_filter.access_challenge" from file /etc/freeradius/3.0/mods-enabled/attr_filter
reading pairlist file /etc/freeradius/3.0/mods-config/attr_filter/access_challenge
  # Instantiating module "attr_filter.accounting_response" from file /etc/freeradius/3.0/mods-enabled/attr_filter
reading pairlist file /etc/freeradius/3.0/mods-config/attr_filter/accounting_response
  # Instantiating module "IPASS" from file /etc/freeradius/3.0/mods-enabled/realm
  # Instantiating module "suffix" from file /etc/freeradius/3.0/mods-enabled/realm
  # Instantiating module "bangpath" from file /etc/freeradius/3.0/mods-enabled/realm
  # Instantiating module "realmpercent" from file /etc/freeradius/3.0/mods-enabled/realm
  # Instantiating module "ntdomain" from file /etc/freeradius/3.0/mods-enabled/realm
  # Instantiating module "auth_log" from file /etc/freeradius/3.0/mods-enabled/detail.log
rlm_detail (auth_log): 'User-Password' suppressed, will not appear in detail output
  # Instantiating module "reply_log" from file /etc/freeradius/3.0/mods-enabled/detail.log
  # Instantiating module "pre_proxy_log" from file /etc/freeradius/3.0/mods-enabled/detail.log
  # Instantiating module "post_proxy_log" from file /etc/freeradius/3.0/mods-enabled/detail.log
  # Instantiating module "expiration" from file /etc/freeradius/3.0/mods-enabled/expiration
  # Instantiating module "linelog" from file /etc/freeradius/3.0/mods-enabled/linelog
  # Instantiating module "log_accounting" from file /etc/freeradius/3.0/mods-enabled/linelog
  # Instantiating module "preprocess" from file /etc/freeradius/3.0/mods-enabled/preprocess
reading pairlist file /etc/freeradius/3.0/mods-config/preprocess/huntgroups
reading pairlist file /etc/freeradius/3.0/mods-config/preprocess/hints
  # Instantiating module "files" from file /etc/freeradius/3.0/mods-enabled/files
reading pairlist file /etc/freeradius/3.0/mods-config/files/authorize
reading pairlist file /etc/freeradius/3.0/mods-config/files/accounting
reading pairlist file /etc/freeradius/3.0/mods-config/files/pre-proxy
  # Instantiating module "eap" from file /etc/freeradius/3.0/mods-enabled/eap
   # Linked to sub-module rlm_eap_md5
   # Linked to sub-module rlm_eap_leap
   # Linked to sub-module rlm_eap_gtc
   gtc {
        challenge = "Password: "
        auth_type = "PAP"
   }
   # Linked to sub-module rlm_eap_tls
   tls {
        tls = "tls-common"
   }
   tls-config tls-common {
        verify_depth = 0
        ca_path = "/etc/freeradius/3.0/certs"
        pem_file_type = yes
        private_key_file = "/etc/ssl/private/ssl-cert-snakeoil.key"
        certificate_file = "/etc/ssl/certs/ssl-cert-snakeoil.pem"
        ca_file = "/etc/ssl/certs/ca-certificates.crt"
        private_key_password = <<< secret >>>
        dh_file = "/etc/freeradius/3.0/certs/dh"
        fragment_size = 1024
        include_length = yes
        auto_chain = yes
        check_crl = no
        check_all_crl = no
        cipher_list = "DEFAULT"
        cipher_server_preference = no
        ecdh_curve = "prime256v1"
        disable_tlsv1 = yes
        disable_tlsv1_1 = yes
        tls_max_version = "1.2"
        tls_min_version = "1.2"
    cache {
        enable = no
        lifetime = 24
        max_entries = 255
    }
    verify {
        skip_if_ocsp_ok = no
    }
    ocsp {
        enable = no
        override_cert_url = yes
        url = "http://127.0.0.1/ocsp/"
        use_nonce = yes
        timeout = 0
        softfail = no
    }
   }
Please use tls_min_version and tls_max_version instead of disable_tlsv1
Please use tls_min_version and tls_max_version instead of disable_tlsv1_2
   # Linked to sub-module rlm_eap_ttls
   ttls {
        tls = "tls-common"
        default_eap_type = "md5"
        copy_request_to_tunnel = no
        use_tunneled_reply = no
        virtual_server = "inner-tunnel"
        include_length = yes
        require_client_cert = no
   }
tls: Using cached TLS configuration from previous invocation
   # Linked to sub-module rlm_eap_peap
   peap {
        tls = "tls-common"
        default_eap_type = "mschapv2"
        copy_request_to_tunnel = no
        use_tunneled_reply = no
        proxy_tunneled_request_as_eap = yes
        virtual_server = "inner-tunnel"
        soh = no
        require_client_cert = no
   }
tls: Using cached TLS configuration from previous invocation
   # Linked to sub-module rlm_eap_mschapv2
   mschapv2 {
        with_ntdomain_hack = no
        send_error = no
   }
 } # modules
radiusd: #### Loading Virtual Servers ####
server { # from file /etc/freeradius/3.0/radiusd.conf
} # server
server inner-tunnel { # from file /etc/freeradius/3.0/sites-enabled/inner-tunnel
 # Loading authenticate {...}
 # Loading authorize {...}
Ignoring "sql" (see raddb/mods-available/README.rst)
Ignoring "ldap" (see raddb/mods-available/README.rst)
 # Loading session {...}
 # Loading post-proxy {...}
 # Loading post-auth {...}
 # Skipping contents of 'if' as it is always 'false' -- /etc/freeradius/3.0/sites-enabled/inner-tunnel:336
} # server inner-tunnel
server default { # from file /etc/freeradius/3.0/sites-enabled/default
 # Loading authenticate {...}
 # Loading authorize {...}
 # Loading preacct {...}
 # Loading accounting {...}
 # Loading post-proxy {...}
 # Loading post-auth {...}
} # server default
radiusd: #### Opening IP addresses and Ports ####
listen {
        type = "auth"
        ipaddr = 127.0.0.1
        port = 18120
}
listen {
        type = "auth"
        ipaddr = *
        port = 0
   limit {
        max_connections = 16
        lifetime = 0
        idle_timeout = 30
   }
}
listen {
        type = "acct"
        ipaddr = *
        port = 0
   limit {
        max_connections = 16
        lifetime = 0
        idle_timeout = 30
   }
}
listen {
        type = "auth"
        ipv6addr = ::
        port = 0
   limit {
        max_connections = 16
        lifetime = 0
        idle_timeout = 30
   }
}
listen {
        type = "acct"
        ipv6addr = ::
        port = 0
   limit {
        max_connections = 16
        lifetime = 0
        idle_timeout = 30
   }
}
Listening on auth address 127.0.0.1 port 18120 bound to server inner-tunnel
Listening on auth address * port 1812 bound to server default
Listening on acct address * port 1813 bound to server default
Listening on auth address :: port 1812 bound to server default
Listening on acct address :: port 1813 bound to server default
Listening on proxy address * port 53834
Listening on proxy address :: port 34152
Ready to process requests

-----
root@6ea3cc76b3a0:/# radtest jinl admin 127.0.0.1 0 testing123
Sent Access-Request Id 43 from 0.0.0.0:52780 to 127.0.0.1:1812 length 74
        User-Name = "jinl"
        User-Password = "admin"
        NAS-IP-Address = 172.17.0.10
        NAS-Port = 0
        Message-Authenticator = 0x00
        Cleartext-Password = "admin"
Received Access-Accept Id 43 from 127.0.0.1:1812 to 127.0.0.1:52780 length 32
        Centec-Exec-Privilege = 15
root@6ea3cc76b3a0:/#
