### PR TITLE
Fix Docker/Centos8 build

### DIFF
--- a/scripts/docker/centos8/Dockerfile
+++ b/scripts/docker/centos8/Dockerfile
@@ -42,7 +42,7 @@ RUN rpm --import https://ltb-project.org/lib/RPM-GPG-KEY-LTB-project
 # EPEL repository for freetds and hiredis
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 
-RUN yum config-manager --enable PowerTools
+RUN yum config-manager --enable powertools
 # Currently needed for hiredis-devel
 RUN yum config-manager --enable epel-testing
 


### PR DESCRIPTION
It fixes the error

```
Removing intermediate container 061c61571ea7
 ---> 394bf0194252
Step 15/36 : RUN yum config-manager --enable PowerTools
 ---> Running in f50be03b7d6a
Error: No matching repo to modify: PowerTools.
The command '/bin/sh -c yum config-manager --enable PowerTools' returned a non-zero code: 1
```

the parameter is case-sensitive. 