### PR TITLE
Annotate false positive tainted_data (CID #1503893)

### DIFF
--- a/src/protocols/dhcpv4/raw.c
+++ b/src/protocols/dhcpv4/raw.c
@@ -318,6 +318,7 @@ fr_radius_packet_t *fr_dhcv4_raw_packet_recv(int sockfd, struct sockaddr_ll *lin
 	 *      and use that, too?
 	 */
 	memset(packet->vector, 0, sizeof(packet->vector));
+	/* coverity[tainted_data] */
 	memcpy(packet->vector, packet->data + 28, packet->data[2]);
 	packet->vector[packet->data[2]] = packet->code & 0xff;
 


### PR DESCRIPTION
In fr_dhcv4_raw_packet_recv() (is there a reason for that
spelling?), coverity claims the downcast of packet->data
in the fr_dhcpv4_packet_get_option() call taints the contents
of packet->data, but it's cast to, and the called function
takes, a const-qualified pointer, so in what sense can it be
tainted?