### PR TITLE
Correct check for no extension in check_library_exists()

### DIFF
--- a/scripts/jlibtool.c
+++ b/scripts/jlibtool.c
@@ -1533,7 +1533,7 @@ static char *check_library_exists(command_t *cmd, char const *arg, int pathlen,
 
 	strcpy(newarg + newpathlen, arg + pathlen);
 	ext = strrchr(newarg, '.');
-	if (!ext) {
+	if (!ext || ext == newarg) {
 		ERROR("Error: Library path does not have an extension\n");
 		free(newarg);
 


### PR DESCRIPTION
If libdircheck is true, add_dotlibs() will put .lib/ at the
start of newarg so that ext will never be NULL.