### PR TITLE
Annotate false positive in use of fr_base16_encode() result (CID #150…

### DIFF
--- a/src/bin/radsniff.c
+++ b/src/bin/radsniff.c
@@ -470,6 +470,7 @@ static void rs_packet_print_fancy(uint64_t count, rs_status_t status, fr_pcap_t 
 
 			fr_base16_encode(&FR_SBUFF_OUT(vector, sizeof(vector)),
 					 &FR_DBUFF_TMP(packet->vector, RADIUS_AUTH_VECTOR_LENGTH));
+			/* coverity[uninit_use_in_call] */
 			INFO("\tAuthenticator-Field = 0x%s", vector);
 		}
 	}


### PR DESCRIPTION
…3918)

fr_base16_encode() always puts something in the buffer, if only a NUL
terminator, but coverity doesn't notice, hence the annotation.