### PR TITLE
Always put something in temporary buffer, if only "" (CID #1503992)

### DIFF
--- a/src/lib/util/value.c
+++ b/src/lib/util/value.c
@@ -4975,17 +4975,15 @@ parse:
 
 	/*
 	 *	It's a fixed size src->dst_type, copy to a temporary buffer and
-	 *	\0 terminate if insize >= 0.
+	 *	\0 terminate.
 	 */
-	if (fr_sbuff_remaining(in) > 0) {
-		if (fr_sbuff_remaining(in) >= sizeof(buffer)) {
-			fr_strerror_const("Temporary buffer too small");
-			return -1;
-		}
-
-		memcpy(buffer, fr_sbuff_current(in), fr_sbuff_remaining(in));
-		buffer[fr_sbuff_remaining(in)] = '\0';
+	if (fr_sbuff_remaining(in) >= sizeof(buffer)) {
+		fr_strerror_const("Temporary buffer too small");
+		return -1;
 	}
+
+	memcpy(buffer, fr_sbuff_current(in), fr_sbuff_remaining(in));
+	buffer[fr_sbuff_remaining(in)] = '\0';
 
 	switch (dst_type) {
 	case FR_TYPE_SIZE:


### PR DESCRIPTION
From the point where src->dst_type is determined to have fixed
size, fr_value_box_from_substr() works with a local copy... but
if fr_sbuff_remaining() returned zero, nothing was written in the
local copy. With this change, in that case, the local copy is made
an empty string, NUL-terminated.