### PR TITLE
Don't assign uninitialized data (CID #1503898, #1503965)

### DIFF
--- a/src/lib/redis/cluster.c
+++ b/src/lib/redis/cluster.c
@@ -625,7 +625,8 @@ do { \
 			return rcode;
 		}
 
-		spare->pending_addr = find.addr;
+		spare->pending_addr.inet.dst_ipaddr = find.addr.inet.dst_ipaddr;
+		spare->pending_addr.inet.dst_port = find.addr.inet.dst_port;
 		rcode = cluster_node_connect(cluster, spare);
 		if (rcode < 0) goto error;
 
@@ -660,7 +661,8 @@ do { \
 			spare = fr_fifo_peek(cluster->free_nodes);
 			if (!spare) goto out_of_nodes;
 
-			spare->pending_addr = find.addr;
+			spare->pending_addr.inet.dst_ipaddr = find.addr.inet.dst_ipaddr;
+			spare->pending_addr.inet.dst_port = find.addr.inet.dst_port;
 			if (cluster_node_connect(cluster, spare) < 0) continue;	/* Slave failure is non-fatal */
 
 			SET_ACTIVE(spare);
@@ -2053,7 +2055,8 @@ int fr_redis_cluster_pool_by_node_addr(fr_pool_t **pool, fr_redis_cluster_t *clu
 			pthread_mutex_unlock(&cluster->mutex);
 			return -1;
 		}
-		spare->pending_addr = find.addr;	/* Set the config to be applied */
+		spare->pending_addr.inet.dst_ipaddr = find.addr.inet.dst_ipaddr;	/* Set the config to be applied */
+		spare->pending_addr.inet.dst_port = find.addr.inet.dst_port;
 		if (cluster_node_connect(cluster, spare) < 0) {
 			pthread_mutex_unlock(&cluster->mutex);
 			return -1;


### PR DESCRIPTION
In fr_redis_cluster_pool_by_node_addr() and cluster_map_apply(),
a local fr_redis_cluster_node_t only has a couple of fields set
(namely addr.inet.dsp_{ipaddr, port, presumably the minimum
needed for cluster->used_nodes's comparison function in fr_rb_find().
Later, in some cases the whole addr is assigned to the addr field
of another fr_redis_cluster_node_t, and other than those two fields,
that puts random data in the rest of the addr. Coverity rightly
notices this, so we just assign those fields that were assigned to.