### PR TITLE
Annotate false positive tainted_data on get_chunk() result (CIDs below)

### DIFF
--- a/src/lib/util/trie.c
+++ b/src/lib/util/trie.c
@@ -1146,6 +1146,7 @@ static void *trie_node_match(fr_trie_t *trie, uint8_t const *key, int start_bit,
 	fr_trie_node_t *node = (fr_trie_node_t *) trie;
 
 	chunk = get_chunk(key, start_bit, node->bits);
+	/* coverity[tainted_data] */
 	if (!node->trie[chunk]) {
 		MPRINT2("no match for node chunk %02x at %d\n", chunk, __LINE__);
 		return NULL;
@@ -1383,6 +1384,7 @@ static int trie_node_insert(TALLOC_CTX *ctx, fr_trie_t **trie_p, uint8_t const *
 	 *	No existing trie, create a brand new trie from
 	 *	the key.
 	 */
+	/* coverity[tainted_data] */
 	if (!node->trie[chunk]) {
 		node->trie[chunk] = trie_key_alloc(ctx, key, start_bit + node->bits, end_bit, data);
 		if (!node->trie[chunk]) {
@@ -1937,6 +1939,7 @@ static void *trie_node_remove(TALLOC_CTX *ctx, fr_trie_t **trie_p, uint8_t const
 	void *data;
 
 	chunk = get_chunk(key, start_bit, node->bits);
+	/* coverity[tainted_data] */
 	if (!node->trie[chunk]) return NULL;
 
 	data = trie_key_remove(ctx, &node->trie[chunk], key, start_bit + node->bits, end_bit);


### PR DESCRIPTION
coverity doesn't realize the relation between node->bits and the
allocated space for node->trie.

CIDs: #1503960, #1503982, #1504064