### PR TITLE
missing_lock, not missing_unlock (CID #1414431)

### DIFF
--- a/src/lib/server/exfile.c
+++ b/src/lib/server/exfile.c
@@ -508,7 +508,6 @@ try_lock:
 
 	exfile_trigger_exec(ef, &ef->entries[i], "reserve");
 
-	/* coverity[missing_unlock] */
 	return ef->entries[i].fd;
 }
 

--- a/src/lib/server/pool.c
+++ b/src/lib/server/pool.c
@@ -295,7 +295,6 @@ static fr_pool_connection_t *connection_find(fr_pool_t *pool, void *conn)
 #endif
 
 			fr_assert(this->in_use == true);
-			/* coverity[missing_unlock] */
 			return this;
 		}
 	}
@@ -518,7 +517,6 @@ static fr_pool_connection_t *connection_spawn(fr_pool_t *pool, request_t *reques
 	pthread_cond_broadcast(&pool->done_spawn);
 	if (unlock) pthread_mutex_unlock(&pool->mutex);
 
-	/* coverity[missing_unlock] */
 	return this;
 }
 
@@ -1051,7 +1049,7 @@ fr_pool_t *fr_pool_init(TALLOC_CTX *ctx,
 		goto error;
 	}
 
-	/* coverity[missing_unlock] */
+	/* coverity[missing_lock] */
 	pool->pending_window = (pool->max_pending > 0) ? pool->max_pending : pool->max;
 
 	if (pool->min > pool->max) {

--- a/src/modules/rlm_detail/rlm_detail.c
+++ b/src/modules/rlm_detail/rlm_detail.c
@@ -379,7 +379,6 @@ static unlang_action_t CC_HINT(nonnull) detail_do(rlm_rcode_t *p_result, module_
 	outfd = exfile_open(inst->ef, buffer, inst->perm);
 	if (outfd < 0) {
 		RPERROR("Couldn't open file %s", buffer);
-		/* coverity[missing_unlock] */
 		RETURN_MODULE_FAIL;
 	}
 

--- a/src/modules/rlm_linelog/rlm_linelog.c
+++ b/src/modules/rlm_linelog/rlm_linelog.c
@@ -782,7 +782,6 @@ finish:
 	talloc_free(vpt);
 	talloc_free(vector);
 
-	/* coverity[missing_unlock] */
 	RETURN_MODULE_RCODE(rcode);
 }
 

--- a/src/modules/rlm_sql/sql.c
+++ b/src/modules/rlm_sql/sql.c
@@ -612,7 +612,6 @@ void rlm_sql_query_log(rlm_sql_t const *inst, request_t *request, sql_acct_secti
 		ERROR("Couldn't open logfile '%s': %s", expanded, fr_syserror(errno));
 
 		talloc_free(expanded);
-		/* coverity[missing_unlock] */
 		return;
 	}
 


### PR DESCRIPTION
Typo in coverity annotation.
This occurs in several files, but the defect only occurs in
src/lib/server/pool.c, so ultimately it would be worth pulling
the others; no need to have unnecessary annotations.