### PR TITLE
Fix rpm build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -443,7 +443,7 @@ rpmbuild/SOURCES/freeradius-server-$(RADIUSD_VERSION_STRING).tar.bz2: freeradius
 	@cp $< $@
 
 rpm: rpmbuild/SOURCES/freeradius-server-$(RADIUSD_VERSION_STRING).tar.bz2
-	@if ! yum-builddep -q -C --assumeno redhat/freeradius.spec 1> /dev/null 2>&1; then \
+	@if ! sudo yum-builddep -q -C --assumeno redhat/freeradius.spec 1> /dev/null 2>&1; then \
 		echo "ERROR: Required depdendencies not found, install them with: yum-builddep redhat/freeradius.spec"; \
 		exit 1; \
 	fi

--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -91,6 +91,7 @@ BuildRequires: net-snmp-utils
 BuildRequires: systemd-devel
 %endif
 BuildRequires: pam-devel
+BuildRequires: pcre2-devel
 BuildRequires: readline-devel
 BuildRequires: zlib-devel
 


### PR DESCRIPTION
- Add missing dependency on pcre2 - %(sub) does not work without pcre2 (and Debian build glue has a dependency on pcre2)
- Allow to "make rpm" as non-root user