### PR TITLE
bootstrap: check existence of openssl's commands

### DIFF
--- a/raddb/certs/bootstrap
+++ b/raddb/certs/bootstrap
@@ -14,6 +14,14 @@ umask 027
 cd "$(dirname "$0")" || exit 1
 
 
+#  check commands of openssl exist
+for cmd in dhparam pkcs12; do
+	if ! openssl ${cmd} -help >/dev/null 2>&1; then
+		echo "Error: command ${cmd} is not supported by openssl."
+		exit 1
+	fi
+done
+
 #
 #  If we have a working "make", then use it.  Otherwise, run the commands
 #  manually.


### PR DESCRIPTION
It calls openssl's commands 'dhparam' and 'pkcs12' in script bootstrap                                                                                                       
which are configurable based on openssl configure options 'no-dh' and 
'no-des'. So check existence of these commands. If not exist, abort from
running of the script.

1. https://github.com/openssl/openssl/blob/master/apps/build.info#L37
2. https://github.com/openssl/openssl/blob/master/apps/build.info#L22

Signed-off-by: Kai Kang <kai.kang@windriver.com>