### PR TITLE
Adapt jlibtool to work with BIND's build system

### DIFF
--- a/scripts/jlibtool.c
+++ b/scripts/jlibtool.c
@@ -2014,9 +2014,10 @@ static int parse_input_file_name(char const *arg, command_t *cmd)
 			 *	directory, not the .la file itself.
 			 *	Otherwise, we'll do odd things.
 			 */
-			if (cmd->output == OUT_LIB) {
+			if (cmd->output == OUT_LIB && pathlen > 0) {
 				char *tmp = lt_strdup(arg);
 				tmp[pathlen] = '\0';
+				DEBUG("Adding: %s\n", tmp);
 				push_count_chars(cmd->arglist, tmp);
 			} else {
 				cmd->output = OUT_LIB;

--- a/scripts/jlibtool.c
+++ b/scripts/jlibtool.c
@@ -2969,7 +2969,7 @@ static void parse_args(int argc, char *argv[], command_t *cmd)
 					push_count_chars(cmd->arglist, arg);
 					arg = argv[++a];
 
-					NOTICE(" %s\n", arg);
+					DEBUG("Adding: %s\n", arg);
 
 					push_count_chars(cmd->arglist, arg);
 					arg_used = 1;

--- a/scripts/jlibtool.c
+++ b/scripts/jlibtool.c
@@ -2344,6 +2344,9 @@ static void link_fixup(command_t *cmd)
 		if (cmd->options.shared == SHARE_SHARED) {
 			cmd->install_path = LIBDIR;
 		}
+		if (cmd->output == OUT_LIB) {
+			cmd->output = OUT_STATIC_LIB_ONLY;
+		}
 	}
 
 	if (cmd->output == OUT_DYNAMIC_LIB_ONLY ||

--- a/scripts/jlibtool.c
+++ b/scripts/jlibtool.c
@@ -1166,6 +1166,8 @@ static int parse_long_opt(char const *arg, command_t *cmd)
 		print_config(value);
 
 		exit(0);
+	} else if (strcmp(var, "tag") == 0) {
+		DEBUG("discard --tag=%s\n", value);
 	} else {
 		return 0;
 	}


### PR DESCRIPTION
Greetings! Especially to whoever drives your twitter account and responded to my wittering over there :-)

I thought it might be worth trying to use jlibtool to make BIND build faster. I got it to work with a bit of hacking. On my MacBook Pro M1 Pro (_sic_) it reduces the time of `make -j all` (after `make clean`) from 22.1s to 16.8s. It fairly consistently saves about 5s, to build about 460 `.c` files. (BIND and FreeRADIUS are remarkably similar in size.) A 20+% speedup is pretty nice, thanks for maintaining jlibtool!

BIND's build system was revamped a few years ago to use autotools in modern style, so I guess that other autotools builds could also benefit from these patches since my test case is not too idiosyncratic. Some of these patches are incidental cleanups that I found on the way.

The main changes here are

  * discard the `--tag` option instead of passing it through
  * relax the library version number format
  * spawn commands directly instead of via the shell (saves me about 0.5s)
  * do not try to link a shared library when jlibtool is not given a `-rpath` option

That last change is the one I am least sure about. There's a fair amount of Mac-related shenanigans in `link_fixup()` which I tripped over, but the change I settled on is not specific to MacOS. However I am not sure if it is cromulent to change `cmd->output` at a relatively late stage, or if jlibtool should have made a different decision earlier.

Anyway, I hope these changes are OK; let me know if I need to change or improve anything!