### PR TITLE
Annotate false positive in fr_dbuff_init() (CIDs listed below)

### DIFF
--- a/src/lib/util/dbuff.h
+++ b/src/lib/util/dbuff.h
@@ -348,6 +348,7 @@ static inline CC_HINT(nonnull) void _fr_dbuff_init(fr_dbuff_t *out, uint8_t cons
  *				of the buffer we're deconding.
  */
 #define fr_dbuff_init(_out, _start, _len_or_end) \
+/* coverity[overrun-local] */ \
 _fr_dbuff_init(_out, \
 	       (uint8_t const *)(_start), \
 	       _Generic((_len_or_end), \


### PR DESCRIPTION
The end pointer is set to point just past the space given to it.
This is legal in C, and is only compared with, not dereferenced.

CIDs affected:
1503895, 1503905, 1503907, 1503914, 1503915, 1503924, 1503956,
1503970, 1503973, 1503979, 1503980, 1503988, 1504000, 1504034,
1504035, 1504039, 1504040, 1504046, 1504059

Yes, this is an annotation inside a macro, but if it works (it's not in the
middle of control flow like the SBUFF_PARSE_[U]INT_DEF macros)
we've learned something; if not we've lost nothing.