### PR TITLE
Annotate false positive on NUL termination (CID #1504058)

### DIFF
--- a/scripts/jlibtool.c
+++ b/scripts/jlibtool.c
@@ -2005,6 +2005,7 @@ static int parse_input_file_name(char const *arg, command_t *cmd)
 			 */
 			if (target->add_minus_l) {
 				if (libtype == TYPE_DYNAMIC_LIB) {
+					/* coverity[string_null] */
 					add_minus_l(cmd->shared_opts.dependencies, newarg);
 				} else if ((cmd->output == OUT_LIB) && (libtype == TYPE_STATIC_LIB)) {
 					explode_static_lib(cmd, newarg);


### PR DESCRIPTION
Coverity is faked out by check_library_exists(), which either
returns NULL (which the caller checks for) or returns a pointer
to a NUL-terminated string.