### PR TITLE
v3.0.x: MySQL sqlippool SP: Run as invoker, not definer; close transaction on error

### DIFF
--- a/raddb/mods-config/sql/ippool-dhcp/mysql/procedure-no-skip-locked.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/procedure-no-skip-locked.sql
@@ -50,6 +50,7 @@ CREATE PROCEDURE fr_allocate_previous_or_new_framedipaddress (
 	IN v_lease_duration INT,
 	IN v_requested_address VARCHAR(15)
 )
+SQL SECURITY INVOKER
 proc:BEGIN
 	DECLARE r_address VARCHAR(15);
 

--- a/raddb/mods-config/sql/ippool-dhcp/mysql/procedure.sql
+++ b/raddb/mods-config/sql/ippool-dhcp/mysql/procedure.sql
@@ -38,8 +38,15 @@ CREATE PROCEDURE fr_dhcp_allocate_previous_or_new_framedipaddress (
 	IN v_lease_duration INT,
 	IN v_requested_address VARCHAR(15)
 )
+SQL SECURITY INVOKER
 proc:BEGIN
 	DECLARE r_address VARCHAR(15);
+
+	DECLARE EXIT HANDLER FOR SQLEXCEPTION
+	BEGIN
+		ROLLBACK;
+		RESIGNAL;
+	END;
 
 	SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
 

--- a/raddb/mods-config/sql/ippool/mysql/procedure-no-skip-locked.sql
+++ b/raddb/mods-config/sql/ippool/mysql/procedure-no-skip-locked.sql
@@ -54,6 +54,7 @@ CREATE PROCEDURE fr_allocate_previous_or_new_framedipaddress (
         IN v_pool_key VARCHAR(64),
         IN v_lease_duration INT
 )
+SQL SECURITY INVOKER
 proc:BEGIN
         DECLARE r_address VARCHAR(15);
 

--- a/raddb/mods-config/sql/ippool/mysql/procedure.sql
+++ b/raddb/mods-config/sql/ippool/mysql/procedure.sql
@@ -42,8 +42,15 @@ CREATE PROCEDURE fr_allocate_previous_or_new_framedipaddress (
         IN v_pool_key VARCHAR(64),
         IN v_lease_duration INT
 )
+SQL SECURITY INVOKER
 proc:BEGIN
         DECLARE r_address VARCHAR(15);
+
+        DECLARE EXIT HANDLER FOR SQLEXCEPTION
+        BEGIN
+            ROLLBACK;
+            RESIGNAL;
+        END;
 
         SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
 


### PR DESCRIPTION
In MariaDB/MySQL, stored procedures default to running in the context of
the definer rather than the invoker.

This is a problem in a streaming replication scenario since the definer
is often the root user who has the "super" power to write to a read-only
database (unless super-read-only is enabled, which is not available for
MariaDB), thus breaking the replication timeline.

Additionally, exiting an SP does not finalise any running transaction.
If an exception is raised within the SP (e.g. due to the database being
read-only) we must handle this and finalise the transaction, otherwise
subsequent calls to "SET TRANSACTION ISOLATION LEVEL READ COMMITTED"
will fail ad nauseam until the connection is finally closed.