### PR TITLE
Handle coverity false positive in SBUFF_PARSE_FLOAT_DEF() (CID #1504042)

### DIFF
--- a/src/lib/util/sbuff.c
+++ b/src/lib/util/sbuff.c
@@ -1268,6 +1268,7 @@ fr_slen_t fr_sbuff_out_##_name(fr_sbuff_parse_error_t *err, _type *out, fr_sbuff
 		return -1; \
 	} \
 	errno = 0; /* this is needed as parsing functions don't reset errno */ \
+	/* coverity[uninit] */ \
 	res = _func(buff, &end); \
 	if (errno == ERANGE) { \
 		if (res > 0) { \


### PR DESCRIPTION
`fr_sbuff_out_bstrncpy_allowed()` always copies at least the
terminating NUL, so buff is always initialized before the `_func()`
call.