### PR TITLE
Annotate false positive reverse negative (CID #720487)

### DIFF
--- a/src/listen/control/radmin.c
+++ b/src/listen/control/radmin.c
@@ -1116,6 +1116,7 @@ int main(int argc, char **argv)
 	/*
 	 *	Run commands from the command-line.
 	 */
+	/* coverity[check_after_sink] */
 	if (num_commands >= 0) {
 		int i;
 


### PR DESCRIPTION
coverity flags the check whether there are commands to run
with the comment "You might be using variable num_commands
before verifying that it is >=0."