### PR TITLE
Catch invalid status values in tls_cache_session_ticket_app_data_get …

### DIFF
--- a/src/lib/tls/cache.c
+++ b/src/lib/tls/cache.c
@@ -1265,6 +1265,9 @@ static SSL_TICKET_RETURN tls_cache_session_ticket_app_data_get(SSL *ssl, SSL_SES
 	switch (status) {
 	case SSL_TICKET_EMPTY:
 	case SSL_TICKET_NO_DECRYPT:
+	case SSL_TICKET_FATAL_ERR_MALLOC:
+	case SSL_TICKET_FATAL_ERR_OTHER:
+	case SSL_TICKET_NONE:
 #ifdef __clang_analyzer__
 	default:
 #endif


### PR DESCRIPTION
…(CID #1503904)

The switch didn't deal with all defined status values. We add them and
leave the default always present to make explicit how they should be
treated and to catch invalid values... and to assure the reader and
coverity that we will never pass a NULL request pointer to
tls_cache_app_data_get().