### PR TITLE
Let coverity see the code clang static analysis sees (CID #1507222)

### DIFF
--- a/src/lib/util/dict_util.c
+++ b/src/lib/util/dict_util.c
@@ -3234,7 +3234,7 @@ static int _dict_free(fr_dict_t *dict)
 		}
 	}
 
-#ifdef __clang_analyzer__
+#if defined(__clang_analyzer__) || defined(__COVERITY__)
 	if (!dict->root) return -1;
 #endif
 


### PR DESCRIPTION
The conditional compilation now shows both the dict->root test that
avoids complaints about using dict->root without checking for NULL
first.