### PR TITLE
Ignore fr_event_timer_in() return here, too (CID #154036)

### DIFF
--- a/src/lib/ldap/connection.c
+++ b/src/lib/ldap/connection.c
@@ -734,8 +734,8 @@ static void ldap_trunk_request_demux(fr_event_list_t *el, fr_trunk_connection_t 
 	/*
 	 *  Reset the idle timeout event
 	 */
-	fr_event_timer_in(ttrunk, el, &ttrunk->ev,
-			  ttrunk->t->config->idle_timeout, _ldap_trunk_idle_timeout, ttrunk);
+	(void) fr_event_timer_in(ttrunk, el, &ttrunk->ev,
+				 ttrunk->t->config->idle_timeout, _ldap_trunk_idle_timeout, ttrunk);
 
 	do {
 		/*


### PR DESCRIPTION
Like 1503936, this is in a callback and will reuse the idle timeout event.