### PR TITLE
Fix capabilities in service file

### DIFF
--- a/debian/freeradius.service
+++ b/debian/freeradius.service
@@ -42,7 +42,7 @@ RestartSec=5
 NoNewPrivileges=true
 
 # Allow binding to secure ports, broadcast addresses, and raw interfaces.
-CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_BROADCAST CAP_NET_RAW CAP_SETUID CAP_SETGID CAP_CHOWN CAP_DAC_OVERRIDE
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_BROADCAST CAP_NET_RAW CAP_SETUID CAP_SETGID CAP_CHOWN CAP_DAC_OVERRIDE
 
 # Private /tmp that isn't shared by other processes
 PrivateTmp=true


### PR DESCRIPTION
As freeradius is not run as root we need to request extra capabilities
wiht AmbientCapabilities instead of limiting the set with
CapabilityBoundingSet.

see: https://bugs.debian.org/985967