### PR TITLE
Fix idle_timeout

### DIFF
--- a/src/lib/server/pool.c
+++ b/src/lib/server/pool.c
@@ -1383,7 +1383,7 @@ void fr_pool_connection_release(fr_pool_t *pool, request_t *request, void *conn)
 	/*
 	 *	Record when the connection was last released
 	 */
-	this->last_reserved = fr_time();
+	this->last_released = fr_time();
 	pool->state.last_released = this->last_released;
 
 	/*


### PR DESCRIPTION
fr_pool_connection_release() recorded connection's last_reserved time
instead of last_released.
Since the last_released time of the connection was not updated,
the starting point of the idle_timeout was
always the connection opened time instead of the connection released time.

This commit fixes it.