### PR TITLE
Add init parameter to LST creation

### DIFF
--- a/src/lib/io/master.c
+++ b/src/lib/io/master.c
@@ -552,7 +552,7 @@ static fr_io_connection_t *fr_io_connection_alloc(fr_io_instance_t const *inst,
 	 *	client.
 	 */
 	MEM(connection->client->pending = fr_lst_alloc(connection->client, pending_packet_cmp,
-							 fr_io_pending_packet_t, lst_id));
+							 fr_io_pending_packet_t, lst_id, 0));
 
 	/*
 	 *	Clients for connected sockets are always a /32 or /128.
@@ -1457,7 +1457,7 @@ do_read:
 		 */
 		if (state == PR_CLIENT_PENDING) {
 			MEM(client->pending = fr_lst_alloc(client, pending_packet_cmp,
-							     fr_io_pending_packet_t, lst_id));
+							     fr_io_pending_packet_t, lst_id, 0));
 		}
 
 		/*
@@ -2489,7 +2489,7 @@ static ssize_t mod_write(fr_listen_t *li, void *packet_ctx, fr_time_t request_ti
 	 */
 	if (!thread->pending_clients) {
 		MEM(thread->pending_clients = fr_lst_alloc(thread, pending_client_cmp,
-							   fr_io_client_t, pending_id));
+							   fr_io_client_t, pending_id, 0));
 	}
 
 	fr_assert(client->pending_id < 0);
@@ -2955,7 +2955,7 @@ int fr_master_io_listen(TALLOC_CTX *ctx, fr_io_instance_t *inst, fr_schedule_t *
 	 */
 	MEM(thread->trie = fr_trie_alloc(thread, NULL, NULL));
 	MEM(thread->alive_clients = fr_lst_alloc(thread, alive_client_cmp,
-						   fr_io_client_t, alive_id));
+						   fr_io_client_t, alive_id, 0));
 
 	/*
 	 *	Set the listener to call our master trampoline function.

--- a/src/lib/util/event.c
+++ b/src/lib/util/event.c
@@ -2277,7 +2277,7 @@ fr_event_list_t *fr_event_list_alloc(TALLOC_CTX *ctx, fr_event_status_cb_t statu
 	el->kq = -1;	/* So destructor can be used before kqueue() provides us with fd */
 	talloc_set_destructor(el, _event_list_free);
 
-	el->times = fr_lst_talloc_alloc(el, fr_event_timer_cmp, fr_event_timer_t, lst_id);
+	el->times = fr_lst_talloc_alloc(el, fr_event_timer_cmp, fr_event_timer_t, lst_id, 0);
 	if (!el->times) {
 		fr_strerror_const("Failed allocating event lst");
 	error:
@@ -2292,7 +2292,7 @@ fr_event_list_t *fr_event_list_alloc(TALLOC_CTX *ctx, fr_event_status_cb_t statu
 	}
 
 #ifdef LOCAL_PID
-	el->pids = fr_lst_talloc_alloc(el, fr_event_pid_cmp, fr_event_pid_t, lst_id);
+	el->pids = fr_lst_talloc_alloc(el, fr_event_pid_cmp, fr_event_pid_t, lst_id, 0);
 	if (!el->pids) {
 		fr_strerror_const("Failed allocating PID lst");
 		goto error;

--- a/src/lib/util/lst.h
+++ b/src/lib/util/lst.h
@@ -56,9 +56,14 @@ typedef int8_t (*fr_lst_cmp_t)(void const *a, void const *b);
  * @param[in] _cmp		Comparator used to compare elements.
  * @param[in] _type		Of elements.
  * @param[in] _field		to store LST indexes in.
+ * @param[in] _init		initial capacity (0 for default initial size);
+ *				the capacity will be rounded up to a power of two.
+ * @return
+ *	- A pointer to the new LST.
+ *	- NULL on error
  */
-#define fr_lst_alloc(_ctx, _cmp, _type, _field) \
-	_fr_lst_alloc(_ctx, _cmp, NULL, (size_t)offsetof(_type, _field))
+#define fr_lst_alloc(_ctx, _cmp, _type, _field, _init) \
+	_fr_lst_alloc(_ctx, _cmp, NULL, (size_t)offsetof(_type, _field), _init)
 
 /** Creates an LST that verifies elements are of a specific talloc type
  *
@@ -66,14 +71,16 @@ typedef int8_t (*fr_lst_cmp_t)(void const *a, void const *b);
  * @param[in] _cmp		Comparator used to compare elements.
  * @param[in] _talloc_type	of elements.
  * @param[in] _field		to store heap indexes in.
+ * @param[in] _init		initial capacity (0 for default initial size);
+ *				the capacity will be rounded up to a power of two.
  * @return
  *	- A pointer to the new LST.
  *	- NULL on error.
  */
-#define fr_lst_talloc_alloc(_ctx, _cmp, _talloc_type, _field) \
-	_fr_lst_alloc(_ctx, _cmp, #_talloc_type, (size_t)offsetof(_talloc_type, _field))
+#define fr_lst_talloc_alloc(_ctx, _cmp, _talloc_type, _field, _init) \
+	_fr_lst_alloc(_ctx, _cmp, #_talloc_type, (size_t)offsetof(_talloc_type, _field), _init)
 
-fr_lst_t *_fr_lst_alloc(TALLOC_CTX *ctx, fr_lst_cmp_t cmp, char const *type, size_t offset) CC_HINT(nonnull(2));
+fr_lst_t *_fr_lst_alloc(TALLOC_CTX *ctx, fr_lst_cmp_t cmp, char const *type, size_t offset, fr_lst_index_t init) CC_HINT(nonnull(2));
 
 /** Check if an entry is inserted into an LST.
  *

--- a/src/lib/util/lst_tests.c
+++ b/src/lib/util/lst_tests.c
@@ -67,7 +67,7 @@ static void lst_test_basic(void)
 	fr_lst_t	*lst;
 	lst_thing	values[NVALUES];
 
-	lst = fr_lst_alloc(NULL, lst_cmp, lst_thing, idx);
+	lst = fr_lst_alloc(NULL, lst_cmp, lst_thing, idx, NVALUES);
 	TEST_CHECK(lst != NULL);
 
 	populate_values(values, NUM_ELEMENTS(values));
@@ -83,6 +83,7 @@ static void lst_test_basic(void)
 		TEST_CHECK(value != NULL);
 		TEST_CHECK(!fr_lst_entry_inserted(value->idx));
 		TEST_CHECK(value->data == i);
+		TEST_MSG("iteration %u, popped %u", i, value->data);
 	}
 	talloc_free(lst);
 }
@@ -104,7 +105,7 @@ static void lst_test(int skip)
 		done_init = true;
 	}
 
-	lst = fr_lst_alloc(NULL, lst_cmp, lst_thing, idx);
+	lst = fr_lst_alloc(NULL, lst_cmp, lst_thing, idx, 0);
 	TEST_CHECK(lst != NULL);
 
 	values = calloc(LST_TEST_SIZE, sizeof(lst_thing));
@@ -182,7 +183,7 @@ static void lst_stress_realloc(void)
 		done_init = true;
 	}
 
-	lst = fr_lst_alloc(NULL, lst_cmp, lst_thing, idx);
+	lst = fr_lst_alloc(NULL, lst_cmp, lst_thing, idx, 0);
 	TEST_CHECK(lst != NULL);
 	hp = fr_heap_alloc(NULL, lst_cmp, lst_thing, idx, 0);
 
@@ -259,7 +260,7 @@ static void lst_burn_in(void)
 	array = calloc(BURN_IN_OPS, sizeof(lst_thing));
 	for (unsigned int i = 0; i < BURN_IN_OPS; i++) array[i].data = rand() % 65537;
 
-	lst = fr_lst_alloc(NULL, lst_cmp, lst_thing, idx);
+	lst = fr_lst_alloc(NULL, lst_cmp, lst_thing, idx, 0);
 
 	for (unsigned int i = 0; i < BURN_IN_OPS; i++) {
 		lst_thing	*ret_thing = NULL;
@@ -311,7 +312,7 @@ static void lst_cycle(void)
 		done_init = true;
 	}
 
-	lst = fr_lst_alloc(NULL, lst_cmp, lst_thing, idx);
+	lst = fr_lst_alloc(NULL, lst_cmp, lst_thing, idx, 0);
 	TEST_CHECK(lst != NULL);
 
 	values = calloc(LST_CYCLE_SIZE, sizeof(lst_thing));
@@ -388,7 +389,7 @@ static void lst_iter(void)
 	lst_thing	values[NVALUES], *data;
 
 
-	lst = fr_lst_alloc(NULL, lst_cmp, lst_thing, idx);
+	lst = fr_lst_alloc(NULL, lst_cmp, lst_thing, idx, 0);
 	TEST_CHECK(lst != NULL);
 
 	populate_values(values, NUM_ELEMENTS(values));
@@ -449,7 +450,7 @@ static void queue_cmp(unsigned int count)
 		populate_values(values, count);
 
 		start_alloc = fr_time();
-		lst = fr_lst_alloc(NULL, lst_cmp, lst_thing, idx);
+		lst = fr_lst_alloc(NULL, lst_cmp, lst_thing, idx, 0);
 		end_alloc = fr_time();
 		TEST_CHECK(lst != NULL);
 


### PR DESCRIPTION
The parameter determines the initial capacity choice: 0 will get
the default initial capacity, while any other value will be rounded
up to a power of 2 and used as the initial capacity.