### PR TITLE
Consistently use bracket, not brace, for annotations (CID #1448182)

### DIFF
--- a/src/listen/dhcpv6/proto_dhcpv6.c
+++ b/src/listen/dhcpv6/proto_dhcpv6.c
@@ -334,7 +334,7 @@ static ssize_t mod_encode(void const *instance, request_t *request, uint8_t *buf
 		if (client_id) {
 			size_t len = fr_nbo_to_uint16(client_id + 2);
 			if ((data_len + 4 + len) <= buffer_len) {
-				/* coverity[tainted_data} */
+				/* coverity[tainted_data] */
 				memcpy(buffer + data_len, client_id, 4 + len);
 				data_len += 4 + len;
 			}


### PR DESCRIPTION
Typo