### PR TITLE
Annotate SBUFF_PARSE_[U]INT_DEF() bounds checking (CID #1504004, #150…

### DIFF
--- a/src/lib/util/sbuff.c
+++ b/src/lib/util/sbuff.c
@@ -1140,11 +1140,14 @@ fr_slen_t fr_sbuff_out_##_name(fr_sbuff_parse_error_t *err, _type *out, fr_sbuff
 		if (err) *err = FR_SBUFF_PARSE_ERROR_NOT_FOUND; \
 		return -1; \
 	} \
+	/* coverity[result_independent_of_operands] */ \
 	if ((num > (_max)) || ((errno == EINVAL) && (num == 0)) || ((errno == ERANGE) && (num == LLONG_MAX))) { \
 		if (err) *err = FR_SBUFF_PARSE_ERROR_NUM_OVERFLOW; \
 		*out = (_type)(_max); \
 		return -1; \
-	} else if ((num < (_min)) || ((errno == ERANGE) && (num == LLONG_MIN))) { \
+	} else \
+	/* coverity[result_independent_of_operands] */ \
+	if ((num < (_min)) || ((errno == ERANGE) && (num == LLONG_MIN))) { \
 		if (err) *err = FR_SBUFF_PARSE_ERROR_NUM_UNDERFLOW; \
 		*out = (_type)(_min); \
 		return -1; \
@@ -1203,6 +1206,7 @@ fr_slen_t fr_sbuff_out_##_name(fr_sbuff_parse_error_t *err, _type *out, fr_sbuff
 		if (err) *err = FR_SBUFF_PARSE_ERROR_NOT_FOUND; \
 		return -1; \
 	} \
+	/* coverity[result_independent_of_operands] */ \
 	if ((num > (_max)) || ((errno == EINVAL) && (num == 0)) || ((errno == ERANGE) && (num == ULLONG_MAX))) { \
 		if (err) *err = FR_SBUFF_PARSE_ERROR_NUM_OVERFLOW; \
 		*out = (_type)(_max); \


### PR DESCRIPTION
…4045)

For signed or unsigned long long, the bounds checking will have
tests that always have the same result, which triggers coverity.
The fiddling with _Generic() required to avoid this is excessive,
and the macros as they stand pass tests. We therefore annotate
those comparisons to placate coverity.