### PR TITLE
Fix CANONICAL_PATH when $(top_srcdir) has symlinks

### DIFF
--- a/scripts/boiler.mk
+++ b/scripts/boiler.mk
@@ -317,7 +317,7 @@ endef
 #   top-level directory, the canonical form is the absolute path (i.e. from
 #   the root of the filesystem) also without "./" or "../" sequences.
 define CANONICAL_PATH
-$(patsubst ${CURDIR}/%,%,$(abspath ${1}))
+$(patsubst $(PWD)/%,%,$(patsubst ${CURDIR}/%,%,$(abspath ${1})))
 endef
 
 # COMPILE_C_CMDS - Commands for compiling C source code.

--- a/src/tests/all.mk
+++ b/src/tests/all.mk
@@ -116,7 +116,7 @@ define TEST_BOOTSTRAP
 #
 #  The test files are files without extensions.
 #
-OUTPUT.$(TEST) := $(patsubst %/,%,$(subst $(top_srcdir)/src,$(BUILD_DIR),$(abspath $(DIR))))
+OUTPUT.$(TEST) := $(patsubst %/,%,$(subst src/,$(BUILD_DIR)/,$(call CANONICAL_PATH,$(DIR))))
 OUTPUT := $$(OUTPUT.$(TEST))
 
 #

--- a/src/tests/keywords/all.mk
+++ b/src/tests/keywords/all.mk
@@ -59,7 +59,7 @@ $(OUTPUT)/depends.mk: $(addprefix $(DIR)/,$(sort $(FILES))) | $(OUTPUT)
 		fi; \
 		y=`grep 'PROTOCOL: ' $$x | sed 's/.*://;s/  / /g'`; \
 		if [ "$$y" != "" ]; then \
-			z=`echo $$x | sed 's,.*/,,;s/-/_/g'`; \
+			z=`echo $$x | sed 's,src/tests/keywords/,,;s/-/_/g'`; \
 			echo "UNIT_TEST_KEYWORD_ARGS.$$z=-p $$y" >> $@; \
 			echo "" >> $@; \
 		fi \

--- a/src/tests/map/all.mk
+++ b/src/tests/map/all.mk
@@ -32,7 +32,7 @@ $(OUTPUT)/%: $(DIR)/% $(TEST_BIN_DIR)/unit_test_map
 			echo FAILED: "$(MAP_UNIT) -d $(top_srcdir)/raddb -D $(top_srcdir)/share/dictionary -r \"$@\" \"$<\""; \
 			exit 1; \
 		fi; \
-		FOUND=$$(grep -E '^(Error : )?.*/$(notdir $<)' $@.log | head -1 | sed 's/.*\[//;s/\].*//'); \
+		FOUND=$$(grep -E '^(Error : )?$<' $@.log | head -1 | sed 's/.*\[//;s/\].*//'); \
 		EXPECTED=$$(grep -n ERROR $< | sed 's/:.*//'); \
 		if [ "$$EXPECTED" != "$$FOUND" ]; then \
 			cat "$@.log"; \

--- a/src/tests/modules/all.mk
+++ b/src/tests/modules/all.mk
@@ -103,7 +103,7 @@ $(OUTPUT)/%: $(DIR)/%.unlang $(TEST_BIN_DIR)/unit_test_module | build.raddb
 			echo "MODULE_TEST_DIR=$(dir $<) MODULE_TEST_UNLANG=$< $(TEST_BIN)/unit_test_module -D share/dictionary -d src/tests/modules/ -i \"$@.attrs\" -f \"$@.attrs\" -r \"$@\" -xx"; \
 			exit 1; \
 		fi; \
-		FOUND=$$(grep -E 'Error : .*/$(notdir $<)' $@.log | head -1 | sed 's/.*\[//;s/\].*//'); \
+		FOUND=$$(grep -E 'Error : $<' $@.log | head -1 | sed 's/.*\[//;s/\].*//'); \
 		EXPECTED=$$(grep -n ERROR $< | sed 's/:.*//'); \
 		if [ "$$EXPECTED" != "$$FOUND" ]; then \
 			cat "$@.log"; \

--- a/src/tests/radclient/all.mk
+++ b/src/tests/radclient/all.mk
@@ -61,10 +61,6 @@ $(OUTPUT)/%: $(DIR)/% | $(TEST).radiusd_kill $(TEST).radiusd_start
 	$(Q)if [ "$$(uname -s)" = "Darwin" ]; then sed -i .bak 's/via lo0/via lo/g' $(FOUND); fi
 	$(Q)if [ "$$(uname -s)" = "FreeBSD" ]; then sed -i .bak 's/via (null)/via lo/g' $(FOUND); fi
 #
-#	Lets normalize pathnames
-#
-	$(Q)sed -i.bak 's,[^" ]*\(src/tests\),\1,' $(FOUND)
-#
 #	Remove all entries with "^_EXIT.*CALLED .*/"
 #	It is necessary to match all builds with/without -DNDEBUG
 #


### PR DESCRIPTION
I figured out the differences in my builds vs. CI builds: in my setup /home is a symlink and this causes Makefile glue to use absolute paths in many places where relative paths are used in CI builds

This happens because CANONICAL_PATH does not handle this case properly.

The fix makes most of #4602 (rev c2a6977a551acea0d927daa324e0353fa64ba221) not necessary - I backed it out in a separate commit in this PR.