### PR TITLE
Annotate false positive (CID #1506689)

### DIFF
--- a/src/lib/redis/redis.c
+++ b/src/lib/redis/redis.c
@@ -470,6 +470,7 @@ int fr_redis_tuple_from_map(TALLOC_CTX *pool, char const *out[], size_t out_len[
 		return -1;
 	}
 	key_len = (size_t)slen;
+	/* coverity[uninit_use_in_call] */
 	key = talloc_bstrndup(pool, key_buf, key_len);
 	if (!key) return -1;
 


### PR DESCRIPTION
fr_redis_tuple_from_map() does check for error return from
tmpl_print(), so by the time talloc_bstrndup() is called,
key_buf should be initialized.