### PR TITLE
Annotate uses of buffers that really are initialized (CIDs listed below)

### DIFF
--- a/src/bin/radsniff.c
+++ b/src/bin/radsniff.c
@@ -470,6 +470,7 @@ static void rs_packet_print_fancy(uint64_t count, rs_status_t status, fr_pcap_t 
 
 			fr_base16_encode(&FR_SBUFF_OUT(vector, sizeof(vector)),
 					 &FR_DBUFF_TMP(packet->vector, RADIUS_AUTH_VECTOR_LENGTH));
+			/* coverity[uninit_use_in_call] */
 			INFO("\tAuthenticator-Field = 0x%s", vector);
 		}
 	}

--- a/src/lib/util/sbuff_tests.c
+++ b/src/lib/util/sbuff_tests.c
@@ -137,6 +137,7 @@ static void test_bstrncpy(void)
 	TEST_CASE("Copy 5 bytes to out");
 	slen = fr_sbuff_out_bstrncpy(&FR_SBUFF_OUT(out, sizeof(out)), &sbuff, 5);
 	TEST_CHECK_SLEN(slen, 5);
+	/* coverity[uninit_use_in_call] */
 	TEST_CHECK_STRCMP(out, "i am ");
 	TEST_CHECK_STRCMP(sbuff.p, "a test string");
 
@@ -212,6 +213,7 @@ static void test_bstrncpy_allowed(void)
 	TEST_CASE("Copy 5 bytes to out");
 	slen = fr_sbuff_out_bstrncpy_allowed(&FR_SBUFF_OUT(out, sizeof(out)), &sbuff, 5, allow_lowercase_and_space);
 	TEST_CHECK_SLEN(slen, 5);
+	/* coverity[uninit_use_in_call] */
 	TEST_CHECK_STRCMP(out, "i am ");
 	TEST_CHECK_STRCMP(sbuff.p, "a test string");
 
@@ -300,6 +302,7 @@ static void test_bstrncpy_until(void)
 	TEST_CASE("Copy 5 bytes to out");
 	slen = fr_sbuff_out_bstrncpy_until(&FR_SBUFF_OUT(out, sizeof(out)), &sbuff, 5, NULL, NULL);
 	TEST_CHECK_SLEN(slen, 5);
+	/* coverity[uninit_use_in_call] */
 	TEST_CHECK_STRCMP(out, "i am ");
 	TEST_CHECK_STRCMP(sbuff.p, "a test string");
 
@@ -571,6 +574,7 @@ static void test_unescape_until(void)
 		slen = fr_sbuff_out_unescape_until(&FR_SBUFF_OUT(tmp_out, sizeof(tmp_out)), &sbuff, SIZE_MAX,
 						   &FR_SBUFF_TERM("g"), &pipe_rules_both);
 		TEST_CHECK_SLEN(slen, 26);
+		/* coverity[uninit_use_in_call] */
 		TEST_CHECK_STRCMP(tmp_out, "i |x|0am a |t|est strinh  ");
 		TEST_CHECK_STRCMP(sbuff.p, "");
 	}
@@ -685,6 +689,7 @@ static void test_unescape_multi_char_terminals(void)
 
 	slen = fr_sbuff_out_bstrncpy_until(&FR_SBUFF_OUT(out, sizeof(out)), &sbuff, SIZE_MAX, &tt, NULL);
 	TEST_CHECK(slen == 3);
+	/* coverity[uninit_use_in_call] */
 	TEST_CHECK_STRCMP(out, "foo");
 
 	fr_sbuff_advance(&sbuff, 1);
@@ -724,6 +729,7 @@ static void test_eof_terminal(void)
 
 	slen = fr_sbuff_out_bstrncpy_until(&FR_SBUFF_OUT(out, sizeof(out)), &sbuff, SIZE_MAX, &tt_eof, NULL);
 	TEST_CHECK(slen == 4);
+	/* coverity[uninit_use_in_call] */
 	TEST_CHECK_STRCMP(out, " bar");
 
 	TEST_CHECK(fr_sbuff_is_terminal(&sbuff, &tt_eof) == true);
@@ -807,6 +813,7 @@ static void test_no_advance(void)
 	TEST_CHECK(sbuff.p == sbuff.start);
 	slen = fr_sbuff_out_bstrncpy_exact(&FR_SBUFF_OUT(out, sizeof(out)), &FR_SBUFF(&sbuff), 5);
 	TEST_CHECK(slen == 5);
+	/* coverity[uninit_use_in_call] */
 	TEST_CHECK(strcmp(out, "i am ") == 0);
 	TEST_CHECK(sbuff.p == sbuff.start);
 }


### PR DESCRIPTION
Declaring a local buffer and passing the address of a temporary
sbuff created to use it is a common idiom, but coverity doesn't
recognize when the functions called always put something in the
buffer, if only a NUL terminator. We therefore annotate the first
use of such buffers.

CIDs affected:
1503918, 1503925,153930, 1503945, 1503966, 1504019, 1504053,
1504067