### PR TITLE
Uniform way of dealing with static analysis

### DIFF
--- a/src/include/build.h
+++ b/src/include/build.h
@@ -38,11 +38,25 @@ extern "C" {
 #endif
 
 /*
- *	Reduce spurious errors from clang scan by having
+ *	Static analyzers don't notice or can't infer some properties
+ *	of the code, and hence may give false positives. To deal with
+ *	them, there is some conditionally compiled code in various
+ *	places. The following lets the code change minimally if and
+ *	when new static analyzers are added.
+ */
+#ifdef __clang_analyzer__
+#define STATIC_ANALYZER	1
+#endif
+#ifdef __COVERITY__
+#define STATIC_ANALYZER 1
+#endif
+
+/*
+ *	Reduce spurious errors from static analyzers by having
  *	all paths that find the da to be NULL, result
  *	in program exit.
  */
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 #  define WITH_VERIFY_PTR	1
 #endif
 

--- a/src/lib/eap_aka_sim/decode.c
+++ b/src/lib/eap_aka_sim/decode.c
@@ -691,7 +691,7 @@ static ssize_t sim_decode_pair_value(TALLOC_CTX *ctx, fr_pair_list_t *out, fr_di
 			return -1;
 		}
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 		if (!parent->parent) return -1; /* stupid static analyzers */
 #endif
 		fr_assert(parent->parent);

--- a/src/lib/io/master.c
+++ b/src/lib/io/master.c
@@ -1246,8 +1246,8 @@ redo:
 			return 0;
 		}
 
-#ifdef __clang_analyzer__
-		saremote.ss_family = AF_INET; /* clang doesn't know that accept() initializes this */
+#ifdef STATIC_ANALYZER
+		saremote.ss_family = AF_INET; /* static analyzer doesn't know that accept() initializes this */
 #endif
 
 		/*

--- a/src/lib/server/auth.c
+++ b/src/lib/server/auth.c
@@ -158,7 +158,7 @@ unlang_action_t rad_virtual_server(rlm_rcode_t *p_result, request_t *request)
 #endif
 
 	if (!request->async) {
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 		if (!request->parent) RETURN_MODULE_FAIL;
 #endif
 		fr_assert(request->parent != NULL);

--- a/src/lib/server/module.c
+++ b/src/lib/server/module.c
@@ -268,7 +268,7 @@ static int8_t module_instance_name_cmp(void const *one, void const *two)
 	 *	This happens, as dl_inst is is used in
 	 *	as the loop condition above.
 	 */
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!fr_cond_assert(a->dl_inst)) return +1;
 	if (!fr_cond_assert(b->dl_inst)) return -1;
 #endif

--- a/src/lib/server/paircmp.c
+++ b/src/lib/server/paircmp.c
@@ -582,7 +582,7 @@ int paircmp(request_t *request,
 		switch (check_item->op) {
 		case T_OP_EQ:
 		default:
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 			if (!check_item->da) return -1;
 #endif
 

--- a/src/lib/server/password.c
+++ b/src/lib/server/password.c
@@ -700,9 +700,9 @@ do_header:
 		return new;
 	}
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	/*
-	 *	clang isn't smart enough to notice that "normify" clears out n1.
+	 *	static analyzer isn't smart enough to notice that "normify" clears out n1.
 	 */
 	memset(n1, 0, sizeof(n1));
 #endif

--- a/src/lib/server/rad_assert.h
+++ b/src/lib/server/rad_assert.h
@@ -34,7 +34,7 @@ extern "C" {
 
 #ifdef NDEBUG
 #  define fr_assert(_expr)
-#elif !defined(__clang_analyzer__)
+#elif !defined(STATIC_ANALYZER)
 #  define fr_assert(_expr) ((void) ((_expr) ? (void) 0 : (void) fr_assert_exit(__FILE__, __LINE__, #_expr)))
 #else
 #  include <assert.h>

--- a/src/lib/tls/cache.c
+++ b/src/lib/tls/cache.c
@@ -1268,7 +1268,7 @@ static SSL_TICKET_RETURN tls_cache_session_ticket_app_data_get(SSL *ssl, SSL_SES
 	case SSL_TICKET_FATAL_ERR_MALLOC:
 	case SSL_TICKET_FATAL_ERR_OTHER:
 	case SSL_TICKET_NONE:
-#if defined(__clang_analyzer__) || defined(__COVERITY__)
+#ifdef STATIC_ANALYZER
 	default:
 #endif
 		return SSL_TICKET_RETURN_IGNORE_RENEW;	/* Send a new ticket */

--- a/src/lib/tls/verify.c
+++ b/src/lib/tls/verify.c
@@ -243,7 +243,7 @@ int fr_tls_verify_cert_cb(int ok, X509_STORE_CTX *x509_ctx)
 			}
 	     	}
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 		/*
 		 *	Container can never be NULL, because if container
 		 *	was previously NULL, i will be <= depth.

--- a/src/lib/unlang/edit.c
+++ b/src/lib/unlang/edit.c
@@ -279,7 +279,7 @@ static int apply_edits(request_t *request, unlang_frame_state_edit_t *state, map
 
 	fr_assert(state->lhs.vp != NULL);
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!state->lhs.vp) return -1;
 #endif
 
@@ -657,7 +657,7 @@ static unlang_action_t process_edit(rlm_rcode_t *p_result, request_t *request, u
 			goto check_rhs;
 
 		case UNLANG_EDIT_EXPANDED_RHS:
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 			if (!state->lhs.vp) goto error;
 #endif
 

--- a/src/lib/unlang/load_balance.c
+++ b/src/lib/unlang/load_balance.c
@@ -36,7 +36,7 @@ static unlang_action_t unlang_load_balance_next(rlm_rcode_t *p_result, request_t
 	unlang_frame_state_redundant_t	*redundant = talloc_get_type_abort(frame->state, unlang_frame_state_redundant_t);
 	unlang_group_t			*g = unlang_generic_to_group(frame->instruction);
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!redundant->found) {
 		*p_result = RLM_MODULE_FAIL;
 		return UNLANG_ACTION_CALCULATE_RESULT;

--- a/src/lib/unlang/xlat_expr.c
+++ b/src/lib/unlang/xlat_expr.c
@@ -288,7 +288,7 @@ static xlat_action_t xlat_binary_op(TALLOC_CTX *ctx, fr_dcursor_t *out,
 	a = fr_dlist_head(in);
 	b = fr_dlist_next(in, a);
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!a || !b) return XLAT_ACTION_FAIL;
 #else
 	fr_assert(a != NULL);
@@ -2413,7 +2413,7 @@ static ssize_t tokenize_expression(xlat_exp_head_t *head, xlat_exp_t **out, fr_s
 	}
 
 redo:
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!lhs) return 0;	/* shut up stupid analyzer */
 #else
 	fr_assert(lhs != NULL);
@@ -2512,8 +2512,8 @@ redo:
 		talloc_free(lhs);
 		FR_SBUFF_ERROR_RETURN_ADJ(&our_in, slen);
 	}
-	
-#ifdef __clang_analyzer__
+
+#ifdef STATIC_ANALYZER
 	if (!rhs) {
 		talloc_free(lhs);
 		FR_SBUFF_ERROR_RETURN(&our_in);

--- a/src/lib/unlang/xlat_tokenize.c
+++ b/src/lib/unlang/xlat_tokenize.c
@@ -1013,7 +1013,7 @@ static int xlat_tokenize_string(xlat_exp_head_t *head,
 			xlat_exp_set_type(node, XLAT_ONE_LETTER);
 			xlat_exp_set_name_buffer_shallow(node, str);
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 			if (!node->fmt) goto error;
 #endif
 

--- a/src/lib/util/dbuff.c
+++ b/src/lib/util/dbuff.c
@@ -28,7 +28,7 @@ RCSID("$Id$")
 #include <freeradius-devel/util/dbuff.h>
 #include <freeradius-devel/util/syserror.h>
 
-#if defined(__clang_analyzer__) || !defined(NDEBUG)
+#if defined(STATIC_ANALYZER) || !defined(NDEBUG)
 #  define CHECK_DBUFF_INIT(_sbuff)	if (!(_sbuff)->extend && (unlikely(!(_sbuff)->buff) || unlikely(!(_sbuff)->start) || unlikely(!(_sbuff)->end) || unlikely(!(_sbuff)->p))) return 0;
 #else
 #  define CHECK_DBUFF_INIT(_sbuff)

--- a/src/lib/util/debug.h
+++ b/src/lib/util/debug.h
@@ -191,7 +191,7 @@ NEVER_RETURNS void	_fr_exit(char const *file, int line, int status, bool now);
 #  define fr_assert(_x)
 #  define fr_assert_msg(_x, _msg, ...)
 #  define fr_assert_fail(_msg, ...)
-#elif !defined(__clang_analyzer__)
+#elif !defined(STATIC_ANALYZER)
 /** Calls panic_action ifndef NDEBUG, else logs error
  *
  * @param[in] _x	expression to test (should evaluate to true)

--- a/src/lib/util/decode.c
+++ b/src/lib/util/decode.c
@@ -84,7 +84,7 @@ ssize_t fr_pair_raw_from_network(TALLOC_CTX *ctx, fr_pair_list_t *out, fr_dict_a
 	fr_dict_attr_t *unknown;
 	fr_dict_attr_t const *child;
 
-#if defined(__clang_analyzer__) || !defined(NDEBUG)
+#if defined(STATIC_ANALYZER) || !defined(NDEBUG)
 	if (!parent->parent) return -1; /* stupid static analyzers */
 #endif
 

--- a/src/lib/util/dict_tokenize.c
+++ b/src/lib/util/dict_tokenize.c
@@ -831,7 +831,7 @@ static int dict_read_process_attribute(dict_tokenize_ctx_t *ctx, char **argv, in
 	}
 #endif
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!ctx->dict) return -1;
 #endif
 
@@ -1044,7 +1044,7 @@ static int dict_read_process_enum(dict_tokenize_ctx_t *ctx, char **argv, int arg
 	 *	Maybe we do want a flag field for named time deltas?
 	 */
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!ctx->dict) return -1;
 #endif
 
@@ -1136,7 +1136,7 @@ static int dict_read_process_member(dict_tokenize_ctx_t *ctx, char **argv, int a
 		if (!dict_attr_flags_valid(ctx->dict, ctx->stack[ctx->stack_depth].da, argv[2], NULL, type, &flags)) return -1;
 	}
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!ctx->dict) return -1;
 #endif
 
@@ -1675,7 +1675,7 @@ post_option:
 	 */
 	dict = dict_by_protocol_name(argv[0]);
 	if (dict) {
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 		if (!dict->root) return -1;
 #endif
 
@@ -1686,7 +1686,7 @@ post_option:
 		}
 
 	} else if ((dict = dict_by_protocol_num(value)) != NULL) {
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 		if (!dict->root || !dict->root->name || !argv[0]) return -1;
 #endif
 

--- a/src/lib/util/dict_unknown.c
+++ b/src/lib/util/dict_unknown.c
@@ -65,7 +65,7 @@ fr_dict_attr_t const *fr_dict_unknown_add(fr_dict_t *dict, fr_dict_attr_t const 
 			return NULL;
 		}
 	} else {
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 		if (!unknown->parent) return NULL;
 #endif
 		parent = unknown->parent;
@@ -124,7 +124,7 @@ fr_dict_attr_t const *fr_dict_unknown_add(fr_dict_t *dict, fr_dict_attr_t const 
 		return n;
 	}
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!unknown->name) return NULL;
 #endif
 

--- a/src/lib/util/dict_util.c
+++ b/src/lib/util/dict_util.c
@@ -3234,7 +3234,7 @@ static int _dict_free(fr_dict_t *dict)
 		}
 	}
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!dict->root) return -1;
 #endif
 

--- a/src/lib/util/dl.c
+++ b/src/lib/util/dl.c
@@ -126,7 +126,7 @@ static int8_t dl_symbol_init_cmp(void const *one, void const *two)
 
 	if (!a->symbol && !b->symbol) return 0;
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!fr_cond_assert(a->symbol && b->symbol)) return 0;	/* Bug in clang scan ? */
 #endif
 
@@ -149,7 +149,7 @@ static int8_t dl_symbol_free_cmp(void const *one, void const *two)
 
 	if (!a->symbol && !b->symbol) return 0;
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!fr_cond_assert(a->symbol && b->symbol)) return 0;	/* Bug in clang scan ? */
 #endif
 

--- a/src/lib/util/hw.c
+++ b/src/lib/util/hw.c
@@ -93,14 +93,14 @@ uint32_t fr_hw_num_cores_active(void)
 	/*
 	 *	Catch Linux weirdness.
 	 *
-	 *	You'd think this'd be enough to quite clang scan,
+	 *	You'd think this'd be enough to quiet clang scan,
 	 *	but it's not.
 	 */
 	if (unlikely((tsibs == 0) || (lcores == 0) || (lcores > tsibs))) return 1;
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	/*
-	 *	Prevent clang scanner from warning about divide by zero
+	 *	Prevent static analyzer from warning about divide by zero
 	 */
 	if ((tsibs / lcores) == 0) return 1;
 #endif

--- a/src/lib/util/machine.c
+++ b/src/lib/util/machine.c
@@ -234,7 +234,7 @@ fr_machine_t *fr_machine_alloc(TALLOC_CTX *ctx, fr_machine_def_t const *def, voi
 	fr_assert(!m->current->def->exit);
 	fr_assert(m->current->def->process);
 
-#if defined(__clang_analyzer__)
+#ifdef STATIC_ANALYZER
 	if (!m->current || !m->current->def || !m->current->def->process) {
 		talloc_free(m);
 		return NULL;

--- a/src/lib/util/misc.h
+++ b/src/lib/util/misc.h
@@ -85,7 +85,7 @@ void		fr_talloc_verify_cb(const void *ptr, int depth,
  */
 static inline bool is_whitespace(char const *value)
 {
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (*value == '\0') return false;	/* clang analyzer doesn't seem to know what isspace does */
 #endif
 	do {
@@ -127,7 +127,7 @@ static inline bool is_whitespace(char const *value)
  */
 static inline bool is_integer(char const *value)
 {
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (*value == '\0') return false;	/* clang analyzer doesn't seem to know what isdigit does */
 #endif
 	do {

--- a/src/lib/util/pair.c
+++ b/src/lib/util/pair.c
@@ -1618,7 +1618,7 @@ void fr_pair_validate_debug(TALLOC_CTX *ctx, fr_pair_t const *failed[2])
 	fr_pair_aprint(ctx, &value, NULL, list);
 	fr_pair_aprint(ctx, &str, NULL, filter);
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!value || !str) return;
 #endif
 

--- a/src/lib/util/sbuff.c
+++ b/src/lib/util/sbuff.c
@@ -43,7 +43,7 @@ fr_table_num_ordered_t const sbuff_parse_error_table[] = {
 };
 size_t sbuff_parse_error_table_len = NUM_ELEMENTS(sbuff_parse_error_table);
 
-#if defined(__clang_analyzer__) || !defined(NDEBUG)
+#if defined(STATIC_ANALYZER) || !defined(NDEBUG)
 #  define CHECK_SBUFF_INIT(_sbuff)	if (!(_sbuff)->extend && (unlikely(!(_sbuff)->buff) || unlikely(!(_sbuff)->start) || unlikely(!(_sbuff)->end) || unlikely(!(_sbuff)->p))) return 0;
 #else
 #  define CHECK_SBUFF_INIT(_sbuff)

--- a/src/lib/util/sha1.c
+++ b/src/lib/util/sha1.c
@@ -81,7 +81,7 @@ void fr_sha1_transform(uint32_t state[static 5], uint8_t const buffer[static 64]
 	state[3] += d;
 	state[4] += e;
 
-#  ifndef __clang_analyzer__
+#  ifndef STATIC_ANALYZER
 	/* Wipe variables */
 	a = b = c = d = e = 0;
 #  endif
@@ -155,7 +155,7 @@ void fr_sha1_final(uint8_t digest[static SHA1_DIGEST_LENGTH], fr_sha1_ctx *conte
 		digest[i] = (uint8_t)((context->state[i>>2] >> ((3-(i & 3)) * 8) ) & 255);
 	}
 
-#  ifndef __clang_analyzer__
+#  ifndef STATIC_ANALYZER
 	/* Wipe variables */
 	i = j = 0;
 	memset(context->buffer, 0, 64);
@@ -177,7 +177,7 @@ void fr_sha1_final_no_len(uint8_t digest[static SHA1_DIGEST_LENGTH], fr_sha1_ctx
 		digest[i] = (uint8_t)((context->state[i>>2] >> ((3-(i & 3)) * 8) ) & 255);
 	}
 
-#  ifndef __clang_analyzer__
+#  ifndef STATIC_ANALYZER
 	/* Wipe variables */
 	i = j = 0;
 	memset(context->buffer, 0, 64);

--- a/src/lib/util/udpfromto.c
+++ b/src/lib/util/udpfromto.c
@@ -98,10 +98,10 @@ int udpfromto_init(int s)
 	errno = ENOSYS;
 
 	/*
-	 *	Clang analyzer doesn't see that getsockname initialises
+	 *	Static analyzer doesn't see that getsockname initialises
 	 *	the memory passed to it.
 	 */
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	memset(&si, 0, sizeof(si));
 #endif
 
@@ -214,10 +214,10 @@ int recvfromto(int fd, void *buf, size_t len, int flags,
 	}
 
 	/*
-	 *	Clang analyzer doesn't see that getsockname initialises
+	 *	Static analyzer doesn't see that getsockname initialises
 	 *	the memory passed to it.
 	 */
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	memset(&si, 0, sizeof(si));
 #endif
 

--- a/src/lib/util/value.c
+++ b/src/lib/util/value.c
@@ -2811,7 +2811,7 @@ static inline int fr_value_box_cast_integer_to_integer(UNUSED TALLOC_CTX *ctx, f
 #define SIGN_PROMOTE(_int, _len)	((_len) < sizeof(_int) ? \
 					(_int) | (~((__typeof__(_int))0)) << ((_len) << 3) : (_int))
 
-#if !defined(NDEBUG) || defined(__clang_analyzer__)
+#if !defined(NDEBUG) || defined(STATIC_ANALYZER)
 	/*
 	 *	Helps catch invalid fr_value_box_field_sizes
 	 *	entries, and shuts up clang analyzer.

--- a/src/modules/rlm_passwd/rlm_passwd.c
+++ b/src/modules/rlm_passwd/rlm_passwd.c
@@ -581,9 +581,9 @@ static unlang_action_t CC_HINT(nonnull) mod_passwd_map(rlm_rcode_t *p_result, mo
 		/*
 		 *	Ensure we have the string form of the attribute
 		 */
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 		/*
-		 *	clang scan misses that fr_pair_print_value_quoted
+		 *	static analyzer misses that fr_pair_print_value_quoted
 		 *	always terminates the buffer.
 		 */
 		buffer[0] = '\0';

--- a/src/protocols/dhcpv4/decode.c
+++ b/src/protocols/dhcpv4/decode.c
@@ -426,7 +426,7 @@ static ssize_t decode_option(TALLOC_CTX *ctx, fr_pair_list_t *out,
 	fr_dict_attr_t const	*da;
 	fr_dhcpv4_ctx_t		*packet_ctx = decode_ctx;
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!packet_ctx || !packet_ctx->tmp_ctx) return PAIR_DECODE_FATAL_ERROR;
 #endif
 

--- a/src/protocols/dhcpv6/decode.c
+++ b/src/protocols/dhcpv6/decode.c
@@ -304,7 +304,7 @@ static ssize_t decode_option(TALLOC_CTX *ctx, fr_pair_list_t *out,
 	fr_dict_attr_t const	*da;
 	fr_dhcpv6_decode_ctx_t	*packet_ctx = decode_ctx;
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!packet_ctx || !packet_ctx->tmp_ctx) return PAIR_DECODE_FATAL_ERROR;
 #endif
 

--- a/src/protocols/dns/decode.c
+++ b/src/protocols/dns/decode.c
@@ -58,7 +58,7 @@ static ssize_t decode_value_trampoline(TALLOC_CTX *ctx, fr_pair_list_t *out,
 
 		return fr_pair_dns_labels_from_network(ctx, out, parent, packet_ctx->packet, data, data_len, packet_ctx->lb, false);
 	}
-	
+
 	return decode_value(ctx, out, parent, data, data_len, decode_ctx);
 }
 
@@ -181,7 +181,7 @@ static ssize_t decode_option(TALLOC_CTX *ctx, fr_pair_list_t *out,
 	fr_dict_attr_t const	*da;
 	fr_dns_ctx_t		*packet_ctx = decode_ctx;
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!packet_ctx || !packet_ctx->tmp_ctx) return PAIR_DECODE_FATAL_ERROR;
 #endif
 

--- a/src/protocols/radius/decode.c
+++ b/src/protocols/radius/decode.c
@@ -436,7 +436,7 @@ static ssize_t decode_rfc(TALLOC_CTX *ctx, fr_pair_list_t *out,
 	fr_dict_attr_t const	*da;
 	fr_radius_ctx_t		*packet_ctx = decode_ctx;
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!packet_ctx || !packet_ctx->tmp_ctx) return PAIR_DECODE_FATAL_ERROR;
 #endif
 
@@ -658,7 +658,7 @@ ssize_t fr_radius_decode_tlv(TALLOC_CTX *ctx, fr_pair_list_t *out,
 	fr_pair_list_init(&head);
 	if (data_len < 3) return -1; /* type, length, value */
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!packet_ctx->tmp_ctx) return -1;
 #endif
 
@@ -720,7 +720,7 @@ static ssize_t decode_vsa_internal(TALLOC_CTX *ctx, fr_pair_list_t *out,
 	ssize_t			attrlen, my_len;
 	fr_dict_attr_t const	*da;
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!packet_ctx->tmp_ctx) return -1;
 #endif
 
@@ -1004,7 +1004,7 @@ static ssize_t decode_wimax(TALLOC_CTX *ctx, fr_pair_list_t *out,
 	uint8_t	const		*attr, *end;
 	fr_dict_attr_t const	*da;
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!packet_ctx->tmp_ctx) return -1;
 #endif
 
@@ -1244,7 +1244,7 @@ static ssize_t  CC_HINT(nonnull) decode_vsa(TALLOC_CTX *ctx, fr_pair_list_t *out
 
 	fr_pair_list_init(&head);
 
-#ifdef __clang_analyzer__
+#ifdef STATIC_ANALYZER
 	if (!packet_ctx->tmp_ctx) return -1;
 #endif
 


### PR DESCRIPTION
Static analysis doesn't necessarily infer all properties of code
and thus may give false positives. Since we use at least two static
analyzers, clang's and coverity, we define STATIC_ANALYZER if and
only if some static analysis is running, and check it instead of
a macro specific to a particular static analyzer. It's defined,
or not, in src/include/build.h, so that adding a new static
analyzer only requires adding code, not changing it.