### PR TITLE
Linking libm fixes CentOS 7 builds

### DIFF
--- a/configure
+++ b/configure
@@ -8628,6 +8628,51 @@ fi
 
 
 
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for sqrt in -lm" >&5
+printf %s "checking for sqrt in -lm... " >&6; }
+if test ${ac_cv_lib_m_sqrt+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lm  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+char sqrt ();
+int
+main (void)
+{
+return sqrt ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_lib_m_sqrt=yes
+else $as_nop
+  ac_cv_lib_m_sqrt=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_m_sqrt" >&5
+printf "%s\n" "$ac_cv_lib_m_sqrt" >&6; }
+if test "x$ac_cv_lib_m_sqrt" = xyes
+then :
+  printf "%s\n" "#define HAVE_LIBM 1" >>confdefs.h
+
+  LIBS="-lm $LIBS"
+
+fi
+
+
+
 ac_header_dirent=no
 for ac_hdr in dirent.h sys/ndir.h sys/dir.h ndir.h; do
   as_ac_Header=`printf "%s\n" "ac_cv_header_dirent_$ac_hdr" | $as_tr_sh`

--- a/configure.ac
+++ b/configure.ac
@@ -917,6 +917,11 @@ dnl #  older Linuxes for clock_gettime.
 dnl #
 AC_CHECK_LIB(rt, clock_gettime)
 
+dnl #
+dnl #  Check for -lm
+dnl #
+AC_CHECK_LIB(m, sqrt)
+
 dnl #############################################################
 dnl #
 dnl #  2b. Checks for system header files

--- a/src/include/autoconf.h.in
+++ b/src/include/autoconf.h.in
@@ -208,6 +208,9 @@
 /* Define to 1 if you have the `dl' library (-ldl). */
 #undef HAVE_LIBDL
 
+/* Define to 1 if you have the `m' library (-lm). */
+#undef HAVE_LIBM
+
 /* Define to 1 if you have the `nsl' library (-lnsl). */
 #undef HAVE_LIBNSL
 


### PR DESCRIPTION
Since 09adee3bfaff25b6a97ee942ce1228c0af02fc69 we need to link libm for fpclassify().