### PR TITLE
Deal with complaints about len parameter of fr_udp_checksum (CIDs below)

### DIFF
--- a/src/lib/util/net.c
+++ b/src/lib/util/net.c
@@ -89,7 +89,7 @@ size_t fr_net_af_table_len = NUM_ELEMENTS(fr_net_af_table);
 		return -1;
 	}
 
-	expected = fr_udp_checksum((uint8_t const *) udp, ntohs(udp->len), udp->checksum,
+	expected = fr_udp_checksum((uint8_t const *) udp, udp_len, udp->checksum,
 				   ip->ip_src, ip->ip_dst);
 	if (udp->checksum != expected) {
 		fr_strerror_printf("UDP checksum invalid, packet: 0x%04hx calculated: 0x%04hx",

--- a/src/protocols/dhcpv4/pcap.c
+++ b/src/protocols/dhcpv4/pcap.c
@@ -90,7 +90,7 @@ int fr_dhcpv4_pcap_send(fr_pcap_t *pcap, uint8_t *dst_ether_addr, fr_radius_pack
 	memcpy(dhcp, packet->data, packet->data_len);
 
 	/* UDP checksum is done here */
-	udp_hdr->checksum = fr_udp_checksum((uint8_t const *)udp_hdr, ntohs(udp_hdr->len), udp_hdr->checksum,
+	udp_hdr->checksum = fr_udp_checksum((uint8_t const *)udp_hdr, l4_len, udp_hdr->checksum,
 					    packet->socket.inet.src_ipaddr.addr.v4,
 					    packet->socket.inet.dst_ipaddr.addr.v4);
 

--- a/src/protocols/dhcpv4/raw.c
+++ b/src/protocols/dhcpv4/raw.c
@@ -153,7 +153,7 @@ int fr_dhcpv4_raw_packet_send(int sockfd, struct sockaddr_ll *link_layer,
 
 	/* UDP checksum is done here */
 	udp_hdr->checksum = fr_udp_checksum((uint8_t const *)(dhcp_packet + ETH_HDR_SIZE + IP_HDR_SIZE),
-					    ntohs(udp_hdr->len), udp_hdr->checksum,
+					    l4_len, udp_hdr->checksum,
 					    packet->socket.inet.src_ipaddr.addr.v4, packet->socket.inet.dst_ipaddr.addr.v4);
 
 	return sendto(sockfd, dhcp_packet, (ETH_HDR_SIZE + IP_HDR_SIZE + UDP_HDR_SIZE + packet->data_len),


### PR DESCRIPTION
CIDs 1504068, 1503957, 150468
use the length directly rather than byte swapping it twice