### PR TITLE
Constrain rcodes mapped to eap codes (CID #1503933)

### DIFF
--- a/src/lib/eap_aka_sim/module.c
+++ b/src/lib/eap_aka_sim/module.c
@@ -91,6 +91,8 @@ static unlang_action_t mod_encode(rlm_rcode_t *p_result, module_ctx_t const *mct
 		return UNLANG_ACTION_CALCULATE_RESULT;
 	}
 
+	fr_assert(rcode < RLM_MODULE_NUMCODES);
+
 	/*
 	 *	If there is a subtype vp, verify the return
 	 *	code allows us send EAP-SIM/AKA/AKA' data back.


### PR DESCRIPTION
Coverity notices that there are rlm_rcode_t values that
exceed the bounds on rcode_to_eap_code[].