### PR TITLE
Annotate false positive tainted_data (CID #1503921)

### DIFF
--- a/src/protocols/dns/base.c
+++ b/src/protocols/dns/base.c
@@ -248,6 +248,7 @@ bool fr_dns_packet_ok(uint8_t const *packet, size_t packet_len, bool query, fr_d
 					return false;
 				}
 
+				/* coverity[tainted_data] */
 				if (!fr_dns_marker[offset]) {
 					DECODE_FAIL(POINTER_TO_NON_LABEL);
 					return false;


### PR DESCRIPTION
By construction, 0 <= offset <= 0x3fff, so it is in range as
a subscript for fr_dns_marker.