### PR TITLE
fix compile error

### DIFF
--- a/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c
@@ -250,7 +250,7 @@ static sql_rcode_t sql_socket_init(rlm_sql_handle_t *handle, rlm_sql_config_t *c
 #if HAVE_TLS_OPTIONS
 	{
 		enum mysql_option ssl_mysql_opt;
-		unsigned int   	  ssl_mysql_arg = SL_MODE_PREFERRED;
+		unsigned int   	  ssl_mysql_arg = SSL_MODE_PREFERRED;
 		bool              ssl_mode_isset = false;
 
 #  if defined(MARIADB_VERSION_ID) || defined(MARIADB_BASE_VERSION)


### PR DESCRIPTION
I see the commit [f808391](https://github.com/FreeRADIUS/freeradius-server/commit/f8083917aec91b17b9d72e46dbd5883114270cc5).
but in mysql.h, the enum name should be SSL_MODE_PREFERRED not the SL_MODE_PREFERRED, I think this is a spelling mistake.
But in different versions of mysql-devel, some versions don't have enum mysql_ssl_mode,  such as mariadb-devel.x86_64 1:5.5.68, does it cause compilation failure in these versions and do we need to care about this.