### PR TITLE
Only one declaration for fr_tls_session_async_handshake()

### DIFF
--- a/src/lib/tls/base-h
+++ b/src/lib/tls/base-h
@@ -495,8 +495,6 @@ unlang_action_t fr_tls_session_async_handshake(rlm_rcode_t *p_result, int *prior
 
 int 		fr_tls_session_alert(request_t *request, fr_tls_session_t *tls_session, uint8_t level, uint8_t description);
 
-unlang_action_t fr_tls_session_async_handshake(request_t *request, fr_tls_session_t *session);
-
 fr_tls_session_t *fr_tls_session_init_client(TALLOC_CTX *ctx, fr_tls_conf_t *conf);
 
 fr_tls_session_t *fr_tls_session_init_server(TALLOC_CTX *ctx, fr_tls_conf_t *conf, request_t *request, bool client_cert);


### PR DESCRIPTION
Removed the one inconsistent with uses.