### PR TITLE
fuzzer-fetch-artifacts: Align with artifact name and contents; better usage

### DIFF
--- a/scripts/build/fuzzer-fetch-artifacts
+++ b/scripts/build/fuzzer-fetch-artifacts
@@ -8,6 +8,10 @@
 
 set -e
 
+#
+#  Run from the project top-level directory
+#
+cd $(dirname $0/)/../..
 
 REPRODUCER_DIR=build/fuzzer
 
@@ -17,23 +21,45 @@ usage() {
  cat <<EOF
 Usage:
 
-  export GITHUB_TOKEN=<...>
   $0 [ <git-repo> | <download-uri> | <artifact-zip> ]
+
+  Arguments are either:
 
   git-repo     - Either the name of a git remote (default "origin"), or a repo
                  slug such as "FreeRADIUS/freeradius-server".
+
                  This mode will list the download-uris of the available fuzzer
                  artifacts for the repo.
 
   download-uri - "https://api.github.com/..."
+
                  This mode will download the specified artifact and extract the
-                 reproducers that it contains.
+                 reproducers that it contains. (The list of available fuzzer
+                 artifacts is ouput by the preceeding mode.)
 
   artifact-zip - "path/to/downloaded/artifact/fuzzer-radius-701e5be.zip"
-                 This mode will extract the reproducers from a manually
-                 downloaded artifact ZIP file.
 
-  Fuzzer artifacts are identified by their name which starts "fuzzer-"
+                 This mode will extract the reproducers from a manually
+                 downloaded artifact ZIP file. The ZIP can for located in the
+                 summary web page for the run within GitHub Actions.
+
+  Note: A PAT is required to access the GitHub API. Export this in the
+  GITHUB_TOKEN environment variable.
+
+  Note: Fuzzer artifacts are identified by their name "clang-fuzzer"
+
+  Typical workflow is as follows:
+
+      $ export GITHUB_TOKEN=<...>    # PAT that has the "repo:public" permission
+
+      # Show artifact list for the given repo or slug (default "origin")
+      $0 FreeRADIUS/freeradius-server
+
+      # Download and extract an fuzzer artifact ZIP file (output of the above command)
+      $0 https://api.github.com/repos/FreeRADIUS/freeradius-server/actions/artifacts/103258361/zip
+
+      # Run a reproducer (output of the above command)
+      scripts/build/fuzzer build/fuzzer/util/crash-ca2b3f7c2d2e2fe36bc6480d71cf6601cbdb6c62
 
   Reproducers are extracted to $REPRODUCER_DIR
 
@@ -104,11 +130,11 @@ list_artifacts() {
     exit 1
   fi
 
-  echo "List of fuzzer artifacts from $ACTIONS_API:"
+  echo "List of fuzzer artifacts from $ACTIONS_API/artifacts:"
   echo
   RESULT=$(
     echo "$RESULT" | sed '$d' | \
-    jq ".artifacts[]|select((.name|startswith(\"fuzzer-\")) and (.expired==false)) | \"$0 \(.archive_download_url)  # \(.created_at) \(.name)\"" --raw-output
+    jq ".artifacts[]|select((.name|startswith(\"clang-fuzzer\")) and (.expired==false)) | \"$0 \(.archive_download_url)  # \(.created_at) \(.name)\"" --raw-output
   )
 
   if [ -z "$RESULT" ]; then
@@ -206,7 +232,7 @@ extract_artifact() {
   echo "Extracting reproducers from $ARTIFACT_ZIP to $REPRODUCER_DIR..."
 
   TMPDIR=$(mktemp -d /tmp/fuzzer.XXXXXX)
-  if ! unzip -q "$ARTIFACT_ZIP" -d "$TMPDIR" -x 'fuzz-*.log'; then
+  if ! unzip -q "$ARTIFACT_ZIP" -d "$TMPDIR" -x '*.log'; then
     echo "Failed to extract $ARTIFACT_ZIP" >&2
     exit 1
   fi


### PR DESCRIPTION
```
$ export GITHUB_TOKEN=[redacted]
$ ./scripts/build/fuzzer-fetch-artifacts FreeRADIUS/freeradius-server
List of fuzzer artifacts from https://api.github.com/repos/FreeRADIUS/freeradius-server/actions/artifacts:

./scripts/build/fuzzer-fetch-artifacts https://api.github.com/repos/FreeRADIUS/freeradius-server/actions/artifacts/103258361/zip  # 2021-10-15T13:09:15Z clang-fuzzer
./scripts/build/fuzzer-fetch-artifacts https://api.github.com/repos/FreeRADIUS/freeradius-server/actions/artifacts/103255748/zip  # 2021-10-15T13:01:42Z clang-fuzzer
./scripts/build/fuzzer-fetch-artifacts https://api.github.com/repos/FreeRADIUS/freeradius-server/actions/artifacts/103247762/zip  # 2021-10-15T12:37:33Z clang-fuzzer
./scripts/build/fuzzer-fetch-artifacts https://api.github.com/repos/FreeRADIUS/freeradius-server/actions/artifacts/103246963/zip  # 2021-10-15T12:34:29Z clang-fuzzer
./scripts/build/fuzzer-fetch-artifacts https://api.github.com/repos/FreeRADIUS/freeradius-server/actions/artifacts/103244515/zip  # 2021-10-15T12:26:51Z clang-fuzzer
./scripts/build/fuzzer-fetch-artifacts https://api.github.com/repos/FreeRADIUS/freeradius-server/actions/artifacts/103242885/zip  # 2021-10-15T12:21:04Z clang-fuzzer
./scripts/build/fuzzer-fetch-artifacts https://api.github.com/repos/FreeRADIUS/freeradius-server/actions/artifacts/103050729/zip  # 2021-10-14T22:21:56Z clang-fuzzer
./scripts/build/fuzzer-fetch-artifacts https://api.github.com/repos/FreeRADIUS/freeradius-server/actions/artifacts/103049427/zip  # 2021-10-14T22:17:42Z clang-fuzzer

Run the above commands to download and extract the reproducers.

$ ./scripts/build/fuzzer-fetch-artifacts https://api.github.com/repos/FreeRADIUS/freeradius-server/actions/artifacts/103258361/zip
Downloading https://api.github.com/repos/FreeRADIUS/freeradius-server/actions/artifacts/103258361/zip to /tmp/fuzzer.SHn2fX...

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 40443    0 40443    0     0  52050      0 --:--:-- --:--:-- --:--:-- 52050

Extracting reproducers from /tmp/fuzzer.SHn2fX to build/fuzzer...

scripts/build/fuzzer build/fuzzer/util/slow-unit-dd171eaaedc0c4701fbdc6ea1934beabcc1649e1

You should now be able to reproduce by running the above commands.
```