### PR TITLE
Don't check a value we know isn't NULL (CID #1503909)

### DIFF
--- a/src/listen/load/proto_load_step.c
+++ b/src/listen/load/proto_load_step.c
@@ -208,7 +208,7 @@ static int mod_open(fr_listen_t *li)
 
 	fr_assert((cf_parent(inst->cs) != NULL) && (cf_parent(cf_parent(inst->cs)) != NULL));	/* listen { ... } */
 
-	thread->name = talloc_typed_asprintf(thread, "load_step from filename %s", inst->filename ? inst->filename : "none");
+	thread->name = talloc_typed_asprintf(thread, "load_step from filename %s", inst->filename);
 	thread->parent = talloc_parent(li);
 
 	return 0;


### PR DESCRIPTION
inst->filename will not be NULL. The check for that (after it's
already been used in open()) makes coverity complain, so we should
have the courage of our convictions.