### PR TITLE
Annotate false positive uninit_use (CID #1503898)

### DIFF
--- a/src/lib/redis/cluster.c
+++ b/src/lib/redis/cluster.c
@@ -2053,6 +2053,7 @@ int fr_redis_cluster_pool_by_node_addr(fr_pool_t **pool, fr_redis_cluster_t *clu
 			pthread_mutex_unlock(&cluster->mutex);
 			return -1;
 		}
+		/* coverity[uninit_use] */
 		spare->pending_addr = find.addr;	/* Set the config to be applied */
 		if (cluster_node_connect(cluster, spare) < 0) {
 			pthread_mutex_unlock(&cluster->mutex);


### PR DESCRIPTION
find is uninitialized and only has a small portion of find.addr.inet set in fr_redis_cluster_pool_by_node_addr(), but then all of find.addr is assigned to spare->pending_addr, hence coverity complains. It turna out, though, that cluster_node_connect() only uses the part that did get set.