### PR TITLE
remove, or rather move, check of parent in parse_input() (CID #1469153

### DIFF
--- a/src/lib/server/cf_file.c
+++ b/src/lib/server/cf_file.c
@@ -1674,6 +1674,8 @@ static int parse_input(cf_stack_t *stack)
 	buff[2] = stack->buff[2];
 	buff[3] = stack->buff[3];
 
+	fr_assert(parent != NULL);
+
 	/*
 	 *	Catch end of a subsection.
 	 */
@@ -1888,7 +1890,7 @@ static int parse_input(cf_stack_t *stack)
 		/*
 		 *	As a hack, allow any operators when using &foo=bar
 		 */
-		if ((!parent || !frame->special) && (buff[1][0] != '&')) {
+		if (!frame->special && (buff[1][0] != '&')) {
 			ERROR("%s[%d]: Invalid operator in assignment for %s ...",
 			      frame->filename, frame->lineno, buff[1]);
 			return -1;


### PR DESCRIPTION
Earlier in the code, parent->allow_unlang is tested; if parent
is NULL, it will break there, so the later check is unnecessary...
but better to check before the first use.