### PR TITLE
map_afrom_cp: unescape double-quoted and back-quoted RHS prior to parsing it

### DIFF
--- a/src/lib/server/map.c
+++ b/src/lib/server/map.c
@@ -99,6 +99,8 @@ int map_afrom_cp(TALLOC_CTX *ctx, map_t **out, map_t *parent, CONF_PAIR *cp,
 {
 	map_t		*map;
 	char const	*attr, *value, *marker_subject;
+	char		*unescaped_value = NULL;
+	fr_sbuff_parse_rules_t const *p_rules;
 	ssize_t		slen;
 	fr_token_t	type;
 
@@ -164,15 +166,32 @@ int map_afrom_cp(TALLOC_CTX *ctx, map_t **out, map_t *parent, CONF_PAIR *cp,
 	 *	RHS might be an attribute reference.
 	 */
 	type = cf_pair_value_quote(cp);
+	p_rules = value_parse_rules_unquoted[type]; /* We're not searching for quotes */
+	if (type == T_DOUBLE_QUOTED_STRING || type == T_BACK_QUOTED_STRING) {
+		slen = fr_sbuff_out_aunescape_until(map, &unescaped_value,
+				&FR_SBUFF_IN(value, talloc_array_length(value) - 1), SIZE_MAX, p_rules->terminals, p_rules->escapes);
+		if (slen < 0) {
+			marker_subject = value;
+			goto marker;
+		}
+		value = unescaped_value;
+		p_rules = NULL;
+	} else {
+		slen = talloc_array_length(value) - 1;
+	}
 
 	slen = tmpl_afrom_substr(map, &map->rhs,
-				 &FR_SBUFF_IN(value, strlen(value)),
+				 &FR_SBUFF_IN(value, slen),
 				 type,
-				 value_parse_rules_unquoted[type],	/* We're not searching for quotes */
+				 p_rules,
 				 rhs_rules);
 	if (slen < 0) {
 		marker_subject = value;
 		goto marker;
+	}
+	if (unescaped_value != NULL) {
+		talloc_free(unescaped_value);
+		unescaped_value = NULL;
 	}
 
 	if (!map->rhs) {
@@ -214,6 +233,10 @@ int map_afrom_cp(TALLOC_CTX *ctx, map_t **out, map_t *parent, CONF_PAIR *cp,
 	return 0;
 
 error:
+	if (unescaped_value != NULL) {
+		talloc_free(unescaped_value);
+		unescaped_value = NULL;
+	}
 	talloc_free(map);
 	return -1;
 }

--- a/src/tests/keywords/length
+++ b/src/tests/keywords/length
@@ -32,6 +32,7 @@ update request {
 	&Tmp-Integer-0        := "%(length:%{Tmp-String-2})"
 	&Tmp-Integer-1        := "%(length:%{Tmp-Octets-0})"
 	&Tmp-Integer-2        := "%(length:%{Tmp-IP-Address-0})"
+	&Tmp-Integer-3        := "%(length:\"hello, world\")"
 	&Tmp-Integer-4        := "%(length:%{Tmp-Integer-0})"
 	&Tmp-Integer-6        := "%(length:%{Tmp-Cast-Ifid})"
 	&Tmp-Integer-7        := "%(length:%{Tmp-Cast-IPv6Addr})"
@@ -54,6 +55,10 @@ if (&Tmp-Integer-2 != 4) {
 	test_fail
 }
 
+# String - "hello, world"
+if (&Tmp-Integer-3 != 12) {
+	test_fail
+}
 
 # Integer - bin 0x39383734
 if (&Tmp-Integer-4 != 4) {


### PR DESCRIPTION
@alandekok 

This is an updated patch from #4590. 
All test cases now pass.