### PR TITLE
Deal with remaining declarations after statements.

### DIFF
--- a/src/bin/dhcpclient.c
+++ b/src/bin/dhcpclient.c
@@ -323,8 +323,7 @@ static fr_radius_packet_t *fr_dhcpv4_recv_raw_loop(int lsockfd,
 	/* display offer(s) received */
 	if (nb_offer > 0 ) {
 		DEBUG("Received %d DHCP Offer(s):", nb_offer);
-		int i;
-		for (i = 0; i < nb_reply; i++) {
+		for (int i = 0; i < nb_reply; i++) {
 			char server_addr_buf[INET6_ADDRSTRLEN];
 			char offered_addr_buf[INET6_ADDRSTRLEN];
 

--- a/src/bin/radsniff.c
+++ b/src/bin/radsniff.c
@@ -2360,13 +2360,14 @@ int main(int argc, char *argv[])
 		{
 			pcap_if_t *all_devices = NULL;
 			pcap_if_t *dev_p;
+			int i;
 
 			if (pcap_findalldevs(&all_devices, errbuf) < 0) {
 				ERROR("Error getting available capture devices: %s", errbuf);
 				goto finish;
 			}
 
-			int i = 1;
+			i = 1;
 			for (dev_p = all_devices;
 			     dev_p;
 			     dev_p = dev_p->next) {

--- a/src/lib/ldap/base.c
+++ b/src/lib/ldap/base.c
@@ -534,6 +534,8 @@ fr_ldap_rcode_t fr_ldap_search_async(int *msgid, request_t *request,
 	LDAPControl			*our_serverctrls[LDAP_MAX_CONTROLS];
 	LDAPControl			*our_clientctrls[LDAP_MAX_CONTROLS];
 
+	char **search_attrs;
+
 	fr_ldap_control_merge(our_serverctrls, our_clientctrls,
 			      NUM_ELEMENTS(our_serverctrls),
 			      NUM_ELEMENTS(our_clientctrls),
@@ -549,7 +551,6 @@ fr_ldap_rcode_t fr_ldap_search_async(int *msgid, request_t *request,
 	 *	OpenLDAP library doesn't declare attrs array as const, but
 	 *	it really should be *sigh*.
 	 */
-	char **search_attrs;
 	memcpy(&search_attrs, &attrs, sizeof(attrs));
 
 	if (filter) {
@@ -632,8 +633,7 @@ static void ldap_trunk_query_cancel(UNUSED request_t *request, fr_state_signal_t
 #define SET_LDAP_CTRLS(_dest, _src) \
 do { \
 	if (!_src) break; \
-	int	i; \
-	for (i = 0; i < LDAP_MAX_CONTROLS; i++) { \
+	for (int i = 0; i < LDAP_MAX_CONTROLS; i++) { \
 		if (!(_src[i])) break; \
 		_dest[i].control = _src[i]; \
 	} \

--- a/src/lib/ldap/connection.c
+++ b/src/lib/ldap/connection.c
@@ -226,16 +226,18 @@ static int _ldap_connection_free(fr_ldap_connection_t *c)
 
 	if (!c->handle) return 0;	/* Don't need to do anything else if we don't yet have a handle */
 
-	LDAPControl	*our_serverctrls[LDAP_MAX_CONTROLS];
-	LDAPControl	*our_clientctrls[LDAP_MAX_CONTROLS];
+	{
+		LDAPControl	*our_serverctrls[LDAP_MAX_CONTROLS];
+		LDAPControl	*our_clientctrls[LDAP_MAX_CONTROLS];
 
-	fr_ldap_control_merge(our_serverctrls, our_clientctrls,
-			      NUM_ELEMENTS(our_serverctrls),
-			      NUM_ELEMENTS(our_clientctrls),
-			      c, NULL, NULL);
+		fr_ldap_control_merge(our_serverctrls, our_clientctrls,
+				      NUM_ELEMENTS(our_serverctrls),
+				      NUM_ELEMENTS(our_clientctrls),
+				      c, NULL, NULL);
 
-	DEBUG3("Closing connection %p libldap handle %p", c->handle, c);
-	ldap_unbind_ext(c->handle, our_serverctrls, our_clientctrls);	/* Same code as ldap_unbind_ext_s */
+		DEBUG3("Closing connection %p libldap handle %p", c->handle, c);
+		ldap_unbind_ext(c->handle, our_serverctrls, our_clientctrls);	/* Same code as ldap_unbind_ext_s */
+	}
 
 	c->handle = NULL;
 

--- a/src/lib/server/command.c
+++ b/src/lib/server/command.c
@@ -297,8 +297,9 @@ static int split_alternation(char **input, char **output)
 
 	if ((*str == '[') || (*str == '(')) {
 		char end;
-		quote = *(str++);
 		int count = 0;
+
+		quote = *(str++);
 
 		if (quote == '[') {
 			end = ']';
@@ -469,8 +470,9 @@ static int split(char **input, char **output, bool syntax_string)
 
 	} else if (syntax_string && ((*str == '[') || (*str == '('))) {
 		char end;
-		quote = *(str++);
 		int count = 0;
+
+		quote = *(str++);
 
 		if (quote == '[') {
 			end = ']';

--- a/src/lib/server/connection.c
+++ b/src/lib/server/connection.c
@@ -393,9 +393,11 @@ static inline void connection_watch_call(fr_connection_t *conn, fr_dlist_head_t 
 #define WATCH_PRE(_conn) \
 do { \
 	if (fr_dlist_empty(&(_conn)->watch_pre[(_conn)->pub.state])) break; \
-	HANDLER_BEGIN(conn, &(_conn)->watch_pre[(_conn)->pub.state]); \
-	connection_watch_call((_conn), &(_conn)->watch_pre[(_conn)->pub.state]); \
-	HANDLER_END(conn); \
+	{ \
+		HANDLER_BEGIN(conn, &(_conn)->watch_pre[(_conn)->pub.state]); \
+		connection_watch_call((_conn), &(_conn)->watch_pre[(_conn)->pub.state]); \
+		HANDLER_END(conn); \
+	} \
 } while(0)
 
 /** Call the post handler watch functions
@@ -404,9 +406,11 @@ do { \
 #define WATCH_POST(_conn) \
 do { \
 	if (fr_dlist_empty(&(_conn)->watch_post[(_conn)->pub.state])) break; \
-	HANDLER_BEGIN(conn, &(_conn)->watch_post[(_conn)->pub.state]); \
-	connection_watch_call((_conn), &(_conn)->watch_post[(_conn)->pub.state]); \
-	HANDLER_END(conn); \
+	{ \
+		HANDLER_BEGIN(conn, &(_conn)->watch_post[(_conn)->pub.state]); \
+		connection_watch_call((_conn), &(_conn)->watch_post[(_conn)->pub.state]); \
+		HANDLER_END(conn); \
+	} \
 } while(0)
 
 /** Remove a watch function from a pre/post[state] list

--- a/src/lib/server/map_async.c
+++ b/src/lib/server/map_async.c
@@ -475,9 +475,10 @@ int map_to_list_mod(TALLOC_CTX *ctx, vp_list_mod_t **out,
 	switch (mutated->rhs->type) {
 	case TMPL_TYPE_XLAT:
 	{
-		fr_assert(tmpl_xlat(mutated->rhs) != NULL);
 		fr_dcursor_t	from;
 		fr_value_box_t	*vb, *n_vb;
+
+		fr_assert(tmpl_xlat(mutated->rhs) != NULL);
 
 	assign_values:
 		fr_assert(tmpl_is_attr(mutated->lhs));

--- a/src/lib/server/tmpl_eval.c
+++ b/src/lib/server/tmpl_eval.c
@@ -899,10 +899,9 @@ int tmpl_copy_pairs(TALLOC_CTX *ctx, fr_pair_list_t *out, request_t *request, tm
 	fr_pair_t		*vp;
 	fr_dcursor_t		from;
 	tmpl_dcursor_ctx_t	cc;
+	int err;
 
 	TMPL_VERIFY(vpt);
-
-	int err;
 
 	fr_assert(tmpl_is_attr(vpt) || tmpl_is_list(vpt));
 
@@ -944,10 +943,9 @@ int tmpl_copy_pair_children(TALLOC_CTX *ctx, fr_pair_list_t *out, request_t *req
 	fr_pair_t		*vp;
 	fr_dcursor_t		from;
 	tmpl_dcursor_ctx_t	cc;
+	int err;
 
 	TMPL_VERIFY(vpt);
-
-	int err;
 
 	fr_assert(tmpl_is_attr(vpt) || tmpl_is_list(vpt));
 

--- a/src/lib/tls/session.c
+++ b/src/lib/tls/session.c
@@ -1772,10 +1772,9 @@ fr_tls_session_t *fr_tls_session_alloc_server(TALLOC_CTX *ctx, SSL_CTX *ssl_ctx,
 		EVP_MD_CTX	*md_ctx;
 		uint8_t		digest[SHA256_DIGEST_LENGTH];
 
-		fr_assert(conf->cache.id_name);
-
 		static_assert(sizeof(digest) <= SSL_MAX_SSL_SESSION_ID_LENGTH,
 			      "SSL_MAX_SSL_SESSION_ID_LENGTH must be >= SHA256_DIGEST_LENGTH");
+		fr_assert(conf->cache.id_name);
 
 		if (tmpl_aexpand(tls_session, &context_id, request, conf->cache.id_name, NULL, NULL) < 0) {
 			RPEDEBUG("Failed expanding session ID");

--- a/src/lib/tls/session.h
+++ b/src/lib/tls/session.h
@@ -196,11 +196,13 @@ static inline CC_HINT(nonnull) void _fr_tls_session_request_bind(char const *fil
 	RDEBUG3("%s[%u] - Binding SSL * (%p) to request (%p)", file, line, ssl, request);
 
 #ifndef NDEBUG
-	request_t *old;
-	old = SSL_get_ex_data(ssl, FR_TLS_EX_INDEX_REQUEST);
-	if (old) {
-		(void)talloc_get_type_abort(ssl, request_t);
-		fr_assert(0);
+	{
+		request_t *old;
+		old = SSL_get_ex_data(ssl, FR_TLS_EX_INDEX_REQUEST);
+		if (old) {
+			(void)talloc_get_type_abort(ssl, request_t);
+			fr_assert(0);
+		}
 	}
 #endif
 	ret = SSL_set_ex_data(ssl, FR_TLS_EX_INDEX_REQUEST, request);

--- a/src/lib/unlang/xlat_eval.c
+++ b/src/lib/unlang/xlat_eval.c
@@ -996,10 +996,9 @@ xlat_action_t xlat_frame_eval(TALLOC_CTX *ctx, fr_dcursor_t *out, xlat_exp_head_
 	xlat_action_t		xa = XLAT_ACTION_DONE;
 	xlat_exp_t const       	*node;
 	fr_value_box_list_t	result;		/* tmp list so debug works correctly */
+	fr_value_box_t		*value;
 
 	fr_value_box_list_init(&result);
-
-	fr_value_box_t		*value;
 
 	*child = NULL;
 

--- a/src/lib/unlang/xlat_tokenize.c
+++ b/src/lib/unlang/xlat_tokenize.c
@@ -620,6 +620,7 @@ static inline int xlat_tokenize_attribute(xlat_exp_head_t *head, fr_sbuff_t *in,
 	xlat_exp_t		*node;
 
 	fr_sbuff_marker_t	m_s;
+	tmpl_rules_t		 our_t_rules;
 
 	XLAT_DEBUG("ATTRIBUTE <-- %pV", fr_box_strvalue_len(fr_sbuff_current(in), fr_sbuff_remaining(in)));
 
@@ -630,8 +631,6 @@ static inline int xlat_tokenize_attribute(xlat_exp_head_t *head, fr_sbuff_t *in,
 	 *	and instead are "virtual" attributes like
 	 *	Foreach-Variable-N.
 	 */
-	tmpl_rules_t		 our_t_rules;
-
 	if (t_rules) {
 		memset(&our_t_rules, 0, sizeof(our_t_rules));
 		our_t_rules = *t_rules;

--- a/src/lib/util/acutest.h
+++ b/src/lib/util/acutest.h
@@ -1829,6 +1829,7 @@ int
 main(int argc, char** argv)
 {
     int i;
+    int index;
 
     acutest_argv0_ = argv[0];
 
@@ -1911,7 +1912,7 @@ main(int argc, char** argv)
             printf("1..%d\n", (int) acutest_count_);
     }
 
-    int index = acutest_worker_index_;
+    index = acutest_worker_index_;
     for(i = 0; acutest_list_[i].func != NULL; i++) {
         int run = (acutest_test_data_[i].flags & ACUTEST_FLAG_RUN_);
         if (acutest_skip_mode_) /* Run all tests except those listed. */

--- a/src/lib/util/inet.c
+++ b/src/lib/util/inet.c
@@ -1570,20 +1570,23 @@ int fr_interface_to_ethernet(char const *interface, fr_ethernet_t *ethernet)
 		if (strcmp(i->ifa_name, interface) != 0) continue;
 
 #if defined(__linux__) || defined(__EMSCRIPTEN__)
-		struct sockaddr_ll *ll;
+		{
+			struct sockaddr_ll *ll;
 
-		ll = (struct sockaddr_ll *) i->ifa_addr;
-		if ((ll->sll_hatype != 1) || (ll->sll_halen != 6)) continue;
+			ll = (struct sockaddr_ll *) i->ifa_addr;
+			if ((ll->sll_hatype != 1) || (ll->sll_halen != 6)) continue;
 
-		memcpy(ethernet->addr, ll->sll_addr, 6);
-
+			memcpy(ethernet->addr, ll->sll_addr, 6);
+		}
 #else
-		struct sockaddr_dl *ll;
+		{
+			struct sockaddr_dl *ll;
 
-		ll = (struct sockaddr_dl *) i->ifa_addr;
-		if (ll->sdl_alen != 6) continue;
+			ll = (struct sockaddr_dl *) i->ifa_addr;
+			if (ll->sdl_alen != 6) continue;
 
-		memcpy(ethernet->addr, LLADDR(ll), 6);
+			memcpy(ethernet->addr, LLADDR(ll), 6);
+		}
 #endif
 		ret = 0;
 		break;

--- a/src/lib/util/lst_tests.c
+++ b/src/lib/util/lst_tests.c
@@ -510,8 +510,10 @@ static void queue_cmp(unsigned int count)
 	 */
 	{
 		lst_thing	**array;
+		fr_time_t	start_alloc, end_alloc, start_insert, end_insert, start_pop, end_pop, end_pop_first;
+
 		populate_values(values, count);
-		fr_time_t	start_alloc, end_alloc, start_insert, end_insert, start_pop, end_pop, end_pop_first = fr_time_wrap(0);
+		end_pop_first = fr_time_wrap(0);
 
 		start_alloc = fr_time();
 		array = talloc_array(NULL, lst_thing *, count);

--- a/src/lib/util/minmax_heap_tests.c
+++ b/src/lib/util/minmax_heap_tests.c
@@ -458,8 +458,10 @@ static void queue_cmp(unsigned int count)
 	 */
 	{
 		minmax_heap_thing	**array;
+		fr_time_t		start_alloc, end_alloc, start_insert, end_insert, start_pop, end_pop, end_pop_first;
+
 		populate_values(values, count);
-		fr_time_t		start_alloc, end_alloc, start_insert, end_insert, start_pop, end_pop, end_pop_first = fr_time_min();
+		end_pop_first = fr_time_min();
 
 		start_alloc = fr_time();
 		array = talloc_array(NULL, minmax_heap_thing *, count);

--- a/src/lib/util/net.c
+++ b/src/lib/util/net.c
@@ -69,11 +69,11 @@ size_t fr_net_af_table_len = NUM_ELEMENTS(fr_net_af_table);
 	/*
 	 *	UDP header validation.
 	 */
-	udp = (udp_header_t const *)data;
 	uint16_t udp_len;
 	ssize_t diff;
 	uint16_t expected;
 
+	udp = (udp_header_t const *)data;
 	udp_len = ntohs(udp->len);
 	diff = udp_len - remaining;
 	/* Truncated data */

--- a/src/modules/rlm_eap/types/rlm_eap_fast/eap_fast.c
+++ b/src/modules/rlm_eap/types/rlm_eap_fast/eap_fast.c
@@ -921,9 +921,10 @@ fr_radius_packet_code_t eap_fast_process(request_t *request, eap_session_t *eap_
 	if (!eap_fast_verify(request, tls_session, data, data_len)) return FR_RADIUS_CODE_ACCESS_REJECT;
 
 	if (t->stage == EAP_FAST_TLS_SESSION_HANDSHAKE) {
+		char buf[256];
+
 		fr_assert(t->mode == EAP_FAST_UNKNOWN);
 
-		char buf[256];
 		if (strstr(SSL_CIPHER_description(SSL_get_current_cipher(tls_session->ssl),
 						  buf, sizeof(buf)), "Au=None")) {
 			/* FIXME enforce MSCHAPv2 - RFC 5422 section 3.2.2 */

--- a/src/modules/rlm_eap/types/rlm_eap_peap/peap.c
+++ b/src/modules/rlm_eap/types/rlm_eap_peap/peap.c
@@ -303,8 +303,9 @@ static void eap_peap_inner_to_pairs(TALLOC_CTX *ctx, fr_pair_list_t *pairs,
  */
 static int eap_peap_inner_from_pairs(request_t *request, fr_tls_session_t *tls_session, fr_pair_list_t *vps)
 {
-	fr_assert(!fr_pair_list_empty(vps));
 	fr_pair_t *this;
+
+	fr_assert(!fr_pair_list_empty(vps));
 
 	/*
 	 *	Send the EAP data in the first attribute, WITHOUT the

--- a/src/modules/rlm_isc_dhcp/rlm_isc_dhcp.c
+++ b/src/modules/rlm_isc_dhcp/rlm_isc_dhcp.c
@@ -256,8 +256,9 @@ redo:
 
 static int skip_spaces(rlm_isc_dhcp_tokenizer_t *state, char *p)
 {
-	state->ptr = p;
 	char *start = p;
+
+	state->ptr = p;
 
 	fr_skip_whitespace(state->ptr);
 

--- a/src/modules/rlm_perl/rlm_perl.c
+++ b/src/modules/rlm_perl/rlm_perl.c
@@ -546,16 +546,14 @@ static xlat_action_t perl_xlat(TALLOC_CTX *ctx, fr_dcursor_t *out,
  */
 static void perl_parse_config(CONF_SECTION *cs, int lvl, HV *rad_hv)
 {
-	if (!cs || !rad_hv) return;
-
 	int indent_section = (lvl + 1) * 4;
 	int indent_item = (lvl + 2) * 4;
 
+	if (!cs || !rad_hv) return;
+
 	DEBUG("%*s%s {", indent_section, " ", cf_section_name1(cs));
 
-	CONF_ITEM *ci = NULL;
-
-	while ((ci = cf_item_next(cs, ci))) {
+	for (CONF_ITEM *ci = NULL; (ci = cf_item_next(cs, ci)); ) {
 		/*
 		 *  This is a section.
 		 *  Create a new HV, store it as a reference in current HV,
@@ -665,10 +663,9 @@ static void perl_store_vps(UNUSED TALLOC_CTX *ctx, request_t *request, fr_pair_l
 			   const char *hash_name, const char *list_name)
 {
 	fr_pair_t *vp;
+	fr_dcursor_t cursor;
 
 	hv_undef(rad_hv);
-
-	fr_dcursor_t cursor;
 
 	RINDENT();
 	fr_pair_list_sort(vps, fr_pair_cmp_by_da);

--- a/src/protocols/dhcpv4/raw.c
+++ b/src/protocols/dhcpv4/raw.c
@@ -184,6 +184,7 @@ fr_radius_packet_t *fr_dhcv4_raw_packet_recv(int sockfd, struct sockaddr_ll *lin
 	uint16_t		udp_dst_port;
 	size_t			dhcp_data_len;
 	socklen_t		sock_len;
+	uint8_t			data_offset;
 
 	packet = fr_radius_packet_alloc(NULL, false);
 	if (!packet) {
@@ -204,7 +205,7 @@ fr_radius_packet_t *fr_dhcv4_raw_packet_recv(int sockfd, struct sockaddr_ll *lin
 	sock_len = sizeof(struct sockaddr_ll);
 	data_len = recvfrom(sockfd, raw_packet, MAX_PACKET_SIZE, 0, (struct sockaddr *)link_layer, &sock_len);
 
-	uint8_t data_offset = ETH_HDR_SIZE + IP_HDR_SIZE + UDP_HDR_SIZE; /* DHCP data datas after Ethernet, IP, UDP */
+	data_offset = ETH_HDR_SIZE + IP_HDR_SIZE + UDP_HDR_SIZE; /* DHCP data datas after Ethernet, IP, UDP */
 
 	if (data_len <= data_offset) DISCARD_RP("Payload (%d) smaller than required for layers 2+3+4", (int)data_len);
 

--- a/src/protocols/tacacs/base.c
+++ b/src/protocols/tacacs/base.c
@@ -132,6 +132,7 @@ int fr_tacacs_body_xor(fr_tacacs_packet_t const *pkt, uint8_t *body, size_t body
 	uint8_t pad[MD5_DIGEST_LENGTH];
 	uint8_t *buf;
 	int pad_offset;
+	size_t pos;
 
 	if (!secret) {
 		if (pkt->hdr.flags & FR_TAC_PLUS_UNENCRYPTED_FLAG)
@@ -160,7 +161,7 @@ int fr_tacacs_body_xor(fr_tacacs_packet_t const *pkt, uint8_t *body, size_t body
 
 	fr_md5_calc(pad, buf, pad_offset);
 
-	size_t pos = 0;
+	pos = 0;
 	do {
 		for (size_t i = 0; i < MD5_DIGEST_LENGTH && pos < body_len; i++, pos++)
 			body[pos] ^= pad[i];


### PR DESCRIPTION
These cases are less trivial than double semicolons between declarations. Some just require moving declarations to the front of the block, others require otherwise gratuitous blocks.