### PR TITLE
Fix UNIT_TEST_KEYWORD_ARGS when BUILD_DIR is an absolute path name

### DIFF
--- a/src/tests/eapol_test/all.mk
+++ b/src/tests/eapol_test/all.mk
@@ -108,13 +108,13 @@ $(OUTPUT)/%.ok: $(DIR)/%.conf $(if $(POST_INSTALL_MAKEFILE_ARG),,$(BUILD_DIR)/li
 	${Q}$(MAKE) $(POST_INSTALL_MAKEFILE_ARG) --no-print-directory test.$(METHOD).radiusd_kill
 	${Q}$(MAKE) $(POST_INSTALL_MAKEFILE_ARG) --no-print-directory test.$(METHOD).radiusd_start $(POST_INSTALL_RADIUSD_BIN_ARG)
 	${Q}if ! $(EAPOL_TEST) -t 10 -c $< -p $(TEST_PORT) -s $(SECRET) $(KEY) > $(EAPOL_TEST_LOG) 2>&1; then	\
-		echo "Last entries in supplicant log ($(EAPOL_TEST_LOG):";	\
+		echo "Last entries in supplicant log ($(EAPOL_TEST_LOG)):";	\
 		tail -n 40 "$(EAPOL_TEST_LOG)";							\
 		echo "--------------------------------------------------";		\
 		tail -n 40 "$(RADIUS_LOG)";						\
 		echo "Last entries in server log ($(RADIUS_LOG)):";			\
 		echo "--------------------------------------------------";		\
-		echo "RADIUSD :  OUTPUT=$(dir $@) TESTDIR=$(dir $<) TEST=$(METHOD) TEST_PORT=$(TEST_PORT) $(RADIUSD_BIN) -fxxx -n servers -d $(dir $<)config -D $(DICT_PATH) -lstdout -f";\";\
+		echo "RADIUSD :  OUTPUT=$(dir $@) TESTDIR=$(dir $<) TEST=$(METHOD) TEST_PORT=$(TEST_PORT) $(RADIUSD_BIN) -fxxx -n servers -d $(dir $<)config -D $(DICT_PATH) -lstdout -f"; \
 		echo "EAPOL   :  $(EAPOL_TEST) -c \"$<\" -p $(TEST_PORT) -s $(SECRET) $(KEY) "; \
 		echo "           log is in $(OUT)"; \
 		rm -f $(BUILD_DIR)/tests/test.eap;                                      \

--- a/src/tests/keywords/all.mk
+++ b/src/tests/keywords/all.mk
@@ -59,7 +59,7 @@ $(OUTPUT)/depends.mk: $(addprefix $(DIR)/,$(sort $(FILES))) | $(OUTPUT)
 		fi; \
 		y=`grep 'PROTOCOL: ' $$x | sed 's/.*://;s/  / /g'`; \
 		if [ "$$y" != "" ]; then \
-			z=`echo $$x | sed 's,src/tests/keywords/,,;s/-/_/g'`; \
+			z=`echo $$x | sed 's,.*/,,;s/-/_/g'`; \
 			echo "UNIT_TEST_KEYWORD_ARGS.$$z=-p $$y" >> $@; \
 			echo "" >> $@; \
 		fi \

--- a/src/tests/map/all.mk
+++ b/src/tests/map/all.mk
@@ -32,7 +32,7 @@ $(OUTPUT)/%: $(DIR)/% $(TEST_BIN_DIR)/unit_test_map
 			echo FAILED: "$(MAP_UNIT) -d $(top_srcdir)/raddb -D $(top_srcdir)/share/dictionary -r \"$@\" \"$<\""; \
 			exit 1; \
 		fi; \
-		FOUND=$$(grep -E '^(Error : )?$<' $@.log | head -1 | sed 's/.*\[//;s/\].*//'); \
+		FOUND=$$(grep -E '^(Error : )?.*/$(notdir $<)' $@.log | head -1 | sed 's/.*\[//;s/\].*//'); \
 		EXPECTED=$$(grep -n ERROR $< | sed 's/:.*//'); \
 		if [ "$$EXPECTED" != "$$FOUND" ]; then \
 			cat "$@.log"; \

--- a/src/tests/modules/all.mk
+++ b/src/tests/modules/all.mk
@@ -103,7 +103,7 @@ $(OUTPUT)/%: $(DIR)/%.unlang $(TEST_BIN_DIR)/unit_test_module | build.raddb
 			echo "MODULE_TEST_DIR=$(dir $<) MODULE_TEST_UNLANG=$< $(TEST_BIN)/unit_test_module -D share/dictionary -d src/tests/modules/ -i \"$@.attrs\" -f \"$@.attrs\" -r \"$@\" -xx"; \
 			exit 1; \
 		fi; \
-		FOUND=$$(grep -E 'Error : $<' $@.log | head -1 | sed 's/.*\[//;s/\].*//'); \
+		FOUND=$$(grep -E 'Error : .*/$(notdir $<)' $@.log | head -1 | sed 's/.*\[//;s/\].*//'); \
 		EXPECTED=$$(grep -n ERROR $< | sed 's/:.*//'); \
 		if [ "$$EXPECTED" != "$$FOUND" ]; then \
 			cat "$@.log"; \

--- a/src/tests/radclient/all.mk
+++ b/src/tests/radclient/all.mk
@@ -61,6 +61,10 @@ $(OUTPUT)/%: $(DIR)/% | $(TEST).radiusd_kill $(TEST).radiusd_start
 	$(Q)if [ "$$(uname -s)" = "Darwin" ]; then sed -i .bak 's/via lo0/via lo/g' $(FOUND); fi
 	$(Q)if [ "$$(uname -s)" = "FreeBSD" ]; then sed -i .bak 's/via (null)/via lo/g' $(FOUND); fi
 #
+#	Lets normalize pathnames
+#
+	$(Q)sed -i.bak 's,[^" ]*\(src/tests\),\1,' $(FOUND)
+#
 #	Remove all entries with "^_EXIT.*CALLED .*/"
 #	It is necessary to match all builds with/without -DNDEBUG
 #


### PR DESCRIPTION
This fixes "make test" for keyword tests that use PROTOCOL: tag