### PR TITLE
Annotate calls that as used will not return NULL (CID #1503961)

### DIFF
--- a/src/lib/util/pair_list_perf_test.c
+++ b/src/lib/util/pair_list_perf_test.c
@@ -215,10 +215,13 @@ static void pair_list_init(TALLOC_CTX *ctx, fr_pair_t ***out, fr_dict_t const *d
 			 *  to use for duplicating attributes to required percentage.
 			 *  Duplicates are at the beginning of the source list
 			 */
+			/* coverity[null_returns] */
 			vp = fr_pair_list_head(&list);
 			for (j = 0; j < (size_t)(input_count * perc / 100); j++) {
+				/* coverity[null_returns] */
 				new_vp = fr_pair_copy(ctx, vp);
 				fr_pair_append(&dups, new_vp);
+				/* coverity[null_returns] */
 				vp = fr_pair_list_next(&list, vp);
 			}
 		}


### PR DESCRIPTION
The calls in question are those in pair_list_init() that iterate
over a pair list built up from a string. As long as the string
is non-empty, the pair list won't be empty. As long as perc (the
percentage) is no larger than 100, the code won't pass NULL to
fr_pair_copy()... and one can see that's the case for all calls
to pair_list_init(). Coverity apparently doesn't look at that
context.