### PR TITLE
Correct success returns for fr_lst_{insert, extract}()

### DIFF
--- a/src/lib/util/lst.c
+++ b/src/lib/util/lst.c
@@ -620,7 +620,7 @@ int fr_lst_extract(fr_lst_t *lst, void *data)
 	}
 
 	_fr_lst_extract(lst, 0, data);
-	return 1;
+	return 0;
 }
 
 int fr_lst_insert(fr_lst_t *lst, void *data)
@@ -643,7 +643,7 @@ int fr_lst_insert(fr_lst_t *lst, void *data)
 	}
 
 	_fr_lst_insert(lst, 0, data);
-	return 1;
+	return 0;
 }
 
 fr_lst_index_t fr_lst_num_elements(fr_lst_t *lst)


### PR DESCRIPTION
This change makes them consistent with the heap functions,
simplifying migration from heap to LST.