### PR TITLE
Quiet coverity (CID #1503969, #1504008)

### DIFF
--- a/src/modules/rlm_logintime/timestr.c
+++ b/src/modules/rlm_logintime/timestr.c
@@ -210,7 +210,7 @@ int timestr_match(fr_time_delta_t *out, char const *tmstr, fr_time_t when)
 	time_t t = fr_time_to_sec(when);
 
 	tm = localtime_r(&t, &s_tm);
-	now = tm->tm_wday * DAYMIN + tm->tm_hour * 60 + tm->tm_min;
+	now = (int64_t) (tm->tm_wday) * DAYMIN + (int64_t) (tm->tm_hour) * 60 + tm->tm_min;
 	tot = 0;
 	memset(bitmap, 0, sizeof(bitmap));
 	week_fill(bitmap, tmstr);


### PR DESCRIPTION
timestr_match() converts time from the beginning of the week in
a struct tm to minutes. Coverity doesn't consider the bounds
on those values (tm_wday and tm_hour), and thus warns of possible
overflow.