### PR TITLE
Annotate false positive tainted_data (CID #1451665)

### DIFF
--- a/src/protocols/radius/packet.c
+++ b/src/protocols/radius/packet.c
@@ -190,6 +190,7 @@ int fr_radius_packet_decode(TALLOC_CTX *ctx, fr_pair_list_t *out,
 		 *	This may return many VPs
 		 */
 		fr_assert(ptr != NULL);
+		/* coverity[tainted_data] */
 		my_len = fr_radius_decode_pair(ctx, &tmp_list, ptr, packet_length, &packet_ctx);
 		if (my_len < 0) {
 		fail:


### PR DESCRIPTION
This one is interesting. fr_radius_packet_log_hex(), called
if NDEBUG is defined and the debug level is high enough, in
turn calls fr_nbo_to_uint16() and fr_box_octets(). The results
are used in log messages, Typically when bytes are swapped, the
entity to which the result is stored is considered tainted, but
here coverity thinks the data being read is tainted. That
propagates back to place where the defect is claimed.