### PR TITLE
Fix undeclared variable when compiling with TLS + without DHCP

### DIFF
--- a/src/main/modules.c
+++ b/src/main/modules.c
@@ -1360,7 +1360,7 @@ static int load_byserver(CONF_SECTION *cs)
 #if defined(WITH_VMPS) || defined(WITH_DHCP)
 		CONF_SECTION *subcs;
 #endif
-#ifdef WITH_DHCP
+#if defined(WITH_DHCP) || defined(WITH_TLS)
 		DICT_ATTR const *da;
 #endif
 


### PR DESCRIPTION
When compiling without DHCP support but with TLS support compile
fails due to an undeclared variable in modules.c

src/main/modules.c:1386:3: error: ‘da’ undeclared

Modify variable declaration to be included based on WITH_TLS flag
as well as WITH_DHCP