### PR TITLE
Use OpenSSL 3.0 library context to access MD4 and MD5

### DIFF
--- a/src/lib/radius.c
+++ b/src/lib/radius.c
@@ -567,7 +567,7 @@ static void make_passwd(uint8_t *output, ssize_t *outlen,
 	fr_md5_init(&context);
 	fr_md5_init(&old);
 	fr_md5_update(&context, (uint8_t const *) secret, strlen(secret));
-	fr_md5_copy(old, context);
+	fr_md5_copy(&old, &context);
 
 	/*
 	 *	Do first pass.
@@ -576,7 +576,7 @@ static void make_passwd(uint8_t *output, ssize_t *outlen,
 
 	for (n = 0; n < len; n += AUTH_PASS_LEN) {
 		if (n > 0) {
-			fr_md5_copy(context, old);
+			fr_md5_copy(&context, &old);
 			fr_md5_update(&context,
 				       passwd + n - AUTH_PASS_LEN,
 				       AUTH_PASS_LEN);
@@ -662,7 +662,7 @@ static void make_tunnel_passwd(uint8_t *output, ssize_t *outlen,
 	fr_md5_init(&context);
 	fr_md5_init(&old);
 	fr_md5_update(&context, (uint8_t const *) secret, strlen(secret));
-	fr_md5_copy(old, context);
+	fr_md5_copy(&old, &context);
 
 	fr_md5_update(&context, vector, AUTH_VECTOR_LEN);
 	fr_md5_update(&context, &output[0], 2);
@@ -671,7 +671,7 @@ static void make_tunnel_passwd(uint8_t *output, ssize_t *outlen,
 		size_t block_len;
 
 		if (n > 0) {
-			fr_md5_copy(context, old);
+			fr_md5_copy(&context, &old);
 			fr_md5_update(&context,
 				       output + 2 + n - AUTH_PASS_LEN,
 				       AUTH_PASS_LEN);
@@ -4593,7 +4593,7 @@ int rad_pwencode(char *passwd, size_t *pwlen, char const *secret,
 	fr_md5_init(&context);
 	fr_md5_init(&old);
 	fr_md5_update(&context, (uint8_t const *) secret, secretlen);
-	fr_md5_copy(old, context);		/* save intermediate work */
+	fr_md5_copy(&old, &context);		/* save intermediate work */
 
 	/*
 	 *	Encrypt it in place.  Don't bother checking
@@ -4604,7 +4604,7 @@ int rad_pwencode(char *passwd, size_t *pwlen, char const *secret,
 			fr_md5_update(&context, vector, AUTH_PASS_LEN);
 			fr_md5_final(digest, &context);
 		} else {
-			fr_md5_copy(context, old);
+			fr_md5_copy(&context, &old);
 			fr_md5_update(&context,
 				     (uint8_t *) passwd + n - AUTH_PASS_LEN,
 				     AUTH_PASS_LEN);
@@ -4653,7 +4653,7 @@ int rad_pwdecode(char *passwd, size_t pwlen, char const *secret,
 	fr_md5_init(&context);
 	fr_md5_init(&old);
 	fr_md5_update(&context, (uint8_t const *) secret, secretlen);
-	fr_md5_copy(old, context);		/* save intermediate work */
+	fr_md5_copy(&old, &context);		/* save intermediate work */
 
 	/*
 	 *	The inverse of the code above.
@@ -4663,7 +4663,7 @@ int rad_pwdecode(char *passwd, size_t pwlen, char const *secret,
 			fr_md5_update(&context, vector, AUTH_VECTOR_LEN);
 			fr_md5_final(digest, &context);
 
-			fr_md5_copy(context, old);
+			fr_md5_copy(&context, &old);
 			if (pwlen > AUTH_PASS_LEN) {
 				fr_md5_update(&context, (uint8_t *) passwd,
 					     AUTH_PASS_LEN);
@@ -4671,7 +4671,7 @@ int rad_pwdecode(char *passwd, size_t pwlen, char const *secret,
 		} else {
 			fr_md5_final(digest, &context);
 
-			fr_md5_copy(context, old);
+			fr_md5_copy(&context, &old);
 			if (pwlen > (n + AUTH_PASS_LEN)) {
 				fr_md5_update(&context, (uint8_t *) passwd + n,
 					     AUTH_PASS_LEN);
@@ -4825,7 +4825,7 @@ ssize_t rad_tunnel_pwdecode(uint8_t *passwd, size_t *pwlen, char const *secret, 
 	fr_md5_init(&context);
 	fr_md5_init(&old);
 	fr_md5_update(&context, (uint8_t const *) secret, secretlen);
-	fr_md5_copy(old, context);		/* save intermediate work */
+	fr_md5_copy(&old, &context);		/* save intermediate work */
 
 	/*
 	 *	Set up the initial key:
@@ -4852,7 +4852,7 @@ ssize_t rad_tunnel_pwdecode(uint8_t *passwd, size_t *pwlen, char const *secret, 
 
 			fr_md5_final(digest, &context);
 
-			fr_md5_copy(context, old);
+			fr_md5_copy(&context, &old);
 
 			/*
 			 *	A quick check: decrypt the first octet
@@ -4872,7 +4872,7 @@ ssize_t rad_tunnel_pwdecode(uint8_t *passwd, size_t *pwlen, char const *secret, 
 
 			fr_md5_final(digest, &context);
 
-			fr_md5_copy(context, old);
+			fr_md5_copy(&context, &old);
 			fr_md5_update(&context, passwd + n + 2, block_len);
 		}
 


### PR DESCRIPTION
Enabling the legacy provider in the global context is not enough if the
system is in FIPS mode. Instead, load providers in local context for both MD5 and
MD4.

Remove EVP_MD_CTX_FLAG_NON_FIPS_ALLOW flag since it does not have any
effect anymore.

Signed-off-by: Antonio Torres <antorres@redhat.com>