### PR TITLE
Don't do EV_SET for fr_event_fd_noop

### DIFF
--- a/src/lib/util/event.c
+++ b/src/lib/util/event.c
@@ -690,7 +690,7 @@ static ssize_t fr_event_build_evset(
 			}
 
 			new_func = *(fr_event_fd_cb_t const *)((uint8_t const *)new + map->offset);
-			if (new_func) {
+			if (new_func && (new_func != fr_event_fd_noop)) {
 				EVENT_DEBUG("\t%s curr set (%p)", map->name, new_func);
 				current_fflags |= map->fflags;
 				has_current_func = true;


### PR DESCRIPTION
When `fr_network_suspend()` is called and subsequently `fr_event_filter_update(socket->nr->el, socket->listen->fd, FR_EVENT_FILTER_IO, pause_read);`, `ef->active`  may contain `fr_event_fd_noop` as write handler and `EVFILT_WRITE` kevent is added so network thread starts to consume 100% CPU while radiusd is idle because network socket is always ready for writing and `fr_event_fd_noop` gets called in a loop.