### PR TITLE
Annotate false positive alloc_strlen issues (CIDs listed below)

### DIFF
--- a/src/lib/util/pair_legacy_tests.c
+++ b/src/lib/util/pair_legacy_tests.c
@@ -132,6 +132,7 @@ static void test_fr_pair_list_afrom_file(void)
 	fr_pair_t      *vp;
 	fr_pair_list_t list;
 	char const     *buffer = "Test-Uint32-0 = 123\nTest-String-0 = \"Testing123\"\n";
+	/* coverity[alloc_strlen] */
 	FILE           *fp = open_buffer_as_file(buffer, strlen(buffer));
 	bool           pfiledone;
 
@@ -169,6 +170,7 @@ static void test_fr_pair_list_move_op(void)
 	fr_pair_list_t old_list, new_list;
 	bool           pfiledone;
 	char const     *fake_file = "Test-Uint32-0 = 123\nTest-String-0 = \"Testing123\"\n";
+	/* coverity[alloc_strlen] */
 	FILE           *fp = open_buffer_as_file(fake_file, strlen(fake_file));
 
 	fr_pair_list_init(&old_list);

--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -2165,6 +2165,7 @@ size_t rest_uri_escape(UNUSED request_t *request, char *out, size_t outlen, char
 {
 	char *escaped;
 
+	/* coverity[alloc_strlen] */
 	escaped = curl_escape(raw, strlen(raw));
 	strlcpy(out, escaped, outlen);
 	curl_free(escaped);


### PR DESCRIPTION
1503922, 1503986
         Honest, you don't want the NUL terminator in the
         FILE open_buffer_as_file() (or more accurately,
         fmemopen()) creates.
1503983
         curl_escape() call; if you pass 0 for length, the
         function itself will call strlen() to determine length.