### PR TITLE
Make memmove() copy terminating NUL in add_dotlibs()

### DIFF
--- a/scripts/jlibtool.c
+++ b/scripts/jlibtool.c
@@ -1417,7 +1417,7 @@ static void add_dotlibs(char *buffer)
 	} else {
 		name++;
 	}
-	memmove(name + 6, name, strlen(name));
+	memmove(name + 6, name, strlen(name) + 1);
 	memcpy(name, ".libs/", 6);
 }
 


### PR DESCRIPTION
To end up with buffer holding a proper NUL-terminated
string in the common cases, memmove() must move the
name string and its terminating NUL. This may be the
cause underlying CID #1504058, so that it won't need
an annotation...or not.