### PR TITLE
Add #include <sys/types.h> to the ssize_t test program

### DIFF
--- a/configure
+++ b/configure
@@ -15487,6 +15487,7 @@ else $as_nop
 
         #include <stdint.h>
         #include <stddef.h>
+        #include <sys/types.h>
 
         int main(int argc, char **argv) {
           return _Generic((ssize_t)(0), int64_t: 1, default: 0);

--- a/m4/ax_cc.m4
+++ b/m4/ax_cc.m4
@@ -398,6 +398,7 @@ AC_CACHE_CHECK([if ssize_t == int64_t], [ax_cv_cc_ssize_same_as_int64],[
       AC_LANG_SOURCE([
         #include <stdint.h>
         #include <stddef.h>
+        #include <sys/types.h>
 
         int main(int argc, char **argv) {
           return _Generic((ssize_t)(0), int64_t: 1, default: 0);


### PR DESCRIPTION
That's (at least one place) where ssize_t gets defined, so the
test program can work as intended. (The header's there for Mac
OS X as well.)