### PR TITLE
Updating Aruba dict with VSA used in Aruba C2C product

### DIFF
--- a/share/dictionary/radius/dictionary.aruba
+++ b/share/dictionary/radius/dictionary.aruba
@@ -71,6 +71,9 @@ ATTRIBUTE	STP-Admin-Edge-Port			58	integer
 
 ATTRIBUTE	UBT-Gateway-CPPM-Role			59	string
 
+ATTRIBUTE  	Aruba-AP-MAC-Address        		60      string
+ATTRIBUTE  	Aruba-Device-MAC-Address    		61      string
+
 VALUE	AirGroup-Device-Type		Personal-Device		1
 VALUE	AirGroup-Device-Type		Shared-Device		2
 VALUE	AirGroup-Device-Type		Deleted-Device		3


### PR DESCRIPTION
Adding two new aruba VSA for Aruba's campus-to-cloud (C2C) environment. 