### PR TITLE
Make room for NUL in the extreme case in xlat_config_escape().

### DIFF
--- a/src/lib/server/main_config.c
+++ b/src/lib/server/main_config.c
@@ -443,7 +443,7 @@ static int xlat_config_escape(UNUSED request_t *request, fr_value_box_t *vb, UNU
 	static char const	disallowed[] = "%{}\\'\"`";
 	size_t 			outmax = vb->vb_length * 3;
 	size_t			outlen = 0;
-	char 			escaped[outmax];
+	char 			escaped[outmax + 1];
 	char const		*in, *end;
 	char			*out = escaped;
 


### PR DESCRIPTION
The VLA escaped[] can handle the probably unlikely worst case of
every character from the value box requiring MIME encoding...
except that a NUL is appended, so one might as well accommodate
it in that worst case.