### PR TITLE
Annotate false positive in fr_dict_attr_verify() (CID #1504052)

### DIFF
--- a/src/lib/util/dict_util.c
+++ b/src/lib/util/dict_util.c
@@ -4172,6 +4172,7 @@ void fr_dict_attr_verify(char const *file, int line, fr_dict_attr_t const *da)
 		/*
 		 *	Check the namespace hash table is ok
 		 */
+		/* coverity[dereference] */
 		fr_hash_table_verify(dict_attr_namespace(da));
 	}
 		break;


### PR DESCRIPTION
The preceding fr_assert_msg() should keep attributes without
namespaces from reaching the dict_attr_namespace() call, so it
should never return NULL... but coverity doesn't know that.