### PR TITLE
Fix unnecessary periodic close/open in connection pools

### DIFF
--- a/src/lib/server/pool.c
+++ b/src/lib/server/pool.c
@@ -686,7 +686,14 @@ static int connection_check(fr_pool_t *pool, request_t *request)
 		 *	delete all of them.
 		 */
 		spawn = 0;
-		/* leave extra alone from above */
+		/*
+		 *	But if the pool size is already "min", we
+		 *	don't delete them.
+		 */
+		if ((pool->state.num + pool->state.pending) == pool->min) {
+			extra = 0;
+		}
+		/* Otherwise, leave extra alone from above */
 
 	/*
 	 *	min < num < max


### PR DESCRIPTION
When "min" and "max" values of the connection pool setting were the same,
periodic connection closing and opening occurred.
It was different from the closing caused
"uses", "lifetime", and "idle_timeout" settings.
"spare" setting is not helpful since it is capped to zero
by "min" and "max" are the same.

The behavior of the issue is as follows.
When the number of connections was "max" and there was an idol connection,
it was closed without checking "min".
Then, the number of connections dropped below "min" due to the close.
Therefore, a new connection was opened immediately
and the number of connections reached "max"
since "min" and "max" were the same.
These occurred repeatedly.
So periodic close/open happened.

This commit fixes the issue
by adding the "min" check to prevent unnecessary closing connections.