### PR TITLE
Annotate uses of buffer after fr_base16_decode() (CIDs below)

### DIFF
--- a/src/lib/server/tmpl_tokenize.c
+++ b/src/lib/server/tmpl_tokenize.c
@@ -2691,6 +2691,7 @@ static ssize_t tmpl_afrom_ether_substr(TALLOC_CTX *ctx, tmpl_t **out, fr_sbuff_t
 	vb = tmpl_value(vpt);
 
 	fr_value_box_init(vb, FR_TYPE_ETHERNET, NULL, false);
+	/* coverity[uninit_use_in_call] */
 	memcpy(vb->vb_ether, buff, sizeof(vb->vb_ether));
 
 	*out = vpt;

--- a/src/modules/rlm_pap/rlm_pap.c
+++ b/src/modules/rlm_pap/rlm_pap.c
@@ -788,6 +788,7 @@ static unlang_action_t CC_HINT(nonnull) pap_auth_lm(rlm_rcode_t *p_result,
 	len = xlat_eval(charbuf, sizeof(charbuf), request, "%(mschap:LM-Hash %{User-Password})", NULL, NULL);
 	if (len < 0) RETURN_MODULE_FAIL;
 
+	/* coverity[uninit_use_in_call] */
 	if ((fr_base16_decode(NULL, &FR_DBUFF_TMP(digest, sizeof(digest)), &FR_SBUFF_IN(charbuf, len), false) !=
 	     (ssize_t)known_good->vp_length) ||
 	    (fr_digest_cmp(digest, known_good->vp_octets, known_good->vp_length) != 0)) {
@@ -853,6 +854,7 @@ static unlang_action_t CC_HINT(nonnull) pap_auth_ns_mta_md5(rlm_rcode_t *p_resul
 		fr_md5_calc(buff, (uint8_t *) buff2, p - buff2);
 	}
 
+	/* coverity[uninit_use_in_call] */
 	if (fr_digest_cmp(digest, buff, 16) != 0) {
 		REDEBUG("NS-MTA-MD5 digest does not match \"known good\" digest");
 		RETURN_MODULE_REJECT;


### PR DESCRIPTION
Coverity doesn't recognize that fr_base16_decode() fills in
the output buffer passed to it. (In CID 1503958, coverity
objects to the fr_base16_decode() call itself.)

CIDs: 150466, 1503958, 1504041