### PR TITLE
Annotate false positive on curl_escape call (CID #1503903)

### DIFF
--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -383,6 +383,7 @@ static size_t rest_encode_post(void *out, size_t size, size_t nmemb, void *userd
 		RDEBUG2("Encoding attribute \"%s\"", vp->da->name);
 
 		if (ctx->state == READ_STATE_ATTR_BEGIN) {
+			/* coverity[alloc_strlen] */
 			escaped = curl_escape(vp->da->name, strlen(vp->da->name));
 			if (!escaped) {
 				REDEBUG("Failed escaping string \"%s\"", vp->da->name);


### PR DESCRIPTION
The NUL terminator isn't counted in the length parameter of
curl_escape():
1. You can pass 0 and curl_escape() will itself use strlen().
2. The example code from "man curl_escape" gives a length
   that doesn't include the NUL terminator.

We therefore annotate the call to placate coverity.