### PR TITLE
Correct error check on fr_base16_decode() for octets (CID #1503992)

### DIFF
--- a/src/lib/util/value.c
+++ b/src/lib/util/value.c
@@ -4716,9 +4716,7 @@ parse:
 		 */
 		fr_sbuff_set(&our_in, &hex_start);
 
-		if (unlikely(fr_base16_decode(NULL,
-					      &FR_DBUFF_TMP(bin_buff, hex_len),
-					      &our_in, false) != (ssize_t)ret) < 0) {
+		if (unlikely(fr_base16_decode(NULL, &FR_DBUFF_TMP(bin_buff, hex_len), &our_in, false) < 0)) {
 			talloc_free(bin_buff);
 			return fr_sbuff_error(&our_in);
 		}


### PR DESCRIPTION
network_max_size() returns ~0 for octets, which when stored in ret,
a ssize_t, becomes -1. (Presumably this reflects that its max length
can vary.) Thus it makes no sense for it to appear in the test of
fr_base16_decode()'s return value.