### PR TITLE
DS-Lite-Tunnel-Name data type should be 'octets'

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -4,6 +4,7 @@ FreeRADIUS 3.0.27 Tue 20 Sep 2022 12:00:00 EDT urgency=low
 
 	Bug fixes
 	* Fix rlm_python3 build with python >= 3.10. Fixes #4441
+	* The DS-Lite-Tunnel-Name data type should be 'octets'.
 
 FreeRADIUS 3.0.26 Tue 20 Sep 2022 12:00:00 EDT urgency=low
 	Feature improvements

--- a/share/dictionary.rfc6519
+++ b/share/dictionary.rfc6519
@@ -8,4 +8,4 @@
 #	$Id$
 #
 
-ATTRIBUTE	DS-Lite-Tunnel-Name			144	string
+ATTRIBUTE	DS-Lite-Tunnel-Name			144	octets


### PR DESCRIPTION
Backport from v3.2.x (be3b0426df)