### PR TITLE
Fix comment on status line length in rlm_rest

### DIFF
--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -1285,8 +1285,8 @@ static size_t rest_response_header(void *in, size_t size, size_t nmemb, void *us
 		/*
 		 *  HTTP/<version> <reason_code>[ <reason_phrase>]\r\n
 		 *
-		 *  "HTTP/1.1 " (8) + "100 " (4) + "\r\n" (2) = 14
-		 *  "HTTP/2 " (8) + "100 " (4) + "\r\n" (2) = 12
+		 *  "HTTP/1.1 " (9) + "100" (3) + "\r\n" (2) = 14
+		 *  "HTTP/2 " (7) + "100" (3) + "\r\n" (2) = 12
 		 */
 		if ((end - p) < 12) {
 			REDEBUG("Malformed HTTP header: Status line too short");


### PR DESCRIPTION
I stumbled upon this minor miscalculation (actually, a serious of miscalculations – you only need to count wrong often enough to make it work out in the end ;)) when debugging HTTP/2 issues on an old version of FreeRADIUS.

There's nothing wrong here (my FreeRADIUS was simply too old), it's only a minor issue in the comment.