### PR TITLE
Convert tests to use fr_fast_rand() rather than srand()/rand()

### DIFF
--- a/src/lib/util/heap_tests.c
+++ b/src/lib/util/heap_tests.c
@@ -1,5 +1,6 @@
 #include <freeradius-devel/util/acutest.h>
 #include <freeradius-devel/util/time.h>
+#include <freeradius-devel/util/rand.h>
 
 #include "heap.c"
 
@@ -45,11 +46,12 @@ static void heap_test(int skip)
 	heap_thing	*array;
 	int		left;
 	int		ret;
-
+	fr_fast_rand_t	rand_ctx;
 	static bool	done_init = false;
 
 	if (!done_init) {
-		srand((unsigned int)time(NULL));
+		rand_ctx.a = fr_rand();
+		rand_ctx.b = fr_rand();
 		done_init = true;
 	}
 
@@ -61,7 +63,7 @@ static void heap_test(int skip)
 	/*
 	 *	Initialise random values
 	 */
-	for (i = 0; i < HEAP_TEST_SIZE; i++) array[i].data = rand() % 65537;
+	for (i = 0; i < HEAP_TEST_SIZE; i++) array[i].data = fr_fast_rand(&rand_ctx) % 65537;
 
 #if 0
 	for (i = 0; i < HEAP_TEST_SIZE; i++) {
@@ -147,11 +149,12 @@ static void heap_test_order(void)
 	int		data = 0;
 	unsigned int	count = 0;
 	int		ret;
-
+	fr_fast_rand_t	rand_ctx;
 	static bool	done_init = false;
 
 	if (!done_init) {
-		srand((unsigned int)time(NULL));
+		rand_ctx.a = fr_rand();
+		rand_ctx.b = fr_rand();
 		done_init = true;
 	}
 
@@ -163,7 +166,7 @@ static void heap_test_order(void)
 	/*
 	 *	Initialise random values
 	 */
-	for (i = 0; i < HEAP_TEST_SIZE; i++) array[i].data = rand() % 65537;
+	for (i = 0; i < HEAP_TEST_SIZE; i++) array[i].data = fr_fast_rand(&rand_ctx) % 65537;
 
 	TEST_CASE("insertions");
 	for (i = 0; i < HEAP_TEST_SIZE; i++) {
@@ -229,11 +232,12 @@ static void heap_cycle(void)
 	int		inserted, removed;
 	int		ret;
 	fr_time_t	start_insert, start_remove, start_swap, end;
-
+	fr_fast_rand_t	rand_ctx;
 	static bool	done_init = false;
 
 	if (!done_init) {
-		srand((unsigned int)time(NULL));
+		rand_ctx.a = fr_rand();
+		rand_ctx.b = fr_rand();
 		done_init = true;
 	}
 
@@ -245,7 +249,7 @@ static void heap_cycle(void)
 	/*
 	 *	Initialise random values
 	 */
-	for (i = 0; i < HEAP_CYCLE_SIZE; i++) array[i].data = rand() % 65537;
+	for (i = 0; i < HEAP_CYCLE_SIZE; i++) array[i].data = fr_fast_rand(&rand_ctx) % 65537;
 
 	start_insert = fr_time();
 	TEST_CASE("insertions");

--- a/src/lib/util/lst_tests.c
+++ b/src/lib/util/lst_tests.c
@@ -177,12 +177,14 @@ static void lst_stress_realloc(void)
 	fr_lst_t	*lst;
 	fr_heap_t	*hp;
 	lst_thing	*lst_array, *hp_array;
+	fr_fast_rand_t	rand_ctx;
 	static bool	done_init = false;
 	int		ret;
 	lst_thing	*from_lst, *from_hp;
 
 	if (!done_init) {
-		srand((unsigned int) time(NULL));
+		rand_ctx.a = fr_rand();
+		rand_ctx.b = fr_rand();
 		done_init = true;
 	}
 
@@ -196,7 +198,9 @@ static void lst_stress_realloc(void)
 	/*
 	 *	Initialise random values
 	 */
-	for (unsigned int i = 0; i < 2 * INITIAL_CAPACITY; i++) lst_array[i].data = hp_array[i].data = rand() % 65537;
+	for (unsigned int i = 0; i < 2 * INITIAL_CAPACITY; i++) {
+		lst_array[i].data = hp_array[i].data = fr_fast_rand(&rand_ctx) % 65537;
+	}
 
 	/* Add the first INITIAL_CAPACITY values to lst and to hp */
 	TEST_CASE("partial fill");
@@ -251,16 +255,18 @@ static void lst_burn_in(void)
 {
 	fr_lst_t	*lst = NULL;
 	lst_thing	*array = NULL;
+	fr_fast_rand_t	rand_ctx;
 	static bool	done_init = false;
 	int		insert_count = 0;
 
 	if (!done_init) {
-		srand((unsigned int) time(NULL));
+		rand_ctx.a = fr_rand();
+		rand_ctx.b = fr_rand();
 		done_init = true;
 	}
 
 	array = calloc(BURN_IN_OPS, sizeof(lst_thing));
-	for (unsigned int i = 0; i < BURN_IN_OPS; i++) array[i].data = rand() % 65537;
+	for (unsigned int i = 0; i < BURN_IN_OPS; i++) array[i].data = fr_fast_rand(&rand_ctx) % 65537;
 
 	/* Make init small to exercise growing the pivot stack. */
 	lst = fr_lst_alloc(NULL, lst_cmp, lst_thing, idx, 32);

--- a/src/lib/util/minmax_heap_tests.c
+++ b/src/lib/util/minmax_heap_tests.c
@@ -131,14 +131,12 @@ static void minmax_heap_test(int skip)
 	minmax_heap_thing	*array;
 	int			left;
 	int			ret;
-
+	fr_fast_rand_t		rand_ctx;
 	static bool		done_init = false;
 
 	if (!done_init) {
-		unsigned int	seed = /* 1634677281 */ (unsigned int) time(NULL);
-
-		// fprintf(stderr, "seed %u\n", seed);
-		srand(seed);
+		rand_ctx.a = fr_rand();
+		rand_ctx.b = fr_rand();
 		done_init = true;
 	}
 
@@ -150,7 +148,7 @@ static void minmax_heap_test(int skip)
 	/*
 	 *	Initialise random values
 	 */
-	for (i = 0; i < MINMAX_HEAP_TEST_SIZE; i++) array[i].data = rand() % 65537;
+	for (i = 0; i < MINMAX_HEAP_TEST_SIZE; i++) array[i].data = fr_fast_rand(&rand_ctx) % 65537;
 
 	TEST_CASE("insertions");
 	for (i = 0; i < MINMAX_HEAP_TEST_SIZE; i++) {
@@ -228,16 +226,18 @@ static void minmax_heap_burn_in(void)
 {
 	fr_minmax_heap_t	*hp = NULL;
 	minmax_heap_thing	*array = NULL;
+	fr_fast_rand_t		rand_ctx;
 	static bool		done_init = false;
 	int			insert_count = 0;
 
 	if (!done_init) {
-		srand((unsigned int) time(0));
+		rand_ctx.a = fr_rand();
+		rand_ctx.b = fr_rand();
 		done_init = true;
 	}
 
 	array = calloc(BURN_IN_OPS, sizeof(minmax_heap_thing));
-	for (unsigned int i = 0; i < BURN_IN_OPS; i++) array[i].data = rand() % 65537;
+	for (unsigned int i = 0; i < BURN_IN_OPS; i++) array[i].data = fr_fast_rand(&rand_ctx) % 65537;
 
 	hp = fr_minmax_heap_alloc(NULL, minmax_heap_cmp, minmax_heap_thing, idx, 0);
 
@@ -289,11 +289,12 @@ static void minmax_heap_test_order(void)
 	unsigned int		data;
 	unsigned int		count;
 	int			ret;
-
+	fr_fast_rand_t		rand_ctx;
 	static bool	done_init = false;
 
 	if (!done_init) {
-		srand((unsigned int)time(NULL));
+		rand_ctx.a = fr_rand();
+		rand_ctx.b = fr_rand();
 		done_init = true;
 	}
 
@@ -305,7 +306,7 @@ static void minmax_heap_test_order(void)
 	/*
 	 *	Initialise random values
 	 */
-	for (i = 0; i < MINMAX_HEAP_TEST_SIZE; i++) array[i].data = rand() % 65537;
+	for (i = 0; i < MINMAX_HEAP_TEST_SIZE; i++) array[i].data = fr_fast_rand(&rand_ctx) % 65537;
 
 	TEST_CASE("insertions for min");
 	for (i = 0; i < MINMAX_HEAP_TEST_SIZE; i++) {
@@ -527,11 +528,12 @@ static void minmax_heap_cycle(void)
 	int			inserted, removed;
 	int			ret;
 	fr_time_t		start_insert, start_remove, start_swap, end;
-
+	fr_fast_rand_t		rand_ctx;
 	static bool		done_init = false;
 
 	if (!done_init) {
-		srand((unsigned int)time(NULL));
+		rand_ctx.a = fr_rand();
+		rand_ctx.b = fr_rand();
 		done_init = true;
 	}
 
@@ -543,7 +545,7 @@ static void minmax_heap_cycle(void)
 	/*
 	 *	Initialise random values
 	 */
-	for (i = 0; i < MINMAX_HEAP_CYCLE_SIZE; i++) array[i].data = rand() % 65537;
+	for (i = 0; i < MINMAX_HEAP_CYCLE_SIZE; i++) array[i].data = fr_fast_rand(&rand_ctx) % 65537;
 
 	start_insert = fr_time();
 	TEST_CASE("insertions");

--- a/src/lib/util/pair_list_perf_test.c
+++ b/src/lib/util/pair_list_perf_test.c
@@ -48,6 +48,7 @@ static void pair_list_perf_init(void);
 
 #include <freeradius-devel/util/dict_test.h>
 #include <freeradius-devel/server/base.h>
+#include <freeradius-devel/util/rand.h>
 
 /*
  *      Global variables
@@ -306,8 +307,11 @@ static void do_test_fr_pair_append(unsigned int len, unsigned int perc, unsigned
 	fr_time_t	start, end;
 	fr_time_delta_t	used = fr_time_delta_wrap(0);
 	size_t		input_count = talloc_array_length(source_vps);
+	fr_fast_rand_t	rand_ctx;
 
 	fr_pair_list_init(&test_vps);
+	rand_ctx.a = fr_rand();
+	rand_ctx.b = fr_rand();
 
 	/*
 	 *  Only use up to the number of pairs needed from the source to maintain ratio
@@ -320,7 +324,7 @@ static void do_test_fr_pair_append(unsigned int len, unsigned int perc, unsigned
 	 */
 	for (i = 0; i < reps; i++) {
 		for (j = 0; j < len; j++) {
-			int idx = rand() % input_count;
+			int idx = fr_fast_rand(&rand_ctx) % input_count;
 			new_vp = fr_pair_copy(autofree, source_vps[idx]);
 			start = fr_time();
 			fr_pair_append(&test_vps, new_vp);
@@ -346,15 +350,18 @@ static void do_test_fr_pair_find_by_da_idx(unsigned int len, unsigned int perc, 
 	fr_time_delta_t		used = fr_time_delta_wrap(0);
 	fr_dict_attr_t const	*da;
 	size_t			input_count = talloc_array_length(source_vps);
+	fr_fast_rand_t		rand_ctx;
 
 	fr_pair_list_init(&test_vps);
 	if (input_count > len) input_count = len;
+	rand_ctx.a = fr_rand();
+	rand_ctx.b = fr_rand();
 
 	/*
 	 *  Initialise the test list
 	 */
 	for (i = 0; i < len; i++) {
-		int idx = rand() % input_count;
+		int idx = fr_fast_rand(&rand_ctx) % input_count;
 		new_vp = fr_pair_copy(autofree, source_vps[idx]);
 		fr_pair_append(&test_vps, new_vp);
 	}
@@ -364,7 +371,7 @@ static void do_test_fr_pair_find_by_da_idx(unsigned int len, unsigned int perc, 
 	 */
 	for (i = 0; i < reps; i++) {
 		for (j = 0; j < len; j++) {
-			int idx = rand() % input_count;
+			int idx = fr_fast_rand(&rand_ctx) % input_count;
 			da = source_vps[idx]->da;
 			start = fr_time();
 			(void) fr_pair_find_by_da_idx(&test_vps, da, 0);
@@ -389,15 +396,18 @@ static void do_test_find_nth(unsigned int len, unsigned int perc, unsigned int r
 	fr_time_delta_t		used = fr_time_delta_wrap(0);
 	fr_dict_attr_t const	*da;
 	size_t			input_count = talloc_array_length(source_vps);
+	fr_fast_rand_t		rand_ctx;
 
 	fr_pair_list_init(&test_vps);
 	if (input_count > len) input_count = len;
+	rand_ctx.a = fr_rand();
+	rand_ctx.b = fr_rand();
 
 	/*
 	 *  Initialise the test list
 	 */
 	for (i = 0; i < len; i++) {
-		int idx = rand() % input_count;
+		int idx = fr_fast_rand(&rand_ctx) % input_count;
 		new_vp = fr_pair_copy(autofree, source_vps[idx]);
 		fr_pair_append(&test_vps, new_vp);
 	}
@@ -409,7 +419,7 @@ static void do_test_find_nth(unsigned int len, unsigned int perc, unsigned int r
 	nth_item = perc == 0 ? 1 : (unsigned int)(len * perc / 100);
 	for (i = 0; i < reps; i++) {
 		for (j = 0; j < len; j++) {
-			int idx = rand() % input_count;
+			int idx = fr_fast_rand(&rand_ctx) % input_count;
 
 			da = source_vps[idx]->da;
 			start = fr_time();
@@ -434,13 +444,16 @@ static void do_test_fr_pair_list_free(unsigned int len, unsigned int perc, unsig
 	fr_time_t	start, end;
 	fr_time_delta_t	used = fr_time_delta_wrap(0);
 	size_t		input_count = talloc_array_length(source_vps);
+	fr_fast_rand_t	rand_ctx;
 
 	fr_pair_list_init(&test_vps);
 	if (input_count > len) input_count = len;
+	rand_ctx.a = fr_rand();
+	rand_ctx.b = fr_rand();
 
 	for (i = 0; i < reps; i++) {
 		for (j = 0; j < len; j++) {
-			int idx = rand() % input_count;
+			int idx = fr_fast_rand(&rand_ctx) % input_count;
 			new_vp = fr_pair_copy(autofree, source_vps[idx]);
 			fr_pair_append(&test_vps, new_vp);
 		}


### PR DESCRIPTION
Coverity considers rand() risky, but data structure tests don't
require cryptographically secure pseudorandom numbers. This should
take care of CIDs 1469120, 1469179, 1503927, 1503935, 1503941,
1503967, 1503977, 1503990, 1504015, 1504048, and 1504054.