### PR TITLE
ippool: Fix missing 'Called-Station-Id' in the MySQL/procedure.sql

### DIFF
--- a/raddb/mods-config/sql/ippool/mysql/procedure.sql
+++ b/raddb/mods-config/sql/ippool/mysql/procedure.sql
@@ -21,6 +21,7 @@
 -- 		'%{control:${pool_name}}', \
 -- 		'%{User-Name}', \
 -- 		'%{Calling-Station-Id}', \
+--		'%{Called-Station-Id}', \
 -- 		'%{NAS-IP-Address}', \
 -- 		'${pool_key}', \
 -- 		${lease_duration} \
@@ -38,6 +39,7 @@ CREATE PROCEDURE fr_allocate_previous_or_new_framedipaddress (
         IN v_pool_name VARCHAR(64),
         IN v_username VARCHAR(64),
         IN v_callingstationid VARCHAR(64),
+        IN v_calledstationid VARCHAR(64),
         IN v_nasipaddress VARCHAR(15),
         IN v_pool_key VARCHAR(64),
         IN v_lease_duration INT
@@ -122,6 +124,7 @@ proc:BEGIN
                 nasipaddress = v_nasipaddress,
                 pool_key = v_pool_key,
                 callingstationid = v_callingstationid,
+                calledstationid = v_calledstationid,
                 username = v_username,
                 expiry_time = NOW() + INTERVAL v_lease_duration SECOND
         WHERE framedipaddress = r_address;

--- a/raddb/mods-config/sql/ippool/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mysql/queries.conf
@@ -87,6 +87,7 @@ allocate_update = "\
 #		'%{control:${pool_name}}', \
 #		'%{User-Name}', \
 #		'%{Calling-Station-Id}', \
+#		'%{Called-Station-Id}', \
 #		'%{NAS-IP-Address}', \
 #		'${pool_key}', \
 #		${lease_duration} \


### PR DESCRIPTION
As the scheme.sql has the 'calledstationid' field, we should fill it up.