### PR TITLE
Annotate false positive uninit (CID #1503938, #1504037)

### DIFF
--- a/src/bin/radict.c
+++ b/src/bin/radict.c
@@ -148,11 +148,15 @@ static void da_print_info_td(fr_dict_t const *dict, fr_dict_attr_t const *da)
 	fr_hash_iter_t		iter;
 	fr_dict_enum_value_t		*enumv;
 
-	(void)fr_dict_attr_oid_print(&FR_SBUFF_OUT(oid_str, sizeof(oid_str)), NULL, da, false);
+	if (fr_dict_attr_oid_print(&FR_SBUFF_OUT(oid_str, sizeof(oid_str)), NULL, da, false) <= 0) {
+		fr_strerror_printf("OID string too long");
+		fr_exit(EXIT_FAILURE);
+	}
 
 	fr_dict_attr_flags_print(&FR_SBUFF_OUT(flags, sizeof(flags)), dict, da->type, &da->flags);
 
 	/* Protocol Name Type */
+	/* coverity[uninit_use_in_call] */
 	printf("%s\t%s\t%s\t%s\t%s\n",
 	       fr_dict_root(dict)->name,
 	       oid_str,


### PR DESCRIPTION
Both instances appear in the same printf() call.

1503938: flags is large enough that fr_dict_attr_flags_print()
         will not run out of space, the only way it can return
         an error.
1504037: NULL is passed as the ancestor, and coverity doesn't
         complain about evaluating da->type, so it must not
         think da is NULL. Given that, the fr_dict_attr_oid_print()
         call here also can only fail by running out of room.
         oid_str is 512 bytes, but here the length depends on
         da->depth. It appears that 512 bytes suffices in practice,
         but we'll check the return value and exit after logging
         an error if it proves not to.