### PR TITLE
Check for NULL return from fr_rb_find(). (CID #1503952)

### DIFF
--- a/src/modules/proto_ldap_sync/sync.c
+++ b/src/modules/proto_ldap_sync/sync.c
@@ -939,6 +939,7 @@ sync_config_t const *sync_state_config_get(fr_ldap_connection_t *conn, int msgid
 	find.msgid = msgid;
 
 	sync = fr_rb_find(tree, &find);
+	if (!sync) return NULL;
 	return sync->config;
 }
 


### PR DESCRIPTION
The caller has to be able to handle a return of NULL already, and it is not clear that this call will always pass a msgid that will be found. This avoids dereferencing a NULL and placates coverity.