### PR TITLE
Just adjust ext when removing "mod_" (CID #1504300)

### DIFF
--- a/scripts/jlibtool.c
+++ b/scripts/jlibtool.c
@@ -1249,12 +1249,11 @@ static char *truncate_dll_name(char const *path)
 
 	if (strncmp(newname, "mod_", 4) == 0) {
 		memmove(newname, newname + 4, len + ext_len - 4 + 1);
+		ext -= 4;
 		len -= 4;
 	}
 
-	if (len > 8) {
-		memmove(newname + 8, strchr(newname, '.'), ext_len + 1);
-	}
+	if (len > 8) memmove(newname + 8, ext, ext_len + 1);
 
 	return tmppath;
 }


### PR DESCRIPTION
One need only adjust ext by 4 when, in truncate_dll_name(), one
removes "mod_". Then if len exceeds 8 ext still points at the
extension, and coverity can't kvetch about not checking the value
strchr() returns (Using strchr() the second time means
"mumblefrotz.foo.dll" won't behave as expected; does that ever
turn up in practice?)