### PR TITLE
Deal with time of check/time of use complaints (CIDs below)

### DIFF
--- a/src/lib/server/cf_file.c
+++ b/src/lib/server/cf_file.c
@@ -533,6 +533,7 @@ static int cf_file_open(CONF_SECTION *cs, char const *filename, bool from_dir, F
 		my_file.cs = cs;
 		my_file.filename = filename;
 
+		/* coverity[fs_check_call] */
 		if (stat(filename, &my_file.buf) < 0) goto error;
 
 		file = fr_rb_find(tree, &my_file);

--- a/src/lib/util/dl.c
+++ b/src/lib/util/dl.c
@@ -551,6 +551,7 @@ dl_t *dl_by_name(dl_loader_t *dl_loader, char const *name, void *uctx, bool uctx
 			 *	Check if the dlopen() failed
 			 *	because of access permissions.
 			 */
+			/* coverity[fs_check_call] */
 			if (access(path, access_mode) < 0) {
 				/*
 				 *	It doesn't exist,

--- a/src/modules/rlm_sql/drivers/rlm_sql_sqlite/rlm_sql_sqlite.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_sqlite/rlm_sql_sqlite.c
@@ -696,6 +696,7 @@ static int mod_bootstrap(module_inst_ctx_t const *mctx)
 							   main_config->raddb_dir, config->sql_db));
 	}
 
+	/* coverity[fs_check_call] */
 	if (stat(inst->filename, &buf) == 0) {
 		exists = true;
 	} else if (errno == ENOENT) {


### PR DESCRIPTION
1400053: the call coverity complains about is just there to
         determine why the dlopen() failed.
1445217: the fopen() return is checked, so any changes between
         the stat() call and it should be detected.
1503910: here, the unlink() return is checked