### PR TITLE
Use calloc(), not malloc() to allocate heap/lst elements from the (me…

### DIFF
--- a/src/lib/util/heap_tests.c
+++ b/src/lib/util/heap_tests.c
@@ -56,7 +56,7 @@ static void heap_test(int skip)
 	hp = fr_heap_alloc(NULL, heap_cmp, heap_thing, heap);
 	TEST_CHECK(hp != NULL);
 
-	array = malloc(sizeof(heap_thing) * HEAP_TEST_SIZE);
+	array = calloc(HEAP_TEST_SIZE, sizeof(heap_thing));
 
 	/*
 	 *	Initialise random values
@@ -155,7 +155,7 @@ static void heap_cycle(void)
 	hp = fr_heap_alloc(NULL, heap_cmp, heap_thing, heap);
 	TEST_CHECK(hp != NULL);
 
-	array = malloc(sizeof(heap_thing) * HEAP_CYCLE_SIZE);
+	array = calloc(HEAP_CYCLE_SIZE, sizeof(heap_thing));
 
 	/*
 	 *	Initialise random values

--- a/src/lib/util/lst_tests.c
+++ b/src/lib/util/lst_tests.c
@@ -94,7 +94,7 @@ static void lst_test(int skip)
 	lst = fr_lst_alloc(NULL, heap_cmp, heap_thing, index);
 	TEST_CHECK(lst != NULL);
 
-	array = malloc(sizeof(heap_thing) * LST_TEST_SIZE);
+	array = calloc(LST_TEST_SIZE, sizeof(heap_thing));
 
 	/*
 	 *	Initialise random values


### PR DESCRIPTION
…mory) heap

malloc(), in the C standard and in the man page, is described as not
initializing the memory it allocates. A standard-conforming C compiler
could thus compile versions of the tests that fail fr_{heap, lst}_insert()
checks that keep an item from being inserted twice or into more than one
heap or lst with the same index displacement.

calloc() zeroes the allocated memory.