### PR TITLE
Don't hide other homeservers when one is removed

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -9,6 +9,8 @@ FreeRADIUS 3.0.26 Thu 07 Oct 2021 12:00:00 EDT urgency=low
 	  tested with wpa_supplicant and Windows 11.
 	* Add %{concat:foo[*] ;}, which concatenates a set
 	  of attributes, separated by a character.
+	* Fix for incompelete home server list after deleting a
+	  home server via radmin.
 
 	Bug fixes
 	* Ensure PBKDF2 always uses at least one iteration

--- a/src/include/realms.h
+++ b/src/include/realms.h
@@ -204,6 +204,7 @@ CONF_SECTION	*home_server_cs_afrom_client(CONF_SECTION *client);
 home_server_t	*home_server_byname(char const *name, int type);
 #endif
 #ifdef WITH_STATS
+extern int home_server_max_number;
 home_server_t	*home_server_bynumber(int number);
 #endif
 home_pool_t	*home_pool_byname(char const *name, int type);

--- a/src/main/command.c
+++ b/src/main/command.c
@@ -1151,7 +1151,11 @@ static int command_show_home_servers(rad_listen_t *listener, int argc, char *arg
 
 	char buffer[256];
 
-	for (i = 0; (home = home_server_bynumber(i)) != NULL; i++) {
+	for (i = 0; i < home_server_max_number; i++) {
+
+		if ((home = home_server_bynumber(i)) == NULL)
+			continue;
+
 		/*
 		 *	Internal "virtual" home server.
 		 */

--- a/src/main/realms.c
+++ b/src/main/realms.c
@@ -96,7 +96,7 @@ static realm_config_t *realm_config = NULL;
 static rbtree_t	*home_servers_byaddr = NULL;
 static rbtree_t	*home_servers_byname = NULL;
 #ifdef WITH_STATS
-static int home_server_max_number = 0;
+int home_server_max_number = 0;
 static rbtree_t	*home_servers_bynumber = NULL;
 #endif
 


### PR DESCRIPTION
With dynamic_homeservers the "bynumber" lookup becomes gappy due to deletions,
so we should not stop at such gaps when listing all homeservers.