### PR TITLE
fr_value_box_from_network: Fix NULL pointer dereference when truncating

### DIFF
--- a/src/lib/util/value.c
+++ b/src/lib/util/value.c
@@ -1654,7 +1654,7 @@ ssize_t fr_value_box_from_network(TALLOC_CTX *ctx,
 	 *	For array entries, we only decode one value at a time.
 	 */
 	if (len > max) {
-		if (!enumv->flags.array) {
+		if (enumv && !enumv->flags.array) {
 			fr_strerror_printf("Found trailing garbage parsing type \"%s\". "
 					   "Expected length <= %zu bytes, got %zu bytes",
 					   fr_type_to_str(type),

--- a/src/tests/keywords/unpack
+++ b/src/tests/keywords/unpack
@@ -23,6 +23,13 @@ if (&Tmp-Integer-0 != 772) {
 	test_fail
 }
 
+# truncation
+&Tmp-String-0 := "0x0011223344556677"
+&Tmp-String-1 := "%(unpack:%{Tmp-String-0} 0 ether)"
+if (&Tmp-String-1 != "00:11:22:33:44:55") {
+	test_fail
+}
+
 &Tmp-String-0 := "0x48656C6C6F"
 &Tmp-String-1 := "%(unpack:%{Tmp-String-0} 0 string)"
 if (&Tmp-String-1 != "Hello") {


### PR DESCRIPTION
Fixes the following segmentation fault:

```
(gdb) bt
#0  0x00007ffff7b7d507 in fr_value_box_from_network (ctx=0x1ae2c30, dst=0x1ae33b0, type=FR_TYPE_ETHERNET,
    enumv=0x0, dbuff=0x7fffffffdb70, len=34, tainted=false) at src/lib/util/value.c:1657
#1  0x00007fffe7e33b51 in unpack_xlat (ctx=0x1ae2c30, out=0x1ad03f0, xctx=0x7fffffffde00, request=0x1abc4f0,
    in=0x1ad0440) at src/modules/rlm_unpack/rlm_unpack.c:116
#2  0x00007ffff7109ff1 in xlat_frame_eval_repeat (ctx=0x1ae2c30, out=0x1ad03f0, child=0x7fffffffe038,
    alternate=0x1ad0468, request=0x1abc4f0, head=0x15f5470, in=0x1ad03e8, result=0x1ad0440)
    at src/lib/unlang/xlat_eval.c:824
#3  0x00007ffff70f4706 in unlang_xlat_repeat (p_result=0x1abc6bc, request=0x1abc4f0, frame=0x1abc848)
    at src/lib/unlang/xlat.c:290
#4  0x00007ffff70e4584 in frame_eval (priority=0x1abc6b8, result=0x1abc6bc, frame=0x1abc848,
    request=0x1abc4f0) at src/lib/unlang/interpret.c:500
#5  unlang_interpret (request=0x1abc4f0) at src/lib/unlang/interpret.c:684
#6  0x00007ffff6eac8d4 in worker_run_request (start=..., worker=0x176b770) at src/lib/io/worker.c:1184
#7  fr_worker_post_event (el=0x173db70, now=..., uctx=0x176b770) at src/lib/io/worker.c:1402
#8  0x00007ffff7b2c779 in fr_event_service (el=0x173db70) at src/lib/util/event.c:2507
#9  0x00007ffff7b2c86a in fr_event_loop (el=0x173db70) at src/lib/util/event.c:2547
#10 0x00007ffff73c3a76 in main_loop_start () at src/lib/server/main_loop.c:214
#11 0x0000000000405eb6 in main (argc=2, argv=0x7fffffffe538) at src/bin/radiusd.c:956
```