### PR TITLE
Remove FR_LOCATE_DIR macro

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -38,73 +38,6 @@ fi
 ])
 
 dnl #
-dnl #  Locate the directory in which a particular file is found.
-dnl #
-dnl #  Usage: FR_LOCATE_DIR(MYSQLLIB_DIR, libmysqlclient.a)
-dnl #
-dnl #    Defines the variable MYSQLLIB_DIR to be the directory(s) in
-dnl #    which the file libmysqlclient.a is to be found.
-dnl #
-dnl #
-AC_DEFUN([FR_LOCATE_DIR],
-[
-dnl # If we have the program 'locate', then the problem of finding a
-dnl # particular file becomes MUCH easier.
-dnl #
-
-dnl #
-dnl #  No 'locate' defined, do NOT do anything.
-dnl #
-if test "x$LOCATE" != "x"; then
-dnl #
-dnl #  Root through a series of directories, looking for the given file.
-dnl #
-DIRS=
-file=$2
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-  dnl #
-  dnl #  When asked for 'foo', locate will also find 'foo_bar', which we
-  dnl #  don't want.  We want that EXACT filename.
-  dnl #
-  dnl #  We ALSO want to be able to look for files like 'mysql/mysql.h',
-  dnl #  and properly match them, too.  So we try to strip off the last
-  dnl #  part of the filename, using the name of the file we're looking
-  dnl #  for.  If we CANNOT strip it off, then the name will be unchanged.
-  dnl #
-  base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-  dnl #
-  dnl #  Exclude a number of directories.
-  dnl #
-  exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-  dnl #
-  dnl #  OK, we have an exact match.  Let's be sure that we only find ONE
-  dnl #  matching directory.
-  dnl #
-  already=`echo \$$1 ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-dnl #
-dnl #  And remember the directory in which we found the file.
-dnl #
-eval "$1=\"\$$1 $DIRS\""
-])
-
-
-dnl #
 dnl #  Auto-populate smart_try_dir for includes
 dnl #
 AC_DEFUN([FR_SMART_PKGCONFIG_INCLUDE], [
@@ -205,8 +138,6 @@ dnl #
 dnl #  Try to guess possible locations.
 dnl #
 if test "x$smart_lib" = "x"; then
-FR_LOCATE_DIR(smart_lib_dir,[lib$1${libltdl_cv_shlibext}])
-FR_LOCATE_DIR(smart_lib_dir,[lib$1.a])
 
 for try in $smart_lib_dir /usr/local/lib /opt/lib; do
   AC_MSG_CHECKING([for $2 in -l$1 in $try])
@@ -335,11 +266,6 @@ dnl #
 dnl #  Try to guess possible locations.
 dnl #
 if test "x$smart_include" = "x"; then
-
-for prefix in $smart_prefix; do
-  FR_LOCATE_DIR(_smart_include_dir,"${_prefix}/${1}")
-done
-FR_LOCATE_DIR(_smart_include_dir, $1)
 
 for try in $_smart_include_dir; do
   AC_MSG_CHECKING([for $1 in $try])

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -59,9 +59,10 @@ m4_ifndef([AC_CONFIG_MACRO_DIRS], [m4_defun([_AM_CONFIG_MACRO_DIRS], [])m4_defun
 # configured tree to be moved without reconfiguration.
 
 AC_DEFUN([AM_AUX_DIR_EXPAND],
-[AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT])dnl
-# Expand $ac_aux_dir to an absolute path.
-am_aux_dir=`cd "$ac_aux_dir" && pwd`
+[dnl Rely on autoconf to set up CDPATH properly.
+AC_PREREQ([2.50])dnl
+# expand $ac_aux_dir to an absolute path
+am_aux_dir=`cd $ac_aux_dir && pwd`
 ])
 
 # Fake the existence of programs that GNU maintainers use.  -*- Autoconf -*-

--- a/configure
+++ b/configure
@@ -675,7 +675,6 @@ KQUEUE_LIBS
 TALLOC_LDFLAGS
 TALLOC_LIBS
 DIRNAME
-LOCATE
 AUTOHEADER
 AUTOCONF
 ACLOCAL
@@ -7944,9 +7943,8 @@ fi
 
 
 missing_dir=`cd $ac_aux_dir && pwd`
-
-# Expand $ac_aux_dir to an absolute path.
-am_aux_dir=`cd "$ac_aux_dir" && pwd`
+# expand $ac_aux_dir to an absolute path
+am_aux_dir=`cd $ac_aux_dir && pwd`
 
 
   if test x"${MISSING+set}" != xset; then
@@ -7974,51 +7972,6 @@ AUTOCONF=${AUTOCONF-"${am_missing_run}autoconf"}
 
 
 AUTOHEADER=${AUTOHEADER-"${am_missing_run}autoheader"}
-
-
-# Extract the first word of "locate", so it can be a program name with args.
-set dummy locate; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_path_LOCATE+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  case $LOCATE in
-  [\\/]* | ?:[\\/]*)
-  ac_cv_path_LOCATE="$LOCATE" # Let the user override the test with a path.
-  ;;
-  *)
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_path_LOCATE="$as_dir$ac_word$ac_exec_ext"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  ;;
-esac
-fi
-LOCATE=$ac_cv_path_LOCATE
-if test -n "$LOCATE"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $LOCATE" >&5
-printf "%s\n" "$LOCATE" >&6; }
-else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-fi
 
 
 # Extract the first word of "dirname", so it can be a program name with args.
@@ -9307,60 +9260,6 @@ fi
 
 if test "x$smart_lib" = "x"; then
 
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libtalloc${libltdl_cv_shlibext}
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libtalloc.a
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
 for try in $smart_lib_dir /usr/local/lib /opt/lib; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for _talloc in -ltalloc in $try" >&5
 printf %s "checking for _talloc in -ltalloc in $try... " >&6; }
@@ -9512,60 +9411,6 @@ fi
 
 if test "x$smart_lib" = "x"; then
 
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libkqueue${libltdl_cv_shlibext}
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libkqueue.a
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
 for try in $smart_lib_dir /usr/local/lib /opt/lib; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for kqueue in -lkqueue in $try" >&5
 printf %s "checking for kqueue in -lkqueue in $try... " >&6; }
@@ -9702,60 +9547,6 @@ LIBS="$old_LIBS"
 fi
 
 if test "x$smart_lib" = "x"; then
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libpcap${libltdl_cv_shlibext}
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libpcap.a
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
 
 for try in $smart_lib_dir /usr/local/lib /opt/lib; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for pcap_open_live in -lpcap in $try" >&5
@@ -9916,60 +9707,6 @@ fi
 
 if test "x$smart_lib" = "x"; then
 
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libcollectdclient${libltdl_cv_shlibext}
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libcollectdclient.a
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
 for try in $smart_lib_dir /usr/local/lib /opt/lib; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for lcc_connect in -lcollectdclient in $try" >&5
 printf %s "checking for lcc_connect in -lcollectdclient in $try... " >&6; }
@@ -10102,60 +9839,6 @@ LIBS="$old_LIBS"
 fi
 
 if test "x$smart_lib" = "x"; then
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libcap${libltdl_cv_shlibext}
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libcap.a
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
 
 for try in $smart_lib_dir /usr/local/lib /opt/lib; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for cap_get_proc in -lcap in $try" >&5
@@ -10292,60 +9975,6 @@ fi
 
 if test "x$smart_lib" = "x"; then
 
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libprofiler${libltdl_cv_shlibext}
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libprofiler.a
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
 for try in $smart_lib_dir /usr/local/lib /opt/lib; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ProfilerStart in -lprofiler in $try" >&5
 printf %s "checking for ProfilerStart in -lprofiler in $try... " >&6; }
@@ -10480,60 +10109,6 @@ LIBS="$old_LIBS"
 fi
 
 if test "x$smart_lib" = "x"; then
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libsystemd${libltdl_cv_shlibext}
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libsystemd.a
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
 
 for try in $smart_lib_dir /usr/local/lib /opt/lib; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for sd_notify in -lsystemd in $try" >&5
@@ -10676,60 +10251,6 @@ LIBS="$old_LIBS"
 fi
 
 if test "x$smart_lib" = "x"; then
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libsystemd${libltdl_cv_shlibext}
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libsystemd.a
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
 
 for try in $smart_lib_dir /usr/local/lib /opt/lib; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for sd_watchdog_enabled in -lsystemd in $try" >&5
@@ -11046,63 +10567,6 @@ fi
 
 if test "x$smart_include" = "x"; then
 
-for prefix in $smart_prefix; do
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file="${_prefix}/${1}"
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-done
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=talloc.h
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-
 for try in $_smart_include_dir; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for talloc.h in $try" >&5
 printf %s "checking for talloc.h in $try... " >&6; }
@@ -11284,63 +10748,6 @@ fi
 
 if test "x$smart_include" = "x"; then
 
-for prefix in $smart_prefix; do
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file="${_prefix}/${1}"
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-done
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=sys/event.h
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-
 for try in $_smart_include_dir; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for sys/event.h in $try" >&5
 printf %s "checking for sys/event.h in $try... " >&6; }
@@ -11493,60 +10900,6 @@ fi
 
 if test "x$smart_lib" = "x"; then
 
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libcrypto${libltdl_cv_shlibext}
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libcrypto.a
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
 for try in $smart_lib_dir /usr/local/lib /opt/lib; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for DH_new in -lcrypto in $try" >&5
 printf %s "checking for DH_new in -lcrypto in $try... " >&6; }
@@ -11676,60 +11029,6 @@ LIBS="$old_LIBS"
 fi
 
 if test "x$smart_lib" = "x"; then
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libssl${libltdl_cv_shlibext}
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libssl.a
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
 
 for try in $smart_lib_dir /usr/local/lib /opt/lib; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for SSL_new in -lssl in $try" >&5
@@ -11927,63 +11226,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
-for prefix in $smart_prefix; do
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file="${_prefix}/${1}"
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-done
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=openssl/ssl.h
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
 
 for try in $_smart_include_dir; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for openssl/ssl.h in $try" >&5
@@ -12288,63 +11530,6 @@ fi
 
 if test "x$smart_include" = "x"; then
 
-for prefix in $smart_prefix; do
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file="${_prefix}/${1}"
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-done
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=pcap.h
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-
 for try in $_smart_include_dir; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for pcap.h in $try" >&5
 printf %s "checking for pcap.h in $try... " >&6; }
@@ -12534,63 +11719,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
-for prefix in $smart_prefix; do
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file="${_prefix}/${1}"
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-done
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=collectd/client.h
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
 
 for try in $_smart_include_dir; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for collectd/client.h in $try" >&5
@@ -12782,63 +11910,6 @@ fi
 
 if test "x$smart_include" = "x"; then
 
-for prefix in $smart_prefix; do
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file="${_prefix}/${1}"
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-done
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=sys/capability.h
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-
 for try in $_smart_include_dir; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for sys/capability.h in $try" >&5
 printf %s "checking for sys/capability.h in $try... " >&6; }
@@ -13026,63 +12097,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
-for prefix in $smart_prefix; do
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file="${_prefix}/${1}"
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-done
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=gperftools/profiler.h
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
 
 for try in $_smart_include_dir; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for gperftools/profiler.h in $try" >&5
@@ -13274,63 +12288,6 @@ fi
 
 if test "x$smart_include" = "x"; then
 
-for prefix in $smart_prefix; do
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file="${_prefix}/${1}"
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-done
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=systemd/sd-daemon.h
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-
 for try in $_smart_include_dir; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for systemd/sd-daemon.h in $try" >&5
 printf %s "checking for systemd/sd-daemon.h in $try... " >&6; }
@@ -13516,63 +12473,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
-for prefix in $smart_prefix; do
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file="${_prefix}/${1}"
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-done
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=gnumake.h
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
 
 for try in $_smart_include_dir; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for gnumake.h in $try" >&5
@@ -15807,63 +14707,6 @@ fi
 
 if test "x$smart_include" = "x"; then
 
-for prefix in $smart_prefix; do
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file="${_prefix}/${1}"
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-done
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=execinfo.h
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-
 for try in $_smart_include_dir; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for execinfo.h in $try" >&5
 printf %s "checking for execinfo.h in $try... " >&6; }
@@ -15990,60 +14833,6 @@ LIBS="$old_LIBS"
 fi
 
 if test "x$smart_lib" = "x"; then
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libexecinfo${libltdl_cv_shlibext}
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libexecinfo.a
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
 
 for try in $smart_lib_dir /usr/local/lib /opt/lib; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for backtrace_symbols in -lexecinfo in $try" >&5
@@ -16263,63 +15052,6 @@ fi
 
 if test "x$smart_include" = "x"; then
 
-for prefix in $smart_prefix; do
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file="${_prefix}/${1}"
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-done
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=pcre2.h
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-
 for try in $_smart_include_dir; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for pcre2.h in $try" >&5
 printf %s "checking for pcre2.h in $try... " >&6; }
@@ -16446,60 +15178,6 @@ LIBS="$old_LIBS"
 fi
 
 if test "x$smart_lib" = "x"; then
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libpcre2-8${libltdl_cv_shlibext}
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libpcre2-8.a
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
 
 for try in $smart_lib_dir /usr/local/lib /opt/lib; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for pcre2_compile_8 in -lpcre2-8 in $try" >&5
@@ -16684,63 +15362,6 @@ fi
 
 if test "x$smart_include" = "x"; then
 
-for prefix in $smart_prefix; do
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file="${_prefix}/${1}"
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-done
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=pcre.h
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-
 for try in $_smart_include_dir; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for pcre.h in $try" >&5
 printf %s "checking for pcre.h in $try... " >&6; }
@@ -16867,60 +15488,6 @@ LIBS="$old_LIBS"
 fi
 
 if test "x$smart_lib" = "x"; then
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libpcre${libltdl_cv_shlibext}
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=libpcre.a
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$smart_lib_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "smart_lib_dir=\"\$smart_lib_dir $DIRS\""
-
 
 for try in $smart_lib_dir /usr/local/lib /opt/lib; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for pcre_compile in -lpcre in $try" >&5
@@ -17169,63 +15736,6 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
 fi
 
 if test "x$smart_include" = "x"; then
-
-for prefix in $smart_prefix; do
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file="${_prefix}/${1}"
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
-done
-
-
-if test "x$LOCATE" != "x"; then
-DIRS=
-file=regex.h
-
-for x in `${LOCATE} $file 2>/dev/null`; do
-                    base=`echo $x | sed "s%/${file}%%"`
-  if test "x$x" = "x$base"; then
-    continue;
-  fi
-
-  dir=`${DIRNAME} $x 2>/dev/null`
-        exclude=`echo ${dir} | ${GREP} /home`
-  if test "x$exclude" != "x"; then
-    continue
-  fi
-
-          already=`echo \$_smart_include_dir ${DIRS} | ${GREP} ${dir}`
-  if test "x$already" = "x"; then
-    DIRS="$DIRS $dir"
-  fi
-done
-fi
-
-eval "_smart_include_dir=\"\$_smart_include_dir $DIRS\""
-
 
 for try in $_smart_include_dir; do
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for regex.h in $try" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -792,7 +792,6 @@ AM_MISSING_PROG(ACLOCAL, aclocal, $missing_dir)
 AM_MISSING_PROG(AUTOCONF, autoconf, $missing_dir)
 AM_MISSING_PROG(AUTOHEADER, autoheader, $missing_dir)
 
-AC_PATH_PROG(LOCATE,locate)
 AC_PATH_PROG(DIRNAME,dirname)
 AC_PATH_PROG(GREP,grep)
 

--- a/src/include/autoconf.h.in
+++ b/src/include/autoconf.h.in
@@ -245,11 +245,11 @@
 /* Define to 1 if you have the `mallopt' function. */
 #undef HAVE_MALLOPT
 
-/* Define to 1 if you have the <memory.h> header file. */
-#undef HAVE_MEMORY_H
-
 /* Define to 1 if you have the `memrchr' function. */
 #undef HAVE_MEMRCHR
+
+/* Define to 1 if you have the <minix/config.h> header file. */
+#undef HAVE_MINIX_CONFIG_H
 
 /* Define to 1 if you have the `mkdirat' function. */
 #undef HAVE_MKDIRAT
@@ -548,6 +548,9 @@
 /* Define to 1 if you have the `vsnprintf' function. */
 #undef HAVE_VSNPRINTF
 
+/* Define to 1 if you have the <wchar.h> header file. */
+#undef HAVE_WCHAR_H
+
 /* Define if the compiler supports -Wdocumentation */
 #undef HAVE_WDOCUMENTATION
 
@@ -603,16 +606,20 @@
 /* Solaris-Style ctime_r */
 #undef SOLARISSTYLE
 
-/* Define to 1 if you have the ANSI C header files. */
 /* Define if the compiler supports ssize_t has the same underlying type as
    int64 */
 #undef SSIZE_SAME_AS_INT64
+
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
 #undef STDC_HEADERS
 
 /* SYSV-Style get*byaddr_r */
 #undef SYSVSTYLE
 
-/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
+/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. This
+   macro is obsolete. */
 #undef TIME_WITH_SYS_TIME
 
 /* Define if the compiler supports a thread local storage class */
@@ -622,21 +629,87 @@
 #ifndef _ALL_SOURCE
 # undef _ALL_SOURCE
 #endif
+/* Enable general extensions on macOS.  */
+#ifndef _DARWIN_C_SOURCE
+# undef _DARWIN_C_SOURCE
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# undef __EXTENSIONS__
+#endif
 /* Enable GNU extensions on systems that have them.  */
 #ifndef _GNU_SOURCE
 # undef _GNU_SOURCE
 #endif
-/* Enable threading extensions on Solaris.  */
+/* Enable X/Open compliant socket functions that do not require linking
+   with -lxnet on HP-UX 11.11.  */
+#ifndef _HPUX_ALT_XOPEN_SOCKET_API
+# undef _HPUX_ALT_XOPEN_SOCKET_API
+#endif
+/* Identify the host operating system as Minix.
+   This macro does not affect the system headers' behavior.
+   A future release of Autoconf may stop defining this macro.  */
+#ifndef _MINIX
+# undef _MINIX
+#endif
+/* Enable general extensions on NetBSD.
+   Enable NetBSD compatibility extensions on Minix.  */
+#ifndef _NETBSD_SOURCE
+# undef _NETBSD_SOURCE
+#endif
+/* Enable OpenBSD compatibility extensions on NetBSD.
+   Oddly enough, this does nothing on OpenBSD.  */
+#ifndef _OPENBSD_SOURCE
+# undef _OPENBSD_SOURCE
+#endif
+/* Define to 1 if needed for POSIX-compatible behavior.  */
+#ifndef _POSIX_SOURCE
+# undef _POSIX_SOURCE
+#endif
+/* Define to 2 if needed for POSIX-compatible behavior.  */
+#ifndef _POSIX_1_SOURCE
+# undef _POSIX_1_SOURCE
+#endif
+/* Enable POSIX-compatible threading on Solaris.  */
 #ifndef _POSIX_PTHREAD_SEMANTICS
 # undef _POSIX_PTHREAD_SEMANTICS
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-5:2014.  */
+#ifndef __STDC_WANT_IEC_60559_ATTRIBS_EXT__
+# undef __STDC_WANT_IEC_60559_ATTRIBS_EXT__
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-1:2014.  */
+#ifndef __STDC_WANT_IEC_60559_BFP_EXT__
+# undef __STDC_WANT_IEC_60559_BFP_EXT__
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-2:2015.  */
+#ifndef __STDC_WANT_IEC_60559_DFP_EXT__
+# undef __STDC_WANT_IEC_60559_DFP_EXT__
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-4:2015.  */
+#ifndef __STDC_WANT_IEC_60559_FUNCS_EXT__
+# undef __STDC_WANT_IEC_60559_FUNCS_EXT__
+#endif
+/* Enable extensions specified by ISO/IEC TS 18661-3:2015.  */
+#ifndef __STDC_WANT_IEC_60559_TYPES_EXT__
+# undef __STDC_WANT_IEC_60559_TYPES_EXT__
+#endif
+/* Enable extensions specified by ISO/IEC TR 24731-2:2010.  */
+#ifndef __STDC_WANT_LIB_EXT2__
+# undef __STDC_WANT_LIB_EXT2__
+#endif
+/* Enable extensions specified by ISO/IEC 24747:2009.  */
+#ifndef __STDC_WANT_MATH_SPEC_FUNCS__
+# undef __STDC_WANT_MATH_SPEC_FUNCS__
 #endif
 /* Enable extensions on HP NonStop.  */
 #ifndef _TANDEM_SOURCE
 # undef _TANDEM_SOURCE
 #endif
-/* Enable general extensions on Solaris.  */
-#ifndef __EXTENSIONS__
-# undef __EXTENSIONS__
+/* Enable X/Open extensions.  Define to 500 only if necessary
+   to make mbstate_t available.  */
+#ifndef _XOPEN_SOURCE
+# undef _XOPEN_SOURCE
 #endif
 
 
@@ -655,26 +728,11 @@
 # endif
 #endif
 
-/* Enable large inode numbers on Mac OS X 10.5.  */
-#ifndef _DARWIN_USE_64_BIT_INODE
-# define _DARWIN_USE_64_BIT_INODE 1
-#endif
-
 /* Number of bits in a file offset, on hosts where this is settable. */
 #undef _FILE_OFFSET_BITS
 
 /* Define for large files, on AIX-style hosts. */
 #undef _LARGE_FILES
-
-/* Define to 1 if on MINIX. */
-#undef _MINIX
-
-/* Define to 2 if the system does not provide POSIX.1 features except with
-   this defined. */
-#undef _POSIX_1_SOURCE
-
-/* Define to 1 if you need to in order for `stat' and other things to work. */
-#undef _POSIX_SOURCE
 
 /* Force OSX >= 10.7 Lion to use RFC2292 IPv6 socket options */
 #undef __APPLE_USE_RFC_3542
@@ -688,7 +746,7 @@
 /* Define to `long int' if <sys/types.h> does not define. */
 #undef off_t
 
-/* Define to `int' if <sys/types.h> does not define. */
+/* Define as a signed integer type capable of holding a process identifier. */
 #undef pid_t
 
 /* Define to `unsigned int' if <sys/types.h> does not define. */


### PR DESCRIPTION
Calling "locate" to find include and library paths makes no sense. The
locate database may contain paths comprised of files meant for entirely
different toolchains.

Fixes: https://github.com/FreeRADIUS/freeradius-server/issues/4317