### PR TITLE
hmacmd5: use internal MD5 when FIPS is enabled

### DIFF
--- a/src/lib/hmacmd5.c
+++ b/src/lib/hmacmd5.c
@@ -36,7 +36,7 @@ RCSID("$Id$")
 #include <freeradius-devel/md5.h>
 #include <freeradius-devel/openssl3.h>
 
-#ifdef HAVE_OPENSSL_EVP_H
+#if defined(HAVE_OPENSSL_EVP_H) && !defined(WITH_FIPS)
 /** Calculate HMAC using OpenSSL's MD5 implementation
  *
  * @param digest Caller digest to be filled in.


### PR DESCRIPTION
When the system is in FIPS mode, we need to use internal implementation
of MD5 in order to avoid OpenSSL 3.0 provider limitations.

Related: 947d5d6bd2674a60f7320f0b721e4723243c2285
Signed-off-by: Antonio Torres <antorres@redhat.com>