### PR TITLE
eapol_test-build.sh: Set more permissive CFLAGS for FreeBSD

### DIFF
--- a/scripts/ci/eapol_test-build.sh
+++ b/scripts/ci/eapol_test-build.sh
@@ -89,23 +89,6 @@ if ! [ -e "${HOSTAPD_DIR}/.git" ] && ! git clone --branch "${HOSTAPD_GIT_TAG}" -
     exit 1
 fi
 
-#
-#  Required for LLVM builds until 2.10 which includes commit 12388313a0
-#
-patch -d "${TMP_BUILD_DIR}/hostapd" -p1 --ignore-whitespace <<'EOF'
---- a/src/radius/radius_client.c
-+++ b/src/radius/radius_client.c
-@@ -814,7 +814,7 @@ static void radius_client_receive(int sock, void *eloop_ctx, void *sock_ctx)
- {
-        struct radius_client_data *radius = eloop_ctx;
-        struct hostapd_radius_servers *conf = radius->conf;
--       RadiusType msg_type = (RadiusType) sock_ctx;
-+       RadiusType msg_type = (uintptr_t) sock_ctx;
-        int len, roundtrip;
-        unsigned char buf[3000];
-        struct radius_msg *msg;
-EOF
-
 cp -n "$BUILD_CONF_FILE" "$WPA_SUPPLICANT_DIR/.config"
 
 if ! ${MAKE} -C "${WPA_SUPPLICANT_DIR}" -j8 eapol_test 1>&2 || [ ! -e "${WPA_SUPPLICANT_DIR}/eapol_test" ]; then

--- a/scripts/ci/eapol_test/config_freebsd
+++ b/scripts/ci/eapol_test/config_freebsd
@@ -9,7 +9,7 @@
 # be modified from here. In most cases, these lines should use += in order not
 # to override previous values of the variables.
 
-CFLAGS += -g3 -O0 -Wno-error=deprecated-declarations
+CFLAGS += -g3 -O0 -Wno-error=deprecated-declarations -Wno-error=void-pointer-to-enum-cast
 #CFLAGS += -I/usr/local/include/openssl
 #LIBS += -L/usr/local/lib
 


### PR DESCRIPTION
Patch tries really hard to interact with the console when a patch doesn't apply cleanly.