### PR TITLE
eapol_test-build.sh: Fix typo

### DIFF
--- a/scripts/ci/eapol_test-build.sh
+++ b/scripts/ci/eapol_test-build.sh
@@ -59,9 +59,11 @@ fi
 #
 if openssl version | grep -q "OpenSSL 3\."; then
     export EAPOL_TEST_CFLAGS="${EAPOL_TEST_CFLAGS} -DOPENSSL_USE_DEPRECATED -DOPENSSL_API_COMPAT=0x10101000L"
+    (
     echo "WARNING: Building against OpenSSL 3, setting:"
     echo "  EAPOL_TEST_CFLAGS='${EAPOL_TEST_CFLAGS}'"
     echo "  EAPOL_TEST_LDFLAGS='${EAPOL_TEST_LDFLAGS}'"
+    ) 1>&2
 fi
 
 case "$OSTYPE" in


### PR DESCRIPTION
The scripts stdout should be only the 'eapol_test' binary.
Therefore, let's redirect these messages to stderr.