### PR TITLE
Annotate false positive tainted data in fr_udp_header_check() (CID #1…

### DIFF
--- a/src/lib/util/net.c
+++ b/src/lib/util/net.c
@@ -89,6 +89,7 @@ size_t fr_net_af_table_len = NUM_ELEMENTS(fr_net_af_table);
 		return -1;
 	}
 
+	/* coverity[tainted_data] */
 	expected = fr_udp_checksum((uint8_t const *) udp, udp_len, udp->checksum,
 				   ip->ip_src, ip->ip_dst);
 	if (udp->checksum != expected) {


### PR DESCRIPTION
…504068)

Coverity doesn't recognize the check that diff == 0 as a check of udp_len.