### PR TITLE
Tentative: Nightly pkgs: Build only on distros that satisfy JSON-C >= 1.13

### DIFF
--- a/.github/workflows/ci-deb.yml
+++ b/.github/workflows/ci-deb.yml
@@ -31,10 +31,7 @@ jobs:
           M=$(cat <<EOF
           {
             "env": [
-              { "NAME": "ubuntu-18.04", "OS": "ubuntu:18.04"   },
               { "NAME": "ubuntu-20.04", "OS": "ubuntu:20.04"   },
-              { "NAME": "debian-9",     "OS": "debian:stretch" },
-              { "NAME": "debian-10",    "OS": "debian:buster"  },
               { "NAME": "debian-sid",   "OS": "debian:sid"     }
             ]
           }

--- a/.github/workflows/ci-rpm.yml
+++ b/.github/workflows/ci-rpm.yml
@@ -28,7 +28,6 @@ jobs:
           M=$(cat <<EOF
           {
             "env": [
-              { "NAME": "centos-7", "OS": "centos:7"             },
               { "NAME": "centos-8", "OS": "centos:8"             },
               { "NAME": "fedora-rawhide", "OS": "fedora:rawhide" }
             ]


### PR DESCRIPTION
The current JSON-C version requirement is only satisfied by CentOS >= 8,
Ubuntu >= 20.04 and Debian >= Bullseye (testing).

Building on earlier distros would require that we maintain a local
JSON-C package.

So we remove these builds for now to reduce noise...