### PR TITLE
Make Coverity happy with encode_nas_filter_rule() (CID #1503928)

### DIFF
--- a/src/protocols/radius/encode.c
+++ b/src/protocols/radius/encode.c
@@ -1245,6 +1245,9 @@ static ssize_t encode_nas_filter_rule(fr_dbuff_t *dbuff,
 
 	FR_PROTO_STACK_PRINT(da_stack, depth);
 
+	fr_assert(vp);
+	fr_assert(vp->da);
+
 	fr_dbuff_marker(&hdr, &work_dbuff);
 	fr_dbuff_marker(&frag_hdr, &work_dbuff);
 	fr_dbuff_advance(&hdr, 1);
@@ -1252,7 +1255,7 @@ static ssize_t encode_nas_filter_rule(fr_dbuff_t *dbuff,
 
 	fr_assert(vp->da == attr_nas_filter_rule);
 
-	while (vp) {
+	while (true) {
 		size_t data_len = vp->vp_length;
 		size_t frag_len;
 		char const *p = vp->vp_strvalue;


### PR DESCRIPTION
encode_nas_filter_rule() is never passed a cursor for which
fr_dcursor_current() returns NULL, so the check at the top
of the loop can be eliminated. Coverity should see the assertions
and not complain about the FR_DBUFF_IN_BYTES_RETURN().