### PR TITLE
map_afrom_cp: unescape double-quoted and back-quoted RHS prior to parsing it

### DIFF
--- a/src/lib/server/map.c
+++ b/src/lib/server/map.c
@@ -99,6 +99,7 @@ int map_afrom_cp(TALLOC_CTX *ctx, map_t **out, map_t *parent, CONF_PAIR *cp,
 {
 	map_t		*map;
 	char const	*attr, *value, *marker_subject;
+	fr_sbuff_parse_rules_t const *p_rules;
 	ssize_t		slen;
 	fr_token_t	type;
 
@@ -164,11 +165,23 @@ int map_afrom_cp(TALLOC_CTX *ctx, map_t **out, map_t *parent, CONF_PAIR *cp,
 	 *	RHS might be an attribute reference.
 	 */
 	type = cf_pair_value_quote(cp);
+	p_rules = value_parse_rules_unquoted[type]; /* We're not searching for quotes */
+	if (type == T_DOUBLE_QUOTED_STRING || type == T_BACK_QUOTED_STRING) {
+		char *unescaped_value;
+		slen = fr_sbuff_out_aunescape_until(map, &unescaped_value,
+				&FR_SBUFF_IN(value, strlen(value)), SIZE_MAX, p_rules->terminals, p_rules->escapes);
+		if (slen < 0) {
+			marker_subject = value;
+			goto marker;
+		}
+		value = unescaped_value;
+		p_rules = NULL;
+	}
 
 	slen = tmpl_afrom_substr(map, &map->rhs,
 				 &FR_SBUFF_IN(value, strlen(value)),
 				 type,
-				 value_parse_rules_unquoted[type],	/* We're not searching for quotes */
+				 p_rules,
 				 rhs_rules);
 	if (slen < 0) {
 		marker_subject = value;


### PR DESCRIPTION
This fixes the following regression: the following unlang code could be properly parsed by 3.2.x:

```
update control {
    &DHCP-Redis-Pre-Script := "%(redis:EVAL \"some lua script\" 1 %{control.IP-Pool.Name}"
}
```

In 4.x this generates the following error:

```
/etc/raddb/sites-enabled/dhcp[276]: %(redis:EVAL \"some lua script...
/etc/raddb/sites-enabled/dhcp[276]:         ^: Unexpected text after argument
```

The reason is that `xlat_tokenize_function_args` (and `xlat_tokenize_expansion`) do not obey `fr_sbuff_parse_rules_t` passed to `xlat_tokenize_string` so unescaping RHS does not happen. Moreover - they seem to expect unescaped text and apply their own unescape rules.