### PR TITLE
Check for NULL return from xlat_register() (CID #1507059)

### DIFF
--- a/src/lib/unlang/xlat_builtin.c
+++ b/src/lib/unlang/xlat_builtin.c
@@ -3850,6 +3850,7 @@ static int xlat_protocol_register(fr_dict_t const *dict)
 		snprintf(buffer, sizeof(buffer), "decode.%s", name);
 
 		xlat = xlat_register(NULL, buffer, protocol_decode_xlat, NULL);
+		if (!xlat) return -1;
 		xlat_func_args(xlat, protocol_decode_xlat_args);
 		/* coverity[suspicious_sizeof] */
 		xlat_async_instantiate_set(xlat, protocol_xlat_instantiate, fr_test_point_pair_decode_t *, NULL, tp_decode);
@@ -3865,6 +3866,7 @@ static int xlat_protocol_register(fr_dict_t const *dict)
 		snprintf(buffer, sizeof(buffer), "encode.%s", name);
 
 		xlat = xlat_register(NULL, buffer, protocol_encode_xlat, NULL);
+		if (!xlat) return -1;
 		xlat_func_args(xlat, protocol_encode_xlat_args);
 		/* coverity[suspicious_sizeof] */
 		xlat_async_instantiate_set(xlat, protocol_xlat_instantiate, fr_test_point_pair_encode_t *, NULL, tp_encode);


### PR DESCRIPTION
Barring issues with args, xlat_func_args() will dereference the xlat_t * handed it, and xlat_register()'s callers do check for error return, so it makes sense to check what xlat_register() returns and return error in that case.