### PR TITLE
Ignore fr_sbuff_in_strcpy() return in fr_pair_list_log_sbuff() (CID #…

### DIFF
--- a/src/lib/util/pair_print.c
+++ b/src/lib/util/pair_print.c
@@ -167,7 +167,7 @@ static void fr_pair_list_log_sbuff(fr_log_t const *log, int lvl, fr_pair_t *pare
 			break;
 
 		default:
-			fr_sbuff_in_strcpy(sbuff, " = ");
+			(void) fr_sbuff_in_strcpy(sbuff, " = ");
 			fr_value_box_print_quoted(sbuff, &vp->data, T_DOUBLE_QUOTED_STRING);
 
 			fr_log(log, L_DBG, file, line, "%*s%*s", lvl * 2, "",


### PR DESCRIPTION
…1504278)

sbuff is emptied each time through the for loop, and down this path it will only contain the output of fr_dict_attr_oid_print(), possibly preceded by "raw.". fr_pair_list_log_sbuff() is only called from one place, which passes in an sbuff using an array of 1024 characters. This should suffice to make appending " = " always work.