### PR TITLE
Annotate uses of read preq pointers in test_demux() (CID #1469174)

### DIFF
--- a/src/lib/server/trunk_tests.c
+++ b/src/lib/server/trunk_tests.c
@@ -120,10 +120,12 @@ static void test_demux(UNUSED fr_event_list_t *el, UNUSED fr_trunk_connection_t 
 			break;		/* Hack - just ignore it */
 
 		case FR_TRUNK_REQUEST_STATE_CANCEL_SENT:
+			/* coverity[tainted_data] */
 			fr_trunk_request_signal_cancel_complete(preq->treq);
 			break;
 
 		case FR_TRUNK_REQUEST_STATE_SENT:
+			/* coverity[tainted_data] */
 			fr_trunk_request_signal_complete(preq->treq);
 			break;
 


### PR DESCRIPTION
Trunk tests are written so that the data sent for mux/demux are
test_proto_request_t * values, which coverity considers tainted.