### PR TITLE
Correct print_hex_data() parameters in fr_vmps_print_hex()

### DIFF
--- a/src/protocols/vmps/vmps.c
+++ b/src/protocols/vmps/vmps.c
@@ -494,7 +494,7 @@ void fr_vmps_print_hex(FILE *fp, uint8_t const *packet, size_t packet_len)
 
 		fprintf(fp, "\t\t%08x  %04x  ", id, length);
 
-		print_hex_data(attr + 5, length, 3);
+		print_hex_data(attr + 6, length - 6, 3);
 	}
 }
 


### PR DESCRIPTION
For the loop printing the trailing portions of the packet to be
correct, length must include the four-byte id and two-byte length
as well as the following data. id and length are explicitly printed,
so print_hex_data() would presumably show what follows, but that
would start at attr + 6 and only be length - 6 bytes.