### PR TITLE
v4: Remove ifdefs for longstanding OpenLDAP features

### DIFF
--- a/src/lib/ldap/base.c
+++ b/src/lib/ldap/base.c
@@ -78,7 +78,6 @@ fr_table_num_sorted_t const fr_ldap_scope[] = {
 };
 size_t fr_ldap_scope_len = NUM_ELEMENTS(fr_ldap_scope);
 
-#ifdef LDAP_OPT_X_TLS_NEVER
 fr_table_num_sorted_t const fr_ldap_tls_require_cert[] = {
 	{ L("allow"),	LDAP_OPT_X_TLS_ALLOW	},
 	{ L("demand"),	LDAP_OPT_X_TLS_DEMAND	},
@@ -87,7 +86,6 @@ fr_table_num_sorted_t const fr_ldap_tls_require_cert[] = {
 	{ L("try"),	LDAP_OPT_X_TLS_TRY	}
 };
 size_t fr_ldap_tls_require_cert_len = NUM_ELEMENTS(fr_ldap_tls_require_cert);
-#endif
 
 fr_table_num_sorted_t const fr_ldap_dereference[] = {
 	{ L("always"),	LDAP_DEREF_ALWAYS	},

--- a/src/lib/ldap/base.c
+++ b/src/lib/ldap/base.c
@@ -946,11 +946,7 @@ int fr_ldap_global_config(int debug_level, char const *tls_random_file)
 #define maybe_ldap_global_option(_option, _name, _value) \
 	if (_value) do_ldap_global_option(_option, _name, _value)
 
-#ifdef LDAP_OPT_DEBUG_LEVEL
 	if (debug_level) do_ldap_global_option(LDAP_OPT_DEBUG_LEVEL, "ldap_debug", &debug_level);
-#else
-	if (debug_level) WARN("ldap_debug not honoured as LDAP_OPT_DEBUG_LEVEL is not available");
-#endif
 
 #ifdef LDAP_OPT_X_TLS_RANDOM_FILE
 	/*

--- a/src/lib/ldap/base.c
+++ b/src/lib/ldap/base.c
@@ -905,11 +905,8 @@ LDAP *fr_ldap_handle_thread_local(void)
 	if (!ldap_thread_local_handle) {
 		LDAP *handle;
 
-#ifdef HAVE_LDAP_INITIALIZE
 		ldap_initialize(&handle, "");
-#else
-		handle = ldap_init("", 0);
-#endif
+
 		fr_atexit_thread_local(ldap_thread_local_handle, _ldap_handle_thread_local_free, handle);
 	}
 
@@ -979,11 +976,8 @@ int fr_ldap_init(void)
 	 *
 	 *	See: https://github.com/arr2036/ldapperf/issues/2
 	 */
-#ifdef HAVE_LDAP_INITIALIZE
 	ldap_initialize(&ldap_global_handle, "");
-#else
-	ldap_global_handle = ldap_init("", 0);
-#endif
+
 	if (!ldap_global_handle) {
 		ERROR("Failed initialising global LDAP handle");
 		return -1;

--- a/src/lib/ldap/base.c
+++ b/src/lib/ldap/base.c
@@ -116,11 +116,9 @@ void fr_ldap_timeout_debug(request_t *request, fr_ldap_connection_t const *conn,
 
 	if (request) RINDENT();
 
-#ifdef LDAP_OPT_NETWORK_TIMEOUT
 	if (ldap_get_option(conn->handle, LDAP_OPT_NETWORK_TIMEOUT, &net) != LDAP_OPT_SUCCESS) {
 		ROPTIONAL(REDEBUG, ERROR, "Failed getting LDAP_OPT_NETWORK_TIMEOUT");
 	}
-#endif
 
 #ifdef LDAP_OPT_TIMEOUT
 	if (ldap_get_option(conn->handle, LDAP_OPT_TIMEOUT, &client) != LDAP_OPT_SUCCESS) {
@@ -151,7 +149,6 @@ void fr_ldap_timeout_debug(request_t *request, fr_ldap_connection_t const *conn,
 	}
 #endif
 
-#ifdef LDAP_OPT_NETWORK_TIMEOUT
 	if (net && (net->tv_sec != -1)) {
 		ROPTIONAL(RDEBUG4, DEBUG4, "Client side network I/O timeout : %pVs",
 			  fr_box_time_delta(fr_time_delta_from_timeval(net)));
@@ -159,7 +156,7 @@ void fr_ldap_timeout_debug(request_t *request, fr_ldap_connection_t const *conn,
 		ROPTIONAL(RDEBUG4, DEBUG4, "Client side network I/O timeout : unset");
 
 	}
-#endif
+
 	ROPTIONAL(RDEBUG4, DEBUG4, "Server side result timeout      : %i", server);
 	if (request) REXDENT();
 

--- a/src/lib/ldap/base.c
+++ b/src/lib/ldap/base.c
@@ -116,11 +116,9 @@ void fr_ldap_timeout_debug(request_t *request, fr_ldap_connection_t const *conn,
 		ROPTIONAL(REDEBUG, ERROR, "Failed getting LDAP_OPT_NETWORK_TIMEOUT");
 	}
 
-#ifdef LDAP_OPT_TIMEOUT
 	if (ldap_get_option(conn->handle, LDAP_OPT_TIMEOUT, &client) != LDAP_OPT_SUCCESS) {
 		ROPTIONAL(REDEBUG, ERROR, "Failed getting LDAP_OPT_TIMEOUT");
 	}
-#endif
 
 	if (ldap_get_option(conn->handle, LDAP_OPT_TIMELIMIT, &server) != LDAP_OPT_SUCCESS) {
 		ROPTIONAL(REDEBUG, ERROR, "Failed getting LDAP_OPT_TIMELIMIT");
@@ -135,7 +133,6 @@ void fr_ldap_timeout_debug(request_t *request, fr_ldap_connection_t const *conn,
 		ROPTIONAL(RDEBUG4, DEBUG4, "Client side result timeout (ovr): unset");
 	}
 
-#ifdef LDAP_OPT_TIMEOUT
 	if (client && (client->tv_sec != -1)) {
 		ROPTIONAL(RDEBUG4, DEBUG4, "Client side result timeout (dfl): %pVs",
 			  fr_box_time_delta(fr_time_delta_from_timeval(client)));
@@ -143,7 +140,6 @@ void fr_ldap_timeout_debug(request_t *request, fr_ldap_connection_t const *conn,
 	} else {
 		ROPTIONAL(RDEBUG4, DEBUG4, "Client side result timeout (dfl): unset");
 	}
-#endif
 
 	if (net && (net->tv_sec != -1)) {
 		ROPTIONAL(RDEBUG4, DEBUG4, "Client side network I/O timeout : %pVs",

--- a/src/lib/ldap/base.c
+++ b/src/lib/ldap/base.c
@@ -887,11 +887,7 @@ fr_ldap_query_t *fr_ldap_modify_alloc(TALLOC_CTX *ctx, char const *dn,
 
 static void _ldap_handle_thread_local_free(void *handle)
 {
-#ifdef HAVE_LDAP_UNBIND_EXT_S
 	ldap_unbind_ext_s(handle, NULL, NULL);
-#else
-	ldap_unbind_s(handle);
-#endif
 }
 
 /** Get a thread local dummy LDAP handle
@@ -1053,9 +1049,5 @@ void fr_ldap_free(void)
 	 *	of the module should always work,
 	 *	irrespective of what changes happen in libldap.
 	 */
-#ifdef HAVE_LDAP_UNBIND_EXT_S
 	ldap_unbind_ext_s(ldap_global_handle, NULL, NULL);
-#else
-	ldap_unbind_s(ldap_global_handle);
-#endif
 }

--- a/src/lib/ldap/base.c
+++ b/src/lib/ldap/base.c
@@ -948,14 +948,12 @@ int fr_ldap_global_config(int debug_level, char const *tls_random_file)
 
 	if (debug_level) do_ldap_global_option(LDAP_OPT_DEBUG_LEVEL, "ldap_debug", &debug_level);
 
-#ifdef LDAP_OPT_X_TLS_RANDOM_FILE
 	/*
 	 *	OpenLDAP will error out if we attempt to set
 	 *	this on a handle. Presumably it's global in
 	 *	OpenSSL too.
 	 */
 	maybe_ldap_global_option(LDAP_OPT_X_TLS_RANDOM_FILE, "random_file", tls_random_file);
-#endif
 
 	done_config = true;
 

--- a/src/lib/ldap/base.c
+++ b/src/lib/ldap/base.c
@@ -70,9 +70,7 @@ size_t fr_ldap_supported_extensions_len = NUM_ELEMENTS(fr_ldap_supported_extensi
  */
 fr_table_num_sorted_t const fr_ldap_scope[] = {
 	{ L("base"),	LDAP_SCOPE_BASE },
-#ifdef LDAP_SCOPE_CHILDREN
 	{ L("children"),	LDAP_SCOPE_CHILDREN },
-#endif
 	{ L("one"),	LDAP_SCOPE_ONE	},
 	{ L("sub"),	LDAP_SCOPE_SUB	}
 };

--- a/src/lib/ldap/base.h
+++ b/src/lib/ldap/base.h
@@ -282,10 +282,9 @@ typedef struct {
 	/*
 	 *	For keep-alives.
 	 */
-#ifdef LDAP_OPT_X_KEEPALIVE_IDLE
 	fr_time_delta_t		keepalive_idle;		//!< Number of seconds a connections needs to remain idle
 							//!< before TCP starts sending keepalive probes.
-#endif
+
 #ifdef LDAP_OPT_X_KEEPALIVE_PROBES
 	uint32_t		keepalive_probes;	//!< Number of missed timeouts before the connection is
 							///< dropped.

--- a/src/lib/ldap/base.h
+++ b/src/lib/ldap/base.h
@@ -96,7 +96,7 @@ ldap_create_session_tracking_control LDAP_P((
 #  define LDAP_CONST
 #endif
 
-#if defined(HAVE_LDAP_URL_PARSE) && defined(HAVE_LDAP_IS_LDAP_URL) && defined(HAVE_LDAP_URL_DESC2STR)
+#if defined(HAVE_LDAP_IS_LDAP_URL) && defined(HAVE_LDAP_URL_DESC2STR)
 #  define LDAP_CAN_PARSE_URLS
 #endif
 

--- a/src/lib/ldap/base.h
+++ b/src/lib/ldap/base.h
@@ -96,10 +96,6 @@ ldap_create_session_tracking_control LDAP_P((
 #  define LDAP_CONST
 #endif
 
-#if defined(HAVE_LDAP_URL_DESC2STR)
-#  define LDAP_CAN_PARSE_URLS
-#endif
-
 #define LDAP_MAX_CONTROLS		10		//!< Maximum number of client/server controls.
 							//!< Used to allocate static arrays of control pointers.
 #define LDAP_MAX_ATTRMAP		128		//!< Maximum number of mappings between LDAP and

--- a/src/lib/ldap/base.h
+++ b/src/lib/ldap/base.h
@@ -288,9 +288,7 @@ typedef struct {
 	uint32_t		keepalive_probes;	//!< Number of missed timeouts before the connection is
 							///< dropped.
 
-#ifdef LDAP_OPT_X_KEEPALIVE_INTERVAL
 	fr_time_delta_t		keepalive_interval;	//!< Interval between keepalive probes.
-#endif
 
 	/*
 	 *	Search timelimits

--- a/src/lib/ldap/base.h
+++ b/src/lib/ldap/base.h
@@ -285,10 +285,9 @@ typedef struct {
 	fr_time_delta_t		keepalive_idle;		//!< Number of seconds a connections needs to remain idle
 							//!< before TCP starts sending keepalive probes.
 
-#ifdef LDAP_OPT_X_KEEPALIVE_PROBES
 	uint32_t		keepalive_probes;	//!< Number of missed timeouts before the connection is
 							///< dropped.
-#endif
+
 #ifdef LDAP_OPT_X_KEEPALIVE_INTERVAL
 	fr_time_delta_t		keepalive_interval;	//!< Interval between keepalive probes.
 #endif

--- a/src/lib/ldap/base.h
+++ b/src/lib/ldap/base.h
@@ -96,7 +96,7 @@ ldap_create_session_tracking_control LDAP_P((
 #  define LDAP_CONST
 #endif
 
-#if defined(HAVE_LDAP_IS_LDAP_URL) && defined(HAVE_LDAP_URL_DESC2STR)
+#if defined(HAVE_LDAP_URL_DESC2STR)
 #  define LDAP_CAN_PARSE_URLS
 #endif
 

--- a/src/lib/ldap/base.h
+++ b/src/lib/ldap/base.h
@@ -52,14 +52,6 @@ ldap_create_session_tracking_control LDAP_P((
 #endif
 
 /*
- *	Ensure the have the ldap_create_sort_keylist()
- *	function too, else we can't use ldap_create_sort_control()
- */
-#if !defined(HAVE_LDAP_CREATE_SORT_KEYLIST) || !defined(HAVE_LDAP_FREE_SORT_KEYLIST)
-#  undef HAVE_LDAP_CREATE_SORT_CONTROL
-#endif
-
-/*
  *	Because the LTB people define LDAP_VENDOR_VERSION_PATCH
  *	as X, which precludes its use in printf statements *sigh*
  *

--- a/src/lib/ldap/config.h.in
+++ b/src/lib/ldap/config.h.in
@@ -11,9 +11,6 @@
    function. */
 #undef HAVE_LDAP_CREATE_SESSION_TRACKING_CONTROL
 
-/* Define to 1 if you have the `ldap_start_tls_s' function. */
-#undef HAVE_LDAP_START_TLS_S
-
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
 

--- a/src/lib/ldap/config.h.in
+++ b/src/lib/ldap/config.h.in
@@ -32,9 +32,6 @@
 /* Define to 1 if you have the `ldap_url_desc2str' function. */
 #undef HAVE_LDAP_URL_DESC2STR
 
-/* Define to 1 if you have the `ldap_url_parse' function. */
-#undef HAVE_LDAP_URL_PARSE
-
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
 

--- a/src/lib/ldap/config.h.in
+++ b/src/lib/ldap/config.h.in
@@ -26,9 +26,6 @@
 /* Define to 1 if you have the `ldap_start_tls_s' function. */
 #undef HAVE_LDAP_START_TLS_S
 
-/* Define to 1 if you have the `ldap_url_desc2str' function. */
-#undef HAVE_LDAP_URL_DESC2STR
-
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
 

--- a/src/lib/ldap/config.h.in
+++ b/src/lib/ldap/config.h.in
@@ -11,9 +11,6 @@
    function. */
 #undef HAVE_LDAP_CREATE_SESSION_TRACKING_CONTROL
 
-/* Define to 1 if you have the `ldap_sasl_interactive_bind' function. */
-#undef HAVE_LDAP_SASL_INTERACTIVE_BIND
-
 /* Define to 1 if you have the `ldap_start_tls_s' function. */
 #undef HAVE_LDAP_START_TLS_S
 

--- a/src/lib/ldap/config.h.in
+++ b/src/lib/ldap/config.h.in
@@ -32,9 +32,6 @@
 /* Define to 1 if you have the `ldap_start_tls_s' function. */
 #undef HAVE_LDAP_START_TLS_S
 
-/* Define to 1 if you have the `ldap_unbind_ext_s' function. */
-#undef HAVE_LDAP_UNBIND_EXT_S
-
 /* Define to 1 if you have the `ldap_url_desc2str' function. */
 #undef HAVE_LDAP_URL_DESC2STR
 

--- a/src/lib/ldap/config.h.in
+++ b/src/lib/ldap/config.h.in
@@ -14,12 +14,6 @@
 /* Define to 1 if you have the `ldap_create_sort_control' function. */
 #undef HAVE_LDAP_CREATE_SORT_CONTROL
 
-/* Define to 1 if you have the `ldap_create_sort_keylist' function. */
-#undef HAVE_LDAP_CREATE_SORT_KEYLIST
-
-/* Define to 1 if you have the `ldap_free_sort_keylist' function. */
-#undef HAVE_LDAP_FREE_SORT_KEYLIST
-
 /* Define to 1 if you have the `ldap_sasl_interactive_bind' function. */
 #undef HAVE_LDAP_SASL_INTERACTIVE_BIND
 

--- a/src/lib/ldap/config.h.in
+++ b/src/lib/ldap/config.h.in
@@ -20,9 +20,6 @@
 /* Define to 1 if you have the `ldap_free_sort_keylist' function. */
 #undef HAVE_LDAP_FREE_SORT_KEYLIST
 
-/* Define to 1 if you have the `ldap_initialize' function. */
-#undef HAVE_LDAP_INITIALIZE
-
 /* Define to 1 if you have the `ldap_is_ldap_url' function. */
 #undef HAVE_LDAP_IS_LDAP_URL
 

--- a/src/lib/ldap/config.h.in
+++ b/src/lib/ldap/config.h.in
@@ -11,9 +11,6 @@
    function. */
 #undef HAVE_LDAP_CREATE_SESSION_TRACKING_CONTROL
 
-/* Define to 1 if you have the `ldap_create_sort_control' function. */
-#undef HAVE_LDAP_CREATE_SORT_CONTROL
-
 /* Define to 1 if you have the `ldap_sasl_interactive_bind' function. */
 #undef HAVE_LDAP_SASL_INTERACTIVE_BIND
 

--- a/src/lib/ldap/config.h.in
+++ b/src/lib/ldap/config.h.in
@@ -20,9 +20,6 @@
 /* Define to 1 if you have the `ldap_free_sort_keylist' function. */
 #undef HAVE_LDAP_FREE_SORT_KEYLIST
 
-/* Define to 1 if you have the `ldap_is_ldap_url' function. */
-#undef HAVE_LDAP_IS_LDAP_URL
-
 /* Define to 1 if you have the `ldap_sasl_interactive_bind' function. */
 #undef HAVE_LDAP_SASL_INTERACTIVE_BIND
 

--- a/src/lib/ldap/configure
+++ b/src/lib/ldap/configure
@@ -3928,12 +3928,6 @@ then :
   printf "%s\n" "#define HAVE_LDAP_SASL_INTERACTIVE_BIND 1" >>confdefs.h
 
 fi
-ac_fn_c_check_func "$LINENO" "ldap_unbind_ext_s" "ac_cv_func_ldap_unbind_ext_s"
-if test "x$ac_cv_func_ldap_unbind_ext_s" = xyes
-then :
-  printf "%s\n" "#define HAVE_LDAP_UNBIND_EXT_S 1" >>confdefs.h
-
-fi
 ac_fn_c_check_func "$LINENO" "ldap_start_tls_s" "ac_cv_func_ldap_start_tls_s"
 if test "x$ac_cv_func_ldap_start_tls_s" = xyes
 then :

--- a/src/lib/ldap/configure
+++ b/src/lib/ldap/configure
@@ -3922,13 +3922,7 @@ smart_prefix=
 
 
 	if test "x$fail" = "x"; then
-		ac_fn_c_check_func "$LINENO" "ldap_start_tls_s" "ac_cv_func_ldap_start_tls_s"
-if test "x$ac_cv_func_ldap_start_tls_s" = xyes
-then :
-  printf "%s\n" "#define HAVE_LDAP_START_TLS_S 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "ldap_create_session_tracking_control" "ac_cv_func_ldap_create_session_tracking_control"
+		ac_fn_c_check_func "$LINENO" "ldap_create_session_tracking_control" "ac_cv_func_ldap_create_session_tracking_control"
 if test "x$ac_cv_func_ldap_create_session_tracking_control" = xyes
 then :
   printf "%s\n" "#define HAVE_LDAP_CREATE_SESSION_TRACKING_CONTROL 1" >>confdefs.h

--- a/src/lib/ldap/configure
+++ b/src/lib/ldap/configure
@@ -3940,18 +3940,6 @@ then :
   printf "%s\n" "#define HAVE_LDAP_CREATE_SORT_CONTROL 1" >>confdefs.h
 
 fi
-ac_fn_c_check_func "$LINENO" "ldap_create_sort_keylist" "ac_cv_func_ldap_create_sort_keylist"
-if test "x$ac_cv_func_ldap_create_sort_keylist" = xyes
-then :
-  printf "%s\n" "#define HAVE_LDAP_CREATE_SORT_KEYLIST 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "ldap_free_sort_keylist" "ac_cv_func_ldap_free_sort_keylist"
-if test "x$ac_cv_func_ldap_free_sort_keylist" = xyes
-then :
-  printf "%s\n" "#define HAVE_LDAP_FREE_SORT_KEYLIST 1" >>confdefs.h
-
-fi
 ac_fn_c_check_func "$LINENO" "ldap_create_session_tracking_control" "ac_cv_func_ldap_create_session_tracking_control"
 if test "x$ac_cv_func_ldap_create_session_tracking_control" = xyes
 then :

--- a/src/lib/ldap/configure
+++ b/src/lib/ldap/configure
@@ -3922,13 +3922,7 @@ smart_prefix=
 
 
 	if test "x$fail" = "x"; then
-		ac_fn_c_check_func "$LINENO" "ldap_sasl_interactive_bind" "ac_cv_func_ldap_sasl_interactive_bind"
-if test "x$ac_cv_func_ldap_sasl_interactive_bind" = xyes
-then :
-  printf "%s\n" "#define HAVE_LDAP_SASL_INTERACTIVE_BIND 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "ldap_start_tls_s" "ac_cv_func_ldap_start_tls_s"
+		ac_fn_c_check_func "$LINENO" "ldap_start_tls_s" "ac_cv_func_ldap_start_tls_s"
 if test "x$ac_cv_func_ldap_start_tls_s" = xyes
 then :
   printf "%s\n" "#define HAVE_LDAP_START_TLS_S 1" >>confdefs.h
@@ -4265,12 +4259,10 @@ fi
 smart_prefix=
 
 	if test "x$ac_cv_header_sasl_sasl_h" = "xyes"; then
-	  if test x"$ac_cv_func_ldap_sasl_interactive_bind" = "xyes"; then
 
 printf "%s\n" "#define WITH_SASL 1" >>confdefs.h
 
 	    SASL="sasl_s.c sasl.c"
-	  fi
 	fi
 
 	targetname=libfreeradius-ldap

--- a/src/lib/ldap/configure
+++ b/src/lib/ldap/configure
@@ -3958,12 +3958,6 @@ then :
   printf "%s\n" "#define HAVE_LDAP_CREATE_SESSION_TRACKING_CONTROL 1" >>confdefs.h
 
 fi
-ac_fn_c_check_func "$LINENO" "ldap_url_desc2str" "ac_cv_func_ldap_url_desc2str"
-if test "x$ac_cv_func_ldap_url_desc2str" = xyes
-then :
-  printf "%s\n" "#define HAVE_LDAP_URL_DESC2STR 1" >>confdefs.h
-
-fi
 
 
 		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC options needed to detect all undeclared functions" >&5

--- a/src/lib/ldap/configure
+++ b/src/lib/ldap/configure
@@ -3958,12 +3958,6 @@ then :
   printf "%s\n" "#define HAVE_LDAP_CREATE_SESSION_TRACKING_CONTROL 1" >>confdefs.h
 
 fi
-ac_fn_c_check_func "$LINENO" "ldap_url_parse" "ac_cv_func_ldap_url_parse"
-if test "x$ac_cv_func_ldap_url_parse" = xyes
-then :
-  printf "%s\n" "#define HAVE_LDAP_URL_PARSE 1" >>confdefs.h
-
-fi
 ac_fn_c_check_func "$LINENO" "ldap_is_ldap_url" "ac_cv_func_ldap_is_ldap_url"
 if test "x$ac_cv_func_ldap_is_ldap_url" = xyes
 then :

--- a/src/lib/ldap/configure
+++ b/src/lib/ldap/configure
@@ -3958,12 +3958,6 @@ then :
   printf "%s\n" "#define HAVE_LDAP_CREATE_SESSION_TRACKING_CONTROL 1" >>confdefs.h
 
 fi
-ac_fn_c_check_func "$LINENO" "ldap_is_ldap_url" "ac_cv_func_ldap_is_ldap_url"
-if test "x$ac_cv_func_ldap_is_ldap_url" = xyes
-then :
-  printf "%s\n" "#define HAVE_LDAP_IS_LDAP_URL 1" >>confdefs.h
-
-fi
 ac_fn_c_check_func "$LINENO" "ldap_url_desc2str" "ac_cv_func_ldap_url_desc2str"
 if test "x$ac_cv_func_ldap_url_desc2str" = xyes
 then :

--- a/src/lib/ldap/configure
+++ b/src/lib/ldap/configure
@@ -3934,12 +3934,6 @@ then :
   printf "%s\n" "#define HAVE_LDAP_START_TLS_S 1" >>confdefs.h
 
 fi
-ac_fn_c_check_func "$LINENO" "ldap_initialize" "ac_cv_func_ldap_initialize"
-if test "x$ac_cv_func_ldap_initialize" = xyes
-then :
-  printf "%s\n" "#define HAVE_LDAP_INITIALIZE 1" >>confdefs.h
-
-fi
 ac_fn_c_check_func "$LINENO" "ldap_create_sort_control" "ac_cv_func_ldap_create_sort_control"
 if test "x$ac_cv_func_ldap_create_sort_control" = xyes
 then :

--- a/src/lib/ldap/configure
+++ b/src/lib/ldap/configure
@@ -3934,12 +3934,6 @@ then :
   printf "%s\n" "#define HAVE_LDAP_START_TLS_S 1" >>confdefs.h
 
 fi
-ac_fn_c_check_func "$LINENO" "ldap_create_sort_control" "ac_cv_func_ldap_create_sort_control"
-if test "x$ac_cv_func_ldap_create_sort_control" = xyes
-then :
-  printf "%s\n" "#define HAVE_LDAP_CREATE_SORT_CONTROL 1" >>confdefs.h
-
-fi
 ac_fn_c_check_func "$LINENO" "ldap_create_session_tracking_control" "ac_cv_func_ldap_create_session_tracking_control"
 if test "x$ac_cv_func_ldap_create_session_tracking_control" = xyes
 then :

--- a/src/lib/ldap/configure.ac
+++ b/src/lib/ldap/configure.ac
@@ -109,17 +109,7 @@ if test x$with_[]modname_useropt != xno; then
 
 	if test "x$fail" = "x"; then
 		AC_CHECK_FUNCS(
-			ldap_sasl_interactive_bind \
-			ldap_unbind_ext_s \
-			ldap_start_tls_s \
-			ldap_initialize \
-			ldap_create_sort_control \
-			ldap_create_sort_keylist \
-			ldap_free_sort_keylist \
-			ldap_create_session_tracking_control \
-			ldap_url_parse \
-			ldap_is_ldap_url \
-			ldap_url_desc2str
+			ldap_create_session_tracking_control
 		)
 
 		AC_CHECK_DECLS([ldap_create_session_tracking_control], [], [], [[#include <ldap.h>]])

--- a/src/lib/ldap/connection.c
+++ b/src/lib/ldap/connection.c
@@ -121,7 +121,6 @@ DIAG_ON(unused-macros)
 	 */
 	do_ldap_option(LDAP_OPT_REFERRALS, "chase_referrals", LDAP_OPT_OFF);
 
-#ifdef LDAP_OPT_NETWORK_TIMEOUT
 	/*
 	 *	A value of zero results in an handle configuration failure.
 	 *
@@ -133,7 +132,6 @@ DIAG_ON(unused-macros)
 		       (fr_time_delta_ispos(config->net_timeout) ?
 				&fr_time_delta_to_timeval(config->net_timeout) :
 				&(struct timeval) { .tv_sec = -1, .tv_usec = 0 }));
-#endif
 
 	do_ldap_option(LDAP_OPT_TIMELIMIT, "srv_timelimit", &fr_time_delta_to_timeval(config->srv_timelimit));
 
@@ -441,7 +439,6 @@ fr_connection_t	*fr_ldap_connection_state_alloc(TALLOC_CTX *ctx, fr_event_list_t
 
 int fr_ldap_connection_timeout_set(fr_ldap_connection_t const *c, fr_time_delta_t timeout)
 {
-#ifdef LDAP_OPT_NETWORK_TIMEOUT
 	int ldap_errno;
 
 	/*
@@ -455,7 +452,6 @@ int fr_ldap_connection_timeout_set(fr_ldap_connection_t const *c, fr_time_delta_
 		       (fr_time_delta_ispos(timeout) ?
 		       		&fr_time_delta_to_timeval(timeout) :
 		       		&(struct timeval) { .tv_sec = -1, .tv_usec = 0 }));
-#endif
 
 	return 0;
 
@@ -465,8 +461,6 @@ error:
 
 int fr_ldap_connection_timeout_reset(fr_ldap_connection_t const *c)
 {
-
-#ifdef LDAP_OPT_NETWORK_TIMEOUT
 	int ldap_errno;
 
 	/*
@@ -480,7 +474,6 @@ int fr_ldap_connection_timeout_reset(fr_ldap_connection_t const *c)
 		       (fr_time_delta_ispos(c->config->net_timeout) ?
 		       		&fr_time_delta_to_timeval(c->config->net_timeout) :
 				&(struct timeval) { .tv_sec = -1, .tv_usec = 0 }));
-#endif
 
 	return 0;
 

--- a/src/lib/ldap/connection.c
+++ b/src/lib/ldap/connection.c
@@ -138,7 +138,6 @@ DIAG_ON(unused-macros)
 	keepalive = fr_time_delta_to_sec(config->keepalive_interval);
 	do_ldap_option(LDAP_OPT_X_KEEPALIVE_INTERVAL, "keepalive_interval", &keepalive);
 
-#ifdef HAVE_LDAP_START_TLS_S
 	/*
 	 *	Set all of the TLS options
 	 */
@@ -178,7 +177,6 @@ DIAG_ON(unused-macros)
 			     "configuration");
 		}
 	}
-#endif /* HAVE_LDAP_START_TLS_S */
 
 	return 0;
 }

--- a/src/lib/ldap/connection.c
+++ b/src/lib/ldap/connection.c
@@ -67,7 +67,7 @@ static char const *ldap_msg_types[UINT8_MAX] = {
 int fr_ldap_connection_configure(fr_ldap_connection_t *c, fr_ldap_config_t const *config)
 {
 	LDAP				*handle = NULL;
-	int				ldap_errno, ldap_version, keepalive;
+	int				ldap_errno, ldap_version, keepalive, probes;
 
 	fr_assert(config->server);
 
@@ -141,13 +141,8 @@ DIAG_ON(unused-macros)
 	keepalive = fr_time_delta_to_sec(config->keepalive_idle);
 	do_ldap_option(LDAP_OPT_X_KEEPALIVE_IDLE, "keepalive_idle", &keepalive);
 
-#ifdef LDAP_OPT_X_KEEPALIVE_PROBES
-	{
-		int probes = config->keepalive_probes;
-
-		do_ldap_option(LDAP_OPT_X_KEEPALIVE_PROBES, "keepalive_probes", &probes);
-	}
-#endif
+	probes = config->keepalive_probes;
+	do_ldap_option(LDAP_OPT_X_KEEPALIVE_PROBES, "keepalive_probes", &probes);
 
 #ifdef LDAP_OPT_X_KEEPALIVE_INTERVAL
 	{

--- a/src/lib/ldap/connection.c
+++ b/src/lib/ldap/connection.c
@@ -237,7 +237,6 @@ static int _ldap_connection_free(fr_ldap_connection_t *c)
 
 	if (!c->handle) return 0;	/* Don't need to do anything else if we don't yet have a handle */
 
-#ifdef HAVE_LDAP_UNBIND_EXT_S
 	LDAPControl	*our_serverctrls[LDAP_MAX_CONTROLS];
 	LDAPControl	*our_clientctrls[LDAP_MAX_CONTROLS];
 
@@ -248,10 +247,7 @@ static int _ldap_connection_free(fr_ldap_connection_t *c)
 
 	DEBUG3("Closing connection %p libldap handle %p", c->handle, c);
 	ldap_unbind_ext(c->handle, our_serverctrls, our_clientctrls);	/* Same code as ldap_unbind_ext_s */
-#else
-	DEBUG3("Closing connection %p libldap handle %p", c->handle, c);
-	ldap_unbind(c->handle);						/* Same code as ldap_unbind_s */
-#endif
+
 	c->handle = NULL;
 
 	return 0;

--- a/src/lib/ldap/connection.c
+++ b/src/lib/ldap/connection.c
@@ -66,8 +66,8 @@ static char const *ldap_msg_types[UINT8_MAX] = {
  */
 int fr_ldap_connection_configure(fr_ldap_connection_t *c, fr_ldap_config_t const *config)
 {
-	LDAP				*handle = NULL;
-	int				ldap_errno, ldap_version, keepalive, probes;
+	LDAP	*handle = NULL;
+	int	ldap_errno, ldap_version, keepalive, probes, is_server;
 
 	fr_assert(config->server);
 
@@ -174,13 +174,10 @@ DIAG_ON(unused-macros)
 	 *	Counter intuitively the TLS context appears to need to be initialised
 	 *	after all the TLS options are set on the handle.
 	 */
-#  ifdef LDAP_OPT_X_TLS_NEWCTX
-	{
-		/* Always use the new TLS configuration context */
-		int is_server = 0;
-		do_ldap_option(LDAP_OPT_X_TLS_NEWCTX, "new TLS context", &is_server);
-	}
-#  endif
+
+	/* Always use the new TLS configuration context */
+	is_server = 0;
+	do_ldap_option(LDAP_OPT_X_TLS_NEWCTX, "new TLS context", &is_server);
 
 	if (config->sasl_secprops) do_ldap_option(LDAP_OPT_X_SASL_SECPROPS, "sasl_secprops", config->sasl_secprops);
 

--- a/src/lib/ldap/connection.c
+++ b/src/lib/ldap/connection.c
@@ -144,13 +144,8 @@ DIAG_ON(unused-macros)
 	probes = config->keepalive_probes;
 	do_ldap_option(LDAP_OPT_X_KEEPALIVE_PROBES, "keepalive_probes", &probes);
 
-#ifdef LDAP_OPT_X_KEEPALIVE_INTERVAL
-	{
-		int keepalive = fr_time_delta_to_sec(config->keepalive_interval);
-
-		do_ldap_option(LDAP_OPT_X_KEEPALIVE_INTERVAL, "keepalive_interval", &keepalive);
-	}
-#endif
+	keepalive = fr_time_delta_to_sec(config->keepalive_interval);
+	do_ldap_option(LDAP_OPT_X_KEEPALIVE_INTERVAL, "keepalive_interval", &keepalive);
 
 #ifdef HAVE_LDAP_START_TLS_S
 	/*

--- a/src/lib/ldap/connection.c
+++ b/src/lib/ldap/connection.c
@@ -71,21 +71,12 @@ int fr_ldap_connection_configure(fr_ldap_connection_t *c, fr_ldap_config_t const
 
 	fr_assert(config->server);
 
-#ifdef HAVE_LDAP_INITIALIZE
 	ldap_errno = ldap_initialize(&handle, config->server);
 	if (ldap_errno != LDAP_SUCCESS) {
 		ERROR("ldap_initialize failed: %s", ldap_err2string(ldap_errno));
 	error:
 		return -1;
 	}
-#else
-	handle = ldap_init(config->server, config->port);
-	if (!handle) {
-		ERROR("ldap_init failed");
-	error:
-		return -1;
-	}
-#endif
 
 	DEBUG3("New connection %p libldap handle %p", c, handle);
 

--- a/src/lib/ldap/connection.c
+++ b/src/lib/ldap/connection.c
@@ -162,11 +162,9 @@ DIAG_ON(unused-macros)
 	maybe_ldap_option(LDAP_OPT_X_TLS_CERTFILE, "certificate_file", config->tls_certificate_file);
 	maybe_ldap_option(LDAP_OPT_X_TLS_KEYFILE, "private_key_file", config->tls_private_key_file);
 
-#  ifdef LDAP_OPT_X_TLS_REQUIRE_CERT
 	if (config->tls_require_cert_str) {
 		do_ldap_option(LDAP_OPT_X_TLS_REQUIRE_CERT, "require_cert", &config->tls_require_cert);
 	}
-#  endif
 
 	if (config->tls_min_version_str) {
 		do_ldap_option(LDAP_OPT_X_TLS_PROTOCOL_MIN, "tls_min_version", &config->tls_min_version);

--- a/src/lib/ldap/connection.c
+++ b/src/lib/ldap/connection.c
@@ -185,11 +185,9 @@ DIAG_ON(unused-macros)
 	}
 #  endif
 
-#  ifdef LDAP_OPT_X_TLS_PROTOCOL_MIN
 	if (config->tls_min_version_str) {
 		do_ldap_option(LDAP_OPT_X_TLS_PROTOCOL_MIN, "tls_min_version", &config->tls_min_version);
 	}
-#  endif
 
 	/*
 	 *	Counter intuitively the TLS context appears to need to be initialised

--- a/src/lib/ldap/connection.c
+++ b/src/lib/ldap/connection.c
@@ -67,7 +67,7 @@ static char const *ldap_msg_types[UINT8_MAX] = {
 int fr_ldap_connection_configure(fr_ldap_connection_t *c, fr_ldap_config_t const *config)
 {
 	LDAP				*handle = NULL;
-	int				ldap_errno, ldap_version;
+	int				ldap_errno, ldap_version, keepalive;
 
 	fr_assert(config->server);
 
@@ -138,13 +138,8 @@ DIAG_ON(unused-macros)
 	ldap_version = LDAP_VERSION3;
 	do_ldap_option(LDAP_OPT_PROTOCOL_VERSION, "ldap_version", &ldap_version);
 
-#ifdef LDAP_OPT_X_KEEPALIVE_IDLE
-	{
-		int keepalive = fr_time_delta_to_sec(config->keepalive_idle);
-
-		do_ldap_option(LDAP_OPT_X_KEEPALIVE_IDLE, "keepalive_idle", &keepalive);
-	}
-#endif
+	keepalive = fr_time_delta_to_sec(config->keepalive_idle);
+	do_ldap_option(LDAP_OPT_X_KEEPALIVE_IDLE, "keepalive_idle", &keepalive);
 
 #ifdef LDAP_OPT_X_KEEPALIVE_PROBES
 	{

--- a/src/lib/ldap/util.c
+++ b/src/lib/ldap/util.c
@@ -292,7 +292,6 @@ int fr_ldap_parse_url_extensions(LDAPControl **sss, size_t sss_len, char *extens
 			p++;
 		}
 
-#ifdef HAVE_LDAP_CREATE_SORT_CONTROL
 		/*
 		 *	Server side sort control
 		 */
@@ -329,7 +328,6 @@ int fr_ldap_parse_url_extensions(LDAPControl **sss, size_t sss_len, char *extens
 
 			continue;
 		}
-#endif
 
 		fr_strerror_printf("URL extension \"%s\" not supported", p);
 		return -1;

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -1688,9 +1688,7 @@ static int mod_detach(module_detach_ctx_t const *mctx)
 {
 	rlm_ldap_t *inst = talloc_get_type_abort(mctx->inst->data, rlm_ldap_t);
 
-#ifdef HAVE_LDAP_CREATE_SORT_CONTROL
 	if (inst->userobj_sort_ctrl) ldap_control_free(inst->userobj_sort_ctrl);
-#endif
 
 	fr_pool_free(inst->pool);
 
@@ -1937,14 +1935,6 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 	}
 #endif
 
-#ifndef HAVE_LDAP_CREATE_SORT_CONTROL
-	if (inst->userobj_sort_by) {
-		cf_log_err(conf, "Configuration item 'sort_by' not supported.  "
-			   "Linked libldap does not provide ldap_create_sort_control function");
-		goto error;
-	}
-#endif
-
 	/*
 	 *	Initialise server with zero length string to
 	 *	make code below simpler.
@@ -2161,7 +2151,6 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 		goto error;
 	}
 
-#ifdef HAVE_LDAP_CREATE_SORT_CONTROL
 	/*
 	 *	Build the server side sort control for user objects
 	 */
@@ -2187,7 +2176,6 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 			goto error;
 		}
 	}
-#endif
 
 	if (inst->handle_config.tls_require_cert_str) {
 		/*

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -2205,26 +2205,15 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 	 */
 	inst->userobj_scope = fr_table_value_by_str(fr_ldap_scope, inst->userobj_scope_str, -1);
 	if (inst->userobj_scope < 0) {
-#ifdef LDAP_SCOPE_CHILDREN
 		cf_log_err(conf, "Invalid 'user.scope' value \"%s\", expected 'sub', 'one', 'base' or 'children'",
 			   inst->userobj_scope_str);
-#else
-		cf_log_err(conf, "Invalid 'user.scope' value \"%s\", expected 'sub', 'one' or 'children'",
-			   inst->userobj_scope_str);
-#endif
 		goto error;
 	}
 
 	inst->groupobj_scope = fr_table_value_by_str(fr_ldap_scope, inst->groupobj_scope_str, -1);
 	if (inst->groupobj_scope < 0) {
-#ifdef LDAP_SCOPE_CHILDREN
 		cf_log_err(conf, "Invalid 'group.scope' value \"%s\", expected 'sub', 'one', 'base' or 'children'",
 			   inst->groupobj_scope_str);
-#else
-		cf_log_err(conf, "Invalid 'group.scope' value \"%s\", expected 'sub', 'one' or 'children'",
-			   inst->groupobj_scope_str);
-#endif
-
 		goto error;
 	}
 

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -1596,11 +1596,10 @@ static unlang_action_t user_modify(rlm_rcode_t *p_result, rlm_ldap_t const *inst
 			mod_s[total].mod_op = LDAP_MOD_DELETE;
 			break;
 
-#ifdef LDAP_MOD_INCREMENT
 		case T_OP_INCRM:
 			mod_s[total].mod_op = LDAP_MOD_INCREMENT;
 			break;
-#endif
+
 		default:
 			REDEBUG("Operator '%s' is not supported for LDAP modify operations",
 				fr_table_str_by_value(fr_tokens_table, op, "<INVALID>"));

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -1976,7 +1976,6 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 			}
 		}
 
-#ifdef LDAP_CAN_PARSE_URLS
 		/*
 		 *	Split original server value out into URI, server and port
 		 *	so whatever initialization function we use later will have
@@ -2075,7 +2074,6 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 		 *	We need to construct an LDAP URI
 		 */
 		} else
-#endif	/* HAVE_LDAP_URL_PARSE && HAVE_LDAP_IS_LDAP_URL && LDAP_URL_DESC2STR */
 		/*
 		 *	If it's not an URL, or we don't have the functions necessary
 		 *	to break apart the URL and recombine it, then just treat
@@ -2095,12 +2093,8 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 			 */
 			if (strchr(value, '/')) {
 			bad_server_fmt:
-#ifdef LDAP_CAN_PARSE_URLS
 				cf_log_err(conf, "Invalid 'server' entry, must be in format <server>[:<port>] or "
 					      "an ldap URI (ldap|cldap|ldaps|ldapi)://<server>:<port>");
-#else
-				cf_log_err(conf, "Invalid 'server' entry, must be in format <server>[:<port>]");
-#endif
 				return -1;
 			}
 

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -158,9 +158,8 @@ static CONF_PARSER option_config[] = {
 	 */
 	{ FR_CONF_OFFSET("net_timeout", FR_TYPE_TIME_DELTA, rlm_ldap_t, handle_config.net_timeout), .dflt = "10" },
 
-#ifdef LDAP_OPT_X_KEEPALIVE_IDLE
 	{ FR_CONF_OFFSET("idle", FR_TYPE_TIME_DELTA, rlm_ldap_t, handle_config.keepalive_idle), .dflt = "60" },
-#endif
+
 #ifdef LDAP_OPT_X_KEEPALIVE_PROBES
 	{ FR_CONF_OFFSET("probes", FR_TYPE_UINT32, rlm_ldap_t, handle_config.keepalive_probes), .dflt = "3" },
 #endif

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -1945,14 +1945,6 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 	}
 #endif
 
-#ifndef HAVE_LDAP_URL_PARSE
-	if (inst->handle_config.use_referral_credentials) {
-		cf_log_err(conf, "Configuration item 'use_referral_credentials' not supported.  "
-			   "Linked libldap does not support URL parsing");
-		goto error;
-	}
-#endif
-
 	/*
 	 *	Initialise server with zero length string to
 	 *	make code below simpler.

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -2178,7 +2178,6 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 		DEBUG4("rlm_ldap (%s) - LDAP server string: %s", mctx->inst->name, inst->handle_config.server);
 	}
 
-#ifdef LDAP_OPT_X_TLS_NEVER
 	/*
 	 *	Workaround for servers which support LDAPS but not START TLS
 	 */
@@ -2187,7 +2186,6 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 	} else {
 		inst->handle_config.tls_mode = 0;
 	}
-#endif
 
 	/*
 	 *	Convert dereference strings to enumerated constants
@@ -2259,7 +2257,6 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 #endif
 
 	if (inst->handle_config.tls_require_cert_str) {
-#ifdef LDAP_OPT_X_TLS_NEVER
 		/*
 		 *	Convert cert strictness to enumerated constants
 		 */
@@ -2270,13 +2267,6 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 				      "'demand', 'allow', 'try' or 'hard'", inst->handle_config.tls_require_cert_str);
 			goto error;
 		}
-#else
-		cf_log_err(conf, "Modifying 'tls.require_cert' is not supported by current "
-			      "version of libldap. Please upgrade or substitute current libldap and "
-			      "rebuild this module");
-
-		goto error;
-#endif
 	}
 
 	if (inst->handle_config.tls_min_version_str) {

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -75,9 +75,7 @@ static CONF_PARSER tls_config[] = {
 
 	{ FR_CONF_OFFSET("require_cert", FR_TYPE_STRING, fr_ldap_config_t, tls_require_cert_str) },
 
-#ifdef LDAP_OPT_X_TLS_PROTOCOL_MIN
 	{ FR_CONF_OFFSET("tls_min_version", FR_TYPE_STRING, fr_ldap_config_t, tls_min_version_str) },
-#endif
 
 	CONF_PARSER_TERMINATOR
 };
@@ -2288,8 +2286,7 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 #endif
 	}
 
-if (inst->handle_config.tls_min_version_str) {
-#ifdef LDAP_OPT_X_TLS_PROTOCOL_MIN
+	if (inst->handle_config.tls_min_version_str) {
 		if (strcmp(inst->handle_config.tls_min_version_str, "1.2") == 0) {
 			inst->handle_config.tls_min_version = LDAP_OPT_X_TLS_PROTOCOL_TLS1_2;
 
@@ -2303,13 +2300,6 @@ if (inst->handle_config.tls_min_version_str) {
 			cf_log_err(conf, "Invalid 'tls.tls_min_version' value \"%s\"", inst->handle_config.tls_min_version_str);
 			goto error;
 		}
-#else
-		cf_log_err(conf, "This version of libldap does not support tls.tls_min_version."
-			      " Please upgrade or substitute current libldap and "
-			      "rebuild this module");
-		goto error;
-
-#endif
 	}
 
 	/*

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -160,9 +160,8 @@ static CONF_PARSER option_config[] = {
 
 	{ FR_CONF_OFFSET("idle", FR_TYPE_TIME_DELTA, rlm_ldap_t, handle_config.keepalive_idle), .dflt = "60" },
 
-#ifdef LDAP_OPT_X_KEEPALIVE_PROBES
 	{ FR_CONF_OFFSET("probes", FR_TYPE_UINT32, rlm_ldap_t, handle_config.keepalive_probes), .dflt = "3" },
-#endif
+
 #ifdef LDAP_OPT_X_KEEPALIVE_INTERVAL
 	{ FR_CONF_OFFSET("interval", FR_TYPE_TIME_DELTA, rlm_ldap_t, handle_config.keepalive_interval), .dflt = "30" },
 #endif

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -162,9 +162,7 @@ static CONF_PARSER option_config[] = {
 
 	{ FR_CONF_OFFSET("probes", FR_TYPE_UINT32, rlm_ldap_t, handle_config.keepalive_probes), .dflt = "3" },
 
-#ifdef LDAP_OPT_X_KEEPALIVE_INTERVAL
 	{ FR_CONF_OFFSET("interval", FR_TYPE_TIME_DELTA, rlm_ldap_t, handle_config.keepalive_interval), .dflt = "30" },
-#endif
 
 	{ FR_CONF_OFFSET("dereference", FR_TYPE_STRING, rlm_ldap_t, handle_config.dereference_str) },
 

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -151,14 +151,12 @@ static CONF_PARSER option_config[] = {
 
 	{ FR_CONF_OFFSET("sasl_secprops", FR_TYPE_STRING, rlm_ldap_t, handle_config.sasl_secprops) },
 
-#ifdef LDAP_OPT_NETWORK_TIMEOUT
 	/*
 	 *	We use this config option to populate libldap's LDAP_OPT_NETWORK_TIMEOUT -
 	 *	timeout on network activity - specifically libldap's initial call to "connect"
 	 *	Must be non-zero for async connections to start correctly.
 	 */
 	{ FR_CONF_OFFSET("net_timeout", FR_TYPE_TIME_DELTA, rlm_ldap_t, handle_config.net_timeout), .dflt = "10" },
-#endif
 
 #ifdef LDAP_OPT_X_KEEPALIVE_IDLE
 	{ FR_CONF_OFFSET("idle", FR_TYPE_TIME_DELTA, rlm_ldap_t, handle_config.keepalive_idle), .dflt = "60" },


### PR DESCRIPTION
Since only OpenLDAP's libldap is supported, the `ifdef`s for features which have been in libldap for years can be removed.