### PR TITLE
CentOS 7 has glibc 2.17 which does not support %Z in strptime(3)

### DIFF
--- a/src/tests/keywords/date
+++ b/src/tests/keywords/date
@@ -13,7 +13,7 @@ update request {
 }
 
 # Some systems report GMT some UTC...
-if (&Tmp-String-0 != "Fri 22 Sep 17:25:00 GMT 2017") && (&Tmp-String-0 != "Fri 22 Sep 17:25:00 UTC 2017") {
+if (&Tmp-String-0 != "Fri 22 Sep 17:25:00 2017") {
 	test_fail
 }
 

--- a/src/tests/keywords/radius.conf
+++ b/src/tests/keywords/radius.conf
@@ -38,7 +38,7 @@ modules {
 	}
 
 	date {
-		format = "%a %d %b %H:%M:%S %Z %Y"
+		format = "%a %d %b %H:%M:%S %Y"
 		utc = yes
 	}
 


### PR DESCRIPTION
%Z support was added in glibc 2.19: https://sourceware.org/bugzilla/show_bug.cgi?id=14876