### PR TITLE
Annotate "tainted data" in fr_udp_header_check() call (CID #1504049)

### DIFF
--- a/src/protocols/dhcpv4/pcap.c
+++ b/src/protocols/dhcpv4/pcap.c
@@ -188,6 +188,7 @@ fr_radius_packet_t *fr_dhcpv4_pcap_recv(fr_pcap_t *pcap)
 	/*
 	 *	UDP header validation.
 	 */
+	/* coverity[tainted_data] */
 	ret = fr_udp_header_check(p, (header->caplen - (p - data)), ip);
 	if (ret < 0) return NULL;
 


### PR DESCRIPTION
Coverity claims that the "downcast" of a uint8_t const * to ip_header_t const * taints "the data that this pointer points to". "this pointer" must be p, because coverity says not a word about dereferences of ip. The pointed at data isn't changed, being const qualified. p and the passed length are checked in fr_udp_header_check().