### PR TITLE
Remove needless checks from xlat_config_escape().

### DIFF
--- a/src/lib/server/main_config.c
+++ b/src/lib/server/main_config.c
@@ -459,28 +459,18 @@ static int xlat_config_escape(UNUSED request_t *request, fr_value_box_t *vb, UNU
 		 *	mime-encoded equivalents.
 		 */
 		if ((in[0] < 32)) {
-			if (outlen >= (outmax - 3)) return -1;
-
 			snprintf(out, outlen, "=%02X", (unsigned char) in[0]);
 			out += 3;
 			outlen += 3;
 			continue;
-
-		} else if (strchr(disallowed, *in) != NULL) {
-			if (outlen >= (outmax - 2)) return -1;
-
+		}
+		if (strchr(disallowed, *in) != NULL) {
 			out[0] = '\\';
 			out[1] = *in;
 			out += 2;
 			outlen += 2;
 			continue;
 		}
-
-		/*
-		 *	Only one byte left.
-		 */
-		if (outlen >= (outmax - 1)) return -1;
-
 		/*
 		 *	Allowed character.
 		 */


### PR DESCRIPTION
The VLA escaped[] is declared to be large enough to hold the text
from the value box even if every single character needs the
largest possible encoding (MIME, which takes three characters to
encode one). The bound checks will therefore never cause an error
return.