### PR TITLE
Fix several attributes updating the data-type from integer to date.

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -46,6 +46,7 @@ FreeRADIUS 3.0.24 Thu 10 Jun 2021 12:00:00 EDT urgency=low
 	* Outbound proxying over TCP / TLS is better able to deal with
 	  partial TCP reads, and has fewer issues with slow networks.
 	* Fix wrong data-type of Acct-Delay-Time in rlm_unix.
+	* Fix several attributes updating the data-type from integer to date.
 
 FreeRADIUS 3.0.23 Thu 10 Jun 2021 12:00:00 EDT urgency=low
 	Feature improvements

--- a/share/dictionary.3com
+++ b/share/dictionary.3com
@@ -47,7 +47,7 @@ ATTRIBUTE	3Com-End-Date				7	string
 ATTRIBUTE	3Com-URL				8	string
 
 ATTRIBUTE	3Com-Connect_Id				26	integer
-ATTRIBUTE	3Com-NAS-Startup-Timestamp		59	integer
+ATTRIBUTE	3Com-NAS-Startup-Timestamp		59	date
 ATTRIBUTE	3Com-Ip-Host-Addr			60	string
 ATTRIBUTE	3Com-Product-ID				255	string
 

--- a/share/dictionary.3gpp2
+++ b/share/dictionary.3gpp2
@@ -120,7 +120,7 @@ ATTRIBUTE	3GPP2-DNS-Update-Required		75	integer
 # 77 ?
 #ATTRIBUTE	3GPP2-Always-On			78	integer
 ATTRIBUTE	3GPP2-Foreign-Agent-Address		79	ipaddr
-ATTRIBUTE	3GPP2-Last-User-Activity-Time		80	integer
+ATTRIBUTE	3GPP2-Last-User-Activity-Time		80	date
 ATTRIBUTE	3GPP2-MN-AAA-Removal-Indication		81	integer
 ATTRIBUTE	3GPP2-RN-Packet-Data-Inactivity-Timer	82	integer
 ATTRIBUTE	3GPP2-Forward-PDCH-RC			83	integer

--- a/share/dictionary.ascend
+++ b/share/dictionary.ascend
@@ -265,7 +265,7 @@ ATTRIBUTE	Ascend-User-Acct-Host			139	ipaddr
 ATTRIBUTE	Ascend-User-Acct-Port			140	integer
 ATTRIBUTE	Ascend-User-Acct-Key			141	string
 ATTRIBUTE	Ascend-User-Acct-Base			142	integer
-ATTRIBUTE	Ascend-User-Acct-Time			143	integer
+ATTRIBUTE	Ascend-User-Acct-Time			143	date
 ATTRIBUTE	Ascend-Assign-IP-Client			144	ipaddr
 ATTRIBUTE	Ascend-Assign-IP-Server			145	ipaddr
 ATTRIBUTE	Ascend-Assign-IP-Global-Pool		146	string

--- a/share/dictionary.ascend.illegal
+++ b/share/dictionary.ascend.illegal
@@ -44,7 +44,7 @@ ATTRIBUTE	X-Ascend-User-Acct-Host			139	ipaddr
 ATTRIBUTE	X-Ascend-User-Acct-Port			140	integer
 ATTRIBUTE	X-Ascend-User-Acct-Key			141	string
 ATTRIBUTE	X-Ascend-User-Acct-Base			142	integer
-ATTRIBUTE	X-Ascend-User-Acct-Time			143	integer
+ATTRIBUTE	X-Ascend-User-Acct-Time			143	date
 ATTRIBUTE	X-Ascend-Assign-IP-Client		144	ipaddr
 ATTRIBUTE	X-Ascend-Assign-IP-Server		145	ipaddr
 ATTRIBUTE	X-Ascend-Assign-IP-Global-Pool		146	string

--- a/share/dictionary.epygi
+++ b/share/dictionary.epygi
@@ -58,9 +58,9 @@ ATTRIBUTE	Epygi-OrigIpPort			179	integer
 ATTRIBUTE	Epygi-DestIpPort			180	integer
 ATTRIBUTE	Epygi-CallingPartyNumber		181	string
 ATTRIBUTE	Epygi-CalledPartyNumber			182	string
-ATTRIBUTE	Epygi-DateTimeOrigination		183	integer
-ATTRIBUTE	Epygi-DateTimeConnect			184	integer
-ATTRIBUTE	Epygi-DateTimeDisconnect		185	integer
+ATTRIBUTE	Epygi-DateTimeOrigination		183	date
+ATTRIBUTE	Epygi-DateTimeConnect			184	date
+ATTRIBUTE	Epygi-DateTimeDisconnect		185	date
 ATTRIBUTE	Epygi-Duration				186	integer
 ATTRIBUTE	Epygi-OutSourceRTP_IP			187	integer
 ATTRIBUTE	Epygi-OutDestRTP_IP			188	integer

--- a/share/dictionary.ericsson
+++ b/share/dictionary.ericsson
@@ -128,7 +128,7 @@ ATTRIBUTE	Ericsson-ViG-Service-Description	122	string
 ATTRIBUTE	Ericsson-ViG-Service-Specific-Info	123	string
 ATTRIBUTE	Ericsson-ViG-Proxy-IP-Address		124	ipaddr
 ATTRIBUTE	Ericsson-ViG-Auth-DataRequest		125	integer
-ATTRIBUTE	Ericsson-ViG-IPT-Time-Stamp		126	integer
+ATTRIBUTE	Ericsson-ViG-IPT-Time-Stamp		126	date
 ATTRIBUTE	Ericsson-ViG-User-Name-Info		127	integer
 
 END-VENDOR	Ericsson

--- a/share/dictionary.h3c
+++ b/share/dictionary.h3c
@@ -47,7 +47,7 @@ VALUE	H3C-Exec-Privilege		Manage			3
 ATTRIBUTE	H3C-NAT-IP-Address			32	ipaddr
 ATTRIBUTE	H3C-NAT-Start-Port			33	integer
 ATTRIBUTE	H3C-NAT-End-Port			34	integer
-ATTRIBUTE	H3C-NAS-Startup-Timestamp		59	integer
+ATTRIBUTE	H3C-NAS-Startup-Timestamp		59	date
 ATTRIBUTE	H3C-Ip-Host-Addr			60	string
 ATTRIBUTE	H3C-User-Notify				61	string
 ATTRIBUTE	H3C-User-HeartBeat			62	string

--- a/share/dictionary.huawei
+++ b/share/dictionary.huawei
@@ -50,8 +50,8 @@ ATTRIBUTE	Huawei-Qos-Profile-Name			31	string
 ATTRIBUTE	Huawei-SIP-Server			32	string
 ATTRIBUTE	Huawei-User-Password			33	string
 ATTRIBUTE	Huawei-Command-Mode			34	string
-ATTRIBUTE	Huawei-Renewal-Time			35	integer
-ATTRIBUTE	Huawei-Rebinding-Time			36	integer
+ATTRIBUTE	Huawei-Renewal-Time			35	date
+ATTRIBUTE	Huawei-Rebinding-Time			36	date
 ATTRIBUTE	Huawei-IGMP-Enable			37	integer
 ATTRIBUTE	Huawei-Destnation-IP-Addr		39	string
 ATTRIBUTE	Huawei-Destnation-Volume		40	string
@@ -108,7 +108,7 @@ ATTRIBUTE	Huawei-Acct-Packet-Type			106	integer
 ATTRIBUTE	Huawei-Call-Reference			107	integer
 ATTRIBUTE	Huawei-PSTN-Port			108	integer
 ATTRIBUTE	Huawei-Voip-Service-Type		109	integer
-ATTRIBUTE	Huawei-Acct-Connection-Time		110	integer
+ATTRIBUTE	Huawei-Acct-Connection-Time		110	date
 ATTRIBUTE	Huawei-Error-Reason			112	integer
 ATTRIBUTE	Huawei-Remain-Monney			113	integer
 ATTRIBUTE	Huawei-Org-GK-ipaddr			123	ipaddr

--- a/share/dictionary.localweb
+++ b/share/dictionary.localweb
@@ -18,7 +18,7 @@ ATTRIBUTE	Local-Web-Border-Router			193	string
 ATTRIBUTE	Local-Web-Tx-Limit			200	integer
 ATTRIBUTE	Local-Web-Rx-Limit			201	integer
 
-ATTRIBUTE	Local-Web-Acct-Time			210	integer
+ATTRIBUTE	Local-Web-Acct-Time			210	date
 ATTRIBUTE	Local-Web-Acct-Duration			211	integer
 ATTRIBUTE	Local-Web-Acct-Interim-Tx-Bytes		212	integer
 ATTRIBUTE	Local-Web-Acct-Interim-Rx-Bytes		213	integer

--- a/share/dictionary.lucent
+++ b/share/dictionary.lucent
@@ -155,7 +155,7 @@ ATTRIBUTE	Lucent-User-Acct-Host			139	ipaddr
 ATTRIBUTE	Lucent-User-Acct-Port			140	integer
 ATTRIBUTE	Lucent-User-Acct-Key			141	string
 ATTRIBUTE	Lucent-User-Acct-Base			142	integer
-ATTRIBUTE	Lucent-User-Acct-Time			143	integer
+ATTRIBUTE	Lucent-User-Acct-Time			143	date
 ATTRIBUTE	Lucent-Assign-IP-Client			144	ipaddr
 ATTRIBUTE	Lucent-Assign-IP-Server			145	ipaddr
 ATTRIBUTE	Lucent-Assign-IP-Global-Pool		146	string
@@ -447,7 +447,7 @@ ATTRIBUTE	Lucent-Min-SNR				20113	integer
 ATTRIBUTE	Lucent-Max-SNR				20114	integer
 ATTRIBUTE	Lucent-Local-Retrain-Requested		20115	integer
 ATTRIBUTE	Lucent-Remote-Retrain-Requested		20116	integer
-ATTRIBUTE	Lucent-Connection-Time			20117	integer
+ATTRIBUTE	Lucent-Connection-Time			20117	date
 ATTRIBUTE	Lucent-Modem-Disconnect-Reason		20118	integer
 ATTRIBUTE	Lucent-Retrain-Reason			20119	integer
 

--- a/share/dictionary.walabi
+++ b/share/dictionary.walabi
@@ -24,7 +24,7 @@ ATTRIBUTE	WB-Auth-BW-Quota			3	integer
 ATTRIBUTE	WB-Auth-BW-Count			4	integer
 ATTRIBUTE	WB-Auth-Upload-Limit			5	integer
 ATTRIBUTE	WB-Auth-Download-Limit			6	integer
-ATTRIBUTE	WB-Auth-Login-Time			7	integer
+ATTRIBUTE	WB-Auth-Login-Time			7	date
 ATTRIBUTE	WB-Auth-Logout-Time			8	integer
 ATTRIBUTE	WB-Auth-Time-Diff			9	integer
 ATTRIBUTE	WB-Auth-BW-Usage			10	integer


### PR DESCRIPTION
Affected the below list:

share/dictionary.3com
share/dictionary.3gpp2
share/dictionary.alcatel.sr
share/dictionary.ascend
share/dictionary.ascend.illegal
share/dictionary.epygi
share/dictionary.ericsson
share/dictionary.h3c
share/dictionary.huawei
share/dictionary.localweb
share/dictionary.lucent
share/dictionary.walabi