### PR TITLE
Fix when filename starts with a directory separator (is an absolute path)

### DIFF
--- a/src/bin/unit_test_attribute.c
+++ b/src/bin/unit_test_attribute.c
@@ -3738,7 +3738,9 @@ int main(int argc, char *argv[])
 
 			fr_dlist_init(&lines, command_line_range_t, entry);
 
-			while (fr_sbuff_adv_until(&in, SIZE_MAX, &dir_sep, '\0')) {
+			while (fr_sbuff_extend(&in)) {
+				fr_sbuff_adv_until(&in, SIZE_MAX, &dir_sep, '\0');
+
 				switch (*fr_sbuff_current(&in)) {
 				case '/':
 					fr_sbuff_set(&dir_end, &in);


### PR DESCRIPTION
This fixes the following crash in "make test":

```
UNIT-TEST radius vendor
if ! build/make/jlibtool --debug --mode=execute ./build/bin/local/unit_test_attribute  -F ./src/tests/fuzzer-c
orpus -D ./share/dictionary -d /home/ubuntu/work/viasat/freeradius-server-upstream/src/tests/unit -r "build/te
sts/unit/protocols/radius/vendor.txt" /home/ubuntu/work/viasat/freeradius-server-upstream/src/tests/unit/proto
cols/radius/vendor.txt; then \
        echo "TZ=GMT build/make/jlibtool --debug --mode=execute ./build/bin/local/unit_test_attribute  -F ./src/tests/fuzzer-corpus -D ./share/dictionary -d /home/ubuntu/work/viasat/freeradius-server-upstream/src/tests/unit -r \"build/tests/unit/protocols/radius/vendor.txt\" /home/ubuntu/work/viasat/freeradius-server-upstream/src/tests/unit/protocols/radius/vendor.txt"; \
        rm -f build/tests/test.unit; \
        exit 1; \
fi
CAUGHT SIGNAL: Segmentation fault
Backtrace of last 12 frames:
/Users/fjoe/work/viasat/freeradius-server-upstream/build/lib/local/.libs/libfreeradius-util.so(fr_fault+0xe8)[0x7f9acb96e036]
/lib64/libpthread.so.0(+0xf630)[0x7f9ac93eb630]
/lib64/libc.so.6(+0x16f8c1)[0x7f9ac8f378c1]
/Users/fjoe/work/viasat/freeradius-server-upstream/build/lib/local/.libs/libfreeradius-util.so(+0x32115)[0x7f9acb977115]
/Users/fjoe/work/viasat/freeradius-server-upstream/build/lib/local/.libs/libfreeradius-util.so(+0x33d18)[0x7f9acb978d18]
/Users/fjoe/work/viasat/freeradius-server-upstream/build/lib/local/.libs/libfreeradius-util.so(fr_dict_read+0xef)[0x7f9acb97969c]
./build/bin/local/unit_test_attribute[0x40ac19]
./build/bin/local/unit_test_attribute(process_line+0x25f)[0x40d9d9]
./build/bin/local/unit_test_attribute[0x40e292]
./build/bin/local/unit_test_attribute(main+0xbac)[0x40fa8f]
/lib64/libc.so.6(__libc_start_main+0xf5)[0x7f9ac8dea555]
./build/bin/local/unit_test_attribute[0x404199]
No panic action set
_EXIT(139) CALLED /home/ubuntu/work/viasat/freeradius-server-upstream/src/lib/util/debug.c[1052]
```