### PR TITLE
Annotate false positives of using uninitalized variables (CIDs below)

### DIFF
--- a/src/lib/util/calc.c
+++ b/src/lib/util/calc.c
@@ -919,7 +919,9 @@ static int calc_octets(TALLOC_CTX *ctx, fr_value_box_t *dst, fr_value_box_t cons
 		return ERR_INVALID;	/* invalid operator */
 	}
 
+	/* coverity[uninit_use_in_call] */
 	if (a == &one) fr_value_box_clear_value(&one);
+	/* coverity[uninit_use_in_call] */
 	if (b == &two) fr_value_box_clear_value(&two);
 
 	return 0;
@@ -1019,7 +1021,9 @@ static int calc_string(TALLOC_CTX *ctx, fr_value_box_t *dst, fr_value_box_t cons
 		return ERR_INVALID;	/* invalid operator */
 	}
 
+	/* coverity[uninit_use_in_call] */
 	if (a == &one) fr_value_box_clear_value(&one);
+	/* coverity[uninit_use_in_call] */
 	if (b == &two) fr_value_box_clear_value(&two);
 
 	return 0;


### PR DESCRIPTION
CIDs: #1503917, #1503948, #1503959, #1503989

After the smoke clears, it turns out that (a == &one) is true
iff one was initialized and (b == &two) is true iff two was
initialized, so they're passed to fr_value_box_clear_value()
iff it makes sense.