### PR TITLE
Attempt to quiet coverity on fr_value_box_t assignments (CIDs follow)

### DIFF
--- a/src/lib/eap_aka_sim/decode.c
+++ b/src/lib/eap_aka_sim/decode.c
@@ -802,7 +802,7 @@ static ssize_t sim_decode_pair_value(TALLOC_CTX *ctx, fr_pair_list_t *out, fr_di
 		break;
 
 	case FR_TYPE_UINT16:
-		memcpy(&vp->vp_uint16, p, sizeof(vp->vp_uint16));
+		memcpy((void *) &vp->vp_uint16, p, sizeof(vp->vp_uint16));
 		vp->vp_uint16 = ntohs(vp->vp_uint32);
 		break;
 

--- a/src/lib/redis/redis.c
+++ b/src/lib/redis/redis.c
@@ -210,7 +210,7 @@ int fr_redis_reply_to_value_box(TALLOC_CTX *ctx, fr_value_box_t *out, redisReply
 	fr_value_box_t	*to_cast;
 
 	if (dst_type != FR_TYPE_VOID) {
-		memset(&in, 0, sizeof(in));
+		memset((void *) &in, 0, sizeof(in));
 		to_cast = &in;
 	} else {
 		to_cast = out;

--- a/src/lib/server/snmp.c
+++ b/src/lib/server/snmp.c
@@ -778,9 +778,7 @@ static ssize_t snmp_process_leaf(fr_dcursor_t *out, request_t *request,
 
 	case FR_FREERADIUS_SNMP_OPERATION_VALUE_GET:
 	{
-		fr_value_box_t data;
-
-		memset(&data, 0, sizeof(data));
+		fr_value_box_t data = {};
 
 		/*
 		 *	Verify map is a leaf

--- a/src/lib/server/tmpl_eval.c
+++ b/src/lib/server/tmpl_eval.c
@@ -864,7 +864,7 @@ ssize_t _tmpl_to_atype(TALLOC_CTX *ctx, void *out,
 		default:
 			break;
 		}
-		memcpy(&from_cast, to_cast, sizeof(from_cast));
+		memcpy((void *) &from_cast, to_cast, sizeof(from_cast));
 	}
 
 	RDEBUG4("Copying %zu bytes to %p from offset %zu",
@@ -1467,7 +1467,7 @@ done:
 	};
 
 	fr_dlist_move(out, &list);
-	return 0;		
+	return 0;
 }
 
 

--- a/src/lib/util/value.h
+++ b/src/lib/util/value.h
@@ -442,7 +442,7 @@ void fr_value_box_init(fr_value_box_t *vb, fr_type_t type, fr_dict_attr_t const 
 	 *	Hopefully the compiler is smart enough to optimise
 	 *	this away.
 	 */
-	memcpy(vb, &(fr_value_box_t){
+	memcpy((void *) vb, &(fr_value_box_t){
 		.type = type,
 		.enumv = enumv,
 		.tainted = tainted

--- a/src/modules/rlm_detail/rlm_detail.c
+++ b/src/modules/rlm_detail/rlm_detail.c
@@ -216,7 +216,7 @@ static void detail_fr_pair_fprint(TALLOC_CTX *ctx, FILE *out, fr_pair_t const *s
 	vp = talloc(ctx, fr_pair_t);
 	if (!vp) return;
 
-	memcpy(vp, stacked, sizeof(*vp));
+	memcpy((void *) vp, stacked, sizeof(*vp));
 	vp->op = T_OP_EQ;
 	fr_pair_fprint(out, vp);
 	talloc_free(vp);

--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -870,7 +870,7 @@ static fr_pair_t *json_pair_alloc_leaf(UNUSED rlm_rest_t const *instance, UNUSED
 		return NULL;
 	}
 
-	memset(&src, 0, sizeof(src));
+	memset((void *) &src, 0, sizeof(src));
 
 	switch (json_object_get_type(leaf)) {
 	case json_type_int:

--- a/src/protocols/vmps/vmps.c
+++ b/src/protocols/vmps/vmps.c
@@ -170,7 +170,7 @@ int fr_vmps_decode(TALLOC_CTX *ctx, fr_pair_list_t *out, uint8_t const *data, si
 	vp = fr_pair_afrom_da(ctx, attr_sequence_number);
 	if (!vp) goto oom;
 
-	memcpy(&vp->vp_uint32, data + 4, 4);
+	memcpy((void *) &vp->vp_uint32, data + 4, 4);
 	vp->vp_uint32 = ntohl(vp->vp_uint32);
 	vp->vp_tainted = true;
 	DEBUG2("&%pP", vp);


### PR DESCRIPTION
CIDs: 1508477, 1508479, 1508480, 1508481, 1508482, 1508483,
      1508484, 1508486

Some members of an fr_value_box_t are const qualified, hence the
complaints about attempts to assign to them or to members of the
union of possible values, some of which are const qualified
(though coverity doesn't appear to complain consistently, e.g. the
FR_TYPE_UINT8 and FR_TYPE_UINT16 cases in the switch in
sim_decode_pair_value() in src/lib/eap_aka_sim/decode.c). We're
trying not to use annotations.