### PR TITLE
CI FreeBSD: Bump vmactions/freebsd-vm and prune before pushback

### DIFF
--- a/.github/workflows/ci-freebsd.yml
+++ b/.github/workflows/ci-freebsd.yml
@@ -51,7 +51,7 @@ jobs:
         key: hostapd-freebsd-${{ env.HOSTAPD_GIT_TAG }}-v4
 
     - name: Test using a FreeBSD VirtualBox VM
-      uses: vmactions/freebsd-vm@v0.1.5
+      uses: vmactions/freebsd-vm@v0.1.6
       with:
         usesh: true
         sync: rsync
@@ -89,6 +89,9 @@ jobs:
           ./configure
           gmake -j `sysctl -n hw.ncpu`
           gmake test
+          # Minimise rsync pushback as it often fails with "ssh_dispatch_run_fatal: Connection to A.B.C.D: message authentication code incorrect"
+          git config --global --add safe.directory $(pwd)
+          git clean -fxd --exclude="$HOSTAPD_BUILD_DIR"
 
     #
     #  If the CI has failed and the branch is ci-debug then we start a tmate


### PR DESCRIPTION
Pushback of the working directory over rsync sometimes fails with
"ssh_dispatch_run_fatal: Connection to A.B.C.D: message authentication code
incorrect" irrespective of the MAC used by the SSH connection.

Cleaning the unnecessary parts of the working directory should reduce the
chances of such failures until the cause is determined.

We keep any changes to the eapol_test build since this is cached between runs.