### PR TITLE
Fix typo

### DIFF
--- a/configure
+++ b/configure
@@ -7339,7 +7339,7 @@ fi
 
 
 old_CFLAGS=$CFLAGS
-if test $ac_cv_prog_suncc = "yes"; then
+if test "$ac_cv_prog_suncc" = "yes"; then
   CFLAGS="$CFLAGS -mt"
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -886,7 +886,7 @@ dnl #
 dnl #  If using pthreads, check for -lpthread (posix) or -lc_r (*BSD)
 dnl #
 old_CFLAGS=$CFLAGS
-if test $ac_cv_prog_suncc = "yes"; then
+if test "$ac_cv_prog_suncc" = "yes"; then
   CFLAGS="$CFLAGS -mt"
 fi
 


### PR DESCRIPTION
It fixes the error:

`./configure: line 7342: test: =: unary operator expected`