### PR TITLE
Set *err to -2 when the list isn't found in tmp_dcursor_init()

### DIFF
--- a/src/lib/server/tmpl_dcursor.c
+++ b/src/lib/server/tmpl_dcursor.c
@@ -373,6 +373,7 @@ fr_pair_t *tmpl_dcursor_init(int *err, TALLOC_CTX *ctx, tmpl_dcursor_ctx_t *cc,
 		if (!list_head) {
 			fr_strerror_printf("List \"%s\" not available in this context",
 					   fr_table_str_by_value(pair_list_table, tmpl_list(vpt), "<INVALID>"));
+			if (err) *err = -2;
 			goto error;
 		}
 		list_ctx = tmpl_list_ctx(request, tmpl_list(vpt));


### PR DESCRIPTION
This change honors the comments describing how err is handled, and
also means, given tmpl_find_vp()'s use of tmpl_dcursor_init(),
means callers of tmpl_find_vp() can check its return value
rather than having to look at the written vp (e.g. sometimes_return();
see CID #1503995).