### PR TITLE
Port closefrom() calls in exec.c to OpenBSD

### DIFF
--- a/src/lib/server/exec.c
+++ b/src/lib/server/exec.c
@@ -309,7 +309,15 @@ static NEVER_RETURNS void exec_child(request_t *request, char **argv, char **env
 	 *	want to leave dangling FD's for the child process
 	 *	to play funky games with, so we close them.
 	 */
-	closefrom(STDERR_FILENO + 1);
+	do {
+		/*
+		 *	Solaris' closefrom returns void.
+		 *	OpenBSD's closefrom returns int and can be EINTR'd.
+		 *	Calling it like this is compatible with both APIs.
+		 */
+		errno = 0;
+		closefrom(STDERR_FILENO + 1);
+	} while (errno == EINTR);
 
 	/*
 	 *	Disarm the thread local destructors

--- a/src/lib/server/exec_legacy.c
+++ b/src/lib/server/exec_legacy.c
@@ -196,7 +196,15 @@ static NEVER_RETURNS void exec_child_legacy(request_t *request, char **argv, cha
 	 *	want to leave dangling FD's for the child process
 	 *	to play funky games with, so we close them.
 	 */
-	closefrom(STDERR_FILENO + 1);
+	do {
+		/*
+		 *	Solaris' closefrom returns void.
+		 *	OpenBSD's closefrom returns int and can be EINTR'd.
+		 *	Calling it like this is compatible with both APIs.
+		 */
+		errno = 0;
+		closefrom(STDERR_FILENO + 1);
+	} while (errno == EINTR);
 
 	/*
 	 *	Disarm the thread local destructors


### PR DESCRIPTION
OpenBSD has a unique version of the closefrom() function which returns int and can be interrupted. Every other OS follows the original Solaris API which returns void and has no error condition. It's possible to be compatible with both.