### PR TITLE
Accomodate coverity in tls_cache_session_ticket_app_data_get() (CID #…

### DIFF
--- a/src/lib/tls/cache.c
+++ b/src/lib/tls/cache.c
@@ -1268,7 +1268,7 @@ static SSL_TICKET_RETURN tls_cache_session_ticket_app_data_get(SSL *ssl, SSL_SES
 	case SSL_TICKET_FATAL_ERR_MALLOC:
 	case SSL_TICKET_FATAL_ERR_OTHER:
 	case SSL_TICKET_NONE:
-#ifdef __clang_analyzer__
+#if defined(__clang_analyzer__) || defined(__COVERITY__)
 	default:
 #endif
 		return SSL_TICKET_RETURN_IGNORE_RENEW;	/* Send a new ticket */


### PR DESCRIPTION
…1503904)

Make the default appear for coverity as well as for clang static
analysis, for the same reason: otherwise, an unexpected status
could pass a NULL request to tls_cache_app_data_get().