### PR TITLE
Fix acct_unique policy

### DIFF
--- a/raddb/policy.d/accounting
+++ b/raddb/policy.d/accounting
@@ -54,6 +54,10 @@ acct_unique {
 			&Acct-Unique-Session-Id := "%{md5:%{User-Name},%{Acct-Session-ID},%{%{NAS-IPv6-Address}:-%{NAS-IP-Address}},%{NAS-Identifier},%{NAS-Port-ID},%{NAS-Port}}"
 		 }
 	}
+
+	update request {
+		&Tmp-String-9 !* ANY
+	}
 }
 
 #


### PR DESCRIPTION
As the 'acct_unique' is setting the request:Tmp-String-9, then we should unset it avoiding to have
the "Tmp-String-9" in /var/log/radius/radacct/detail files