### PR TITLE
Add missing MEM() guards to fr_value_box_alloc_null() calls

### DIFF
--- a/src/lib/unlang/xlat_builtin.c
+++ b/src/lib/unlang/xlat_builtin.c
@@ -1003,7 +1003,7 @@ static void debug_attr_vp(request_t *request, fr_pair_t *vp, tmpl_t const *vpt)
 		REXDENT();
 		RIDEBUG2("}");
 		break;
-		
+
 	default:
 		if (vpt) {
 			RIDEBUG2("&%s.%s = %pV",
@@ -1054,7 +1054,7 @@ static void debug_attr_vp(request_t *request, fr_pair_t *vp, tmpl_t const *vpt)
 			break;
 		}
 
-		dst = fr_value_box_alloc_null(vp);
+		MEM(dst = fr_value_box_alloc_null(vp));
 		/* We expect some to fail */
 		if (fr_value_box_cast(dst, dst, type->value, NULL, &vp->data) < 0) {
 			goto next_type;

--- a/src/modules/rlm_unbound/rlm_unbound.c
+++ b/src/modules/rlm_unbound/rlm_unbound.c
@@ -217,7 +217,7 @@ static void xlat_unbound_callback(void *mydata, int rcode, void *packet, int pac
 					REDEBUG("%s - Invalid data returned", ur->t->inst->name);
 					goto error;
 				}
-				priority_vb = fr_value_box_alloc_null(ur->out_ctx);
+				MEM(priority_vb = fr_value_box_alloc_null(ur->out_ctx));
 				if (fr_value_box_from_network(ur->out_ctx, priority_vb, FR_TYPE_UINT16, NULL,
 							      &dbuff, 2, true) < 0) {
 					talloc_free(priority_vb);


### PR DESCRIPTION
One, in debug_attr_vp(), will silence CID #1507353. The
other is not associated with a coveriy issue, but should
be there. With this change, all fr_value_box_alloc_null()
call returns will either be checked by MEM() or have an
explicit check in the code.