### PR TITLE
ldap: allow to connect on partially open handle

### DIFF
--- a/raddb/mods-available/ldap
+++ b/raddb/mods-available/ldap
@@ -612,7 +612,7 @@ ldap {
 		#  connections during instantiation it will exit.
 		#  Set to 0 to allow the server to start without the
 		#  directory being available.
-		start = ${thread[pool].start_servers}
+		start = 0
 
 		#  Minimum number of connections to keep open
 		min = ${thread[pool].min_spare_servers}

--- a/src/modules/rlm_ldap/ldap.c
+++ b/src/modules/rlm_ldap/ldap.c
@@ -717,7 +717,8 @@ ldap_rcode_t rlm_ldap_bind(rlm_ldap_t const *inst, REQUEST *request, ldap_handle
 	 *	For sanity, for when no connections are viable,
 	 *	and we can't make a new one.
 	 */
-	num = retry ? fr_connection_pool_get_num(inst->pool) : 0;
+	num = 0;
+	if (inst->pool && retry) num = fr_connection_pool_get_num(inst->pool);
 	for (i = num; i >= 0; i--) {
 #ifdef WITH_SASL
 		if (sasl && sasl->mech) {
@@ -758,7 +759,7 @@ ldap_rcode_t rlm_ldap_bind(rlm_ldap_t const *inst, REQUEST *request, ldap_handle
 			break;
 
 		case LDAP_PROC_RETRY:
-			if (retry) {
+			if (num) {
 				*pconn = fr_connection_reconnect(inst->pool, *pconn);
 				if (*pconn) {
 					LDAP_DBGW_REQ("Bind with %s to %s failed: %s. Got new socket, retrying...",
@@ -1563,7 +1564,7 @@ void *mod_conn_create(TALLOC_CTX *ctx, void *instance)
 	}
 
 	status = rlm_ldap_bind(inst, NULL, &conn, conn->inst->admin_identity, conn->inst->admin_password,
-			       &(conn->inst->admin_sasl), false);
+			       &(conn->inst->admin_sasl), true);
 	if (status != LDAP_PROC_SUCCESS) {
 		goto error;
 	}


### PR DESCRIPTION
The LDAP library returns a partially open connection. Setting the
'retry' flag to true during the module inst creation and the pool start
to 0 allows to connect even if the connection is not completely opened
yet.

Signed-off-by: Antonio Torres <antorres@redhat.com>