### PR TITLE
Remove Ubuntu 18.04 from build matrix

### DIFF
--- a/.github/workflows/ci-deb.yml
+++ b/.github/workflows/ci-deb.yml
@@ -34,7 +34,6 @@ jobs:
           M=$(cat <<EOF
           {
             "env": [
-              { "NAME": "ubuntu-18.04", "OS": "ubuntu:18.04"    },
               { "NAME": "ubuntu-20.04", "OS": "ubuntu:20.04"    },
               { "NAME": "debian-10",    "OS": "debian:buster"   },
               { "NAME": "debian-11",    "OS": "debian:bullseye" },


### PR DESCRIPTION
Ubuntu 18.04 uses OpenSSL 1.1.1 which lacks the OPENSSL_INIT_NO_ATEXIT
option used to control cleanup sequence.

Also, 18.04 is likely to be end of life by the time FreeRADIUS v4 is
production ready.