### PR TITLE
Annotate use of truncated time for seed (CID #1508485)

### DIFF
--- a/src/lib/util/rand.c
+++ b/src/lib/util/rand.c
@@ -62,6 +62,7 @@ void fr_rand_seed(void const *data, size_t size)
 			close(fd);
 		} else {
 			fr_rand_pool.randrsl[0] = fd;
+			/* coverity[store_truncates_time_t] */
 			fr_rand_pool.randrsl[1] = time(NULL);
 			fr_rand_pool.randrsl[2] = errno;
 		}


### PR DESCRIPTION
Here the time's just used for a random number seed. 2038 isn't a
problem. From CID #1508485 we know that an explicit cast doesn't
suffice. coverity will still consider it a defect, so we annotate.