### PR TITLE
freeradius-snmp "proxy": Various fixes, improvements and cleanup

### DIFF
--- a/mibs/RADIUS-ACC-SERVER-MIB.mib
+++ b/mibs/RADIUS-ACC-SERVER-MIB.mib
@@ -5,40 +5,53 @@ IMPORTS
        Counter32, Integer32,
        IpAddress, TimeTicks, mib-2      FROM SNMPv2-SMI
        SnmpAdminString                  FROM SNMP-FRAMEWORK-MIB
+       InetAddressType, InetAddress     FROM INET-ADDRESS-MIB
        MODULE-COMPLIANCE, OBJECT-GROUP  FROM SNMPv2-CONF;
 
 radiusAccServMIB MODULE-IDENTITY
-       LAST-UPDATED "9906110000Z" -- 11 Jun 1999
-       ORGANIZATION "IETF RADIUS Working Group."
+       LAST-UPDATED "200608210000Z"  -- 21 August 2006
+       ORGANIZATION "IETF RADIUS Extensions Working Group."
        CONTACT-INFO
-          " Bernard Aboba
-            Microsoft
-            One Microsoft Way
-            Redmond, WA  98052
-            US
+              " Bernard Aboba
+                Microsoft
+                One Microsoft Way
+                Redmond, WA  98052
+                US
 
-            Phone: +1 425 936 6605
-            EMail: bernarda@microsoft.com"
+                Phone: +1 425 936 6605
+                EMail: bernarda@microsoft.com"
        DESCRIPTION
-           "The MIB module for entities implementing the server
-            side of the Remote Access Dialin User Service (RADIUS)
-            accounting protocol."
-       REVISION "9906110000Z"    -- 11 Jun 1999
-       DESCRIPTION "Initial version as published in RFC 2621"
+             "The MIB module for entities implementing the server
+              side of the Remote Authentication Dial-In User
+              Service (RADIUS) accounting protocol.  Copyright (C)
+              The Internet Society (2006).  This version of this
+              MIB module is part of RFC 4671; see the RFC itself
+              for full legal notices."
+       REVISION "200608210000Z"  -- 21 August 2006
+       DESCRIPTION
+             "Revised version as published in RFC 4671.  This
+              version obsoletes that of RFC 2621 by deprecating
+              the MIB table containing IPv4-only address formats
+              and defining a new table to add support for version-
+              neutral IP address formats.  The remaining MIB objects
+              from RFC 2621 are carried forward into this version."
+       REVISION "199906110000Z"    -- 11 Jun 1999
+       DESCRIPTION "Initial version as published in RFC 2621."
        ::= { radiusAccounting 1 }
 
-radiusMIB OBJECT-IDENTITY
+radiusMIB  OBJECT-IDENTITY
        STATUS  current
        DESCRIPTION
-           "The OID assigned to RADIUS MIB work by the IANA."
-        ::= { mib-2 67 }
+             "The OID assigned to RADIUS MIB work by the IANA."
+       ::= { mib-2 67 }
 
 radiusAccounting  OBJECT IDENTIFIER ::= {radiusMIB 2}
 
-radiusAccServMIBObjects     OBJECT IDENTIFIER ::=
-                                                { radiusAccServMIB 1 }
+radiusAccServMIBObjects  OBJECT IDENTIFIER
+      ::= { radiusAccServMIB 1 }
 
-radiusAccServ      OBJECT IDENTIFIER ::= { radiusAccServMIBObjects 1 }
+radiusAccServ  OBJECT IDENTIFIER
+      ::= { radiusAccServMIBObjects 1 }
 
 radiusAccServIdent OBJECT-TYPE
        SYNTAX      SnmpAdminString
@@ -47,7 +60,7 @@ radiusAccServIdent OBJECT-TYPE
        DESCRIPTION
              "The implementation identification string for the
               RADIUS accounting server software in use on the
-              system, for example; `FNS-2.1'"
+              system, for example, 'FNS-2.1'."
        ::= {radiusAccServ 1}
 
 radiusAccServUpTime OBJECT-TYPE
@@ -55,11 +68,11 @@ radiusAccServUpTime OBJECT-TYPE
        MAX-ACCESS  read-only
        STATUS      current
        DESCRIPTION
-             "If the server has a persistent state (e.g., a process),
-              this value will be the time elapsed (in hundredths of a
-              second) since the server process was started.
-              For software without persistent state, this value will
-              be zero."
+             "If the server has a persistent state (e.g., a
+              process), this value will be the time elapsed (in
+              hundredths of a second) since the server process was
+              started.  For software without persistent state, this
+              value will be zero."
        ::= {radiusAccServ 2}
 
 radiusAccServResetTime OBJECT-TYPE
@@ -68,12 +81,12 @@ radiusAccServResetTime OBJECT-TYPE
        STATUS      current
        DESCRIPTION
              "If the server has a persistent state (e.g., a process)
-              and supports a `reset' operation (e.g., can be told to
+              and supports a 'reset' operation (e.g., can be told to
               re-read configuration files), this value will be the
               time elapsed (in hundredths of a second) since the
-              server was `reset.'  For software that does not
-              have persistence or does not support a `reset' operation,
-	      this value will be zero."
+              server was 'reset.'  For software that does not
+              have persistence or does not support a 'reset'
+              operation, this value will be zero."
        ::= {radiusAccServ 3}
 
 radiusAccServConfigReset OBJECT-TYPE
@@ -86,10 +99,10 @@ radiusAccServConfigReset OBJECT-TYPE
        DESCRIPTION
               "Status/action object to reinitialize any persistent
                server state.  When set to reset(2), any persistent
-               server state (such as a process) is reinitialized as if
-               the server had just been started.  This value will
-               never be returned by a read operation.  When read, one
-               of the following values will be returned:
+               server state (such as a process) is reinitialized as
+               if the server had just been started.  This value will
+               never be returned by a read operation.  When read,
+               one of the following values will be returned:
                    other(1) - server in some unknown state;
                    initializing(3) - server (re)initializing;
                    running(4) - server currently running."
@@ -99,85 +112,103 @@ radiusAccServConfigReset OBJECT-TYPE
 
 radiusAccServTotalRequests OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
        STATUS current
        DESCRIPTION
              "The number of packets received on the
               accounting port."
+       REFERENCE "RFC 2866 section 4.1"
        ::= { radiusAccServ 5 }
 
 radiusAccServTotalInvalidRequests OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
        STATUS current
        DESCRIPTION
              "The number of RADIUS Accounting-Request packets
               received from unknown addresses."
+       REFERENCE "RFC 2866 sections 2, 4.1"
        ::= { radiusAccServ 6 }
 
 radiusAccServTotalDupRequests OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
        STATUS current
        DESCRIPTION
              "The number of duplicate RADIUS Accounting-Request
               packets received."
+       REFERENCE "RFC 2866 section 4.1"
        ::= { radiusAccServ 7 }
 
 radiusAccServTotalResponses OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
        STATUS current
        DESCRIPTION
-             "The number of RADIUS Accounting-Response packets sent."
+             "The number of RADIUS Accounting-Response packets
+              sent."
+       REFERENCE "RFC 2866 section 4.2"
        ::= { radiusAccServ 8 }
 
 radiusAccServTotalMalformedRequests OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
        STATUS current
        DESCRIPTION
              "The number of malformed RADIUS Accounting-Request
-              packets received. Bad authenticators or unknown
+              packets received.  Bad authenticators or unknown
               types are not included as malformed Access-Requests."
+       REFERENCE "RFC 2866 section 3"
        ::= { radiusAccServ 9 }
 
 radiusAccServTotalBadAuthenticators OBJECT-TYPE
       SYNTAX Counter32
+      UNITS "packets"
       MAX-ACCESS read-only
       STATUS current
       DESCRIPTION
             "The number of RADIUS Accounting-Request packets
-             which contained invalid Signature attributes."
+             that contained an invalid authenticator."
+      REFERENCE "RFC 2866 section 3"
       ::= { radiusAccServ 10 }
 
 radiusAccServTotalPacketsDropped OBJECT-TYPE
       SYNTAX Counter32
+      UNITS "packets"
       MAX-ACCESS read-only
       STATUS current
       DESCRIPTION
             "The number of incoming packets silently discarded
              for a reason other than malformed, bad authenticators,
              or unknown types."
+      REFERENCE "RFC 2866 section 3"
       ::= { radiusAccServ 11 }
 
 radiusAccServTotalNoRecords OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
        STATUS current
        DESCRIPTION
              "The number of RADIUS Accounting-Request packets
-              which were received and responded to but not
+              that were received and responded to but not
               recorded."
        ::= { radiusAccServ 12 }
 
 radiusAccServTotalUnknownTypes OBJECT-TYPE
       SYNTAX Counter32
+      UNITS "packets"
       MAX-ACCESS read-only
       STATUS current
       DESCRIPTION
-            "The number of RADIUS packets of unknowntype which
+            "The number of RADIUS packets of unknown type that
              were received."
+      REFERENCE "RFC 2866 section 4"
       ::= { radiusAccServ 13 }
 
 -- End of new
@@ -185,7 +216,7 @@ radiusAccServTotalUnknownTypes OBJECT-TYPE
 radiusAccClientTable OBJECT-TYPE
        SYNTAX     SEQUENCE OF RadiusAccClientEntry
        MAX-ACCESS not-accessible
-       STATUS     current
+       STATUS     deprecated
        DESCRIPTION
              "The (conceptual) table listing the RADIUS accounting
               clients with which the server shares a secret."
@@ -194,10 +225,11 @@ radiusAccClientTable OBJECT-TYPE
 radiusAccClientEntry OBJECT-TYPE
        SYNTAX     RadiusAccClientEntry
        MAX-ACCESS not-accessible
-       STATUS     current
+       STATUS     deprecated
        DESCRIPTION
              "An entry (conceptual row) representing a RADIUS
-              accounting client with which the server shares a secret."
+              accounting client with which the server shares a
+              secret."
        INDEX      { radiusAccClientIndex }
        ::= { radiusAccClientTable 1 }
 
@@ -218,7 +250,7 @@ RadiusAccClientEntry ::= SEQUENCE {
 radiusAccClientIndex OBJECT-TYPE
        SYNTAX     Integer32 (1..2147483647)
        MAX-ACCESS not-accessible
-       STATUS     current
+       STATUS     deprecated
        DESCRIPTION
              "A number uniquely identifying each RADIUS accounting
               client with which this server communicates."
@@ -227,7 +259,7 @@ radiusAccClientIndex OBJECT-TYPE
 radiusAccClientAddress OBJECT-TYPE
        SYNTAX     IpAddress
        MAX-ACCESS read-only
-       STATUS     current
+       STATUS     deprecated
        DESCRIPTION
              "The NAS-IP-Address of the RADIUS accounting client
               referred to in this table entry."
@@ -236,11 +268,12 @@ radiusAccClientAddress OBJECT-TYPE
 radiusAccClientID OBJECT-TYPE
        SYNTAX     SnmpAdminString
        MAX-ACCESS read-only
-       STATUS     current
+       STATUS     deprecated
        DESCRIPTION
              "The NAS-Identifier of the RADIUS accounting client
-              referred to in this table entry. This is not necessarily
-              the same as sysName in MIB II."
+              referred to in this table entry.  This is not
+              necessarily the same as sysName in MIB II."
+       REFERENCE "RFC 2865 section 5.32"
        ::= { radiusAccClientEntry 3 }
 
 -- Server Counters
@@ -253,99 +286,343 @@ radiusAccClientID OBJECT-TYPE
 
 radiusAccServPacketsDropped OBJECT-TYPE
       SYNTAX Counter32
+      UNITS "packets"
       MAX-ACCESS read-only
-      STATUS current
+      STATUS deprecated
       DESCRIPTION
            "The number of incoming packets received
             from this client and silently discarded
             for a reason other than malformed, bad
             authenticators, or unknown types."
+     REFERENCE "RFC 2866 section 3"
      ::= { radiusAccClientEntry  4 }
 
 radiusAccServRequests OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
-       STATUS current
+       STATUS deprecated
        DESCRIPTION
              "The number of packets received from this
               client on the accounting port."
+       REFERENCE "RFC 2866 section 4.1"
        ::= { radiusAccClientEntry  5 }
 
 radiusAccServDupRequests OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
-       STATUS current
+       STATUS deprecated
        DESCRIPTION
              "The number of duplicate RADIUS Accounting-Request
               packets received from this client."
+       REFERENCE "RFC 2866 section 4.1"
        ::= { radiusAccClientEntry 6 }
 
 radiusAccServResponses OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
-       STATUS current
+       STATUS deprecated
        DESCRIPTION
              "The number of RADIUS Accounting-Response packets
               sent to this client."
+       REFERENCE "RFC 2866 section 4.2"
        ::= { radiusAccClientEntry  7 }
 
 radiusAccServBadAuthenticators OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
-       STATUS current
+       STATUS deprecated
        DESCRIPTION
              "The number of RADIUS Accounting-Request packets
-              which contained invalid  authenticators received
+              that contained invalid authenticators received
               from this client."
+       REFERENCE "RFC 2866 section 3"
        ::= { radiusAccClientEntry  8 }
 
 radiusAccServMalformedRequests OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
-       STATUS current
+       STATUS deprecated
        DESCRIPTION
              "The number of malformed RADIUS Accounting-Request
-              packets which were received from this client.
+              packets that were received from this client.
               Bad authenticators and unknown types
               are not included as malformed Accounting-Requests."
+       REFERENCE "RFC 2866 section 3"
        ::= { radiusAccClientEntry  9 }
 
 radiusAccServNoRecords OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
-       STATUS current
+       STATUS deprecated
        DESCRIPTION
              "The number of RADIUS Accounting-Request packets
-              which were received and responded to but not
+              that were received and responded to but not
               recorded."
        ::= { radiusAccClientEntry  10 }
 
 radiusAccServUnknownTypes OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS packets of unknown type that
+              were received from this client."
+       REFERENCE "RFC 2866 section 4"
+       ::= { radiusAccClientEntry  11 }
+
+
+radiusAccClientExtTable OBJECT-TYPE
+       SYNTAX     SEQUENCE OF RadiusAccClientExtEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+             "The (conceptual) table listing the RADIUS accounting
+              clients with which the server shares a secret."
+       ::= { radiusAccServ 15 }
+
+radiusAccClientExtEntry OBJECT-TYPE
+       SYNTAX     RadiusAccClientExtEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+             "An entry (conceptual row) representing a RADIUS
+              accounting client with which the server shares a
+              secret."
+       INDEX      { radiusAccClientExtIndex }
+       ::= { radiusAccClientExtTable 1 }
+
+RadiusAccClientExtEntry ::= SEQUENCE {
+       radiusAccClientExtIndex               Integer32,
+       radiusAccClientInetAddressType        InetAddressType,
+       radiusAccClientInetAddress            InetAddress,
+       radiusAccClientExtID                  SnmpAdminString,
+       radiusAccServExtPacketsDropped        Counter32,
+       radiusAccServExtRequests              Counter32,
+       radiusAccServExtDupRequests           Counter32,
+       radiusAccServExtResponses             Counter32,
+       radiusAccServExtBadAuthenticators     Counter32,
+       radiusAccServExtMalformedRequests     Counter32,
+       radiusAccServExtNoRecords             Counter32,
+       radiusAccServExtUnknownTypes          Counter32,
+       radiusAccServerCounterDiscontinuity   TimeTicks
+}
+
+radiusAccClientExtIndex OBJECT-TYPE
+       SYNTAX     Integer32 (1..2147483647)
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+             "A number uniquely identifying each RADIUS accounting
+              client with which this server communicates."
+       ::= { radiusAccClientExtEntry 1 }
+
+       radiusAccClientInetAddressType OBJECT-TYPE
+         SYNTAX     InetAddressType
+         MAX-ACCESS read-only
+         STATUS     current
+         DESCRIPTION
+               "The type of address format used for the
+                radiusAccClientInetAddress object."
+         ::= { radiusAccClientExtEntry 2 }
+
+   radiusAccClientInetAddress OBJECT-TYPE
+         SYNTAX     InetAddress
+         MAX-ACCESS read-only
+         STATUS     current
+         DESCRIPTION
+               "The IP address of the RADIUS accounting
+                client referred to in this table entry, using
+                the IPv6 address format."
+         ::= { radiusAccClientExtEntry 3 }
+
+radiusAccClientExtID OBJECT-TYPE
+       SYNTAX     SnmpAdminString
+       MAX-ACCESS read-only
+       STATUS     current
+       DESCRIPTION
+             "The NAS-Identifier of the RADIUS accounting client
+              referred to in this table entry.  This is not
+              necessarily the same as sysName in MIB II."
+       REFERENCE "RFC 2865 section 5.32"
+       ::= { radiusAccClientExtEntry 4 }
+
+-- Server Counters
+--
+-- Requests - DupRequests - BadAuthenticators - MalformedRequests -
+-- UnknownTypes -  PacketsDropped - Responses = Pending
+--
+-- Requests - DupRequests - BadAuthenticators - MalformedRequests -
+-- UnknownTypes - PacketsDropped - NoRecords = entries logged
+
+radiusAccServExtPacketsDropped OBJECT-TYPE
+      SYNTAX Counter32
+      UNITS "packets"
+      MAX-ACCESS read-only
+      STATUS current
+      DESCRIPTION
+           "The number of incoming packets received from this
+            client and silently discarded for a reason other
+            than malformed, bad authenticators, or unknown types.
+            This counter may experience a discontinuity when the
+            RADIUS Accounting Server module within the managed
+            entity is reinitialized, as indicated by the current
+            value of radiusAccServerCounterDiscontinuity."
+     REFERENCE "RFC 2866 section 3"
+     ::= { radiusAccClientExtEntry  5 }
+
+radiusAccServExtRequests OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
        STATUS current
        DESCRIPTION
-             "The number of RADIUS packets of unknown type which
-              were received from this client."
-       ::= { radiusAccClientEntry  11 }
+             "The number of packets received from this
+              client on the accounting port.  This counter
+              may experience a discontinuity when the
+              RADIUS Accounting Server module within the
+              managed entity is reinitialized, as indicated by
+              the current value of
+              radiusAccServerCounterDiscontinuity."
+       REFERENCE "RFC 2866 section 4.1"
+       ::= { radiusAccClientExtEntry  6 }
+
+radiusAccServExtDupRequests OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of duplicate RADIUS Accounting-Request
+              packets received from this client.  This counter
+              may experience a discontinuity when the RADIUS
+              Accounting Server module within the managed
+              entity is reinitialized, as indicated by the
+              current value of
+              radiusAccServerCounterDiscontinuity."
+       REFERENCE "RFC 2866 section 4.1"
+       ::= { radiusAccClientExtEntry 7 }
+
+radiusAccServExtResponses OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Accounting-Response packets
+              sent to this client.  This counter may experience
+              a discontinuity when the RADIUS Accounting Server
+              module within the managed entity is reinitialized,
+              as indicated by the current value of
+              radiusAccServerCounterDiscontinuity."
+       REFERENCE "RFC 2866 section 4.2"
+       ::= { radiusAccClientExtEntry  8 }
+
+radiusAccServExtBadAuthenticators OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Accounting-Request packets
+              that contained invalid authenticators received
+              from this client.  This counter may experience a
+              discontinuity when the RADIUS Accounting Server
+              module within the managed entity is reinitialized,
+              as indicated by the current value of
+              radiusAccServerCounterDiscontinuity."
+       REFERENCE "RFC 2866 section 3"
+       ::= { radiusAccClientExtEntry  9 }
+
+radiusAccServExtMalformedRequests OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of malformed RADIUS Accounting-Request
+              packets that were received from this client.
+              Bad authenticators and unknown types are not
+              included as malformed Accounting-Requests.  This
+              counter may experience a discontinuity when the
+              RADIUS Accounting Server module within the managed
+              entity is reinitialized, as indicated by the current
+              value of radiusAccServerCounterDiscontinuity."
+       REFERENCE "RFC 2866 section 3"
+       ::= { radiusAccClientExtEntry  10 }
+
+radiusAccServExtNoRecords OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Accounting-Request packets
+              that were received and responded to but not
+              recorded.  This counter may experience a
+              discontinuity when the RADIUS Accounting Server
+              module within the managed entity is reinitialized,
+              as indicated by the current value of
+              radiusAccServerCounterDiscontinuity."
+       ::= { radiusAccClientExtEntry  11 }
+
+radiusAccServExtUnknownTypes OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS packets of unknown type that
+              were received from this client.  This counter may
+              experience a discontinuity when the RADIUS Accounting
+              Server module within the managed entity is
+              reinitialized, as indicated by the current value of
+              radiusAccServerCounterDiscontinuity."
+       REFERENCE "RFC 2866 section 4"
+       ::= { radiusAccClientExtEntry  12 }
+
+radiusAccServerCounterDiscontinuity OBJECT-TYPE
+         SYNTAX TimeTicks
+         UNITS "centiseconds"
+         MAX-ACCESS read-only
+         STATUS current
+         DESCRIPTION
+               "The number of centiseconds since the last
+                discontinuity in the RADIUS Accounting Server
+                counters.  A discontinuity may be the result of
+                a reinitialization of the RADIUS Accounting Server
+                module within the managed entity."
+         ::= { radiusAccClientExtEntry 13 }
 
 
 -- conformance information
 
-radiusAccServMIBConformance
-              OBJECT IDENTIFIER ::= { radiusAccServMIB 2 }
-radiusAccServMIBCompliances
-              OBJECT IDENTIFIER ::= { radiusAccServMIBConformance 1 }
-radiusAccServMIBGroups
-              OBJECT IDENTIFIER ::= { radiusAccServMIBConformance 2 }
+radiusAccServMIBConformance  OBJECT IDENTIFIER
+       ::= { radiusAccServMIB 2 }
+
+radiusAccServMIBCompliances  OBJECT IDENTIFIER
+       ::= { radiusAccServMIBConformance 1 }
+
+radiusAccServMIBGroups  OBJECT IDENTIFIER
+       ::= { radiusAccServMIBConformance 2 }
+
 
 -- compliance statements
 
 radiusAccServMIBCompliance MODULE-COMPLIANCE
-       STATUS  current
+       STATUS  deprecated
        DESCRIPTION
-             "The compliance statement for accounting servers
-              implementing the RADIUS Accounting Server MIB."
+            "The compliance statement for accounting servers
+            implementing the RADIUS Accounting Server MIB.
+            Implementation of this module is for IPv4-only
+            entities, or for backwards compatibility use with
+            entities that support both IPv4 and IPv6."
        MODULE  -- this module
        MANDATORY-GROUPS { radiusAccServMIBGroup }
 
@@ -354,6 +631,35 @@ radiusAccServMIBCompliance MODULE-COMPLIANCE
        DESCRIPTION  "The only SETable value is 'reset' (2)."
 
        ::= { radiusAccServMIBCompliances 1 }
+
+radiusAccServExtMIBCompliance MODULE-COMPLIANCE
+       STATUS  current
+       DESCRIPTION
+            "The compliance statement for accounting
+            servers implementing the RADIUS Accounting
+            Server IPv6 Extensions MIB.  Implementation of
+            this module is for entities that support IPv6,
+            or support IPv4 and IPv6."
+       MODULE  -- this module
+       MANDATORY-GROUPS { radiusAccServExtMIBGroup }
+
+       OBJECT        radiusAccServConfigReset
+       WRITE-SYNTAX  INTEGER { reset(2) }
+       DESCRIPTION  "The only SETable value is 'reset' (2)."
+
+       OBJECT radiusAccClientInetAddressType
+        SYNTAX InetAddressType { ipv4(1), ipv6(2) }
+        DESCRIPTION
+              "An implementation is only required to support
+               IPv4 and globally unique IPv6 addresses."
+
+        OBJECT radiusAccClientInetAddress
+        SYNTAX InetAddress ( SIZE (4|16) )
+        DESCRIPTION
+              "An implementation is only required to support
+               IPv4 and globally unique IPv6 addresses."
+
+       ::= { radiusAccServMIBCompliances 2 }
 
 
 -- units of conformance
@@ -383,11 +689,44 @@ radiusAccServMIBGroup OBJECT-GROUP
                radiusAccServNoRecords,
                radiusAccServUnknownTypes
               }
-      STATUS  current
+      STATUS  deprecated
       DESCRIPTION
             "The collection of objects providing management of
              a RADIUS Accounting Server."
       ::= { radiusAccServMIBGroups 1 }
+
+radiusAccServExtMIBGroup OBJECT-GROUP
+      OBJECTS {radiusAccServIdent,
+               radiusAccServUpTime,
+               radiusAccServResetTime,
+               radiusAccServConfigReset,
+               radiusAccServTotalRequests,
+               radiusAccServTotalInvalidRequests,
+               radiusAccServTotalDupRequests,
+               radiusAccServTotalResponses,
+               radiusAccServTotalMalformedRequests,
+               radiusAccServTotalBadAuthenticators,
+               radiusAccServTotalPacketsDropped,
+               radiusAccServTotalNoRecords,
+               radiusAccServTotalUnknownTypes,
+               radiusAccClientInetAddressType,
+               radiusAccClientInetAddress,
+               radiusAccClientExtID,
+               radiusAccServExtPacketsDropped,
+               radiusAccServExtRequests,
+               radiusAccServExtDupRequests,
+               radiusAccServExtResponses,
+               radiusAccServExtBadAuthenticators,
+               radiusAccServExtMalformedRequests,
+               radiusAccServExtNoRecords,
+               radiusAccServExtUnknownTypes,
+               radiusAccServerCounterDiscontinuity
+              }
+      STATUS  current
+      DESCRIPTION
+            "The collection of objects providing management of
+             a RADIUS Accounting Server."
+      ::= { radiusAccServMIBGroups 2 }
 
 END
 

--- a/mibs/RADIUS-AUTH-SERVER-MIB.mib
+++ b/mibs/RADIUS-AUTH-SERVER-MIB.mib
@@ -5,29 +5,40 @@ IMPORTS
        Counter32, Integer32,
        IpAddress, TimeTicks, mib-2      FROM SNMPv2-SMI
        SnmpAdminString                  FROM SNMP-FRAMEWORK-MIB
+       InetAddressType, InetAddress     FROM INET-ADDRESS-MIB
        MODULE-COMPLIANCE, OBJECT-GROUP  FROM SNMPv2-CONF;
 
 radiusAuthServMIB MODULE-IDENTITY
-       LAST-UPDATED "9906110000Z"
-       ORGANIZATION "IETF RADIUS Working Group."
+       LAST-UPDATED "200608210000Z"  -- 21 August 2006
+       ORGANIZATION "IETF RADIUS Extensions Working Group."
        CONTACT-INFO
               " Bernard Aboba
                 Microsoft
                 One Microsoft Way
                 Redmond, WA  98052
                 US
-
                 Phone: +1 425 936 6605
                 EMail: bernarda@microsoft.com"
        DESCRIPTION
              "The MIB module for entities implementing the server
-              side of the Remote Access Dialin User Service (RADIUS)
-              authentication protocol."
-       REVISION "9906110000Z"    --  11 Jun 1999
-       DESCRIPTION "Initial version as published in RFC 2619"
+              side of the Remote Authentication Dial-In User
+              Service (RADIUS) authentication protocol.  Copyright
+              (C) The Internet Society (2006).  This version of this
+              MIB module is part of RFC 4669; see the RFC itself for
+              full legal notices."
+       REVISION "200608210000Z"  -- 21 August 2006
+       DESCRIPTION
+             "Revised version as published in RFC 4669.  This
+              version obsoletes that of RFC 2619 by deprecating the
+              MIB table containing IPv4-only address formats and
+              defining a new table to add support for version-neutral
+              IP address formats.  The remaining MIB objects from RFC
+              2619 are carried forward into this version."
+       REVISION "199906110000Z"  -- 11 Jun 1999
+       DESCRIPTION "Initial version as published in RFC 2619."
        ::= { radiusAuthentication 1 }
 
-radiusMIB OBJECT-IDENTITY
+radiusMIB  OBJECT-IDENTITY
        STATUS  current
        DESCRIPTION
              "The OID assigned to RADIUS MIB work by the IANA."
@@ -35,10 +46,11 @@ radiusMIB OBJECT-IDENTITY
 
 radiusAuthentication  OBJECT IDENTIFIER ::= {radiusMIB 1}
 
-radiusAuthServMIBObjects     OBJECT IDENTIFIER ::=
-                                                 { radiusAuthServMIB 1 }
+radiusAuthServMIBObjects OBJECT IDENTIFIER
+        ::= { radiusAuthServMIB 1 }
 
-radiusAuthServ      OBJECT IDENTIFIER ::= { radiusAuthServMIBObjects 1 }
+radiusAuthServ  OBJECT IDENTIFIER
+        ::= { radiusAuthServMIBObjects 1 }
 
 radiusAuthServIdent OBJECT-TYPE
        SYNTAX      SnmpAdminString
@@ -47,7 +59,7 @@ radiusAuthServIdent OBJECT-TYPE
        DESCRIPTION
              "The implementation identification string for the
               RADIUS authentication server software in use on the
-              system, for example; `FNS-2.1'"
+              system, for example, 'FNS-2.1'."
        ::= {radiusAuthServ 1}
 
 radiusAuthServUpTime OBJECT-TYPE
@@ -55,11 +67,11 @@ radiusAuthServUpTime OBJECT-TYPE
        MAX-ACCESS  read-only
        STATUS      current
        DESCRIPTION
-             "If the server has a persistent state (e.g., a process),
-              this value will be the time elapsed (in hundredths of a
-              seco) since the server process was started.
-              For software without persistent state, this value will
-              be zero."
+             "If the server has a persistent state (e.g., a
+              process), this value will be the time elapsed (in
+              hundredths of a second) since the server process
+              was started.  For software without persistent state,
+              this value will be zero."
        ::= {radiusAuthServ 2}
 
 radiusAuthServResetTime OBJECT-TYPE
@@ -68,12 +80,12 @@ radiusAuthServResetTime OBJECT-TYPE
        STATUS      current
        DESCRIPTION
              "If the server has a persistent state (e.g., a process)
-              and supports a `reset' operation (e.g., can be told to
+              and supports a 'reset' operation (e.g., can be told to
               re-read configuration files), this value will be the
               time elapsed (in hundredths of a second) since the
-              server was `reset.'  For software that does not
-              have persistence or does not support a `reset' operation,
-              this value will be zero."
+              server was 'reset.'  For software that does not
+              have persistence or does not support a 'reset'
+              operation, this value will be zero."
        ::= {radiusAuthServ 3}
 
 radiusAuthServConfigReset OBJECT-TYPE
@@ -86,90 +98,106 @@ radiusAuthServConfigReset OBJECT-TYPE
        DESCRIPTION
               "Status/action object to reinitialize any persistent
                server state.  When set to reset(2), any persistent
-               server state (such as a process) is reinitialized as if
-               the server had just been started.  This value will
-               never be returned by a read operation.  When read, one of
-               the following values will be returned:
+               server state (such as a process) is reinitialized as
+               if the server had just been started.  This value will
+               never be returned by a read operation.  When read,
+               one of the following values will be returned:
                    other(1) - server in some unknown state;
                    initializing(3) - server (re)initializing;
                    running(4) - server currently running."
        ::= {radiusAuthServ 4}
 
--- New Stats proposed by Dale E. Reed Jr (daler@iea-software.com)
-
 radiusAuthServTotalAccessRequests OBJECT-TYPE
         SYNTAX Counter32
+        UNITS "packets"
         MAX-ACCESS read-only
         STATUS current
         DESCRIPTION
                "The number of packets received on the
                 authentication port."
+        REFERENCE "RFC 2865 section 4.1"
         ::= { radiusAuthServ 5}
 
 radiusAuthServTotalInvalidRequests OBJECT-TYPE
         SYNTAX Counter32
+        UNITS "packets"
         MAX-ACCESS read-only
         STATUS current
         DESCRIPTION
               "The number of RADIUS Access-Request packets
                received from unknown addresses."
+        REFERENCE "RFC 2865 section 4.1"
         ::= { radiusAuthServ 6 }
 
 radiusAuthServTotalDupAccessRequests OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
        STATUS current
        DESCRIPTION
              "The number of duplicate RADIUS Access-Request
               packets received."
+       REFERENCE "RFC 2865 section 4.1"
        ::= { radiusAuthServ 7 }
 
 radiusAuthServTotalAccessAccepts OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
        STATUS current
        DESCRIPTION
              "The number of RADIUS Access-Accept packets sent."
+       REFERENCE "RFC 2865 section 4.2"
        ::= { radiusAuthServ 8 }
 
 radiusAuthServTotalAccessRejects OBJECT-TYPE
       SYNTAX Counter32
+      UNITS "packets"
       MAX-ACCESS read-only
       STATUS current
       DESCRIPTION
             "The number of RADIUS Access-Reject packets sent."
+      REFERENCE "RFC 2865 section 4.3"
       ::= { radiusAuthServ 9 }
 
 radiusAuthServTotalAccessChallenges OBJECT-TYPE
       SYNTAX Counter32
+      UNITS "packets"
       MAX-ACCESS read-only
       STATUS current
       DESCRIPTION
             "The number of RADIUS Access-Challenge packets sent."
+      REFERENCE "RFC 2865 section 4.4"
       ::= { radiusAuthServ 10 }
 
 radiusAuthServTotalMalformedAccessRequests OBJECT-TYPE
       SYNTAX Counter32
+      UNITS "packets"
       MAX-ACCESS read-only
       STATUS current
       DESCRIPTION
             "The number of malformed RADIUS Access-Request
-             packets received. Bad authenticators
+             packets received.  Bad authenticators
              and unknown types are not included as
              malformed Access-Requests."
+      REFERENCE "RFC 2865 section 4.1"
       ::= { radiusAuthServ 11 }
 
 radiusAuthServTotalBadAuthenticators OBJECT-TYPE
       SYNTAX Counter32
+      UNITS "packets"
       MAX-ACCESS read-only
       STATUS current
       DESCRIPTION
             "The number of RADIUS Authentication-Request packets
-             which contained invalid Signature attributes received."
+             that contained invalid Message Authenticator
+             attributes received."
+      REFERENCE "RFC 2865 section 3"
       ::= { radiusAuthServ 12 }
 
 radiusAuthServTotalPacketsDropped OBJECT-TYPE
       SYNTAX Counter32
+      UNITS "packets"
       MAX-ACCESS read-only
       STATUS current
       DESCRIPTION
@@ -177,32 +205,36 @@ radiusAuthServTotalPacketsDropped OBJECT-TYPE
              silently discarded for some reason other
              than malformed, bad authenticators or
              unknown types."
+      REFERENCE "RFC 2865 section 3"
       ::= { radiusAuthServ 13 }
 
 radiusAuthServTotalUnknownTypes OBJECT-TYPE
       SYNTAX Counter32
+      UNITS "packets"
       MAX-ACCESS read-only
       STATUS current
       DESCRIPTION
-            "The number of RADIUS packets of unknown type which
+            "The number of RADIUS packets of unknown type that
              were received."
+      REFERENCE "RFC 2865 section 4"
       ::= { radiusAuthServ 14 }
 
--- End of new
 
 radiusAuthClientTable OBJECT-TYPE
        SYNTAX     SEQUENCE OF RadiusAuthClientEntry
        MAX-ACCESS not-accessible
-       STATUS     current
+       STATUS     deprecated
        DESCRIPTION
-             "The (conceptual) table listing the RADIUS authentication
-              clients with which the server shares a secret."
+             "The (conceptual) table listing the RADIUS
+              authentication clients with which the server shares
+              a secret."
        ::= { radiusAuthServ 15 }
+
 
 radiusAuthClientEntry OBJECT-TYPE
        SYNTAX     RadiusAuthClientEntry
        MAX-ACCESS not-accessible
-       STATUS     current
+       STATUS     deprecated
        DESCRIPTION
              "An entry (conceptual row) representing a RADIUS
               authentication client with which the server shares a
@@ -228,7 +260,7 @@ RadiusAuthClientEntry ::= SEQUENCE {
 radiusAuthClientIndex OBJECT-TYPE
        SYNTAX     Integer32 (1..2147483647)
        MAX-ACCESS not-accessible
-       STATUS     current
+       STATUS     deprecated
        DESCRIPTION
              "A number uniquely identifying each RADIUS
               authentication client with which this server
@@ -238,20 +270,22 @@ radiusAuthClientIndex OBJECT-TYPE
 radiusAuthClientAddress OBJECT-TYPE
        SYNTAX     IpAddress
        MAX-ACCESS read-only
-       STATUS     current
+       STATUS     deprecated
        DESCRIPTION
              "The NAS-IP-Address of the RADIUS authentication client
               referred to in this table entry."
+       REFERENCE "RFC 2865 section 2"
        ::= { radiusAuthClientEntry 2 }
 
 radiusAuthClientID OBJECT-TYPE
        SYNTAX     SnmpAdminString
        MAX-ACCESS read-only
-       STATUS     current
+       STATUS     deprecated
        DESCRIPTION
              "The NAS-Identifier of the RADIUS authentication client
-              referred to in this table entry. This is not necessarily
-              the same as sysName in MIB II."
+              referred to in this table entry.  This is not
+              necessarily the same as sysName in MIB II."
+       REFERENCE "RFC 2865 section 5.32"
        ::= { radiusAuthClientEntry 3 }
 
 -- Server Counters
@@ -267,107 +301,367 @@ radiusAuthClientID OBJECT-TYPE
 
 radiusAuthServAccessRequests OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
-       STATUS current
+       STATUS deprecated
        DESCRIPTION
              "The number of packets received on the authentication
               port from this client."
+       REFERENCE "RFC 2865 section 4.1"
        ::= { radiusAuthClientEntry  4 }
 
 radiusAuthServDupAccessRequests OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
-       STATUS current
+       STATUS deprecated
        DESCRIPTION
              "The number of duplicate RADIUS Access-Request
               packets received from this client."
+       REFERENCE "RFC 2865 section 4.1"
        ::= { radiusAuthClientEntry  5 }
 
 radiusAuthServAccessAccepts OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
-       STATUS current
+       STATUS deprecated
        DESCRIPTION
              "The number of RADIUS Access-Accept packets
               sent to this client."
+       REFERENCE "RFC 2865 section 4.2"
        ::= { radiusAuthClientEntry  6 }
 
 radiusAuthServAccessRejects OBJECT-TYPE
       SYNTAX Counter32
+      UNITS "packets"
       MAX-ACCESS read-only
-      STATUS current
+      STATUS deprecated
       DESCRIPTION
              "The number of RADIUS Access-Reject packets
               sent to this client."
+       REFERENCE "RFC 2865 section 4.3"
        ::= { radiusAuthClientEntry  7 }
 
 radiusAuthServAccessChallenges OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
-       STATUS current
+       STATUS deprecated
        DESCRIPTION
              "The number of RADIUS Access-Challenge packets
               sent to this client."
+       REFERENCE "RFC 2865 section 4.4"
        ::= { radiusAuthClientEntry  8 }
 
 radiusAuthServMalformedAccessRequests OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
-       STATUS current
+       STATUS deprecated
        DESCRIPTION
              "The number of malformed RADIUS Access-Request
               packets received from this client.
-              Bad authenticators and unknown types are not included as
-              malformed Access-Requests."
+              Bad authenticators and unknown types are not included
+              as malformed Access-Requests."
+       REFERENCE "RFC 2865 section 3"
        ::= { radiusAuthClientEntry  9 }
 
 radiusAuthServBadAuthenticators OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
-       STATUS current
+       STATUS deprecated
        DESCRIPTION
              "The number of RADIUS Authentication-Request packets
-              which contained invalid Signature attributes received
-              from this client."
+              that contained invalid Message Authenticator
+              attributes received from this client."
+       REFERENCE "RFC 2865 section 3"
        ::= { radiusAuthClientEntry  10 }
 
 radiusAuthServPacketsDropped OBJECT-TYPE
       SYNTAX Counter32
+      UNITS "packets"
       MAX-ACCESS read-only
-      STATUS current
+      STATUS deprecated
       DESCRIPTION
               "The number of incoming packets from this
                client silently discarded for some reason other
                than malformed, bad authenticators or
                unknown types."
+       REFERENCE "RFC 2865 section 3"
        ::= { radiusAuthClientEntry  11 }
 
 radiusAuthServUnknownTypes OBJECT-TYPE
        SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS deprecated
+       DESCRIPTION
+             "The number of RADIUS packets of unknown type that
+              were received from this client."
+       REFERENCE "RFC 2865 section 4"
+       ::= { radiusAuthClientEntry  12 }
+
+radiusAuthClientExtTable OBJECT-TYPE
+       SYNTAX     SEQUENCE OF RadiusAuthClientExtEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+             "The (conceptual) table listing the RADIUS
+              authentication clients with which the server shares
+              a secret."
+       ::= { radiusAuthServ 16 }
+
+radiusAuthClientExtEntry OBJECT-TYPE
+       SYNTAX     RadiusAuthClientExtEntry
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+             "An entry (conceptual row) representing a RADIUS
+              authentication client with which the server shares a
+              secret."
+       INDEX      { radiusAuthClientExtIndex }
+       ::= { radiusAuthClientExtTable 1 }
+
+RadiusAuthClientExtEntry ::= SEQUENCE {
+       radiusAuthClientExtIndex                 Integer32,
+       radiusAuthClientInetAddressType          InetAddressType,
+       radiusAuthClientInetAddress              InetAddress,
+       radiusAuthClientExtID                    SnmpAdminString,
+       radiusAuthServExtAccessRequests          Counter32,
+       radiusAuthServExtDupAccessRequests       Counter32,
+       radiusAuthServExtAccessAccepts           Counter32,
+       radiusAuthServExtAccessRejects           Counter32,
+       radiusAuthServExtAccessChallenges        Counter32,
+       radiusAuthServExtMalformedAccessRequests Counter32,
+       radiusAuthServExtBadAuthenticators       Counter32,
+       radiusAuthServExtPacketsDropped          Counter32,
+       radiusAuthServExtUnknownTypes            Counter32,
+       radiusAuthServCounterDiscontinuity       TimeTicks
+}
+
+radiusAuthClientExtIndex OBJECT-TYPE
+       SYNTAX     Integer32 (1..2147483647)
+       MAX-ACCESS not-accessible
+       STATUS     current
+       DESCRIPTION
+             "A number uniquely identifying each RADIUS
+              authentication client with which this server
+              communicates."
+       ::= { radiusAuthClientExtEntry 1 }
+
+radiusAuthClientInetAddressType OBJECT-TYPE
+         SYNTAX     InetAddressType
+         MAX-ACCESS read-only
+         STATUS     current
+         DESCRIPTION
+               "The type of address format used for the
+                radiusAuthClientInetAddress object."
+         ::= { radiusAuthClientExtEntry 2 }
+
+   radiusAuthClientInetAddress OBJECT-TYPE
+         SYNTAX     InetAddress
+         MAX-ACCESS read-only
+         STATUS     current
+         DESCRIPTION
+               "The IP address of the RADIUS authentication
+                client referred to in this table entry, using
+                the version-neutral IP address format."
+         ::= { radiusAuthClientExtEntry 3 }
+
+
+radiusAuthClientExtID OBJECT-TYPE
+       SYNTAX     SnmpAdminString
+       MAX-ACCESS read-only
+       STATUS     current
+       DESCRIPTION
+             "The NAS-Identifier of the RADIUS authentication client
+              referred to in this table entry.  This is not
+              necessarily the same as sysName in MIB II."
+       REFERENCE "RFC 2865 section 5.32"
+       ::= { radiusAuthClientExtEntry 4 }
+
+-- Server Counters
+
+--
+-- Responses = AccessAccepts + AccessRejects + AccessChallenges
+--
+-- Requests - DupRequests - BadAuthenticators - MalformedRequests -
+-- UnknownTypes -  PacketsDropped - Responses = Pending
+--
+-- Requests - DupRequests - BadAuthenticators - MalformedRequests -
+-- UnknownTypes - PacketsDropped = entries logged
+
+radiusAuthServExtAccessRequests OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
        MAX-ACCESS read-only
        STATUS current
        DESCRIPTION
-             "The number of RADIUS packets of unknown type which
-              were received from this client."
-       ::= { radiusAuthClientEntry  12 }
+             "The number of packets received on the authentication
+              port from this client.  This counter may experience a
+              discontinuity when the RADIUS Server module within the
+              managed entity is reinitialized, as indicated by the
+              current value of radiusAuthServCounterDiscontinuity."
+       REFERENCE "RFC 2865 section 4.1"
+       ::= { radiusAuthClientExtEntry  5 }
+
+radiusAuthServExtDupAccessRequests OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of duplicate RADIUS Access-Request
+              packets received from this client.  This counter may
+              experience a discontinuity when the RADIUS Server
+              module within the managed entity is reinitialized, as
+              indicated by the current value of
+              radiusAuthServCounterDiscontinuity."
+       REFERENCE "RFC 2865 section 4.1"
+       ::= { radiusAuthClientExtEntry  6 }
+
+radiusAuthServExtAccessAccepts OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Access-Accept packets
+              sent to this client.  This counter may experience a
+              discontinuity when the RADIUS Server module within the
+              managed entity is reinitialized, as indicated by the
+              current value of radiusAuthServCounterDiscontinuity."
+       REFERENCE "RFC 2865 section 4.2"
+       ::= { radiusAuthClientExtEntry  7 }
+
+radiusAuthServExtAccessRejects OBJECT-TYPE
+      SYNTAX Counter32
+      UNITS "packets"
+      MAX-ACCESS read-only
+      STATUS current
+      DESCRIPTION
+             "The number of RADIUS Access-Reject packets
+              sent to this client.  This counter may experience a
+              discontinuity when the RADIUS Server module within the
+              managed entity is reinitialized, as indicated by the
+              current value of radiusAuthServCounterDiscontinuity."
+       REFERENCE "RFC 2865 section 4.3"
+       ::= { radiusAuthClientExtEntry  8 }
+
+radiusAuthServExtAccessChallenges OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Access-Challenge packets
+              sent to this client.  This counter may experience a
+              discontinuity when the RADIUS Server module within the
+              managed entity is reinitialized, as indicated by the
+              current value of radiusAuthServCounterDiscontinuity."
+       REFERENCE "RFC 2865 section 4.4"
+       ::= { radiusAuthClientExtEntry  9 }
+
+radiusAuthServExtMalformedAccessRequests OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of malformed RADIUS Access-Request
+              packets received from this client.  Bad authenticators
+              and unknown types are not included as malformed
+              Access-Requests.  This counter may experience a
+              discontinuity when the RADIUS Server module within the
+              managed entity is reinitialized, as indicated by the
+              current value of radiusAuthServCounterDiscontinuity."
+       REFERENCE "RFC 2865 sections 3, 4.1"
+       ::= { radiusAuthClientExtEntry  10 }
+
+radiusAuthServExtBadAuthenticators OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS Authentication-Request packets
+              that contained invalid Message Authenticator
+              attributes received from this client.  This counter
+              may experience a discontinuity when the RADIUS Server
+              module within the managed entity is reinitialized, as
+              indicated by the current value of
+              radiusAuthServCounterDiscontinuity."
+       REFERENCE "RFC 2865 section 3"
+       ::= { radiusAuthClientExtEntry  11 }
+
+radiusAuthServExtPacketsDropped OBJECT-TYPE
+      SYNTAX Counter32
+      UNITS "packets"
+      MAX-ACCESS read-only
+      STATUS current
+      DESCRIPTION
+             "The number of incoming packets from this client
+              silently discarded for some reason other than
+              malformed, bad authenticators or unknown types.
+              This counter may experience a discontinuity when the
+              RADIUS Server module within the managed entity is
+              reinitialized, as indicated by the current value of
+              radiusAuthServCounterDiscontinuity."
+       REFERENCE "RFC 2865 section 3"
+       ::= { radiusAuthClientExtEntry  12 }
+
+radiusAuthServExtUnknownTypes OBJECT-TYPE
+       SYNTAX Counter32
+       UNITS "packets"
+       MAX-ACCESS read-only
+       STATUS current
+       DESCRIPTION
+             "The number of RADIUS packets of unknown type that
+              were received from this client.  This counter may
+              experience a discontinuity when the RADIUS Server
+              module within the managed entity is reinitialized, as
+              indicated by the current value of
+              radiusAuthServCounterDiscontinuity."
+       REFERENCE "RFC 2865 section 4"
+       ::= { radiusAuthClientExtEntry  13 }
+
+radiusAuthServCounterDiscontinuity OBJECT-TYPE
+         SYNTAX TimeTicks
+         UNITS "centiseconds"
+         MAX-ACCESS read-only
+         STATUS current
+         DESCRIPTION
+               "The number of centiseconds since the last
+                discontinuity in the RADIUS Server counters.
+                A discontinuity may be the result of a
+                reinitialization of the RADIUS Server module
+                within the managed entity."
+         ::= { radiusAuthClientExtEntry 14 }
 
 -- conformance information
 
-radiusAuthServMIBConformance
-              OBJECT IDENTIFIER ::= { radiusAuthServMIB 2 }
-radiusAuthServMIBCompliances
-              OBJECT IDENTIFIER ::= { radiusAuthServMIBConformance 1 }
-radiusAuthServMIBGroups
-              OBJECT IDENTIFIER ::= { radiusAuthServMIBConformance 2 }
+radiusAuthServMIBConformance  OBJECT IDENTIFIER
+       ::= { radiusAuthServMIB 2 }
 
+radiusAuthServMIBCompliances  OBJECT IDENTIFIER
+       ::= { radiusAuthServMIBConformance 1 }
+
+radiusAuthServMIBGroups  OBJECT IDENTIFIER
+       ::= { radiusAuthServMIBConformance 2 }
 
 -- compliance statements
 
 radiusAuthServMIBCompliance MODULE-COMPLIANCE
-            STATUS  current
+            STATUS  deprecated
             DESCRIPTION
-                  "The compliance statement for authentication servers
-                   implementing the RADIUS Authentication Server MIB."
+                  "The compliance statement for authentication
+                   servers implementing the RADIUS Authentication
+                   Server MIB.  Implementation of this module is for
+                   IPv4-only entities, or for backwards compatibility
+                   use with entities that support both IPv4 and
+                   IPv6."
             MODULE  -- this module
             MANDATORY-GROUPS { radiusAuthServMIBGroup }
 
@@ -376,6 +670,37 @@ radiusAuthServMIBCompliance MODULE-COMPLIANCE
             DESCRIPTION  "The only SETable value is 'reset' (2)."
 
             ::= { radiusAuthServMIBCompliances 1 }
+
+
+radiusAuthServMIBExtCompliance MODULE-COMPLIANCE
+            STATUS  current
+            DESCRIPTION
+                  "The compliance statement for authentication
+                   servers implementing the RADIUS Authentication
+                   Server IPv6 Extensions MIB.  Implementation of
+                   this module is for entities that support IPv6,
+                   or support IPv4 and IPv6."
+            MODULE  -- this module
+            MANDATORY-GROUPS { radiusAuthServExtMIBGroup }
+
+            OBJECT        radiusAuthServConfigReset
+            WRITE-SYNTAX  INTEGER { reset(2) }
+            DESCRIPTION  "The only SETable value is 'reset' (2)."
+
+            OBJECT radiusAuthClientInetAddressType
+            SYNTAX InetAddressType { ipv4(1), ipv6(2) }
+            DESCRIPTION
+              "An implementation is only required to support
+               IPv4 and globally unique IPv6 addresses."
+
+            OBJECT radiusAuthClientInetAddress
+            SYNTAX InetAddress ( SIZE (4|16) )
+            DESCRIPTION
+              "An implementation is only required to support
+               IPv4 and globally unique IPv6 addresses."
+
+            ::= { radiusAuthServMIBCompliances 2 }
+
 
 -- units of conformance
 
@@ -406,10 +731,45 @@ radiusAuthServMIBGroup OBJECT-GROUP
                radiusAuthServPacketsDropped,
                radiusAuthServUnknownTypes
               }
-      STATUS  current
+      STATUS  deprecated
       DESCRIPTION
             "The collection of objects providing management of
              a RADIUS Authentication Server."
       ::= { radiusAuthServMIBGroups 1 }
+
+radiusAuthServExtMIBGroup OBJECT-GROUP
+      OBJECTS {radiusAuthServIdent,
+               radiusAuthServUpTime,
+               radiusAuthServResetTime,
+               radiusAuthServConfigReset,
+               radiusAuthServTotalAccessRequests,
+               radiusAuthServTotalInvalidRequests,
+               radiusAuthServTotalDupAccessRequests,
+               radiusAuthServTotalAccessAccepts,
+               radiusAuthServTotalAccessRejects,
+               radiusAuthServTotalAccessChallenges,
+               radiusAuthServTotalMalformedAccessRequests,
+               radiusAuthServTotalBadAuthenticators,
+               radiusAuthServTotalPacketsDropped,
+               radiusAuthServTotalUnknownTypes,
+               radiusAuthClientInetAddressType,
+               radiusAuthClientInetAddress,
+               radiusAuthClientExtID,
+               radiusAuthServExtAccessRequests,
+               radiusAuthServExtDupAccessRequests,
+               radiusAuthServExtAccessAccepts,
+               radiusAuthServExtAccessRejects,
+               radiusAuthServExtAccessChallenges,
+               radiusAuthServExtMalformedAccessRequests,
+               radiusAuthServExtBadAuthenticators,
+               radiusAuthServExtPacketsDropped,
+               radiusAuthServExtUnknownTypes,
+               radiusAuthServCounterDiscontinuity
+              }
+      STATUS  current
+      DESCRIPTION
+            "The collection of objects providing management of
+             a RADIUS Authentication Server."
+      ::= { radiusAuthServMIBGroups 2 }
 
 END

--- a/scripts/snmp-proxy/freeradius-snmp.pl
+++ b/scripts/snmp-proxy/freeradius-snmp.pl
@@ -1,7 +1,8 @@
 #!/usr/bin/perl
 #
-# Copyright (C) 2008 Sky Network Services. All Rights Reserved.
-# 
+# Copyright (C) 2008 Sky Network Services.
+# Copyright (C) 2022 Network RADIUS.
+#
 # This program is free software; you can redistribute it and/or modify it
 # under the same terms as Perl itself.
 #
@@ -15,6 +16,7 @@ use Net::Radius::Packet;
 use Net::Radius::Dictionary;
 use NetSNMP::agent qw/:all/;
 use NetSNMP::ASN qw/:all/;
+use Socket qw(inet_ntop);
 use IO::Socket::INET;
 use Digest::HMAC_MD5;
 use Log::Log4perl qw/:easy/;
@@ -23,7 +25,6 @@ use Log::Log4perl qw/:easy/;
 #$Data::Dumper::Sortkeys = 1;
 #$| = 1;
 
-# config. should be really loaded from some file
 my $cfg = {
     snmp => {
         agent => {
@@ -46,43 +47,59 @@ my $cfg = {
         refresh_rate => 20,
     },
 
-
     log => {
-        level => $DEBUG,
+        level  => $WARN,   # $DEBUG, $ERROR, etc.
         layout => '%d{ISO8601} <%p> (%L) %m%n',
-        file => 'STDERR'
+        file   => 'STDERR'
     },
 
-    clients => undef,
+    clients => 1,    # Or 0 to disable
 };
+
 Log::Log4perl->easy_init($cfg->{log});
 
 INFO 'starting';
+my $running :shared;
 my %snmp_data :shared;
 my @snmp_data_k :shared;
-
+my %snmp_next :shared;
 
 INFO 'initializing snmp';
 my $agent = new NetSNMP::agent(%{$cfg->{snmp}->{agent}});
 
-#lets create the thread as early as possible (but it has to be AFTER initializing snmp)
+radius_stats_init();
+$running = 1;
+
+$SIG{INT} = sub {
+    INFO 'stopping';
+    $running = 0;
+};
+
+#
+#  Background updater thread
+#
 INFO 'launching radius client thread';
 threads->create(\&radius_updater);
 
-#we export only subtrees, not the whole tree
+#
+#  We export only the radiusAuthServ and radiusAccServ subtree
+#
 $agent->register(
     $cfg->{snmp}->{agent}->{Name},
     $cfg->{snmp}->{oid_root}.'.'.$_, \&snmp_handler) or die
   foreach keys %{$cfg->{snmp}->{oid_sub}};
 
 INFO 'entering client main loop';
-$agent->main_loop;
+$agent->agent_check_and_process(1) while $running;
 
-WARN 'something caused me to exit';
-exit 0;
+$agent->shutdown();
+
+$_->join() for threads->list();
 
 
-# initialize common radius client stuff
+#
+#  Initialize common radius client stuff
+#
 sub radius_stats_init {
     our ( $d, $s, $rid );
 
@@ -99,30 +116,38 @@ sub radius_stats_init {
 
 }
 
-# build server status packet, send it, fetch and parse the result
+#
+#  Build server status packet, send it, fetch and parse the result
+#
 sub radius_stats_get {
-    my ( $type, %args ) = @_;
+    my ($type, %args) = @_;
 
-    our ( $d, $s, $rid );
+    our ($d, $s, $rid);
 
     my $p_req = new Net::Radius::Packet $d;
     $p_req->set_code('Status-Server');
     $p_req->set_vsattr('FreeRADIUS', 'FreeRADIUS-Statistics-Type', $type);
     $p_req->set_vsattr('FreeRADIUS', $_, $args{$_}) foreach keys %args;
 
-    #update id
+    #
+    #  Update id
+    #
     $p_req->set_identifier($rid++);
     $p_req->set_authenticator(pack 'C*', map { int rand 255 } 0..15);
 
-    #recalc authenticator
+    #
+    #  Recalc authenticator
+    #
     $p_req->set_attr('Message-Authenticator', "\0"x16, 1);
     $p_req->set_attr('Message-Authenticator', Digest::HMAC_MD5::hmac_md5($p_req->pack, $cfg->{radius}->{secret}), 1);
 
-    #send brand new and shiny request
+    #
+    #  Send brand new and shiny request
+    #
     $s->send($p_req->pack) or die;
 
     my $p_data;
-    if ( defined $s->recv($p_data, 2048) ) {
+    if (defined $s->recv($p_data, 2048)) {
         my $p_res = new Net::Radius::Packet $d, $p_data;
 
         my %response =  map {
@@ -130,182 +155,254 @@ sub radius_stats_get {
         } $p_res->vsattributes($d->vendor_num('FreeRADIUS'));
         return \%response;
 
-    }else {
+    }
+    else {
         warn "no answer, $!\n";
         return undef;
     }
 
 }
 
-#wrappers for specific types of stats
+#
+#  Wrappers for specific types of stats
+#
 sub radius_stats_get_global { return radius_stats_get(0x1f); }
 sub radius_stats_get_client { return radius_stats_get(0x3f, 'FreeRADIUS-Stats-Client-Number' => $_[0]); }
 
-
-#main loop of thread fetching status from freeradius server
+#
+#  Main loop of thread fetching status from freeradius server
+#
 sub radius_updater {
-    radius_stats_init();
 
-    while (1) {
+    while ($running) {
         INFO 'fetching new data';
         my $main_stat = radius_stats_get_global();
 
-        if ( defined $main_stat ) {
+        if (defined $main_stat) {
             my @clients_stat = ();
 
-            if ( $cfg->{clients} ) {
+            if ($cfg->{clients}) {
                 my $client_id = 0;
 
                 while (1) {
                     my $client_stat = radius_stats_get_client($client_id);
-                    last unless exists $client_stat->{'FreeRADIUS-Stats-Client-IP-Address'};
+                    last unless exists $client_stat->{'FreeRADIUS-Stats-Client-IP-Address'} || exists $client_stat->{'FreeRADIUS-Stats-Client-IPv6-Address'};
                     push @clients_stat, $client_stat;
                     $client_id += 1;
                 }
             }
 
-            #todo ng: update on demand, and update only parts of snmp visible stats
-
             INFO 'got data, updating stats';
             radius_snmp_stats($main_stat, \@clients_stat);
 
-        }else {
+        }
+        else {
             WARN 'problem with fetching data';
-
         }
 
         INFO 'stats updated, sleeping';
-        sleep $cfg->{radius}->{refresh_rate};
+        my $now = time;
+        my $next_stats_time = $now + $cfg->{radius}->{refresh_rate};
+        do {
+            sleep 1;
+            $now = time;
+        } while ($now < $next_stats_time && $running);
+
     }
 
 }
 
-#helper to get string from NetSNMP::OID
+#
+#  Helper to get a dotted string from NetSNMP::OID
+#
 sub oid_s { return join '.', $_[0]->to_array; }
 
-#handler for snmp requests from master agent(clients)
+#
+#  Handler for snmp requests from master agent
+#
 sub snmp_handler {
     DEBUG 'got new request';
     my ($handler, $registration_info, $request_info, $requests) = @_;
 
     lock %snmp_data;
     lock @snmp_data_k;
+    lock %snmp_next;
 
-    for ( my $request = $requests; $request; $request = $request->next() ) {
+    for (my $request = $requests; $request; $request = $request->next()) {
         INFO 'request type '.$request_info->getMode.' for oid: '.oid_s($request->getOID);
 
-        if ( $request_info->getMode == MODE_GET ) {
+        if ($request_info->getMode == MODE_GET) {
             my $oid_s = oid_s($request->getOID);
-            if ( exists $snmp_data{$oid_s} ) {
+            if (exists $snmp_data{$oid_s}) {
                 $request->setValue($snmp_data{$oid_s}->[0], ''.$snmp_data{$oid_s}->[1]);
             }
 
-        }elsif ( $request_info->getMode == MODE_GETNEXT ) {
-            foreach my $oid ( @snmp_data_k ) {
-                #the keys is sorted in ascending order, so we are looking for
-                #first value bigger than one in request
-                if ( $request->getOID < NetSNMP::OID->new($oid) ) {
-                    $request->setValue($snmp_data{$oid}->[0], ''.$snmp_data{$oid}->[1]);
-                    $request->setOID($oid);
-                    last;
+        }
+        elsif ($request_info->getMode == MODE_GETNEXT) {
+
+            #
+            #  Do a fast lookup if we can...
+            #
+            my $oid = $snmp_next{oid_s($request->getOID)};
+
+            #
+            #  ... otherwise take the slow route
+            #
+            unless (defined $oid) {
+                foreach ( @snmp_data_k ) {
+                    #the keys is sorted in ascending order, so we are looking for
+                    #first value bigger than one in request
+                    if ($request->getOID < NetSNMP::OID->new($_)) {
+                        $oid = $_;
+                        last;
+                    }
                 }
             }
 
-        }else {
-            #no write support
-            $request->setError($request_info, SNMP_ERR_READONLY);
+            next unless $oid;
 
+            $request->setValue($snmp_data{$oid}->[0], ''.$snmp_data{$oid}->[1]);
+            $request->setOID($oid);
+
+        }
+        else {
+            $request->setError($request_info, SNMP_ERR_READONLY);  # No write support
         }
     }
     DEBUG 'finished processing the request';
 }
 
-#init part of subtree for handling radius auth statistics
+#
+#  Init part of subtree for handling radius AUTH statistics
+#
 sub radius_snmp_stats_init_auth {
-    my ( $snmp_data_n, $oid, $clients ) = @_;
+    my ($snmp_data_n, $oid, $clients) = @_;
 
-    @{$snmp_data_n->{$oid.'.1.1.1.1'} = &share([])} = (ASN_OCTET_STR, ''); #radiusAuthServIdent
-    @{$snmp_data_n->{$oid.'.1.1.1.2'} = &share([])} = (ASN_TIMETICKS, 0); #radiusAuthServUpTime
-    @{$snmp_data_n->{$oid.'.1.1.1.3'} = &share([])} = (ASN_TIMETICKS, 0); #radiusAuthServResetTime
-    @{$snmp_data_n->{$oid.'.1.1.1.4'} = &share([])} = (ASN_INTEGER, 0); #radiusAuthServConfigReset
-    @{$snmp_data_n->{$oid.'.1.1.1.5'} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServTotalAccessRequests
-    @{$snmp_data_n->{$oid.'.1.1.1.6'} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServTotalInvalidRequests
-    @{$snmp_data_n->{$oid.'.1.1.1.7'} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServTotalDupAccessRequests
-    @{$snmp_data_n->{$oid.'.1.1.1.8'} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServTotalAccessAccepts
-    @{$snmp_data_n->{$oid.'.1.1.1.9'} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServTotalAccessRejects
-    @{$snmp_data_n->{$oid.'.1.1.1.10'} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServTotalAccessChallenges
-    @{$snmp_data_n->{$oid.'.1.1.1.11'} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServTotalMalformedAccessRequests
-    @{$snmp_data_n->{$oid.'.1.1.1.12'} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServTotalBadAuthenticators
-    @{$snmp_data_n->{$oid.'.1.1.1.13'} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServTotalPacketsDropped
-    @{$snmp_data_n->{$oid.'.1.1.1.14'} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServTotalUnknownTypes
+    @{$snmp_data_n->{$oid.'.1.1.1.1'}  = &share([])} = (ASN_OCTET_STR, '');     # radiusAuthServIdent
+    @{$snmp_data_n->{$oid.'.1.1.1.2'}  = &share([])} = (ASN_TIMETICKS, 0);      # radiusAuthServUpTime
+    @{$snmp_data_n->{$oid.'.1.1.1.3'}  = &share([])} = (ASN_TIMETICKS, 0);      # radiusAuthServResetTime
+    @{$snmp_data_n->{$oid.'.1.1.1.4'}  = &share([])} = (ASN_INTEGER, 0);        # radiusAuthServConfigReset
+    @{$snmp_data_n->{$oid.'.1.1.1.5'}  = &share([])} = (ASN_COUNTER, 0);        # radiusAuthServTotalAccessRequests
+    @{$snmp_data_n->{$oid.'.1.1.1.6'}  = &share([])} = (ASN_COUNTER, 0);        # radiusAuthServTotalInvalidRequests
+    @{$snmp_data_n->{$oid.'.1.1.1.7'}  = &share([])} = (ASN_COUNTER, 0);        # radiusAuthServTotalDupAccessRequests
+    @{$snmp_data_n->{$oid.'.1.1.1.8'}  = &share([])} = (ASN_COUNTER, 0);        # radiusAuthServTotalAccessAccepts
+    @{$snmp_data_n->{$oid.'.1.1.1.9'}  = &share([])} = (ASN_COUNTER, 0);        # radiusAuthServTotalAccessRejects
+    @{$snmp_data_n->{$oid.'.1.1.1.10'} = &share([])} = (ASN_COUNTER, 0);        # radiusAuthServTotalAccessChallenges
+    @{$snmp_data_n->{$oid.'.1.1.1.11'} = &share([])} = (ASN_COUNTER, 0);        # radiusAuthServTotalMalformedAccessRequests
+    @{$snmp_data_n->{$oid.'.1.1.1.12'} = &share([])} = (ASN_COUNTER, 0);        # radiusAuthServTotalBadAuthenticators
+    @{$snmp_data_n->{$oid.'.1.1.1.13'} = &share([])} = (ASN_COUNTER, 0);        # radiusAuthServTotalPacketsDropped
+    @{$snmp_data_n->{$oid.'.1.1.1.14'} = &share([])} = (ASN_COUNTER, 0);        # radiusAuthServTotalUnknownTypes
 
-    #radiusAuthClientTable
+    #
+    #  radiusAuthClientExtTable
+    #
     for (1 .. scalar @$clients) {
-        @{$snmp_data_n->{$oid.'.1.1.1.15.1.1.'.$_} = &share([])} = (ASN_INTEGER, $_); #radiusAuthClientIndex
-        @{$snmp_data_n->{$oid.'.1.1.1.15.1.2.'.$_} = &share([])} = (ASN_IPADDRESS, pack 'C4', split /\./, $clients->[$_-1]->{'FreeRADIUS-Stats-Client-IP-Address'}); #radiusAuthClientAddress
-        @{$snmp_data_n->{$oid.'.1.1.1.15.1.3.'.$_} = &share([])} = (ASN_OCTET_STR, $clients->[$_-1]->{'FreeRADIUS-Stats-Client-Number'}); #radiusAuthClientID
-#        @{$snmp_data_n->{$oid.'.1.1.1.15.1.4.'.$_} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServAccessRequests
-#        @{$snmp_data_n->{$oid.'.1.1.1.15.1.5.'.$_} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServDupAccessRequests
-#        @{$snmp_data_n->{$oid.'.1.1.1.15.1.6.'.$_} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServAccessAccepts
-#        @{$snmp_data_n->{$oid.'.1.1.1.15.1.7.'.$_} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServAccessRejects
-#        @{$snmp_data_n->{$oid.'.1.1.1.15.1.8.'.$_} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServAccessChallenges
-#        @{$snmp_data_n->{$oid.'.1.1.1.15.1.9.'.$_} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServMalformedAccessRequests
-#        @{$snmp_data_n->{$oid.'.1.1.1.15.1.10.'.$_} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServBadAuthenticators
-#        @{$snmp_data_n->{$oid.'.1.1.1.15.1.11.'.$_} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServPacketsDropped
-#        @{$snmp_data_n->{$oid.'.1.1.1.15.1.12.'.$_} = &share([])} = (ASN_COUNTER, 0); #radiusAuthServUnknownTypes
+
+        my $addrtype;
+        my $addr;
+        if (exists $clients->[$_-1]->{'FreeRADIUS-Stats-Client-IP-Address'}) {
+                $addrtype = 1;
+                $addr = $clients->[$_-1]->{'FreeRADIUS-Stats-Client-IP-Address'};
+        }
+        elsif (exists $clients->[$_-1]->{'FreeRADIUS-Stats-Client-IPv6-Address'}) {
+                $addrtype = 2;
+                $addr = inet_ntop(AF_INET6, $clients->[$_-1]->{'FreeRADIUS-Stats-Client-IPv6-Address'});
+        }
+        else {
+                next;
+        }
+
+        @{$snmp_data_n->{$oid.'.1.1.1.16.1.1.'.$_}  = &share([])} = (ASN_INTEGER, $_);        # radiusAuthClientExtIndex
+        @{$snmp_data_n->{$oid.'.1.1.1.16.1.2.'.$_}  = &share([])} = (ASN_INTEGER, $addrtype); # radiusAuthClientInetAddressType
+        @{$snmp_data_n->{$oid.'.1.1.1.16.1.3.'.$_}  = &share([])} = (ASN_OCTET_STR, $addr);   # radiusAuthClientInetAddress
+        @{$snmp_data_n->{$oid.'.1.1.1.16.1.4.'.$_}  = &share([])} = (ASN_OCTET_STR, $clients->[$_-1]->{'FreeRADIUS-Stats-Client-Number'});        # radiusAuthClientExtID
+        @{$snmp_data_n->{$oid.'.1.1.1.16.1.5.'.$_}  = &share([])} = (ASN_COUNTER, 0);         # radiusAuthServExtAccessRequests
+        @{$snmp_data_n->{$oid.'.1.1.1.16.1.6.'.$_}  = &share([])} = (ASN_COUNTER, 0);         # radiusAuthServExtDupAccessRequests
+        @{$snmp_data_n->{$oid.'.1.1.1.16.1.7.'.$_}  = &share([])} = (ASN_COUNTER, 0);         # radiusAuthServExtAccessAccepts
+        @{$snmp_data_n->{$oid.'.1.1.1.16.1.8.'.$_}  = &share([])} = (ASN_COUNTER, 0);         # radiusAuthServExtAccessRejects
+        @{$snmp_data_n->{$oid.'.1.1.1.16.1.9.'.$_}  = &share([])} = (ASN_COUNTER, 0);         # radiusAuthServExtAccessChallenges
+        @{$snmp_data_n->{$oid.'.1.1.1.16.1.10.'.$_} = &share([])} = (ASN_COUNTER, 0);         # radiusAuthServExtMalformedAccessRequests
+        @{$snmp_data_n->{$oid.'.1.1.1.16.1.11.'.$_} = &share([])} = (ASN_COUNTER, 0);         # radiusAuthServExtBadAuthenticators
+        @{$snmp_data_n->{$oid.'.1.1.1.16.1.12.'.$_} = &share([])} = (ASN_COUNTER, 0);         # radiusAuthServExtPacketsDropped
+        @{$snmp_data_n->{$oid.'.1.1.1.16.1.13.'.$_} = &share([])} = (ASN_COUNTER, 0);         # radiusAuthServExtUnknownTypes
+        @{$snmp_data_n->{$oid.'.1.1.1.16.1.14.'.$_} = &share([])} = (ASN_TIMETICKS, 0);       # radiusAuthServerCounterDiscontinuity
+
     }
 }
 
-#init part of subtree for handling radius acct statistics
+#
+#  Init part of subtree for handling radius ACCT statistics
+#
 sub radius_snmp_stats_init_acct {
     my ( $snmp_data_n, $oid, $clients ) = @_;
 
-    @{$snmp_data_n->{$oid.'.1.1.1.1'} = &share([])} = (ASN_OCTET_STR, ''); #radiusAccServIdent
-    @{$snmp_data_n->{$oid.'.1.1.1.2'} = &share([])} = (ASN_TIMETICKS, 0); #radiusAccServUpTime
-    @{$snmp_data_n->{$oid.'.1.1.1.3'} = &share([])} = (ASN_TIMETICKS, 0); #radiusAccServResetTime
-    @{$snmp_data_n->{$oid.'.1.1.1.4'} = &share([])} = (ASN_INTEGER, 0); #radiusAccServConfigReset
-    @{$snmp_data_n->{$oid.'.1.1.1.5'} = &share([])} = (ASN_COUNTER, 0); #radiusAccServTotalRequests
-    @{$snmp_data_n->{$oid.'.1.1.1.6'} = &share([])} = (ASN_COUNTER, 0); #radiusAccServTotalInvalidRequests
-    @{$snmp_data_n->{$oid.'.1.1.1.7'} = &share([])} = (ASN_COUNTER, 0); #radiusAccServTotalDupRequests
-    @{$snmp_data_n->{$oid.'.1.1.1.8'} = &share([])} = (ASN_COUNTER, 0); #radiusAccServTotalResponses
-    @{$snmp_data_n->{$oid.'.1.1.1.9'} = &share([])} = (ASN_COUNTER, 0); #radiusAccServTotalMalformedRequests
-    @{$snmp_data_n->{$oid.'.1.1.1.10'} = &share([])} = (ASN_COUNTER, 0); #radiusAccServTotalBadAuthenticators
-    @{$snmp_data_n->{$oid.'.1.1.1.11'} = &share([])} = (ASN_COUNTER, 0); #radiusAccServTotalPacketsDropped
-    @{$snmp_data_n->{$oid.'.1.1.1.12'} = &share([])} = (ASN_COUNTER, 0); #radiusAccServTotalNoRecords
-    @{$snmp_data_n->{$oid.'.1.1.1.13'} = &share([])} = (ASN_COUNTER, 0); #radiusAccServTotalUnknownTypes
+    @{$snmp_data_n->{$oid.'.1.1.1.1'}  = &share([])} = (ASN_OCTET_STR, '');     # radiusAccServIdent
+    @{$snmp_data_n->{$oid.'.1.1.1.2'}  = &share([])} = (ASN_TIMETICKS, 0);      # radiusAccServUpTime
+    @{$snmp_data_n->{$oid.'.1.1.1.3'}  = &share([])} = (ASN_TIMETICKS, 0);      # radiusAccServResetTime
+    @{$snmp_data_n->{$oid.'.1.1.1.4'}  = &share([])} = (ASN_INTEGER, 0);        # radiusAccServConfigReset
+    @{$snmp_data_n->{$oid.'.1.1.1.5'}  = &share([])} = (ASN_COUNTER, 0);        # radiusAccServTotalRequests
+    @{$snmp_data_n->{$oid.'.1.1.1.6'}  = &share([])} = (ASN_COUNTER, 0);        # radiusAccServTotalInvalidRequests
+    @{$snmp_data_n->{$oid.'.1.1.1.7'}  = &share([])} = (ASN_COUNTER, 0);        # radiusAccServTotalDupRequests
+    @{$snmp_data_n->{$oid.'.1.1.1.8'}  = &share([])} = (ASN_COUNTER, 0);        # radiusAccServTotalResponses
+    @{$snmp_data_n->{$oid.'.1.1.1.9'}  = &share([])} = (ASN_COUNTER, 0);        # radiusAccServTotalMalformedRequests
+    @{$snmp_data_n->{$oid.'.1.1.1.10'} = &share([])} = (ASN_COUNTER, 0);        # radiusAccServTotalBadAuthenticators
+    @{$snmp_data_n->{$oid.'.1.1.1.11'} = &share([])} = (ASN_COUNTER, 0);        # radiusAccServTotalPacketsDropped
+    @{$snmp_data_n->{$oid.'.1.1.1.12'} = &share([])} = (ASN_COUNTER, 0);        # radiusAccServTotalNoRecords
+    @{$snmp_data_n->{$oid.'.1.1.1.13'} = &share([])} = (ASN_COUNTER, 0);        # radiusAccServTotalUnknownTypes
 
-    #radiusAccClientTable
+    #
+    #  radiusAccClientExtTable
+    #
     for (1 .. scalar @$clients) {
-        @{$snmp_data_n->{$oid.'.1.1.1.14.1.1.'.$_} = &share([])} = (ASN_INTEGER, $_); #radiusAccClientIndex
-        @{$snmp_data_n->{$oid.'.1.1.1.14.1.2.'.$_} = &share([])} = (ASN_IPADDRESS, pack 'C4', split /\./, $clients->[$_-1]->{'FreeRADIUS-Stats-Client-IP-Address'}); #radiusAccClientAddress
-        @{$snmp_data_n->{$oid.'.1.1.1.14.1.3.'.$_} = &share([])} = (ASN_OCTET_STR, $clients->[$_-1]->{'FreeRADIUS-Stats-Client-Number'}); #radiusAccClientID
-#        @{$snmp_data_n->{$oid.'.1.1.1.14.1.4.'.$_} = &share([])} = (ASN_COUNTER, 0); #radiusAccServPacketsDropped
-#        @{$snmp_data_n->{$oid.'.1.1.1.14.1.5.'.$_} = &share([])} = (ASN_COUNTER, 0); #radiusAccServRequests
-#        @{$snmp_data_n->{$oid.'.1.1.1.14.1.6.'.$_} = &share([])} = (ASN_COUNTER, 0); #radiusAccServDupRequests
-#        @{$snmp_data_n->{$oid.'.1.1.1.14.1.7.'.$_} = &share([])} = (ASN_COUNTER, 0); #radiusAccServResponses
-#        @{$snmp_data_n->{$oid.'.1.1.1.14.1.8.'.$_} = &share([])} = (ASN_COUNTER, 0); #radiusAccServBadAuthenticators
-#        @{$snmp_data_n->{$oid.'.1.1.1.14.1.9.'.$_} = &share([])} = (ASN_COUNTER, 0); #radiusAccServMalformedRequests
-#        @{$snmp_data_n->{$oid.'.1.1.1.14.1.10.'.$_} = &share([])} = (ASN_COUNTER, 0); #radiusAccServNoRecords
-#        @{$snmp_data_n->{$oid.'.1.1.1.14.1.11.'.$_} = &share([])} = (ASN_COUNTER, 0); #radiusAccServUnknownTypes
+
+        my $addrtype;
+        my $addr;
+        if (exists $clients->[$_-1]->{'FreeRADIUS-Stats-Client-IP-Address'}) {
+                $addrtype = 1;
+                $addr = $clients->[$_-1]->{'FreeRADIUS-Stats-Client-IP-Address'};
+        }
+        elsif (exists $clients->[$_-1]->{'FreeRADIUS-Stats-Client-IPv6-Address'}) {
+                $addrtype = 2;
+                $addr = inet_ntop(AF_INET6, $clients->[$_-1]->{'FreeRADIUS-Stats-Client-IPv6-Address'});
+        }
+        else {
+                next;
+        }
+
+        @{$snmp_data_n->{$oid.'.1.1.1.15.1.1.'.$_}  = &share([])} = (ASN_INTEGER, $_);        # radiusAccClientExtIndex
+        @{$snmp_data_n->{$oid.'.1.1.1.15.1.2.'.$_}  = &share([])} = (ASN_INTEGER, $addrtype); # radiusAccClientInetAddressType
+        @{$snmp_data_n->{$oid.'.1.1.1.15.1.3.'.$_}  = &share([])} = (ASN_OCTET_STR, $addr);   # radiusAccClientInetAddress
+        @{$snmp_data_n->{$oid.'.1.1.1.15.1.4.'.$_}  = &share([])} = (ASN_OCTET_STR, $clients->[$_-1]->{'FreeRADIUS-Stats-Client-Number'});        # radiusAccClientExtID
+        @{$snmp_data_n->{$oid.'.1.1.1.15.1.5.'.$_}  = &share([])} = (ASN_COUNTER, 0);         # radiusAccServExtPacketsDropped
+        @{$snmp_data_n->{$oid.'.1.1.1.15.1.6.'.$_}  = &share([])} = (ASN_COUNTER, 0);         # radiusAccServExtRequests
+        @{$snmp_data_n->{$oid.'.1.1.1.15.1.7.'.$_}  = &share([])} = (ASN_COUNTER, 0);         # radiusAccServExtDupRequests
+        @{$snmp_data_n->{$oid.'.1.1.1.15.1.8.'.$_}  = &share([])} = (ASN_COUNTER, 0);         # radiusAccServResponses
+        @{$snmp_data_n->{$oid.'.1.1.1.15.1.9.'.$_}  = &share([])} = (ASN_COUNTER, 0);         # radiusAccServExtBadAuthenticators
+        @{$snmp_data_n->{$oid.'.1.1.1.15.1.10.'.$_} = &share([])} = (ASN_COUNTER, 0);         # radiusAccServExtMalformedRequests
+        @{$snmp_data_n->{$oid.'.1.1.1.15.1.11.'.$_} = &share([])} = (ASN_COUNTER, 0);         # radiusAccServExtNoRecords
+        @{$snmp_data_n->{$oid.'.1.1.1.15.1.12.'.$_} = &share([])} = (ASN_COUNTER, 0);         # radiusAccServExtUnknownTypes
+        @{$snmp_data_n->{$oid.'.1.1.1.15.1.13.'.$_} = &share([])} = (ASN_TIMETICKS, 0);       # radiusAccServerCounterDiscontinuity
+
     }
 }
 
-#fill part of subtree with data from radius auth statistics
+#
+#  Fill part of subtree with data from radius AUTH statistics
+#
 sub radius_snmp_stats_fill_auth {
-    my ( $snmp_data_n, $oid, $prefix, $main, $clients ) = @_;
-    #hmm .. proxy?
+    my ($snmp_data_n, $oid, $prefix, $main, $clients) = @_;
 
     my $time = time;
 
-    $snmp_data_n->{$oid.'.1.1.1.1'}->[1] = 'snmp(over)radius';
-    $snmp_data_n->{$oid.'.1.1.1.2'}->[1] = ($time - $main->{'FreeRADIUS-Stats-Start-Time'})*100;
-    $snmp_data_n->{$oid.'.1.1.1.3'}->[1] = ($time - $main->{'FreeRADIUS-Stats-HUP-Time'})*100;
-    $snmp_data_n->{$oid.'.1.1.1.4'}->[1] = 0;
-    $snmp_data_n->{$oid.'.1.1.1.5'}->[1] += $main->{$prefix.'Access-Requests'};
-    $snmp_data_n->{$oid.'.1.1.1.6'}->[1] += $main->{$prefix.'Auth-Invalid-Requests'};
-    $snmp_data_n->{$oid.'.1.1.1.7'}->[1] += $main->{$prefix.'Auth-Duplicate-Requests'};
-    $snmp_data_n->{$oid.'.1.1.1.8'}->[1] += $main->{$prefix.'Access-Accepts'};
-    $snmp_data_n->{$oid.'.1.1.1.9'}->[1] += $main->{$prefix.'Access-Rejects'};
+    $snmp_data_n->{$oid.'.1.1.1.1'}->[1]  = 'snmp(over)radius';
+    $snmp_data_n->{$oid.'.1.1.1.2'}->[1]  = ($time - $main->{'FreeRADIUS-Stats-Start-Time'})*100;
+    $snmp_data_n->{$oid.'.1.1.1.3'}->[1]  = ($time - $main->{'FreeRADIUS-Stats-HUP-Time'})*100;
+    $snmp_data_n->{$oid.'.1.1.1.4'}->[1]  = 0;
+    $snmp_data_n->{$oid.'.1.1.1.5'}->[1]  += $main->{$prefix.'Access-Requests'};
+    $snmp_data_n->{$oid.'.1.1.1.6'}->[1]  += $main->{$prefix.'Auth-Invalid-Requests'};
+    $snmp_data_n->{$oid.'.1.1.1.7'}->[1]  += $main->{$prefix.'Auth-Duplicate-Requests'};
+    $snmp_data_n->{$oid.'.1.1.1.8'}->[1]  += $main->{$prefix.'Access-Accepts'};
+    $snmp_data_n->{$oid.'.1.1.1.9'}->[1]  += $main->{$prefix.'Access-Rejects'};
     $snmp_data_n->{$oid.'.1.1.1.10'}->[1] += $main->{$prefix.'Access-Challenges'};
     $snmp_data_n->{$oid.'.1.1.1.11'}->[1] += $main->{$prefix.'Auth-Malformed-Requests'};
     $snmp_data_n->{$oid.'.1.1.1.12'}->[1] += 0;
@@ -313,114 +410,132 @@ sub radius_snmp_stats_fill_auth {
     $snmp_data_n->{$oid.'.1.1.1.14'}->[1] += $main->{$prefix.'Auth-Unknown-Types'};
 
     for (1 .. scalar @$clients) {
-#         $snmp_data_n->{$oid.'.1.1.1.15.1.4.'.$_}->[1] += $clients->[$_-1]->{$prefix.'Access-Requests'};
-#         $snmp_data_n->{$oid.'.1.1.1.15.1.5.'.$_}->[1] += $clients->[$_-1]->{$prefix.'Auth-Duplicate-Requests'};
-#         $snmp_data_n->{$oid.'.1.1.1.15.1.6.'.$_}->[1] += $clients->[$_-1]->{$prefix.'Access-Accepts'};
-#         $snmp_data_n->{$oid.'.1.1.1.15.1.7.'.$_}->[1] += $clients->[$_-1]->{$prefix.'Access-Rejects'};
-#         $snmp_data_n->{$oid.'.1.1.1.15.1.8.'.$_}->[1] += $clients->[$_-1]->{$prefix.'Access-Challenges'};
-#         $snmp_data_n->{$oid.'.1.1.1.15.1.9.'.$_}->[1] += $clients->[$_-1]->{$prefix.'Auth-Malformed-Requests'};
-#         $snmp_data_n->{$oid.'.1.1.1.15.1.10.'.$_}->[1] += 0;
-#         $snmp_data_n->{$oid.'.1.1.1.15.1.11.'.$_}->[1] += $clients->[$_-1]->{$prefix.'Auth-Dropped-Requests'};
-#         $snmp_data_n->{$oid.'.1.1.1.15.1.12.'.$_}->[1] += $clients->[$_-1]->{$prefix.'Auth-Unknown-Types'};
+        next unless exists $clients->[$_-1]->{'FreeRADIUS-Stats-Client-IP-Address'} || exists $clients->[$_-1]->{'FreeRADIUS-Stats-Client-IPv6-Address'};
+        $snmp_data_n->{$oid.'.1.1.1.16.1.5.'.$_}->[1]  += $clients->[$_-1]->{$prefix.'Access-Requests'}         || 0;
+        $snmp_data_n->{$oid.'.1.1.1.16.1.6.'.$_}->[1]  += $clients->[$_-1]->{$prefix.'Auth-Duplicate-Requests'} || 0;
+        $snmp_data_n->{$oid.'.1.1.1.16.1.7.'.$_}->[1]  += $clients->[$_-1]->{$prefix.'Access-Accepts'}          || 0;
+        $snmp_data_n->{$oid.'.1.1.1.16.1.8.'.$_}->[1]  += $clients->[$_-1]->{$prefix.'Access-Rejects'}          || 0;
+        $snmp_data_n->{$oid.'.1.1.1.16.1.9.'.$_}->[1]  += $clients->[$_-1]->{$prefix.'Access-Challenges'}       || 0;
+        $snmp_data_n->{$oid.'.1.1.1.16.1.10.'.$_}->[1] += $clients->[$_-1]->{$prefix.'Auth-Malformed-Requests'} || 0;
+        $snmp_data_n->{$oid.'.1.1.1.16.1.11.'.$_}->[1] += 0;
+        $snmp_data_n->{$oid.'.1.1.1.16.1.12.'.$_}->[1] += $clients->[$_-1]->{$prefix.'Auth-Dropped-Requests'}   || 0;
+        $snmp_data_n->{$oid.'.1.1.1.16.1.13.'.$_}->[1] += $clients->[$_-1]->{$prefix.'Auth-Unknown-Types'}      || 0;
+        $snmp_data_n->{$oid.'.1.1.1.16.1.14.'.$_}->[1] += 0;
     }
 }
 
-#fill part of subtree with data from radius acct statistics
+#
+#  Fill part of subtree with data from radius ACCT statistics
+#
 sub radius_snmp_stats_fill_acct {
     my ( $snmp_data_n, $oid, $prefix, $main, $clients ) = @_;
-    #hmm .. proxy?
 
     my $time = time;
 
-    $snmp_data_n->{$oid.'.1.1.1.1'}->[1] = 'snmp(over)radius';
-    $snmp_data_n->{$oid.'.1.1.1.2'}->[1] = ($time - $main->{'FreeRADIUS-Stats-Start-Time'})*100;
-    $snmp_data_n->{$oid.'.1.1.1.3'}->[1] = ($time - $main->{'FreeRADIUS-Stats-HUP-Time'})*100;
-    $snmp_data_n->{$oid.'.1.1.1.4'}->[1] = 0;
-    $snmp_data_n->{$oid.'.1.1.1.5'}->[1] += $main->{$prefix.'Accounting-Requests'};
-    $snmp_data_n->{$oid.'.1.1.1.6'}->[1] += $main->{$prefix.'Acct-Invalid-Requests'};
-    $snmp_data_n->{$oid.'.1.1.1.7'}->[1] += $main->{$prefix.'Acct-Duplicate-Requests'};
-    $snmp_data_n->{$oid.'.1.1.1.8'}->[1] += $main->{$prefix.'Accounting-Responses'};
-    $snmp_data_n->{$oid.'.1.1.1.9'}->[1] += $main->{$prefix.'Acct-Malformed-Requests'};
+    $snmp_data_n->{$oid.'.1.1.1.1'}->[1]  = 'snmp(over)radius';
+    $snmp_data_n->{$oid.'.1.1.1.2'}->[1]  = ($time - $main->{'FreeRADIUS-Stats-Start-Time'})*100;
+    $snmp_data_n->{$oid.'.1.1.1.3'}->[1]  = ($time - $main->{'FreeRADIUS-Stats-HUP-Time'})*100;
+    $snmp_data_n->{$oid.'.1.1.1.4'}->[1]  = 0;
+    $snmp_data_n->{$oid.'.1.1.1.5'}->[1]  += $main->{$prefix.'Accounting-Requests'};
+    $snmp_data_n->{$oid.'.1.1.1.6'}->[1]  += $main->{$prefix.'Acct-Invalid-Requests'};
+    $snmp_data_n->{$oid.'.1.1.1.7'}->[1]  += $main->{$prefix.'Acct-Duplicate-Requests'};
+    $snmp_data_n->{$oid.'.1.1.1.8'}->[1]  += $main->{$prefix.'Accounting-Responses'};
+    $snmp_data_n->{$oid.'.1.1.1.9'}->[1]  += $main->{$prefix.'Acct-Malformed-Requests'};
     $snmp_data_n->{$oid.'.1.1.1.10'}->[1] += 0;
     $snmp_data_n->{$oid.'.1.1.1.11'}->[1] += $main->{$prefix.'Acct-Dropped-Requests'};
     $snmp_data_n->{$oid.'.1.1.1.12'}->[1] += 0;
     $snmp_data_n->{$oid.'.1.1.1.13'}->[1] += $main->{$prefix.'Acct-Unknown-Types'};
 
     for (1 .. scalar @$clients) {
-#         $snmp_data_n->{$oid.'.1.1.1.14.1.4.'.$_}->[1] += $clients->[$_-1]->{$prefix.''};# 'radiusAccServPacketsDropped';
-#         $snmp_data_n->{$oid.'.1.1.1.14.1.5.'.$_}->[1] += $clients->[$_-1]->{$prefix.''};# 'radiusAccServRequests';
-#         $snmp_data_n->{$oid.'.1.1.1.14.1.6.'.$_}->[1] += $clients->[$_-1]->{$prefix.''};# 'radiusAccServDupRequests';
-#         $snmp_data_n->{$oid.'.1.1.1.14.1.7.'.$_}->[1] += $clients->[$_-1]->{$prefix.''};# 'radiusAccServResponses';
-#         $snmp_data_n->{$oid.'.1.1.1.14.1.8.'.$_}->[1] += $clients->[$_-1]->{$prefix.''};# 'radiusAccServBadAuthenticators';
-#         $snmp_data_n->{$oid.'.1.1.1.14.1.9.'.$_}->[1] += $clients->[$_-1]->{$prefix.''};# 'radiusAccServMalformedRequests';
-#         $snmp_data_n->{$oid.'.1.1.1.14.1.10.'.$_}->[1] += $clients->[$_-1]->{$prefix.''};# 'radiusAccServNoRecords';
-#         $snmp_data_n->{$oid.'.1.1.1.14.1.11.'.$_}->[1] += $clients->[$_-1]->{$prefix.''};# 'radiusAccServUnknownTypes';
+        next unless exists $clients->[$_-1]->{'FreeRADIUS-Stats-Client-IP-Address'} || exists $clients->[$_-1]->{'FreeRADIUS-Stats-Client-IPv6-Address'};
+        $snmp_data_n->{$oid.'.1.1.1.15.1.5.'.$_}->[1]  += $clients->[$_-1]->{$prefix.'Acct-Dropped-Requests'}   || 0;
+        $snmp_data_n->{$oid.'.1.1.1.15.1.6.'.$_}->[1]  += $clients->[$_-1]->{$prefix.'Accounting-Requests'}     || 0;
+        $snmp_data_n->{$oid.'.1.1.1.15.1.7.'.$_}->[1]  += $clients->[$_-1]->{$prefix.'Acct-Duplicate-Requests'} || 0;
+        $snmp_data_n->{$oid.'.1.1.1.15.1.8.'.$_}->[1]  += $clients->[$_-1]->{$prefix.'Accounting-Responses'}    || 0;
+        $snmp_data_n->{$oid.'.1.1.1.15.1.9.'.$_}->[1]  += 0;
+        $snmp_data_n->{$oid.'.1.1.1.15.1.10.'.$_}->[1] += $clients->[$_-1]->{$prefix.'Acct-Malformed-Requests'} || 0;
+        $snmp_data_n->{$oid.'.1.1.1.15.1.11.'.$_}->[1] += 0;
+        $snmp_data_n->{$oid.'.1.1.1.15.1.12.'.$_}->[1] += $clients->[$_-1]->{$prefix.'Acct-Unknown-Types'}      || 0;
+        $snmp_data_n->{$oid.'.1.1.1.15.1.13.'.$_}->[1] += 0;
     }
 }
 
-#update statistics
+#
+#  Update statistics
+#
 sub radius_snmp_stats {
-    my ( $main, $clients ) = @_;
-
-#print Dumper($main, $clients);
+    my ($main, $clients) = @_;
 
     my %snmp_data_n;
 
-    # we have to go through all oid's
+    #
+    #  We have to go through all oid's
+    #
     foreach my $oid_s ( keys %{$cfg->{snmp}->{oid_sub}} ) {
 
-        #we're rebuilding the tree for data
-        #we could do it only once, but it will change when we will start handling more dynamic
-        #tree (clients)
+        #
+        #  We're rebuilding the tree for data. We could do it only once, but it
+        #  will change when we will start handling more dynamic tree (clients)
+        #
         my %types = map { $_ => 1 } map { /(?:proxy)?(\w+)/; $1 } @{$cfg->{snmp}->{oid_sub}->{$oid_s}};
-        WARN 'two conflicting types for oid '.$oid_s  if scalar keys %types > 1;
+        WARN 'two conflicting types for oid '.$oid_s if scalar keys %types > 1;
 
-        if ( (keys %types)[0] eq 'auth' ) {
+        if ((keys %types)[0] eq 'auth') {
             radius_snmp_stats_init_auth(\%snmp_data_n, $cfg->{snmp}->{oid_root}.'.'.$oid_s, $clients);
-
-        }elsif ( (keys %types)[0] eq 'acct' ) {
+        }
+        elsif ( (keys %types)[0] eq 'acct' ) {
             radius_snmp_stats_init_acct(\%snmp_data_n, $cfg->{snmp}->{oid_root}.'.'.$oid_s, $clients);
-
-        }else {
+        }
+        else {
             WARN 'unknown subtree type '.(keys %types)[0];
-
         }
 
-        #now lets refill the statistics
-        foreach my $type ( @{$cfg->{snmp}->{oid_sub}->{$oid_s}} ) {     
-            if ( $type eq 'auth' ) {
+        #
+        #  Refill the statistics
+        #
+        foreach my $type (@{$cfg->{snmp}->{oid_sub}->{$oid_s}}) {
+            if ($type eq 'auth') {
                 radius_snmp_stats_fill_auth(
                     \%snmp_data_n, $cfg->{snmp}->{oid_root}.'.'.$oid_s,
                     'FreeRADIUS-Total-', $main, $clients);
-
-            }elsif ( $type eq 'proxyauth' ) {
+            }
+            elsif ($type eq 'proxyauth') {
                 radius_snmp_stats_fill_auth(
                     \%snmp_data_n, $cfg->{snmp}->{oid_root}.'.'.$oid_s,
                     'FreeRADIUS-Total-Proxy-', $main, $clients);
-
-            }elsif ( $type eq 'acct' ) {
+            }
+            elsif ($type eq 'acct') {
                 radius_snmp_stats_fill_acct(
                     \%snmp_data_n, $cfg->{snmp}->{oid_root}.'.'.$oid_s,
                     'FreeRADIUS-Total-', $main, $clients);
-
-            }elsif ( $type eq 'proxyacct' ) {
+            }
+            elsif ($type eq 'proxyacct') {
                 radius_snmp_stats_fill_acct(
                     \%snmp_data_n, $cfg->{snmp}->{oid_root}.'.'.$oid_s,
                     'FreeRADIUS-Total-Proxy-', $main, $clients);
-
-            }else {
+            }
+            else {
                 WARN 'unknown subtree type '.$type;
             }
-            
+
         }
     }
 
-    #we rebuild the tree, so lets now lock the shared variables and push new data there
+    #
+    #  Copy the rebuilt tree to the shared variables
+    #
+    my @k = map { oid_s($_) } sort { $a <=> $b } map { NetSNMP::OID->new($_) } keys %snmp_data_n;
+    my %snmp_next_n = ();
+    $snmp_next_n{$k[$_]} = $k[$_+1] for (0 .. $#k-1);
+
     lock %snmp_data;
     lock @snmp_data_k;
+    lock %snmp_next;
 
     %snmp_data = %snmp_data_n;
-    @snmp_data_k = map { oid_s($_) } sort { $a <=> $b } map { NetSNMP::OID->new($_) } keys %snmp_data_n;
+    @snmp_data_k = @k;
+    %snmp_next = %snmp_next_n;
+
 }
 
 =head1 NAME
@@ -442,6 +557,11 @@ then you can walk the tree (default oid):
 
 snmpbulkwalk -On -v2c -cpublic localhost .1.3.6.1.2.1.67
 
+if per-client stats collection is enabled then you can do the following:
+
+snmptable -v2c -cpublic localhost .1.3.6.1.2.1.67.1.1.1.1.16
+snmptable -v2c -cpublic localhost .1.3.6.1.2.1.67.2.1.1.1.15
+
 =head1 DESCRIPTION
 
 =head1 DEPENDENCIES
@@ -458,7 +578,8 @@ Stanislaw Sawa <stanislaw.sawa(at)sns.bskyb.com>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2008 Sky Network Services. All Rights Reserved.
+Copyright (C) 2008 Sky Network Services.
+Copyright (C) 2022 Network RADIUS.
 
 This program is free software; you can redistribute it and/or modify it
 under the same terms as Perl itself.


### PR DESCRIPTION
Accelerate walks with a "next OID" hash.
Enable collection of per-client stats by default.
Populate accounting client table with real data.
Avoid race by hoisting radius_stats_init() out of updater thread.
Have radius_updater thread terminate on SIGINT.
Refresh RADIUS-AUTH-SERVER-MIB and RADIUS-ACC-SERVER-MIBs.
Add IPv6 client support.
Assume default value (0) for non-existent stats attributes.
Whitespace and style.

