### PR TITLE
Remove needless check for FR_TYPE_NULL (CID #1503975)

### DIFF
--- a/src/lib/server/tmpl_tokenize.c
+++ b/src/lib/server/tmpl_tokenize.c
@@ -3171,11 +3171,8 @@ int tmpl_cast_set(tmpl_t *vpt, fr_type_t dst_type)
 	 *	By default, tmpl types cannot be cast to anything.
 	 */
 	default:
-		if (dst_type != FR_TYPE_NULL) {
-			fr_strerror_const("Cannot use cast here.");
-			return -1;
-		}
-		break;
+		fr_strerror_const("Cannot use cast here.");
+		return -1;
 
 	/*
 	 *	These tmpl types are effectively of data type


### PR DESCRIPTION
dst_type == FR_TYPE_NULL is caught earlier, so by the time it gets here, dst_type can't be FR_TYPE_NULL.