### PR TITLE
Annotate false positive uninit (CID #1504020)

### DIFF
--- a/src/lib/util/value.c
+++ b/src/lib/util/value.c
@@ -4922,6 +4922,7 @@ parse:
 		fr_base16_decode(&err, &dbuff, &our_in, true);
 		if (err != FR_SBUFF_PARSE_OK) goto ether_error;
 
+		/* coverity[uninit_use_in_call] */
 		fr_value_box_ethernet_addr(dst, dst_enumv, &ether, tainted);
 
 		return fr_sbuff_set(in, &our_in);


### PR DESCRIPTION
coverity doesn't realize that at this point ether is necessarily
initialized, with all the fr_base16_decode()s successful.