### PR TITLE
Attempt to fix LDAP query cancellation issues

### DIFF
--- a/src/lib/server/trunk.c
+++ b/src/lib/server/trunk.c
@@ -1434,7 +1434,6 @@ static void trunk_request_enter_cancel_complete(fr_trunk_request_t *treq)
 	switch (treq->pub.state) {
 	case FR_TRUNK_REQUEST_STATE_CANCEL_SENT:
 	case FR_TRUNK_REQUEST_STATE_CANCEL:
-		REQUEST_EXTRACT_CANCEL_SENT(treq);
 		break;
 
 	default:


### PR DESCRIPTION
See https://github.com/FreeRADIUS/freeradius-server/issues/4598#issuecomment-1192615161

1) fr_ldap_trunk_search(): revert rev. 2a47fc01ba326431171eb1e53d64d0c009facf44
which causes fr_trunk_request_signal_cancel() to be called twice for some queries
(from _ldap_search_sync_timeout() and ldap_trunk_query_cancel()

2) ldap_trunk_query_cancel(): ignore query->treq == NULL:
query->treq can be NULL for completed queries

3) fr_ldap_trunk_search(), fr_ldap_trunk_modify(): use ttrunk->trunk talloc
context for LDAP queries - the same lifetime as for fr_trunk_request_t,
otherwise queries are free'd when stack frames are freed in frame_cleanup()
and ldap_request_cancel_mux() later on gets treq with free'd treq->preq

4) fr_trunk_request_signal_cancel_complete(): handle treq in
FR_TRUNK_REQUEST_STATE_CANCEL_PARTIAL and FR_TRUNK_REQUEST_STATE_CANCEL,
otherwise ldap_request_cancel_mux() loops on the same treq if this treq
was previously cancelled by fr_trunk_request_signal_cancel() and entered
FR_TRUNK_REQUEST_STATE_CANCEL state