### PR TITLE
Remove extra semicolons at ends of statements and declarations

### DIFF
--- a/src/lib/eap_aka_sim/crypto.c
+++ b/src/lib/eap_aka_sim/crypto.c
@@ -739,7 +739,7 @@ static int ck_ik_prime_derive(fr_aka_sim_keys_t *keys)
 	FR_PROTO_HEX_DUMP(keys->ck_prime, sizeof(keys->ck_prime), "CK'");
 	FR_PROTO_HEX_DUMP(keys->ik_prime, sizeof(keys->ik_prime), "IK'");
 
-	EVP_MD_CTX_destroy(md_ctx);;
+	EVP_MD_CTX_destroy(md_ctx);
 	EVP_PKEY_free(pkey);
 
 	return 0;
@@ -818,7 +818,7 @@ static int aka_prime_prf(uint8_t *out, size_t outlen,
 		p += copy;
 	}
 
-	EVP_MD_CTX_destroy(md_ctx);;
+	EVP_MD_CTX_destroy(md_ctx);
 	EVP_PKEY_free(pkey);
 
 	return 0;

--- a/src/lib/eap_aka_sim/vector.c
+++ b/src/lib/eap_aka_sim/vector.c
@@ -775,7 +775,7 @@ int fr_aka_sim_vector_umts_from_attrs(request_t *request, fr_pair_list_t *vps,
 		ret = vector_umts_from_quintuplets(request, vps, keys);
 		if (ret == 0) {
 			*src = AKA_SIM_VECTOR_SRC_QUINTUPLETS;
-			break;;
+			break;
 		}
 		if (ret < 0) return -1;
 		break;

--- a/src/lib/io/master.c
+++ b/src/lib/io/master.c
@@ -224,7 +224,7 @@ static int8_t pending_client_cmp(void const *one, void const *two)
 static int8_t address_cmp(void const *one, void const *two)
 {
 	fr_io_address_t const *a = talloc_get_type_abort_const(one, fr_io_address_t);
-	fr_io_address_t const *b = talloc_get_type_abort_const(two, fr_io_address_t);;
+	fr_io_address_t const *b = talloc_get_type_abort_const(two, fr_io_address_t);
 	int8_t ret;
 
 	CMP_RETURN(a, b, socket.inet.src_port);

--- a/src/lib/ldap/sasl.c
+++ b/src/lib/ldap/sasl.c
@@ -77,7 +77,7 @@ static void _ldap_sasl_bind_io_error(UNUSED fr_event_list_t *el, UNUSED int fd,
  */
 static int _sasl_interact(UNUSED LDAP *handle, UNUSED unsigned flags, void *uctx, void *sasl_callbacks)
 {
-	fr_ldap_sasl_ctx_t		*sasl_ctx = talloc_get_type_abort(uctx, fr_ldap_sasl_ctx_t);;
+	fr_ldap_sasl_ctx_t		*sasl_ctx = talloc_get_type_abort(uctx, fr_ldap_sasl_ctx_t);
 	sasl_interact_t			*cb = sasl_callbacks;
 	sasl_interact_t			*cb_p;
 

--- a/src/lib/server/tmpl_tokenize.c
+++ b/src/lib/server/tmpl_tokenize.c
@@ -4083,7 +4083,7 @@ void tmpl_attr_to_raw(tmpl_t *vpt)
  */
 int tmpl_attr_unknown_add(tmpl_t *vpt)
 {
-	tmpl_attr_t		*ar = NULL, *next = NULL;;
+	tmpl_attr_t		*ar = NULL, *next = NULL;
 
 	if (!vpt) return 1;
 
@@ -5186,17 +5186,17 @@ ssize_t tmpl_preparse(char const **out, size_t *outlen, char const *in, size_t i
 		goto skip_string;
 
 	case '\'':
-		quote = *(p++);;
+		quote = *(p++);
 		*type = T_SINGLE_QUOTED_STRING;
 		goto skip_string;
 
 	case '`':
-		quote = *(p++);;
+		quote = *(p++);
 		*type = T_BACK_QUOTED_STRING;
 		goto skip_string;
 
 	case '"':
-		quote = *(p++);;
+		quote = *(p++);
 		*type = T_DOUBLE_QUOTED_STRING;
 
 		/*

--- a/src/lib/server/trunk.c
+++ b/src/lib/server/trunk.c
@@ -1066,7 +1066,7 @@ static void trunk_request_enter_unassigned(fr_trunk_request_t *treq)
 static void trunk_request_enter_backlog(fr_trunk_request_t *treq, bool new)
 {
 	fr_trunk_connection_t	*tconn = treq->pub.tconn;
-	fr_trunk_t		*trunk = treq->pub.trunk;;
+	fr_trunk_t		*trunk = treq->pub.trunk;
 
 	switch (treq->pub.state) {
 	case FR_TRUNK_REQUEST_STATE_INIT:

--- a/src/lib/unlang/load_balance.c
+++ b/src/lib/unlang/load_balance.c
@@ -177,7 +177,7 @@ static unlang_action_t unlang_load_balance(rlm_rcode_t *p_result, request_t *req
 
 			hash = fr_hash(p, slen);
 
-			start = hash % g->num_children;;
+			start = hash % g->num_children;
 		}
 
 		RDEBUG3("load-balance starting at child %d", (int) start);

--- a/src/modules/rlm_eap/rlm_eap.c
+++ b/src/modules/rlm_eap/rlm_eap.c
@@ -234,7 +234,7 @@ static eap_type_t eap_process_nak(module_ctx_t const *mctx, request_t *request,
 {
 	rlm_eap_t const *inst = talloc_get_type_abort_const(mctx->inst->data, rlm_eap_t);
 	unsigned int i, s_i = 0;
-	fr_pair_t *vp = NULL;;
+	fr_pair_t *vp = NULL;
 	eap_type_t method = FR_EAP_METHOD_INVALID;
 	eap_type_t sanitised[nak->length];
 

--- a/src/modules/rlm_krb5/rlm_krb5.c
+++ b/src/modules/rlm_krb5/rlm_krb5.c
@@ -286,7 +286,7 @@ static rlm_rcode_t krb5_process_error(rlm_krb5_t const *inst, request_t *request
 	fr_assert(ret != 0);
 
 	if (!fr_cond_assert(inst)) return RLM_MODULE_FAIL;
-	if (!fr_cond_assert(conn)) return RLM_MODULE_FAIL;;	/* Silences warnings */
+	if (!fr_cond_assert(conn)) return RLM_MODULE_FAIL;	/* Silences warnings */
 
 	switch (ret) {
 	case KRB5_LIBOS_BADPWDMATCH:

--- a/src/modules/rlm_radius/rlm_radius_udp.c
+++ b/src/modules/rlm_radius/rlm_radius_udp.c
@@ -1145,7 +1145,7 @@ static int8_t request_prioritise(void const *one, void const *two)
 	/*
 	 *	Prioritise status check packets
 	 */
-	ret = (b->status_check - a->status_check);;
+	ret = (b->status_check - a->status_check);
 	if (ret != 0) return ret;
 
 	/*
@@ -2367,7 +2367,7 @@ static void status_check_reply(fr_trunk_request_t *treq, fr_time_t now)
 
 static void request_demux(UNUSED fr_event_list_t *el, fr_trunk_connection_t *tconn, fr_connection_t *conn, UNUSED void *uctx)
 {
-	udp_handle_t		*h = talloc_get_type_abort(conn->h, udp_handle_t);;
+	udp_handle_t		*h = talloc_get_type_abort(conn->h, udp_handle_t);
 
 	DEBUG3("%s - Reading data for connection %s", h->module_name, h->name);
 

--- a/src/modules/rlm_sql/drivers/rlm_sql_postgresql/rlm_sql_postgresql.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_postgresql/rlm_sql_postgresql.c
@@ -397,7 +397,7 @@ static CC_HINT(nonnull) sql_rcode_t sql_query(rlm_sql_handle_t *handle, rlm_sql_
 		break;
 	}
 
-	return sql_classify_error(inst, status, conn->result);;
+	return sql_classify_error(inst, status, conn->result);
 }
 
 static sql_rcode_t sql_select_query(rlm_sql_handle_t * handle, rlm_sql_config_t const *config, char const *query)

--- a/src/modules/rlm_unbound/rlm_unbound.c
+++ b/src/modules/rlm_unbound/rlm_unbound.c
@@ -256,7 +256,7 @@ static void xlat_unbound_timeout(UNUSED fr_event_list_t *el, UNUSED fr_time_t no
 	unbound_request_t	*ur = talloc_get_type_abort(uctx, unbound_request_t);
 	request_t		*request = ur->request;
 
-	REDEBUG("Timeout waiting for DNS resolution");;
+	REDEBUG("Timeout waiting for DNS resolution");
 	unlang_interpret_mark_runnable(request);
 
 	ur->timedout = true;

--- a/src/protocols/arp/base.c
+++ b/src/protocols/arp/base.c
@@ -216,7 +216,7 @@ ssize_t fr_arp_encode(fr_dbuff_t *dbuff, uint8_t const *original, fr_pair_list_t
 		COPY(tpa, spa);		/* answer is sent to the requestor protocol address */
 	}
 
-	return fr_dbuff_set(dbuff, &work_dbuff);;
+	return fr_dbuff_set(dbuff, &work_dbuff);
 }
 
 /** Decode a raw ARP packet into VPs


### PR DESCRIPTION
Found one while looking through coverity defects, and decided to take a few minutes with grep and an editor to get rid of them all.