### PR TITLE
v4: Add a status to trunks and watchers on state changes

### DIFF
--- a/src/lib/server/trunk.c
+++ b/src/lib/server/trunk.c
@@ -171,6 +171,18 @@ struct fr_trunk_connection_s {
   	/** @} */
 };
 
+/** An entry in a trunk watch function list
+ *
+ */
+typedef struct fr_trunk_watch_entry_s {
+	fr_dlist_t		entry;			//!< List entry.
+	fr_trunk_watch_t	func;			//!< Function to call when a trunk enters
+							///< the state this list belongs to
+	bool			oneshot;		//!< Remove the function after it's called once.
+	bool			enabled;		//!< Whether the watch entry is enabled.
+	void			*uctx;			//!< User data to pass to the function.
+} fr_trunk_watch_entry_t;
+
 /** Main trunk management handle
  *
  */

--- a/src/lib/server/trunk.c
+++ b/src/lib/server/trunk.c
@@ -361,6 +361,13 @@ static fr_table_num_indexed_bit_pos_t const fr_trunk_conn_trigger_names[] = {
 };
 static size_t fr_trunk_conn_trigger_names_len = NUM_ELEMENTS(fr_trunk_conn_trigger_names);
 
+static fr_table_num_ordered_t const fr_trunk_states[] = {
+	{ L("IDLE"),					FR_TRUNK_STATE_IDLE			},
+	{ L("ACTIVE"),					FR_TRUNK_STATE_ACTIVE			},
+	{ L("PENDING"),					FR_TRUNK_STATE_PENDING			}
+};
+static size_t fr_trunk_states_len = NUM_ELEMENTS(fr_trunk_states);
+
 static fr_table_num_ordered_t const fr_trunk_connection_states[] = {
 	{ L("INIT"),					FR_TRUNK_CONN_INIT			},
 	{ L("HALTED"),					FR_TRUNK_CONN_HALTED			},

--- a/src/lib/server/trunk.h
+++ b/src/lib/server/trunk.h
@@ -674,6 +674,18 @@ typedef void (*fr_trunk_request_fail_t)(request_t *request, void *preq, void *rc
  */
 typedef void (*fr_trunk_request_free_t)(request_t *request, void *preq_to_free, void *uctx);
 
+/** Receive a notification when a trunk enters a particular state
+ *
+ * @param[in] trunk	Being watched.
+ * @param[in] prev	State we came from.
+ * @param[in] state	State that was entered (the current state)
+ * @param[in] uctx	that was passed to fr_trunk_add_watch_*.
+ */
+typedef void(*fr_trunk_watch_t)(fr_trunk_t *trunk,
+				fr_trunk_state_t prev, fr_trunk_state_t state, void *uctx);
+
+typedef struct fr_trunk_watch_entry_s fr_trunk_watch_entry_t;
+
 /** I/O functions to pass to fr_trunk_alloc
  *
  */

--- a/src/lib/server/trunk.h
+++ b/src/lib/server/trunk.h
@@ -862,6 +862,15 @@ fr_trunk_t	*fr_trunk_alloc(TALLOC_CTX *ctx, fr_event_list_t *el,
 				char const *log_prefix, void const *uctx, bool delay_start) CC_HINT(nonnull(2, 3, 4));
 /** @} */
 
+/** @name Watchers
+ * @{
+ */
+fr_trunk_watch_entry_t *fr_trunk_add_watch(fr_trunk_t *trunk, fr_trunk_state_t state,
+					   fr_trunk_watch_t watch, bool oneshot, void const *uctx) CC_HINT(nonnull(1));
+
+int		fr_trunk_del_watch(fr_trunk_t *trunk, fr_trunk_state_t state, fr_trunk_watch_t watch);
+/** @} */
+
 #undef _CONST
 
 #ifdef __cplusplus

--- a/src/lib/server/trunk.h
+++ b/src/lib/server/trunk.h
@@ -59,6 +59,13 @@ typedef enum {
 	FR_TRUNK_CANCEL_REASON_REQUEUE			//!< A previously sent request is being requeued.
 } fr_trunk_cancel_reason_t;
 
+typedef enum {
+	FR_TRUNK_STATE_IDLE = 0,			//!< Trunk has no connections
+	FR_TRUNK_STATE_ACTIVE,				//!< Trunk has active connections
+	FR_TRUNK_STATE_PENDING,				//!< Trunk has connections, but none are active
+	FR_TRUNK_STATE_MAX
+} fr_trunk_state_t;
+
 /** What type of I/O events the trunk connection is currently interested in receiving
  *
  */
@@ -292,6 +299,8 @@ struct fr_trunk_pub_s {
 	/** @} */
 
 	bool _CONST		triggers;		//!< do we run the triggers?
+
+	fr_trunk_state_t _CONST	state;			//!< Current state of the trunk.
 };
 
 /** Public fields for the trunk request


### PR DESCRIPTION
The initial use case for this is handling LDAP referrals where multiple possible servers can be contacted to chase a referral.  If no existing trunks are open to any of the possible destinations, then multiple trunks can be opened and the first one to become active will trigger the watcher which will send the query.