### PR TITLE
Remove needless if

### DIFF
--- a/src/lib/util/udp.c
+++ b/src/lib/util/udp.c
@@ -172,8 +172,6 @@ ssize_t udp_recv(int sockfd, int flags,
 	 */
 	if ((flags & UDP_FLAGS_CONNECTED) != 0) {
 		slen = recv(sockfd, data, data_len, sock_flags);
-		if (slen <= 0) goto done;
-
 		goto done;
 	}
 


### PR DESCRIPTION
There's no unused result--the comparison just checks slen, which is
used in the code startng with done:, which is always gone to.