### PR TITLE
Removed the ability to pass NULL as data argument to fr_heap_extract().

### DIFF
--- a/src/lib/util/heap.c
+++ b/src/lib/util/heap.c
@@ -214,30 +214,22 @@ int fr_heap_extract(fr_heap_t *hp, void *data)
 	int32_t parent, child, max;
 
 	/*
-	 *	Extract element.  Default is the first one (pop)
+	 *	Extract element.
 	 */
-	if (!data) {
-		if (unlikely((hp->num_elements == 0) || !hp->p[0])) {
-			fr_strerror_const("Tried to extract element from empty heap");
-			return -1;
-		}
-		parent = 0;
-	} else {		/* extract from the middle */
-		parent = index_get(hp, data);
+	parent = index_get(hp, data);
 
-		/*
-		 *	Out of bounds.
-		 */
-		if (unlikely((parent < 0) || (parent >= hp->num_elements))) {
-			fr_strerror_printf("Heap parent (%i) out of bounds (0-%i)", parent, hp->num_elements);
-			return -1;
-		}
+	/*
+	 *	Out of bounds.
+	 */
+	if (unlikely((parent < 0) || (parent >= hp->num_elements))) {
+		fr_strerror_printf("Heap parent (%i) out of bounds (0-%i)", parent, hp->num_elements);
+		return -1;
+	}
 
-		if (unlikely(data != hp->p[parent])) {
-			fr_strerror_printf("Invalid heap index.  Expected data %p at offset %i, got %p", data,
-					   parent, hp->p[parent]);
-			return -1;
-		}
+	if (unlikely(data != hp->p[parent])) {
+		fr_strerror_printf("Invalid heap index.  Expected data %p at offset %i, got %p", data,
+				   parent, hp->p[parent]);
+		return -1;
 	}
 	max = hp->num_elements - 1;
 

--- a/src/lib/util/heap.h
+++ b/src/lib/util/heap.h
@@ -78,7 +78,7 @@ static inline bool fr_heap_entry_inserted(int32_t heap_id)
 }
 
 int		fr_heap_insert(fr_heap_t *hp, void *data) CC_HINT(nonnull);
-int		fr_heap_extract(fr_heap_t *hp, void *data) CC_HINT(nonnull(1));
+int		fr_heap_extract(fr_heap_t *hp, void *data) CC_HINT(nonnull);
 void		*fr_heap_pop(fr_heap_t *hp) CC_HINT(nonnull);
 void		*fr_heap_peek(fr_heap_t *hp);
 void		*fr_heap_peek_tail(fr_heap_t *hp);

--- a/src/lib/util/heap_tests.c
+++ b/src/lib/util/heap_tests.c
@@ -106,7 +106,7 @@ static void heap_test(int skip)
 		TEST_CHECK((t = fr_heap_peek(hp)) != NULL);
 		TEST_MSG("expected %i elements remaining in the heap", left - i);
 
-		TEST_CHECK(fr_heap_extract(hp, NULL) >= 0);
+		TEST_CHECK(fr_heap_extract(hp, t) >= 0);
 		TEST_MSG("failed extracting %i", i);
 	}
 
@@ -180,7 +180,7 @@ static void heap_cycle(void)
 		TEST_CHECK((t = fr_heap_peek(hp)) != NULL);
 		TEST_MSG("expected %i elements remaining in the heap", to_remove - i);
 
-		TEST_CHECK(fr_heap_extract(hp, NULL) >= 0);
+		TEST_CHECK(fr_heap_extract(hp, t) >= 0);
 		TEST_MSG("failed extracting %i", i);
 	}
 


### PR DESCRIPTION
It was set up to return fr_heap_pop() if passed NULL, but the only
users of that capability were in heap test code.