### PR TITLE
Fallback to `uname -n` on missing `hostname` in radtest

### DIFF
--- a/src/bin/radtest.in
+++ b/src/bin/radtest.in
@@ -100,7 +100,7 @@ if [ "$7" ]
 then
 	nas=$7
 else
-	nas=`hostname`
+	nas=`(hostname || uname -n) 2>/dev/null | sed 1q`
 fi
 
 (


### PR DESCRIPTION
This should work without inetutils being installed, so add a fallback.

Signed-off-by: Christian Hesse <mail@eworm.de>