### PR TITLE
Fix behavior of connection pools when min < num < max

### DIFF
--- a/src/lib/server/pool.c
+++ b/src/lib/server/pool.c
@@ -676,10 +676,12 @@ static int connection_check(fr_pool_t *pool, request_t *request)
 		ROPTIONAL(RINFO, INFO, "Need %i more connections to reach min connections (%i)", spawn, pool->min);
 
 	/*
-	 *	But if we're already at "min", then don't spawn more,
+	 *	But if "min" and "max" are the same and
+	 *	we're already at "min", then don't spawn more,
 	 *	and we don't have any extra idle connections.
 	 */
-	} else if ((pool->state.num + pool->state.pending) >= pool->min) {
+	} else if ((pool->min == pool->max) &&
+		   (pool->state.num + pool->state.pending) == pool->min) {
 		spawn = 0;
 		extra = 0;
 
@@ -694,8 +696,7 @@ static int connection_check(fr_pool_t *pool, request_t *request)
 		 *	delete all of them.
 		 */
 		spawn = 0;
-
-		/* Otherwise, leave extra alone from above */
+		/* leave extra alone from above */
 
 	/*
 	 *	min < num < max


### PR DESCRIPTION
The commit
eeccdfc9324851c6f8a69dc06ceef106f3dd2961
has made an unintended change in the behavior of connection pools when
min < num < max.
It made radiusd did not open or close connections when
min <= num.
However, radiusd needs to open or close connections when
min < num < max.

This commit fixes it.