### PR TITLE
Deal with coverity tainted data defect in mod_track_create() (CID #14…

### DIFF
--- a/src/listen/dhcpv6/proto_dhcpv6_udp.c
+++ b/src/listen/dhcpv6/proto_dhcpv6_udp.c
@@ -414,7 +414,7 @@ static void *mod_track_create(UNUSED void const *instance, UNUSED void *thread_i
 
 	option_len = fr_nbo_to_uint16(option + 2);
 
-	if (option + option_len > packet + packet_len) return NULL;
+	if ((option + option_len) > (packet + packet_len)) return NULL;
 
 	t = (proto_dhcpv6_track_t *) talloc_zero_array(track, uint8_t, t_size + option_len);
 	if (!t) return NULL;

--- a/src/listen/dhcpv6/proto_dhcpv6_udp.c
+++ b/src/listen/dhcpv6/proto_dhcpv6_udp.c
@@ -414,6 +414,8 @@ static void *mod_track_create(UNUSED void const *instance, UNUSED void *thread_i
 
 	option_len = fr_nbo_to_uint16(option + 2);
 
+	if (option + option_len > packet + packet_len) return NULL;
+
 	t = (proto_dhcpv6_track_t *) talloc_zero_array(track, uint8_t, t_size + option_len);
 	if (!t) return NULL;
 
@@ -421,6 +423,7 @@ static void *mod_track_create(UNUSED void const *instance, UNUSED void *thread_i
 
 	memcpy(&t->header, packet, 4); /* packet code + 24-bit transaction ID */
 
+	/* coverity[tainted_data] */
 	memcpy(&t->client_id[0], option + 4, option_len);
 	t->client_id_len = option_len;
 


### PR DESCRIPTION
…69134)

Added a test to make sure option + option_len doesn't extend off the end of the packet. Since in other cases, coverity doesn't recognize the range check that it asks for, we annotate it, too.