### PR TITLE
Annotate issues Coverity see that we have decided to ignore.

### DIFF
--- a/src/lib/tls/log.c
+++ b/src/lib/tls/log.c
@@ -591,6 +591,7 @@ static int tls_log_request_bio_write_cb(BIO *bio, char const *in, int len)
 	 *	to aggregate it, then look for new line chars
 	 *	as an indication we need to print the line.
 	 */
+	/* coverity[checked_return] */
 	fr_sbuff_in_bstrncpy(&lb->sbuff, in, len);
 
 	/*
@@ -674,6 +675,7 @@ static int tls_log_global_bio_write_cb(BIO *bio, char const *in, int len)
 	 *	to aggregate it, then look for new line chars
 	 *	as an indication we need to print the line.
 	 */
+	/* coverity[checked_return] */
 	fr_sbuff_in_bstrncpy(&lb->sbuff, in, len);
 
 	/*

--- a/src/lib/util/log.c
+++ b/src/lib/util/log.c
@@ -672,7 +672,9 @@ void fr_vlog_perror(fr_log_t const *log, fr_log_type_t type, char const *file, i
 			fr_sbuff_in_vsprintf(&sbuff, fmt, aq);
 			va_end(aq);
 
+			/* coverity[checked_return] */
 			fr_sbuff_in_strcpy(&sbuff, ": ");
+			/* coverity[checked_return] */
 			fr_sbuff_in_strcpy(&sbuff, error);	/* may not be talloced with const */
 			error = fr_sbuff_start(&sbuff);
 		}
@@ -698,6 +700,7 @@ void fr_vlog_perror(fr_log_t const *log, fr_log_type_t type, char const *file, i
 
 	fr_sbuff_set_to_start(&sbuff);
 	if (f_rules->subsq_prefix) {
+		/* coverity[checked_return] */
 		fr_sbuff_in_strcpy(&sbuff, f_rules->subsq_prefix);
 		fr_sbuff_marker(&prefix_m, &sbuff);
 	}
@@ -708,6 +711,7 @@ void fr_vlog_perror(fr_log_t const *log, fr_log_type_t type, char const *file, i
 	while ((error = fr_strerror_pop())) {
 		if (f_rules->subsq_prefix) {
 			fr_sbuff_set(&sbuff, &prefix_m);
+			/* coverity[checked_return] */
 			fr_sbuff_in_strcpy(&sbuff, error);	/* may not be talloced with const */
 			error = fr_sbuff_start(&sbuff);
 		}

--- a/src/modules/rlm_smtp/rlm_smtp.c
+++ b/src/modules/rlm_smtp/rlm_smtp.c
@@ -381,6 +381,7 @@ static int str_to_attachments(fr_mail_ctx_t *uctx, curl_mime *mime, char const *
 	}
 
 	/* Copy the filename into the buffer */
+	/* coverity[checked_return] */
 	fr_sbuff_in_bstrncpy(path_buffer, str, len);
 
 	/* Add the file attachment as a mime encoded part */
@@ -485,6 +486,7 @@ static int generate_from_header(rlm_smtp_thread_t *t, fr_mail_ctx_t *uctx, struc
 	(void) fr_sbuff_in_strcpy(&sbuff, from);
 
 	/* Copy the envelope address as the FROM: source */
+	/* coverity[checked_return] */
 	fr_sbuff_in_bstrncpy(&sbuff, inst->envelope_address, strlen(inst->envelope_address));
 	*out = curl_slist_append(*out, sbuff.buff);
 
@@ -567,6 +569,7 @@ static int header_source(rlm_smtp_thread_t *t, fr_mail_ctx_t *uctx, rlm_smtp_t c
 		}
 
 		/* Format the conf item to be a valid SMTP header */
+		/* coverity[checked_return] */
 		fr_sbuff_in_bstrncpy(&conf_buffer, conf_map->lhs->name, conf_map->lhs->len);
 		fr_sbuff_in_strcpy(&conf_buffer, ": ");
 		fr_sbuff_in_bstrncpy(&conf_buffer, expanded_rhs, strlen(expanded_rhs));


### PR DESCRIPTION
This change deals with the following CIDs:
1503889, 1503901, 1503908, 1503916, 1503936, 1504024, 1504280,
1504282, 1503894, 1503899, 1504013

Most of these are sbuff/dbuff operations that can only fail if
the buffers can't be reallocated or have reached their specified
maximum size.

In 1503899, we know, but Coverity doesn't, that no log_keyword
passed to _make_vlog() will overrun the fixed-size buffer it uses.

1503894 is what Coverity thinks is a copy/paste error that clearly
makes sense as written.