### PR TITLE
Reassure coverity about the value passed to print_config() (CID #1504…

### DIFF
--- a/scripts/jlibtool.c
+++ b/scripts/jlibtool.c
@@ -967,6 +967,8 @@ static int run_command(command_t *cmd, count_chars *cc)
 
 static void print_config(char const *value)
 {
+	assert(value != NULL);
+
 	printc(target->ld_run_path, "runpath_var");
 	printc(target->ld_library_path, "shlibpath_var");
 	printc(target->ld_library_path_local, "shlocallibpath_var");


### PR DESCRIPTION
…310)

We can see that print_config() is only called in one spot, from
parse_long_op(), which passes as value the addresss of an auto array
that is guaranteed to contain a possibly empty NUL-terminated string,
suitable for the printc* macros. This being a separatly-compiled
program, we take the portable approach of asserting value is non-
NULL, which we know is true and should convince coverity.