### PR TITLE
Correction to description of function return values

### DIFF
--- a/src/lib/util/dict_unknown.c
+++ b/src/lib/util/dict_unknown.c
@@ -263,8 +263,8 @@ fr_dict_attr_t *fr_dict_unknown_afrom_da(TALLOC_CTX *ctx, fr_dict_attr_t const *
  * @param[in] parent		of the VSA attribute.
  * @param[in] vendor		id.
  * @return
- *	- 0 on success.
- *	- -1 on failure.
+ *	- An fr_dict_attr_t on success.
+ *	- NULL on failure.
  */
 fr_dict_attr_t	*fr_dict_unknown_vendor_afrom_num(TALLOC_CTX *ctx,
 						  fr_dict_attr_t const *parent, unsigned int vendor)
@@ -302,8 +302,8 @@ fr_dict_attr_t	*fr_dict_unknown_vendor_afrom_num(TALLOC_CTX *ctx,
  * @param[in] parent		of the unknown attribute (may also be unknown).
  * @param[in] num		of the unknown attribute.
  * @return
- *	- 0 on success.
- *	- -1 on failure.
+ *	- An fr_dict_attr_t on success.
+ *	- NULL on failure.
  */
 fr_dict_attr_t *fr_dict_unknown_tlv_afrom_num(TALLOC_CTX *ctx, fr_dict_attr_t const *parent, unsigned int num)
 {
@@ -329,8 +329,8 @@ fr_dict_attr_t *fr_dict_unknown_tlv_afrom_num(TALLOC_CTX *ctx, fr_dict_attr_t co
  * @param[in] parent		of the unknown attribute (may also be unknown).
  * @param[in] num		of the unknown attribute.
  * @return
- *	- 0 on success.
- *	- -1 on failure.
+ *	- An fr_dict_attr_t on success.
+ *	- NULL on failure.
  */
 fr_dict_attr_t	*fr_dict_unknown_attr_afrom_num(TALLOC_CTX *ctx, fr_dict_attr_t const *parent, unsigned int num)
 {

--- a/src/lib/util/dict_util.c
+++ b/src/lib/util/dict_util.c
@@ -624,8 +624,8 @@ static int _dict_attr_free(fr_dict_attr_t *da)
  *
  * @param[in] ctx		to allocate attribute in.
  * @return
- *	- 0 on success.
- *	- -1 on failure (memory allocation error).
+ *	- A new, partially completed, fr_dict_attr_t on success.
+ *	- NULL on failure (memory allocation error).
  */
 fr_dict_attr_t *dict_attr_alloc_null(TALLOC_CTX *ctx)
 {


### PR DESCRIPTION
The functions probably used to return a signed integer type; they changed, but the comments didn't.