### PR TITLE
Explicitly ignore fr_event_timer_in() return value (CID #1503936)

### DIFF
--- a/src/lib/ldap/connection.c
+++ b/src/lib/ldap/connection.c
@@ -461,8 +461,8 @@ static void _ldap_trunk_idle_timeout(fr_event_list_t *el, UNUSED fr_time_t now, 
 		/*
 		 *	There are still pending queries - insert a new event
 		 */
-		fr_event_timer_in(ttrunk, el, &ttrunk->ev, ttrunk->t->config->idle_timeout,
-				  _ldap_trunk_idle_timeout, ttrunk);
+		(void) fr_event_timer_in(ttrunk, el, &ttrunk->ev, ttrunk->t->config->idle_timeout,
+					 _ldap_trunk_idle_timeout, ttrunk);
 	}
 }
 


### PR DESCRIPTION
fr_event_timer_in() (actually _fr_event_timer_at()) reuses events where possible, and being in the idle timeout means that there is such an event available for reuse.