### PR TITLE
Resolve show stopper OpenSSL3 problems

### DIFF
--- a/src/main/cb.c
+++ b/src/main/cb.c
@@ -126,7 +126,7 @@ void cbtls_info(SSL const *s, int where, int ret)
  */
 void cbtls_msg(int write_p, int msg_version, int content_type,
 	       void const *inbuf, size_t len,
-	       SSL *ssl, void *arg)
+	       SSL *ssl UNUSED, void *arg)
 {
 	uint8_t const *buf = inbuf;
 	tls_session_t *state = (tls_session_t *)arg;
@@ -189,11 +189,6 @@ void cbtls_msg(int write_p, int msg_version, int content_type,
 	state->info.origin = write_p;
 	state->info.content_type = content_type;
 	state->info.record_len = len;
-#if OPENSSL_VERSION_NUMBER < 0x30000000L
-	state->info.version = msg_version;
-#else
-	state->info.version = SSL_version(ssl);
-#endif
 	state->info.initialized = true;
 
 	if (content_type == SSL3_RT_ALERT) {

--- a/src/main/cb.c
+++ b/src/main/cb.c
@@ -126,7 +126,7 @@ void cbtls_info(SSL const *s, int where, int ret)
  */
 void cbtls_msg(int write_p, int msg_version, int content_type,
 	       void const *inbuf, size_t len,
-	       SSL *ssl UNUSED, void *arg)
+	       SSL *ssl, void *arg)
 {
 	uint8_t const *buf = inbuf;
 	tls_session_t *state = (tls_session_t *)arg;
@@ -136,7 +136,17 @@ void cbtls_msg(int write_p, int msg_version, int content_type,
 	 *	content types.  Which breaks our tracking of
 	 *	the SSL Session state.
 	 */
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
 	if ((msg_version == 0) && (content_type > UINT8_MAX)) {
+#else
+	/*
+         *      "...we do not see the need to resolve application breakage
+         *      just because the documentation now is incorrect."
+         *
+         *      https://github.com/openssl/openssl/issues/17262
+	 */
+	if (content_type > UINT8_MAX && content_type != SSL3_RT_INNER_CONTENT_TYPE) {
+#endif
 		DEBUG4("(TLS) Ignoring cbtls_msg call with pseudo content type %i, version %i",
 		       content_type, msg_version);
 		return;
@@ -179,7 +189,11 @@ void cbtls_msg(int write_p, int msg_version, int content_type,
 	state->info.origin = write_p;
 	state->info.content_type = content_type;
 	state->info.record_len = len;
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
 	state->info.version = msg_version;
+#else
+	state->info.version = SSL_version(ssl);
+#endif
 	state->info.initialized = true;
 
 	if (content_type == SSL3_RT_ALERT) {

--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -1277,7 +1277,7 @@ void tls_session_information(tls_session_t *tls_session)
 #endif
 
 	default:
-		sprintf(buffer, "UNKNOWN TLS VERSION '%04X'", tls_session->info.version);
+		sprintf(buffer, "UNKNOWN TLS VERSION '%04X'", SSL_version(tls_session->ssl));
 		str_version = buffer;
 		break;
 	}

--- a/src/modules/rlm_eap/types/rlm_eap_fast/eap_fast.c
+++ b/src/modules/rlm_eap/types/rlm_eap_fast/eap_fast.c
@@ -128,7 +128,7 @@ static void eap_fast_init_keys(REQUEST *request, tls_session_t *tls_session)
 
 	t->keyblock = talloc(t, eap_fast_keyblock_t);
 
-	eap_fast_tls_gen_challenge(tls_session->ssl, tls_session->info.version, buf, ksize + sizeof(*t->keyblock), "key expansion");
+	eap_fast_tls_gen_challenge(tls_session->ssl, SSL_version(tls_session->ssl), buf, ksize + sizeof(*t->keyblock), "key expansion");
 	memcpy(t->keyblock, &buf[ksize], sizeof(*t->keyblock));
 	memset(buf, 0, ksize + sizeof(*t->keyblock));
 


### PR DESCRIPTION
Tested against:
  * hostap 2.10 {SSL 1.1.1,3.0.2} <-> FreeRADIUS {SSL 1.1.1,3.0.2}: TLS 1.0, 1.1, 1.2 and 1.3 (FR's `make tests`)
  * Windows 11 <-> FreeRADIUS {SSL 1.1.1,3.0.2}: TLS 1.2 and 1.3 for TTLS/PAP and PEAP/EAP-MSCHAPV2