### PR TITLE
Fix calculating accounting offset with sqlite

### DIFF
--- a/raddb/mods-config/sql/main/sqlite/process-radacct-refresh.sh
+++ b/raddb/mods-config/sql/main/sqlite/process-radacct-refresh.sh
@@ -30,7 +30,7 @@ cat <<EOF | sqlite3 "$1"
         PRIMARY KEY (key)
     );
 
-    INSERT INTO vars SELECT 'v_start', COALESCE(DATETIME(MAX(period_start), '+1 seconds'), DATETIME(0, 'unixepoch')) FROM data_usage_by_period;
+    INSERT INTO vars SELECT 'v_start', COALESCE(MAX(period_start), DATETIME(0, 'unixepoch')) FROM data_usage_by_period;
     INSERT INTO vars SELECT 'v_end', CURRENT_TIMESTAMP;
 
 


### PR DESCRIPTION
Adding one second to the timestamp meant that the unclosed period was never substacted on subsquent runs.