### PR TITLE
Annotate strcpy() in make_vlog; log_keyword is always short (CID #150…

### DIFF
--- a/scripts/build/log.c
+++ b/scripts/build/log.c
@@ -38,6 +38,7 @@ void _make_vlog(char const *log_keyword, char const *file, int line, char const 
 	char	buffer[256];
 	char	*p = buffer, *end = (p + (sizeof(buffer) - 1));
 
+	/* coverity[fixed_size_dest] */
 	strcpy(p, log_keyword);
 	p += strlen(p);
 	*p++ = ' ';


### PR DESCRIPTION
…3899)

All calls to make_vlog are done via macros that pass one of
"error", "warning", or "info" as log_keyword, all much shorter
than the 256-byte buffer that accumulates the log entry.