### PR TITLE
eapol_test: Add paths for Brew on OSX/M1

### DIFF
--- a/scripts/ci/eapol_test/config_osx
+++ b/scripts/ci/eapol_test/config_osx
@@ -12,8 +12,8 @@
 CFLAGS += -g3 -O0 -Wno-unknown-warning-option -Wno-error=deprecated-declarations -Wno-error=void-pointer-to-enum-cast
 
 # Use OpenSSL 1.1 for now as eapol_test doesn't support 3.0.0 (as of master HEAD 2/10/2021)
-CFLAGS += -I/usr/local/opt/openssl@1.1/include
-LIBS += -L/usr/local/opt/openssl@1.1/lib
+CFLAGS += -I/usr/local/opt/openssl@1.1/include -I/opt/homebrew/opt/openssl@1.1/include
+LIBS += -L/usr/local/opt/openssl@1.1/lib -L/opt/homebrew/opt/openssl@1.1/lib
 
 # Some Red Hat versions seem to include kerberos header files from OpenSSL, but
 # the kerberos files are not in the default include path. Following line can be


### PR DESCRIPTION
Needed for the Brew running on OSX/M1 due to the new base path is in /opt/homebrew as described on https://earthly.dev/blog/homebrew-on-m1/