### PR TITLE
Check inst->filename before trying to use it (CID #1503909)

### DIFF
--- a/src/listen/cron/proto_cron_crontab.c
+++ b/src/listen/cron/proto_cron_crontab.c
@@ -406,6 +406,7 @@ static int mod_open(fr_listen_t *li)
 	 *	We never read or write to this file, but we need a
 	 *	readable FD in order to bootstrap the process.
 	 */
+	if (inst->filename == NULL) return -1;
 	li->fd = open(inst->filename, O_RDONLY);
 
 	memset(&ipaddr, 0, sizeof(ipaddr));
@@ -414,7 +415,7 @@ static int mod_open(fr_listen_t *li)
 
 	fr_assert((cf_parent(inst->cs) != NULL) && (cf_parent(cf_parent(inst->cs)) != NULL));	/* listen { ... } */
 
-	thread->name = talloc_typed_asprintf(thread, "cron_crontab from filename %s", inst->filename ? inst->filename : "none");
+	thread->name = talloc_typed_asprintf(thread, "cron_crontab from filename %s", inst->filename);
 	thread->parent = talloc_parent(li);
 
 	return 0;


### PR DESCRIPTION
It appears that all invocations of the open function of an fr_app_io_t check for error, so this should suffice (apart from possible error loggign) and should satisfy coverity without annotation.