### PR TITLE
Ignore returns from certain sbuff calls (CIDs #1504025, #1504070)

### DIFF
--- a/src/lib/util/pair_print.c
+++ b/src/lib/util/pair_print.c
@@ -134,8 +134,8 @@ void fr_pair_fprint(FILE *fp, fr_pair_t const *vp)
 	PAIR_VERIFY(vp);
 
 	(void) fr_sbuff_in_char(&sbuff, '\t');
-	fr_pair_print(&sbuff, NULL, vp);
-	fr_sbuff_in_char(&sbuff, '\n');
+	(void) fr_pair_print(&sbuff, NULL, vp);
+	(void) fr_sbuff_in_char(&sbuff, '\n');
 
 	fputs(buff, fp);
 }

--- a/src/modules/rlm_eap/rlm_eap.c
+++ b/src/modules/rlm_eap/rlm_eap.c
@@ -362,14 +362,14 @@ static eap_type_t eap_process_nak(module_ctx_t const *mctx, request_t *request,
 		FR_SBUFF_TALLOC_THREAD_LOCAL(&allowed, 256, 1024);
 
 		for (i = 0; i < s_i; i++) {
-			fr_sbuff_in_sprintf(proposed, "%s (%d), ", eap_type2name(sanitised[i]), sanitised[i]);
+			(void) fr_sbuff_in_sprintf(proposed, "%s (%d), ", eap_type2name(sanitised[i]), sanitised[i]);
 		}
 		fr_sbuff_advance(proposed, -2);
 		fr_sbuff_terminate(proposed);
 
 		vp = NULL;
 		while ((vp = fr_pair_find_by_da(&request->control_pairs, vp, attr_eap_type))) {
-			fr_sbuff_in_sprintf(allowed, "%s (%d), ", eap_type2name(vp->vp_uint32), vp->vp_uint32);
+			(void) fr_sbuff_in_sprintf(allowed, "%s (%d), ", eap_type2name(vp->vp_uint32), vp->vp_uint32);
 		}
 		fr_sbuff_advance(allowed, -2);	/* Negative advance past start should be disallowed */
 		fr_sbuff_terminate(allowed);


### PR DESCRIPTION
These are cases in which sbuffs are either created from C arrays or are allocated from the heap but given initial and maximum sizes. The author(s) of the code presumably chose sizes intended to suffice, but despite that, coverity will notice that the sbuff functions used return a value, and hence will report check_return barring either explicit cast to void or annotation. We therefore cast to void.