### PR TITLE
Remove needless check for NULL fp (CID #1503900)

### DIFF
--- a/src/bin/dhcpclient.c
+++ b/src/bin/dhcpclient.c
@@ -171,7 +171,7 @@ static int request_init(fr_radius_packet_t **out, fr_pair_list_t *packet_vps, ch
 	if (fr_pair_list_afrom_file(packet, dict_dhcpv4, packet_vps, fp, &filedone) < 0) {
 		fr_perror("dhcpclient");
 		fr_radius_packet_free(&packet);
-		if (fp && (fp != stdin)) fclose(fp);
+		if (fp != stdin) fclose(fp);
 		return -1;
 	}
 


### PR DESCRIPTION
stdin isn't NULL, and the code has an error return if fopen() returns NULL, so the check here is superfluous.