### PR TITLE
ssl_mysql_arg use int type instead bool

### DIFF
--- a/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c
@@ -250,7 +250,7 @@ static sql_rcode_t sql_socket_init(rlm_sql_handle_t *handle, rlm_sql_config_t *c
 #if HAVE_TLS_OPTIONS
 	{
 		enum mysql_option ssl_mysql_opt;
-		bool              ssl_mysql_arg = false;
+		int               ssl_mysql_arg = 0;
 		bool              ssl_mode_isset = false;
 
 #  if defined(MARIADB_VERSION_ID) || defined(MARIADB_BASE_VERSION)


### PR DESCRIPTION
I used freeradius 3.0.25 with mysql-community-devel 8.0.27.
I set the tls_required = yes but it not work.
I see the mysql.h MYSQL_OPT_SSL_MODE should be a enum.