### PR TITLE
Fix chunked rlm_rest HTTP body

### DIFF
--- a/raddb/mods-available/rest
+++ b/raddb/mods-available/rest
@@ -90,6 +90,11 @@ rest {
 	#    password     - Password to use for authentication, will be expanded.
 	#    require_auth - Require HTTP authentication.
 	#    timeout      - HTTP request timeout in seconds, defaults to 4.0.
+	#    chunk        - Chunk size to use. If set, HTTP chunked encoding is used to
+	#                   send data to the REST server. Make sure that this is large
+	#                   enough to fit your largest attribute value's text
+	#                   representation.
+	#                   A number like 8192 is good.
 	#
 	#  Additional HTTP headers may be specified with control:REST-HTTP-Header.
 	#  The values of those attributes should be in the format:

--- a/src/modules/rlm_rest/rest.h
+++ b/src/modules/rlm_rest/rest.h
@@ -221,6 +221,8 @@ typedef struct rlm_rest_request_t {
 
 	size_t			chunk;		//!< Chunk size
 
+	rlm_rest_section_t *section;	//!< Configuration data
+
 	void			*encoder;	//!< Encoder specific data.
 } rlm_rest_request_t;
 
@@ -271,7 +273,7 @@ typedef struct rlm_rest_handle_t {
  *	CURLOPT_READFUNCTION prototype.
  */
 typedef size_t (*rest_read_t)(void *ptr, size_t size, size_t nmemb,
-			      void *userdata, rlm_rest_section_t *section);
+			      void *userdata);
 
 /*
  *	Connection API callbacks


### PR DESCRIPTION
Re. #4130.

This fixes rlm_rest's somewhat hidden chunked encoding HTTP feature, which stopped working in #3810.

Additionally, this documents the chunk config parameter.


I've tested this fairly well, I think - however raw_value doesn't seem to do anything for me - even before I made my changes, so I can't really validate that this still works.
In my environment, the value param is always the raw integer value - i.e. Acct-Status-Type in the JSON is always a number, and never "Start" or "Stop" or what not. My understanding is that `raw_value = yes` should make this be the case, but it always seems to be for me, so not sure what's going on there. I didn't even realise it should be translating it for me, so didn't know what I was missing until reading what `raw_value` is supposed to do !