### PR TITLE
Fix ippool 'skip_locked' variable set

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -26,6 +26,7 @@ FreeRADIUS 3.0.24 Thu 10 Jun 2021 12:00:00 EDT urgency=low
 	  are disabled.
 	* Fix chunked rlm_rest HTTP body.  Closes #4131.
 	  Patch from Nathan Ward.
+	* Some fixes around the SQL ippool queries.conf
 
 FreeRADIUS 3.0.23 Thu 10 Jun 2021 12:00:00 EDT urgency=low
 	Feature improvements

--- a/raddb/mods-config/sql/ippool/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mysql/queries.conf
@@ -10,6 +10,7 @@
 #  following if you are running a suitable version of MySQL
 #
 #skip_locked = "SKIP LOCKED"
+skip_locked = ""
 
 #
 #  This series of queries allocates an IP address

--- a/raddb/mods-config/sql/ippool/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool/oracle/queries.conf
@@ -10,6 +10,7 @@
 #  running a suitable version of Oracle
 #
 #skip_locked = "SKIP LOCKED"
+skip_locked = ""
 
 allocate_begin = "commit"
 start_begin = "commit"

--- a/raddb/mods-config/sql/ippool/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool/postgresql/queries.conf
@@ -10,6 +10,7 @@
 #  following if you are running a suitable version of PostgreSQL
 #
 #skip_locked = "SKIP LOCKED"
+skip_locked = ""
 
 #
 #  This series of queries allocates an IP address


### PR DESCRIPTION
If not in use, it must be declared just to make the parser happy.

It fixes errors like:

```
Wed Jul 28 13:51:50 2021 : Debug: including configuration file /etc/freeradius/sites-enabled/inner-tunnel
Wed Jul 28 13:51:50 2021 : Error: /etc/freeradius/mods-config/sql/ippool/mysql/queries.conf[31]: Reference "${skip_locked}" not found
Wed Jul 28 13:51:50 2021 : Error: Errors reading or parsing /etc/freeradius/radiusd.conf
root@automatic-eap-server-radius:/etc/freeradius#
```