### PR TITLE
Fallback to `uname -n` on missing `hostname` in radtest (#4771)

### DIFF
--- a/src/main/radtest.in
+++ b/src/main/radtest.in
@@ -112,7 +112,7 @@ if [ "$7" ]
 then
 	nas=$7
 else
-	nas=`hostname`
+	nas=`(hostname || uname -n) 2>/dev/null | sed 1q`
 fi
 
 (


### PR DESCRIPTION
This should work without inetutils being installed, so add a fallback.

Signed-off-by: Christian Hesse <mail@eworm.de>
(cherry picked from commit 7b2033c644313b4619c35fc8cfcab053f2735816)