### PR TITLE
Don't refer to errno when the pthread library fails

### DIFF
--- a/src/lib/io/schedule.c
+++ b/src/lib/io/schedule.c
@@ -704,6 +704,7 @@ int fr_schedule_destroy(fr_schedule_t **sc_to_free)
 	unsigned int		i;
 	fr_schedule_worker_t	*sw;
 	fr_schedule_network_t	*sn;
+	int			ret;
 
 	if (!sc) return 0;
 
@@ -756,8 +757,8 @@ int fr_schedule_destroy(fr_schedule_t **sc_to_free)
 		 *	exited before the main thread cleans up the
 		 *	module instances.
 		 */
-		if (pthread_join(sn->pthread_id, NULL) != 0) {
-			ERROR("Failed joining network %i: %s", sn->id, fr_syserror(errno));
+		if ((ret = pthread_join(sn->pthread_id, NULL)) != 0) {
+			ERROR("Failed joining network %i: %s", sn->id, fr_syserror(ret));
 		} else {
 			DEBUG2("Network %i joined (cleaned up)", sn->id);
 		}
@@ -790,8 +791,8 @@ int fr_schedule_destroy(fr_schedule_t **sc_to_free)
 		 *	exited before the main thread cleans up the
 		 *	module instances.
 		 */
-		if (pthread_join(sw->pthread_id, NULL) != 0) {
-			ERROR("Failed joining worker %i: %s", sw->id, fr_syserror(errno));
+		if ((ret = pthread_join(sw->pthread_id, NULL)) != 0) {
+			ERROR("Failed joining worker %i: %s", sw->id, fr_syserror(ret));
 		} else {
 			DEBUG2("Worker %i joined (cleaned up)", sw->id);
 		}

--- a/src/modules/rlm_cache/drivers/rlm_cache_rbtree/rlm_cache_rbtree.c
+++ b/src/modules/rlm_cache/drivers/rlm_cache_rbtree/rlm_cache_rbtree.c
@@ -97,6 +97,7 @@ static int mod_detach(module_detach_ctx_t const *mctx)
 static int mod_instantiate(module_inst_ctx_t const *mctx)
 {
 	rlm_cache_rbtree_t *driver = talloc_get_type_abort(mctx->inst->data, rlm_cache_rbtree_t);
+	int ret;
 
 	/*
 	 *	The cache.
@@ -116,8 +117,8 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 		return -1;
 	}
 
-	if (pthread_mutex_init(&driver->mutex, NULL) < 0) {
-		ERROR("Failed initializing mutex: %s", fr_syserror(errno));
+	if ((ret = pthread_mutex_init(&driver->mutex, NULL)) < 0) {
+		ERROR("Failed initializing mutex: %s", fr_syserror(ret));
 		return -1;
 	}
 

--- a/src/modules/rlm_sql/drivers/rlm_sql_cassandra/rlm_sql_cassandra.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_cassandra/rlm_sql_cassandra.c
@@ -728,6 +728,7 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 	bool			do_tls = false;
 	bool			do_latency_aware_routing = false;
 	CassCluster 		*cluster;
+	int			ret;
 
 #define DO_CASS_OPTION(_opt, _x) \
 do {\
@@ -738,8 +739,8 @@ do {\
 	}\
 } while (0)
 
-	if (pthread_mutex_init(&inst->connect_mutex, NULL) < 0) {
-		ERROR("Failed initializing mutex: %s", fr_syserror(errno));
+	if ((ret = pthread_mutex_init(&inst->connect_mutex, NULL)) < 0) {
+		ERROR("Failed initializing mutex: %s", fr_syserror(ret));
 		TALLOC_FREE(inst);
 		return -1;
 	}


### PR DESCRIPTION
When the pthread library fails, errno is referenced even though errno is not set.
Fix to refer to the return code of the pthread library instead of errno.