### PR TITLE
Make TEST_CHECK_*() macros display stringified _got

### DIFF
--- a/src/lib/util/acutest_helpers.h
+++ b/src/lib/util/acutest_helpers.h
@@ -30,7 +30,7 @@ extern "C" {
 #define TEST_CHECK_LEN(_got, _exp) \
 do { \
 	size_t _our_got = (_got); \
-	TEST_CHECK(_exp == _our_got); \
+	TEST_CHECK_(_exp == _our_got, "%s", #_got); \
 	TEST_MSG("Expected length : %zu", (size_t)_exp); \
 	TEST_MSG("Got length      : %zu", (size_t)_our_got); \
 } while(0)
@@ -38,7 +38,7 @@ do { \
 #define TEST_CHECK_SLEN(_got, _exp) \
 do { \
 	ssize_t _our_got = (_got); \
-	TEST_CHECK(_exp == _our_got); \
+	TEST_CHECK_(_exp == _our_got, "%s", #_got); \
 	TEST_MSG("Expected length : %zd", (ssize_t)_exp); \
 	TEST_MSG("Got length      : %zd", (ssize_t)_our_got); \
 } while(0)
@@ -46,14 +46,14 @@ do { \
 #define TEST_CHECK_RET(_got, _exp) \
 do { \
 	int _our_got = (_got); \
-	TEST_CHECK(_exp == _our_got); \
+	TEST_CHECK_(_exp == _our_got, "%s", #_got); \
 	TEST_MSG("Expected ret    : %"PRId64, (int64_t)_exp); \
 	TEST_MSG("Got ret         : %"PRId64, (int64_t)_our_got); \
 } while(0)
 #define TEST_CHECK_SLEN(_got, _exp) \
 do { \
 	ssize_t _our_got = (_got); \
-	TEST_CHECK(_exp == _our_got); \
+	TEST_CHECK_(_exp == _our_got, "%s", #_got); \
 	TEST_MSG("Expected length : %zd", (ssize_t)_exp); \
 	TEST_MSG("Got length      : %zd", (ssize_t)_our_got); \
 } while(0)
@@ -61,7 +61,7 @@ do { \
 #define TEST_CHECK_STRCMP(_got, _exp) \
 do { \
 	char const *_our_got = (_got); \
-	TEST_CHECK(((_exp) != NULL) && ((_got) != NULL) && (strcmp(_exp, _our_got) == 0)); \
+	TEST_CHECK_(((_exp) != NULL) && ((_got) != NULL) && (strcmp(_exp, _our_got) == 0), "%s", #_got); \
 	TEST_MSG("Expected : \"%s\"", _exp); \
 	TEST_MSG("Got      : \"%s\"", _our_got); \
 } while(0)


### PR DESCRIPTION
Makes it clearer what's being compared with the expected value,
though it might take an explicit #define of TEST_MSG_MAXSIZE for
a sufficiently convoluted expression.