### PR TITLE
rlm_python: Strip out -ffat-lto-objects

### DIFF
--- a/src/modules/rlm_python/configure
+++ b/src/modules/rlm_python/configure
@@ -2805,8 +2805,9 @@ $as_echo "$as_me: ${PYTHON_CONFIG_BIN}'s cflags were \"${python_cflags}\"" >&6;}
 			s/ -W[^ ]*/ /g;\
 			s/ -DNDEBUG[[:blank:]]*/ /g;\
 			s/ -frecord-gcc-switches/ /g;\
-			s/ -fstack-clash-protection[[:blank:]]*/ /g;
-			s/ -specs=[^ ]*/ /g;
+			s/ -fstack-clash-protection[[:blank:]]*/ /g;\
+			s/ -specs=[^ ]*/ /g;\
+			s/ -ffat-lto-objects/ /g;
 			'`
 		{ $as_echo "$as_me:${as_lineno-$LINENO}: Sanitized cflags were \"${mod_cflags}\"" >&5
 $as_echo "$as_me: Sanitized cflags were \"${mod_cflags}\"" >&6;}

--- a/src/modules/rlm_python/configure.ac
+++ b/src/modules/rlm_python/configure.ac
@@ -67,6 +67,7 @@ if test x$with_[]modname != xno; then
 		dnl # supported by clang < 11.
 		dnl # Strip -frecord-gcc-switches. We decide if this needs recording, not python.
 		dnl # Strip specs as they're only supported by GCC and cause warnings under clang
+		dnl # Strip -ffat-lto-objects, We decide if we need that, not python.
 		mod_cflags=`echo " $python_cflags" | sed -e '\
 			s/ -I/ -isystem/g;\
 			s/ -isysroot[[ =]]\{0,1\}[[^-]]*/ /g;\
@@ -76,8 +77,9 @@ if test x$with_[]modname != xno; then
 			s/ -W[[^ ]]*/ /g;\
 			s/ -DNDEBUG[[[:blank:]]]*/ /g;\
 			s/ -frecord-gcc-switches/ /g;\
-			s/ -fstack-clash-protection[[[:blank:]]]*/ /g;
-			s/ -specs=[[^ ]]*/ /g;
+			s/ -fstack-clash-protection[[[:blank:]]]*/ /g;\
+			s/ -specs=[[^ ]]*/ /g;\
+			s/ -ffat-lto-objects/ /g;
 			'`
 		AC_MSG_NOTICE([Sanitized cflags were \"${mod_cflags}\"])
 


### PR DESCRIPTION
We must decide which CFLAGS should be used. Not the Python.