### PR TITLE
Fix connection pool with fewer connections than spare setting

### DIFF
--- a/src/lib/server/pool.c
+++ b/src/lib/server/pool.c
@@ -762,7 +762,7 @@ static int connection_check(fr_pool_t *pool, request_t *request)
 		/*
 		 *	Don't open too many pending connections.
 		 */
-		if (pool->state.pending >= pool->max_pending) goto manage_connections;
+		if (pool->state.pending >= pool->pending_window) goto manage_connections;
 
 		/*
 		 *	Don't open too many connections, even if we


### PR DESCRIPTION
The number of connections in the connection pool was not increased
when it is less than the spare setting.
In v4.0.x, unlike v3.0.x, `pool->max_pending` is a configurable value,
with a default value of zero.
Therefore, in the default setting, the conditional expression
`pool->state.pending >= pool->max_pending`
always is true and the number of connections is not increased.

This commit fixes it by using `pool->pending_window`
instead of `pool->max_pending`.