### PR TITLE
Fix undeclared variable when compiling with TLS but without DHCP and …

### DIFF
--- a/src/main/modules.c
+++ b/src/main/modules.c
@@ -1357,7 +1357,7 @@ static int load_byserver(CONF_SECTION *cs)
 	 *	This is a bit of a hack...
 	 */
 	if (!found) do {
-#if defined(WITH_VMPS) || defined(WITH_DHCP)
+#if defined(WITH_VMPS) || defined(WITH_DHCP) || defined(WITH_TLS)
 		CONF_SECTION *subcs;
 #endif
 #if defined(WITH_DHCP) || defined(WITH_TLS)


### PR DESCRIPTION
…without VMPS

When compiling without DHCP and without VMPS but with TLS support
compile fails due to an undeclared variable in modules.c

src/main/modules.c:1387:3: error: 'subcs' undeclared

Modify variable declaration to be included based on WITH_TLS flag as
well as WITH_DHCP and WITH_VMPS