### PR TITLE
Remove initial FR_TYPE_NULL check from fr_value_box_from_substr() (CI…

### DIFF
--- a/src/lib/util/value.c
+++ b/src/lib/util/value.c
@@ -4581,8 +4581,6 @@ ssize_t fr_value_box_from_substr(TALLOC_CTX *ctx, fr_value_box_t *dst,
 	char				buffer[256];
 	fr_slen_t			slen;
 
-	if (!fr_cond_assert(dst_type != FR_TYPE_NULL)) return -1;
-
 	if (!rules) rules = &default_rules;
 
 	fr_strerror_clear();


### PR DESCRIPTION
…D #1504016)

Better to let it be properly handled in the switch statement. This will also get rid of the coverity dead code complaint.