### PR TITLE
Annotate calls we know won't fail (CID #1503939)

### DIFF
--- a/src/lib/util/edit_tests.c
+++ b/src/lib/util/edit_tests.c
@@ -85,8 +85,11 @@ static void add_pairs(fr_pair_list_t *local_pairs)
 
 	fr_pair_list_init(local_pairs);
 
+	/* coverity[dereference] */
 	fr_pair_append(local_pairs, fr_pair_afrom_da(autofree, fr_dict_attr_test_uint32));
+	/* coverity[dereference] */
 	fr_pair_append(local_pairs, fr_pair_afrom_da(autofree, fr_dict_attr_test_octets));
+	/* coverity[dereference] */
 	fr_pair_append(local_pairs, fr_pair_afrom_da(autofree, fr_dict_attr_test_tlv));
 
 	count = fr_pair_list_num_elements(local_pairs);


### PR DESCRIPTION
The individual tests in edit_tests all operate on a three-element pair list they get from add_pairs(), freeing it after they're done. fr_pair_afrom_da() only returns NULL if it runs out of memory-- unlikely in this context, so we annotate the calls that add items to the list.