### PR TITLE
Enforce that [length], if present, must be at the end of the type field

### DIFF
--- a/src/lib/util/dict_tokenize.c
+++ b/src/lib/util/dict_tokenize.c
@@ -196,6 +196,10 @@ static int dict_process_type_field(dict_tokenize_ctx_t *ctx, char const *name, f
 		}
 
 		*q = '\0';
+		if (q[1]) {
+			fr_strerror_const("length, if present, must end type field");
+			return -1;
+		}
 
 		if (!dict_read_sscanf_i(&length, p + 1)) {
 			fr_strerror_printf("Invalid length for '%s[...]'", name);


### PR DESCRIPTION
As the code stands, it doesn't check past the closing ], so that if one were to forget to insert whitespace, one could end up with

`ATTRIBUTE	RAND					1	octets[16]array	# Not an array, single value`

and have some important flags ignored.