### PR TITLE
NetworkOnly value for APC-Service-Type

### DIFF
--- a/share/dictionary/radius/dictionary.apc
+++ b/share/dictionary/radius/dictionary.apc
@@ -37,5 +37,6 @@ VALUE	Service-Type			Device			2
 VALUE	Service-Type			ReadOnly		3
 VALUE	Service-Type			Outlet			4
 VALUE	Service-Type			Card			5
+VALUE Service-Type      NetworkOnly 6
 
 END-VENDOR APC


### PR DESCRIPTION
Herewith we would like to propose the following amendment to the APC dictionary as per:
https://www.apc.com/us/en/faqs/FA156083/ .