### PR TITLE
automatic dynamic server discovery as per RFC7585

### DIFF
--- a/doc/configuration/dynamic_home_servers.md
+++ b/doc/configuration/dynamic_home_servers.md
@@ -190,9 +190,9 @@ authorize {
 			case {
 				# no home server exists, ask DNS
 				update control {
-					&My-Local-String := `%{config:prefix}/bin/naptr-eduroam-freeradius.sh %{1} %{config:prefix}`
+					&Temp-Home-Server-String := `%{config:prefix}/bin/naptr-eduroam-freeradius.sh %{1} %{config:prefix}`
 				}
-				if ("%{control:My-Local-String}" == "" ) {
+				if ("%{control:Temp-Home-Server-String}" == "" ) {
 					reject
 				} else {
 					update control {

--- a/doc/configuration/dynamic_home_servers.md
+++ b/doc/configuration/dynamic_home_servers.md
@@ -190,6 +190,8 @@ authorize {
 			case {
 				# no home server exists, ask DNS
 				update control {
+					# you can add a third parameter for the NAPTR tag to look up, e.g. "aaa+auth:radius.tls.tcp" (RFC7585, OpenRoaming)
+					# if the third parameter is omitted, defaults to "x-eduroam:radius.tls"
 					&Temp-Home-Server-String := `%{config:prefix}/bin/naptr-eduroam-freeradius.sh %{1} %{config:prefix}`
 				}
 				if ("%{control:Temp-Home-Server-String}" == "" ) {

--- a/doc/configuration/dynamic_home_servers.md
+++ b/doc/configuration/dynamic_home_servers.md
@@ -198,7 +198,7 @@ authorize {
 					reject
 				} else {
 					update control {
-						&Home-Server-Name := %{1}
+						&Home-Server-Name := "%{1}"
 					}
 				}
 			}

--- a/scripts/all.mk
+++ b/scripts/all.mk
@@ -23,9 +23,9 @@ $(R)$(bindir)/rlm_sqlippool_tool: scripts/sql/rlm_sqlippool_tool
 	@$(INSTALL) -m 755 $< $@
 
 $(R)$(bindir)/naptr-eduroam.sh: scripts/naptr-eduroam.sh
-        @mkdir -p $(dir $@)
-        @$(INSTALL) -m 755 $< $@
+	@mkdir -p $(dir $@)
+	@$(INSTALL) -m 755 $< $@
 
 $(R)$(bindir)/naptr-eduroam-freeradius.sh: scripts/naptr-eduroam-freeradius.sh
-        @mkdir -p $(dir $@)
-        @$(INSTALL) -m 755 $< $@
+	@mkdir -p $(dir $@)
+	@$(INSTALL) -m 755 $< $@

--- a/scripts/all.mk
+++ b/scripts/all.mk
@@ -1,5 +1,6 @@
 install: $(R)$(sbindir)/rc.radiusd $(R)$(sbindir)/raddebug \
-	$(R)$(bindir)/radsqlrelay $(R)$(bindir)/radcrypt $(R)$(bindir)/rlm_sqlippool_tool
+	$(R)$(bindir)/radsqlrelay $(R)$(bindir)/radcrypt $(R)$(bindir)/rlm_sqlippool_tool \
+	$(R)$(bindir)/naptr-eduroam.sh $(R)$(bindir)/naptr-eduroam-freeradius.sh
 
 $(R)$(sbindir)/rc.radiusd: scripts/rc.radiusd
 	@mkdir -p $(dir $@)
@@ -20,3 +21,11 @@ $(R)$(bindir)/radcrypt: scripts/cryptpasswd
 $(R)$(bindir)/rlm_sqlippool_tool: scripts/sql/rlm_sqlippool_tool
 	@mkdir -p $(dir $@)
 	@$(INSTALL) -m 755 $< $@
+
+$(R)$(bindir)/naptr-eduroam.sh: scripts/naptr-eduroam.sh
+        @mkdir -p $(dir $@)
+        @$(INSTALL) -m 755 $< $@
+
+$(R)$(bindir)/naptr-eduroam-freeradius.sh: scripts/naptr-eduroam-freeradius.sh
+        @mkdir -p $(dir $@)
+        @$(INSTALL) -m 755 $< $@

--- a/scripts/naptr-eduroam-freeradius.sh
+++ b/scripts/naptr-eduroam-freeradius.sh
@@ -19,6 +19,6 @@ TARGET1=`$DIRECTORY/bin/naptr-eduroam.sh $1 $3 | \
 }"
 echo "$TARGET"
 if [ "$TARGET" != "" ]; then 
-	echo "$TARGET" >$DIRECTORY/etc/raddb/home_servers2/$1; 
+	echo "$TARGET" >$DIRECTORY/etc/raddb/home_servers/$1; 
 	$DIRECTORY/sbin/radmin -e "add home_server file $DIRECTORY/etc/raddb/home_servers/$1"&
 fi

--- a/scripts/naptr-eduroam-freeradius.sh
+++ b/scripts/naptr-eduroam-freeradius.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# $1 is the realm to look up
+# $2 is the $prefix of FreeRADIUS
+DIRECTORY=$2
+TARGET1=`$DIRECTORY/bin/naptr-eduroam.sh $1 | \
+	sed s/'^server dynamic_radsec.'/'home_server '/g | \
+	sed s/host/'ipaddr = '/g | sed s/':'/'\n\tport = '/g | \
+	sed s/'\}'//g`
+[[ "$TARGET1" != "" ]] && TARGET="$TARGET1
+	proto = tcp
+	type = auth
+	secret = radsec
+	tls {
+		certificate_file = $DIRECTORY/raddb/certs/server.pem
+		private_key_file = $DIRECTORY/raddb/certs/server.key
+		ca_path = $DIRECTORY/raddb/certs/ca/
+	}
+}"
+echo "$TARGET"
+if [ "$TARGET" != "" ]; then 
+	echo "$TARGET" >$DIRECTORY/etc/raddb/home_servers2/$1; 
+	$DIRECTORY/sbin/radmin -e "add home_server file $DIRECTORY/etc/raddb/home_servers/$1"&
+fi

--- a/scripts/naptr-eduroam-freeradius.sh
+++ b/scripts/naptr-eduroam-freeradius.sh
@@ -12,9 +12,9 @@ TARGET1=`$DIRECTORY/bin/naptr-eduroam.sh $1 $3 | \
 	type = auth
 	secret = radsec
 	tls {
-		certificate_file = $DIRECTORY/raddb/certs/server.pem
-		private_key_file = $DIRECTORY/raddb/certs/server.key
-		ca_path = $DIRECTORY/raddb/certs/ca/
+		certificate_file = $DIRECTORY/etc/raddb/certs/server.pem
+		private_key_file = $DIRECTORY/etc/raddb/certs/server.key
+		ca_path = $DIRECTORY/etc/raddb/certs/
 	}
 }"
 echo "$TARGET"

--- a/scripts/naptr-eduroam-freeradius.sh
+++ b/scripts/naptr-eduroam-freeradius.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # $1 is the realm to look up
 # $2 is the $prefix of FreeRADIUS
+# $3 is the optional NAPTR tag to look up
 DIRECTORY=$2
-TARGET1=`$DIRECTORY/bin/naptr-eduroam.sh $1 | \
+TARGET1=`$DIRECTORY/bin/naptr-eduroam.sh $1 $3 | \
 	sed s/'^server dynamic_radsec.'/'home_server '/g | \
 	sed s/host/'ipaddr = '/g | sed s/':'/'\n\tport = '/g | \
 	sed s/'\}'//g`

--- a/scripts/naptr-eduroam-freeradius.sh
+++ b/scripts/naptr-eduroam-freeradius.sh
@@ -20,5 +20,5 @@ TARGET1=`$DIRECTORY/bin/naptr-eduroam.sh $1 $3 | \
 echo "$TARGET"
 if [ "$TARGET" != "" ]; then 
 	echo "$TARGET" >$DIRECTORY/etc/raddb/home_servers/$1; 
-	$DIRECTORY/sbin/radmin -e "add home_server file $DIRECTORY/etc/raddb/home_servers/$1"&
+	$DIRECTORY/sbin/radmin -e "add home_server file $DIRECTORY/etc/raddb/home_servers/$1"
 fi

--- a/scripts/naptr-eduroam.sh
+++ b/scripts/naptr-eduroam.sh
@@ -1,0 +1,91 @@
+#! /bin/sh
+
+# Example script!
+# This script looks up radsec srv records in DNS for the one
+# realm given as argument, and creates a server template based
+# on that. It currently ignores weight markers, but does sort
+# servers on priority marker, lowest number first.
+# For host command this is column 5, for dig it is column 1.
+
+usage() {
+    echo "Usage: ${0} <realm>"
+    exit 1
+}
+
+test -n "${1}" || usage
+
+DIGCMD=$(command -v dig)
+HOSTCMD=$(command -v host)
+PRINTCMD=$(command -v printf)
+
+validate_host() {
+         echo ${@} | tr -d '\n\t\r' | grep -E '^[_0-9a-zA-Z][-._0-9a-zA-Z]*$'
+}
+
+validate_port() {
+         echo ${@} | tr -d '\n\t\r' | grep -E '^[0-9]+$'
+}
+
+dig_it_srv() {
+    ${DIGCMD} +short srv $SRV_HOST | sort -n -k1 |
+    while read line; do
+        set $line ; PORT=$(validate_port $3) ; HOST=$(validate_host $4)
+        if [ -n "${HOST}" ] && [ -n "${PORT}" ]; then
+            $PRINTCMD "\thost ${HOST%.}:${PORT}\n"
+        fi
+    done
+}
+
+dig_it_naptr() {
+    ${DIGCMD} +short naptr "${REALM}" | grep x-eduroam:radius.tls | sort -n -k1 |
+    while read line; do
+        set $line ; TYPE=$3 ; HOST=$(validate_host $6)
+        if ( [ "$TYPE" = "\"s\"" ] || [ "$TYPE" = "\"S\"" ] ) && [ -n "${HOST}" ]; then
+            SRV_HOST=${HOST%.}
+            dig_it_srv
+        fi
+    done
+}
+
+host_it_srv() {
+    ${HOSTCMD} -t srv $SRV_HOST | sort -n -k5 |
+    while read line; do
+        set $line ; PORT=$(validate_port $7) ; HOST=$(validate_host $8) 
+        if [ -n "${HOST}" ] && [ -n "${PORT}" ]; then
+            $PRINTCMD "\thost ${HOST%.}:${PORT}\n"
+        fi
+    done
+}
+
+host_it_naptr() {
+    ${HOSTCMD} -t naptr "${REALM}" | grep x-eduroam:radius.tls | sort -n -k5 |
+    while read line; do
+        set $line ; TYPE=$7 ; HOST=$(validate_host ${10})
+        if ( [ "$TYPE" = "\"s\"" ] || [ "$TYPE" = "\"S\"" ] ) && [ -n "${HOST}" ]; then
+            SRV_HOST=${HOST%.}
+            host_it_srv
+        fi
+    done
+}
+
+REALM=$(validate_host ${1})
+if [ -z "${REALM}" ]; then
+    echo "Error: realm \"${1}\" failed validation"
+    usage
+fi
+
+if [ -x "${DIGCMD}" ]; then
+    SERVERS=$(dig_it_naptr)
+elif [ -x "${HOSTCMD}" ]; then
+    SERVERS=$(host_it_naptr)
+else
+    echo "${0} requires either \"dig\" or \"host\" command."
+    exit 1
+fi
+
+if [ -n "${SERVERS}" ]; then
+    $PRINTCMD "server dynamic_radsec.${REALM} {\n${SERVERS}\n}\n"
+    exit 0
+fi
+
+exit 10				# No server found.

--- a/scripts/naptr-eduroam.sh
+++ b/scripts/naptr-eduroam.sh
@@ -8,7 +8,7 @@
 # For host command this is column 5, for dig it is column 1.
 
 usage() {
-    echo "Usage: ${0} <realm>"
+    echo "Usage: ${0} <realm> <optional NAPTR tag>"
     exit 1
 }
 
@@ -17,6 +17,8 @@ test -n "${1}" || usage
 DIGCMD=$(command -v dig)
 HOSTCMD=$(command -v host)
 PRINTCMD=$(command -v printf)
+test -n "${2}" && NAPTRTAG="${2}" || NAPTRTAG="x-eduroam:radius.tls"
+
 
 validate_host() {
          echo ${@} | tr -d '\n\t\r' | grep -E '^[_0-9a-zA-Z][-._0-9a-zA-Z]*$'
@@ -37,7 +39,7 @@ dig_it_srv() {
 }
 
 dig_it_naptr() {
-    ${DIGCMD} +short naptr "${REALM}" | grep x-eduroam:radius.tls | sort -n -k1 |
+    ${DIGCMD} +short naptr "${REALM}" | grep $NAPTRTAG | sort -n -k1 |
     while read line; do
         set $line ; TYPE=$3 ; HOST=$(validate_host $6)
         if ( [ "$TYPE" = "\"s\"" ] || [ "$TYPE" = "\"S\"" ] ) && [ -n "${HOST}" ]; then
@@ -58,7 +60,7 @@ host_it_srv() {
 }
 
 host_it_naptr() {
-    ${HOSTCMD} -t naptr "${REALM}" | grep x-eduroam:radius.tls | sort -n -k5 |
+    ${HOSTCMD} -t naptr "${REALM}" | grep $NAPTRTAG | sort -n -k5 |
     while read line; do
         set $line ; TYPE=$7 ; HOST=$(validate_host ${10})
         if ( [ "$TYPE" = "\"s\"" ] || [ "$TYPE" = "\"S\"" ] ) && [ -n "${HOST}" ]; then

--- a/share/dictionary.freeradius.internal
+++ b/share/dictionary.freeradius.internal
@@ -296,6 +296,7 @@ ATTRIBUTE	TOTP-Password				1196	string
 ATTRIBUTE	Proxy-Tunneled-Request-As-EAP		1197	integer
 VALUE	Proxy-Tunneled-Request-As-EAP	No			0
 VALUE	Proxy-Tunneled-Request-As-EAP	Yes			1
+ATTRIBUTE	Temp-Home-Server-String			1198	string
 
 #
 #	Range:	1200-1279


### PR DESCRIPTION
scripts and documentation update to facilitate dynamic server discovery in a more complete fashion (automates DNS lookup and radmin commands) so that enabling dynamic discovery for consortia like eduroam and OpenRoaming is now purely a config change