### PR TITLE
debug: don't set resource hard limit to zero

### DIFF
--- a/src/lib/debug.c
+++ b/src/lib/debug.c
@@ -599,7 +599,7 @@ int fr_set_dumpable(bool allow_core_dumps)
 		struct rlimit no_core;
 
 		no_core.rlim_cur = 0;
-		no_core.rlim_max = 0;
+		no_core.rlim_max = core_limits.rlim_max;
 
 		if (setrlimit(RLIMIT_CORE, &no_core) < 0) {
 			fr_strerror_printf("Failed disabling core dumps: %s", fr_syserror(errno));


### PR DESCRIPTION
Setting the resource hard limit to zero is irreversible, meaning if it
is set to zero then there is no way to set it higher. This means
enabling core dump is not possible, since setting a new resource limit
for RLIMIT_CORE would fail. By only setting the soft limit to zero, we
can disable and enable core dumps without failures.

Ticket in RHEL Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1977572
Signed-off-by: Antonio Torres <antorres@redhat.com>