### PR TITLE
Annotate remaining false positives in sbuff_tests.c (CIDs below)

### DIFF
--- a/src/lib/util/sbuff_tests.c
+++ b/src/lib/util/sbuff_tests.c
@@ -84,6 +84,7 @@ static void test_bstrncpy_exact(void)
 
 	TEST_CASE("Copy 5 bytes to out");
 	slen = fr_sbuff_out_bstrncpy_exact(&FR_SBUFF_OUT(out, sizeof(out)), &sbuff, 5);
+	/* coverity[uninit_use_in_call] */
 	TEST_CHECK_SLEN(slen, 5);
 	TEST_CHECK_STRCMP(out, "i am ");
 	TEST_CHECK_STRCMP(sbuff.p, "a test string");
@@ -430,6 +431,7 @@ static void test_unescape_until(void)
 	TEST_CASE("Copy 5 bytes to out");
 	slen = fr_sbuff_out_unescape_until(&FR_SBUFF_OUT(out, sizeof(out)), &sbuff, 5, NULL, &rules);
 	TEST_CHECK_SLEN(slen, 5);
+	/* coverity[uninit_use_in_call] */
 	TEST_CHECK_STRCMP(out, "i am ");
 	TEST_CHECK_STRCMP(sbuff.p, "a test string");
 
@@ -507,6 +509,7 @@ static void test_unescape_until(void)
 	slen = fr_sbuff_out_unescape_until(&FR_SBUFF_OUT(escape_out, sizeof(escape_out)), &sbuff, SIZE_MAX,
 					   &FR_SBUFF_TERM("g"), &pipe_rules);
 	TEST_CHECK_SLEN(slen, 20);
+	/* coverity[uninit_use_in_call] */
 	TEST_CHECK_STRCMP(escape_out, "i am a |t|est string");
 	TEST_CHECK_STRCMP(sbuff.p, "");
 
@@ -515,6 +518,7 @@ static void test_unescape_until(void)
 	slen = fr_sbuff_out_unescape_until(&FR_SBUFF_OUT(escape_out, sizeof(escape_out)), &sbuff, SIZE_MAX,
 					   &FR_SBUFF_TERM("g"), &pipe_rules_sub);
 	TEST_CHECK_SLEN(slen, 20);
+	/* coverity[uninit_use_in_call] */
 	TEST_CHECK_STRCMP(escape_out, "i am a |t|est strinh");
 	TEST_CHECK_STRCMP(sbuff.p, "");
 


### PR DESCRIPTION
CIDs: #1503906, #1503912, #1504003, #1504019

coverity doesn't recognize that fr_sbuff_out_bstrncpy_exact() and
fr_sbuff_out_unescape_until() will always put something in the
output sbuffs, if only a NUL terminator.