### PR TITLE
Try to make coverity see annotations in SBUFF_PARSE_*INT_DEF()

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -67,7 +67,7 @@ jobs:
           export PATH=`pwd`/coverity_tool/bin:$PATH
           ./configure -with-rlm-python-bin=/usr/bin/python2.7
           cov-configure --template --compiler clang --comptype clangcc
-          cov-build --dir cov-int make
+          cov-build --dir cov-int make --preprocess-first
 
       - name: Display build result
         run: |


### PR DESCRIPTION
I asked whether coverity sees annotations in invocations of
macro definitions containing annotations, and got the suggestion
to add the "--preprocess-first" option to the cov-build command,
and if it made no difference, submit a support case with more info.