### PR TITLE
Add #include <sys/types.h> to the ssize_t test program

### DIFF
--- a/configure
+++ b/configure
@@ -15466,6 +15466,7 @@ else $as_nop
 
         #include <stdint.h>
         #include <stddef.h>
+        #include <sys/types.h>
 
         int main(int argc, char **argv) {
           return _Generic((ssize_t)(0), int64_t: 1, default: 0);


### PR DESCRIPTION
That's (at least one place) where ssize_t gets defined, so the
test program can work as intended. (The header's there for Mac
OS X as well.)