### PR TITLE
Fix connection_check

### DIFF
--- a/src/lib/server/pool.c
+++ b/src/lib/server/pool.c
@@ -647,7 +647,7 @@ static int connection_check(fr_pool_t *pool, request_t *request)
 	fr_time_t		now = fr_time();
 	fr_pool_connection_t	*this, *next;
 
-	if ((now - pool->state.last_checked) >= NSEC) {
+	if ((now - pool->state.last_checked) < NSEC) {
 		pthread_mutex_unlock(&pool->mutex);
 		return 1;
 	}


### PR DESCRIPTION
connection_check() in pool.c did not work
if more than 1 second has passed since the start of radiusd.
This commit makes the function works
as long as more than 1 second has passed since the last time it did work
by fixing a comparison operator.