### PR TITLE
Annotate Coverity dead code false positives.

### DIFF
--- a/src/lib/server/connection.c
+++ b/src/lib/server/connection.c
@@ -296,6 +296,7 @@ static void connection_deferred_signal_process(fr_connection_t *conn)
 		 *	One of the signal handlers freed the connection
 		 *	return immediately.
 		 */
+		/* coverity[deadcode] */
 		if (freed) return;
 	}
 

--- a/src/lib/unlang/xlat_purify.c
+++ b/src/lib/unlang/xlat_purify.c
@@ -79,7 +79,7 @@ int xlat_purify_list(xlat_exp_head_t *head, request_t *request)
 		default:
 			fr_strerror_printf("Internal error - cannot purify xlat");
 			return -1;
-			
+
 		case XLAT_GROUP:
 			rcode = xlat_purify_list(node->group, request);
 			if (rcode < 0) return rcode;
@@ -102,14 +102,14 @@ int xlat_purify_list(xlat_exp_head_t *head, request_t *request)
 			 *	with the children.  But only if the
 			 *	child list is not empty.
 			 */
-			
+
 			if (node->alternate[1]->flags.can_purify) {
 				rcode = xlat_purify_list(node->alternate[1], request);
 				if (rcode < 0) return rcode;
 			}
 			xlat_flags_merge(&node->flags, &node->alternate[1]->flags);
 			break;
-			
+
 		case XLAT_FUNC:
 			/*
 			 *	If the node is not pure, then maybe there's a callback to purify it, OR maybe
@@ -152,6 +152,7 @@ int xlat_purify_list(xlat_exp_head_t *head, request_t *request)
 			 */
 			success = false;
 			(void) unlang_interpret_synchronous(NULL, request);
+			/* coverity[deadcode] */
 			if (!success) return -1;
 
 			/*


### PR DESCRIPTION
This deals with the following CIDs: 1504662, 1469149
In these, Coverity doesn't see that other code will change freed and success so that what it thinks is dead code isn't.