### PR TITLE
Get rid of superfluous test in loop in command_encode_dns_label

### DIFF
--- a/src/bin/unit_test_attribute.c
+++ b/src/bin/unit_test_attribute.c
@@ -1745,7 +1745,7 @@ size_t command_encode_dns_label(command_result_t *result, command_file_ctx_t *cc
 
 	enc_p = cc->buffer_start;
 
-	while (p) {
+	while (true) {
 		fr_value_box_t *box = talloc_zero(NULL, fr_value_box_t);
 
 		fr_skip_whitespace(p);


### PR DESCRIPTION
By virtue of CC_HINT(nonnull), in, and hence p, will be non-NULL
the first time through the loop. To take another iteration, next
must be non-NULL, so that p, set to next + 1, will also be non-NULL;
hence the "while (p)" is effectively "while (true)".