### PR TITLE
Annotate Coverity false positive of non-NUL-termination (CID #1469156)

### DIFF
--- a/scripts/build/dlopen.c
+++ b/scripts/build/dlopen.c
@@ -615,6 +615,7 @@ static void ad_have_feature(char const *symbol)
 	for (last = &ad_define_head; *last != NULL; last = &(*last)->next) {
 		if (def->name[5] > (*last)->name[5]) continue; /* avoid strcmp() for the common case */
 
+		/* coverity[string_null] */
 		if (strcmp(def->name + 5, (*last)->name + 5) > 0) continue;
 		break;
 	}


### PR DESCRIPTION
def->name is built up with memcpy() calls that have the same
effect as sprintf(def->name, "HAVE_%s=1", symbol); The last
memcpy() makes a point of including the '\0' at the end of "=1"
and thus def->name is NUL-terminated, as is def->name + 5 (which
just skips the leading "HAVE_").