### PR TITLE
Fix duplicated index names

### DIFF
--- a/raddb/mods-config/sql/main/sqlite/schema.sql
+++ b/raddb/mods-config/sql/main/sqlite/schema.sql
@@ -136,8 +136,8 @@ CREATE TABLE IF NOT EXISTS radpostauth (
 	authdate timestamp NOT NULL,
 	class varchar(64) default NULL
 );
-CREATE INDEX username ON radpostauth(username);
-CREATE INDEX class ON radpostauth(class);
+CREATE INDEX radpostauth_username ON radpostauth(username);
+CREATE INDEX radpostauth_class ON radpostauth(class);
 
 --
 -- Table structure for table 'nas'


### PR DESCRIPTION
It fixes the below errors:

```
Error: near line 139: index username already exists
Error: near line 140: index class already exists
```

Due to existing others `INDEX` with the same name.