### PR TITLE
Clean up if statements that don't affect control flow (CID #1504005)

### DIFF
--- a/src/lib/tls/session.c
+++ b/src/lib/tls/session.c
@@ -1448,7 +1448,7 @@ DIAG_ON(DIAG_UNKNOWN_PRAGMAS)
 		ua = fr_tls_cache_pending_push(request, tls_session);
 		switch (ua) {
 		case UNLANG_ACTION_FAIL:
-			if (unlang_function_clear(request) < 0) goto error;
+			(void) unlang_function_clear(request);
 			goto error;
 
 		case UNLANG_ACTION_PUSHED_CHILD:
@@ -1465,7 +1465,7 @@ DIAG_ON(DIAG_UNKNOWN_PRAGMAS)
 		ua = fr_tls_verify_cert_pending_push(request, tls_session);
 		switch (ua) {
 		case UNLANG_ACTION_FAIL:
-			if (unlang_function_clear(request) < 0) goto error;
+			(void) unlang_function_clear(request);
 			goto error;
 
 		default:


### PR DESCRIPTION
Since one does a "goto error" no matter what, unlang_function_clear()
only matters for its side effects.