### PR TITLE
Silence coverity about fr_value_box_t assignment (CIDs below)

### DIFF
--- a/src/lib/redis/redis.c
+++ b/src/lib/redis/redis.c
@@ -210,7 +210,7 @@ int fr_redis_reply_to_value_box(TALLOC_CTX *ctx, fr_value_box_t *out, redisReply
 	fr_value_box_t	*to_cast;
 
 	if (dst_type != FR_TYPE_VOID) {
-		memset(&in, 0, sizeof(in));
+		fr_value_box_copy_unsafe(&in, &(fr_value_box_t){});
 		to_cast = &in;
 	} else {
 		to_cast = out;

--- a/src/lib/server/snmp.c
+++ b/src/lib/server/snmp.c
@@ -778,9 +778,7 @@ static ssize_t snmp_process_leaf(fr_dcursor_t *out, request_t *request,
 
 	case FR_FREERADIUS_SNMP_OPERATION_VALUE_GET:
 	{
-		fr_value_box_t data;
-
-		memset(&data, 0, sizeof(data));
+		fr_value_box_t data = (fr_value_box_t) {};
 
 		/*
 		 *	Verify map is a leaf

--- a/src/lib/server/tmpl_eval.c
+++ b/src/lib/server/tmpl_eval.c
@@ -864,7 +864,7 @@ ssize_t _tmpl_to_atype(TALLOC_CTX *ctx, void *out,
 		default:
 			break;
 		}
-		memcpy(&from_cast, to_cast, sizeof(from_cast));
+		fr_value_box_copy_unsafe(&from_cast, to_cast);
 	}
 
 	RDEBUG4("Copying %zu bytes to %p from offset %zu",


### PR DESCRIPTION
CIDs: #1508477, #1508480, #1508482, #1508484, #1508486

1508482 just uses an initializer. For the rest, we create an
always-inlined function, fr_value_box_copy_unsafe(), to simply
copy the raw bytes from one value box to another. Since it's
a function, not a macro, the annotation should work. Since what
fr_value_box_init() was doing didn't work, it too uses the
function (and we had to move the box-to-box copy declarations
and definitions so it would be visible in fr_value_box_init()).