### PR TITLE
rediswho: Fix typo

### DIFF
--- a/src/modules/rlm_rediswho/all.mk.in
+++ b/src/modules/rlm_rediswho/all.mk.in
@@ -7,5 +7,5 @@ endif
 SOURCES		:= $(TARGETNAME).c
 
 SRC_CFLAGS	:= @mod_cflags@
-SRC_CFLAGS	:= -I$(top_builddir)/src/modules/rlm_redis
+SRC_CFLAGS	+= -I$(top_builddir)/src/modules/rlm_redis
 TGT_LDLIBS	:= @mod_ldflags@


### PR DESCRIPTION
Backport from v3.2.x