### PR TITLE
Annotate fs_check_call (CID #1271307)

### DIFF
--- a/src/listen/control/proto_control_unix.c
+++ b/src/listen/control/proto_control_unix.c
@@ -414,6 +414,7 @@ static int fr_server_domain_socket_peercred(char const *path, uid_t UNUSED uid, 
 	/*
 	 *	Check the path.
 	 */
+	/* coverity[fs_check_call] */
 	if (stat(path, &buf) < 0) {
 		if (errno != ENOENT) {
 			fr_strerror_printf("Failed to stat %s: %s", path, fr_syserror(errno));


### PR DESCRIPTION
The unlink() call (the use of the toctou) does check its return code. Also, it's not listed among the UseSet functions in "TOCTTOU Vulnerabilities in Unix-Style File Systems: An Anatomical Study", https://www.usenix.org/legacy/events/fast05/tech/full_papers/wei/wei.pdf