### PR TITLE
Check fr_openssl_init() return in fr_aka_sim_init() (CID #1504435)

### DIFF
--- a/src/lib/eap_aka_sim/base.c
+++ b/src/lib/eap_aka_sim/base.c
@@ -273,7 +273,10 @@ int fr_aka_sim_init(void)
 		return -1;
 	}
 
-	fr_openssl_init();
+	if (fr_openssl_init() < 0) {
+		PERROR("Failed setting up OpenSSL");
+		return -1;
+	}
 
 	instance_count++;
 


### PR DESCRIPTION
Curiously, coverity is no longer noticing this defect, but it seems like a real bug nonetheless.