### PR TITLE
test: Remove listen{} detail

### DIFF
--- a/src/tests/config/test.conf
+++ b/src/tests/config/test.conf
@@ -45,12 +45,6 @@ policy {
 #
 server test {
 	listen {
-		type = detail
-		filename = ${radacctdir}/detail
-		load_factor = 10
-	}
-
-	listen {
 		ipaddr = 127.0.0.1
 		port = ${test_port}
 		type = auth


### PR DESCRIPTION
It only pollutes the logs. We don't need it.