### PR TITLE
fix libressl build

### DIFF
--- a/src/main/cb.c
+++ b/src/main/cb.c
@@ -47,7 +47,7 @@ void cbtls_info(SSL const *s, int where, int ret)
 		if (RDEBUG_ENABLED3) {
 			char const *abbrv = SSL_state_string(s);
 			size_t len;
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 			STACK_OF(SSL_CIPHER) *client_ciphers;
 			STACK_OF(SSL_CIPHER) *server_ciphers;
 #endif
@@ -64,7 +64,7 @@ void cbtls_info(SSL const *s, int where, int ret)
 			/*
 			 *	After a ClientHello, list all the proposed ciphers from the client
 			 */
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 			if (SSL_get_state(s) == TLS_ST_SR_CLNT_HELLO) {
 				int i;
 				int num_ciphers;
@@ -136,7 +136,7 @@ void cbtls_msg(int write_p, int msg_version, int content_type,
 	 *	content types.  Which breaks our tracking of
 	 *	the SSL Session state.
 	 */
-#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#if OPENSSL_VERSION_NUMBER < 0x30000000L || defined(LIBRESSL_VERSION_NUMBER)
 	if ((msg_version == 0) && (content_type > UINT8_MAX)) {
 #else
 	/*
@@ -201,7 +201,7 @@ void cbtls_msg(int write_p, int msg_version, int content_type,
 		state->info.alert_level = 0x00;
 		state->info.alert_description = 0x00;
 
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L && !defined(LIBRESSL_VERSION_NUMBER)
 	} else if (content_type == SSL3_RT_INNER_CONTENT_TYPE && buf[0] == SSL3_RT_APPLICATION_DATA) {
 		/* let tls_ack_handler set application_data */
 		state->info.content_type = SSL3_RT_HANDSHAKE;

--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -684,7 +684,8 @@ tls_session_t *tls_new_session(TALLOC_CTX *ctx, fr_tls_server_conf_t *conf, REQU
 				/*
 				 * Swap empty store with the old one.
 				 */
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
+	!(defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x30500000L)
 				conf->old_x509_store = SSL_CTX_get_cert_store(conf->ctx);
 				/* Bump refcnt so the store is kept allocated till next store replacement */
 				X509_STORE_up_ref(conf->old_x509_store);
@@ -3166,7 +3167,8 @@ int cbtls_verify(int ok, X509_STORE_CTX *ctx)
 	}
 
 	if (lookup == 0) {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
+	!(defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x30500000L)
 		ext_list = X509_get0_extensions(client_cert);
 #else
 		X509_CINF	*client_inf;
@@ -4257,7 +4259,7 @@ post_ca:
 	 *	send it flowers and cake.
 	 */
 	if (min_version <= TLS1_1_VERSION) {
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L && !defined(LIBRESSL_VERSION_NUMBER)
 		int seclevel = SSL_CTX_get_security_level(ctx);
 		int required;;
 

--- a/src/modules/rlm_eap/types/rlm_eap_fast/rlm_eap_fast.c
+++ b/src/modules/rlm_eap/types/rlm_eap_fast/rlm_eap_fast.c
@@ -200,7 +200,8 @@ static void eap_fast_session_ticket(tls_session_t *tls_session, uint8_t *client_
 }
 
 // hostap:src/crypto/tls_openssl.c:tls_sess_sec_cb()
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
+	(defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x30500000L)
 static int _session_secret(SSL *s, void *secret, int *secret_len,
 			   UNUSED STACK_OF(SSL_CIPHER) *peer_ciphers,
 			   UNUSED SSL_CIPHER **cipher, void *arg)
@@ -224,7 +225,8 @@ static int _session_secret(SSL *s, void *secret, int *secret_len,
 
 	RDEBUG("processing PAC-Opaque");
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || \
+	(defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x30500000L)
 	eap_fast_session_ticket(tls_session, s->s3->client_random, s->s3->server_random, secret, secret_len);
 #else
 	uint8_t client_random[SSL3_RANDOM_SIZE];


### PR DESCRIPTION
Fix the following build failure with libressl:

```
src/modules/rlm_eap/types/rlm_eap_fast/rlm_eap_fast.c: In function '_session_secret':
src/modules/rlm_eap/types/rlm_eap_fast/rlm_eap_fast.c:228:47: error: invalid use of incomplete typedef 'SSL' {aka 'struct ssl_st'}
  228 |         eap_fast_session_ticket(tls_session, s->s3->client_random, s->s3->server_random, secret, secret_len);
      |                                               ^~
```

Fixes:
 - http://autobuild.buildroot.org/results/c8df444f4c39f83e254dbb642a5852a1c956f7bb

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>