### PR TITLE
Take out nonnull hint on _fr_dbuff_init() for coverity (CIDs below)

### DIFF
--- a/src/lib/util/dbuff.h
+++ b/src/lib/util/dbuff.h
@@ -327,7 +327,11 @@ DIAG_OFF(maybe-uninitialized)
 /** Does the actual work of initialising a dbuff
  * @private
  */
-static inline CC_HINT(nonnull) void _fr_dbuff_init(fr_dbuff_t *out, uint8_t const *start, uint8_t const *end, bool is_const)
+static inline
+#ifndef __COVERITY__
+CC_HINT(nonnull)
+#endif
+void _fr_dbuff_init(fr_dbuff_t *out, uint8_t const *start, uint8_t const *end, bool is_const)
 {
 	if (unlikely(end < start)) end = start;	/* Could be an assert? */
 


### PR DESCRIPTION
Coverity assumes that the nonnull means we'll dereference the end
pointer... so leave it out when coverity runs.

CIDs: 1503895, 1503905, 1503907, 1503914, 1503915, 1503924
      1503956, 1503970, 1503973, 1503979, 1503980, 1503988
      1504000, 1504034, 1504035, 1504039, 1504040, 1504059