### PR TITLE
v4: Add functionality to rate limit LDAP sync store Cookie

### DIFF
--- a/raddb/sites-available/ldap_sync
+++ b/raddb/sites-available/ldap_sync
@@ -152,6 +152,29 @@ server ldap_sync {
 		}
 
 		#
+		#  When directories provide cookies to track progress through
+		#  the list of changes, these can be provided on every update,
+		#  which can be an excessive rate.
+		#
+		#  FreeRADIUS keeps track of pending change and will only call
+		#  store Cookie once the preceding changes have been processed.
+		#
+		#  These options rate limit how often cookies will be stored.
+		#  Provided all preceding changes have been processed, cookie Store
+		#  will be called on a timed interval or after a number of changes
+		#  have been completed, whichever occurs first.
+		#
+		#  How often to store cookies.
+		#
+		cookie_interval = 10
+
+		#
+		#  Number of completed changes which will prompt the storing
+		#  of a cookie
+		#
+		cookie_changes = 100
+
+		#
 		#  Persistent searches.
 		#
 		#  You can configure an unlimited (within reason, and any limitations

--- a/src/listen/ldap_sync/active_directory.c
+++ b/src/listen/ldap_sync/active_directory.c
@@ -43,13 +43,14 @@ static int active_directory_sync_attr_add(char const *attr, void *uctx)
  * Neither of these controls take values.
  *
  * @param[in] conn 		Connection to issue the search request on.
- * @param[in] config		containing callbacks and search parameters.
+ * @param[in] sync_no		number of the sync in the array of configs.
+ * @param[in] inst		instance of ldap_sync this query relates to.
  * @param[in] cookie		unused for Active Directory
  * @return
  *	- 0 on success
  *	- -1 on failure
  */
-int active_directory_sync_state_init(fr_ldap_connection_t *conn, size_t sync_no, sync_config_t const *config,
+int active_directory_sync_state_init(fr_ldap_connection_t *conn, size_t sync_no, proto_ldap_sync_t const *inst,
 				     UNUSED uint8_t const *cookie)
 {
 	static char const	*notify_oid = LDAP_SERVER_NOTIFICATION_OID;
@@ -60,6 +61,7 @@ int active_directory_sync_state_init(fr_ldap_connection_t *conn, size_t sync_no,
 	sync_state_t		*sync;
 	fr_rb_tree_t		*tree;
 	char const		*filter = NULL;
+	sync_config_t const	*config = inst->sync_config[sync_no];
 
 	fr_assert(conn);
 	fr_assert(config);
@@ -75,7 +77,7 @@ int active_directory_sync_state_init(fr_ldap_connection_t *conn, size_t sync_no,
 		tree = talloc_get_type_abort(conn->uctx, fr_rb_tree_t);
 	}
 
-	sync = sync_state_alloc(tree, conn, sync_no, config);
+	sync = sync_state_alloc(tree, conn, inst, sync_no, config);
 
 	/*
 	 *	Notification control - marks this as a persistent search.

--- a/src/listen/ldap_sync/active_directory.h
+++ b/src/listen/ldap_sync/active_directory.h
@@ -26,7 +26,7 @@
 #include <freeradius-devel/ldap/base.h>
 #include "proto_ldap_sync_ldap.h"
 
-int active_directory_sync_state_init(fr_ldap_connection_t *conn, size_t sync_no, sync_config_t const *config,
-				     UNUSED uint8_t const *cookie);
+int active_directory_sync_state_init(fr_ldap_connection_t *conn, size_t sync_no,
+				     proto_ldap_sync_t const *inst, UNUSED uint8_t const *cookie);
 
 int active_directory_sync_search_entry(sync_state_t *sync, LDAPMessage *msg, UNUSED LDAPControl **ctrls);

--- a/src/listen/ldap_sync/persistent_search.c
+++ b/src/listen/ldap_sync/persistent_search.c
@@ -46,10 +46,11 @@
  * an ldap_abandon message to the server to tell it to cancel the search.
  *
  * @param[in] conn 		Connection to issue the search request on.
- * @param[in] config		containing callbacks and search parameters.
+ * @param[in] sync_no		number of the sync in the array of configs.
+ * @param[in] inst		instance of ldap_sync this query relates to.
  * @param[in] cookie		not applicable to persistent search LDAP servers.
  */
-int persistent_sync_state_init(fr_ldap_connection_t *conn, size_t sync_no, sync_config_t const *config, UNUSED uint8_t const *cookie)
+int persistent_sync_state_init(fr_ldap_connection_t *conn, size_t sync_no, proto_ldap_sync_t const *inst, UNUSED uint8_t const *cookie)
 {
 	static char const	*notify_oid = LDAP_CONTROL_PERSIST_REQUEST;
 	LDAPControl		ctrl = {0}, *ctrls[2] = { &ctrl, NULL };
@@ -57,6 +58,7 @@ int persistent_sync_state_init(fr_ldap_connection_t *conn, size_t sync_no, sync_
 	int			ret;
 	sync_state_t		*sync;
 	fr_rb_tree_t		*tree;
+	sync_config_t		*config = inst->sync_config[sync_no];
 
 	fr_assert(conn);
 	fr_assert(config);
@@ -81,7 +83,7 @@ int persistent_sync_state_init(fr_ldap_connection_t *conn, size_t sync_no, sync_
 		return -1;
 	}
 
-	sync = sync_state_alloc(tree, conn, sync_no, config);
+	sync = sync_state_alloc(tree, conn, inst, sync_no, config);
 
 	memcpy(&ctrl.ldctl_oid, &notify_oid, sizeof(ctrl.ldctl_oid));
 

--- a/src/listen/ldap_sync/persistent_search.c
+++ b/src/listen/ldap_sync/persistent_search.c
@@ -129,6 +129,13 @@ int persistent_sync_state_init(fr_ldap_connection_t *conn, size_t sync_no, proto
 
 	DEBUG3("Sync created with msgid %i", sync->msgid);
 
+	/*
+	 *	Register event to store cookies at a regular interval
+	 *	Whilst persistent search LDAP servers don't provide cookies as such
+	 *	we treat change numbers, if provided, as cookies.
+	 */
+	fr_event_timer_in(sync, conn->conn->el, &sync->cookie_ev, inst->cookie_interval, ldap_sync_cookie_event, sync);
+
 	return 0;
 }
 

--- a/src/listen/ldap_sync/persistent_search.c
+++ b/src/listen/ldap_sync/persistent_search.c
@@ -255,7 +255,7 @@ int persistent_sync_search_entry(sync_state_t *sync, LDAPMessage *msg, LDAPContr
 		 */
 		if (sync->cookie) talloc_free(sync->cookie);
 		sync->cookie = (uint8_t *)talloc_asprintf(sync, "%d", change_no);
-		if (ldap_sync_cookie_store(sync, sync->cookie, false) < 0) goto error;
+		if (ldap_sync_cookie_store(sync, false) < 0) goto error;
 	}
 
 	if (ber_scanf(ber, "}") == LBER_ERROR) {

--- a/src/listen/ldap_sync/persistent_search.h
+++ b/src/listen/ldap_sync/persistent_search.h
@@ -26,7 +26,7 @@
 #include <freeradius-devel/ldap/base.h>
 #include "proto_ldap_sync_ldap.h"
 
-int persistent_sync_state_init(fr_ldap_connection_t *conn, size_t sync_no, sync_config_t const *config,
+int persistent_sync_state_init(fr_ldap_connection_t *conn, size_t sync_no, proto_ldap_sync_t const *inst,
 			       UNUSED uint8_t const *cookie);
 
 int persistent_sync_search_entry(sync_state_t *sync, LDAPMessage *msg, LDAPControl **ctrls);

--- a/src/listen/ldap_sync/proto_ldap_sync.c
+++ b/src/listen/ldap_sync/proto_ldap_sync.c
@@ -53,6 +53,8 @@ static CONF_PARSER const proto_ldap_sync_config[] = {
 
 	{ FR_CONF_OFFSET("max_packet_size", FR_TYPE_UINT32, proto_ldap_sync_t, max_packet_size) },
 	{ FR_CONF_OFFSET("num_messages", FR_TYPE_UINT32, proto_ldap_sync_t, num_messages) },
+	{ FR_CONF_OFFSET("cookie_interval", FR_TYPE_TIME_DELTA, proto_ldap_sync_t, cookie_interval), .dflt = "10" },
+	{ FR_CONF_OFFSET("cookie_changes", FR_TYPE_UINT32, proto_ldap_sync_t, cookie_changes), .dflt = "100" },
 
 	/*
 	 *	Areas of the DIT to listen on

--- a/src/listen/ldap_sync/proto_ldap_sync.h
+++ b/src/listen/ldap_sync/proto_ldap_sync.h
@@ -54,6 +54,10 @@ typedef struct {
 	uint32_t		num_messages;			//!< for message ring buffer
 	uint32_t		priority;			//!< for packet processing.
 
+	fr_time_delta_t		cookie_interval;		//!< Interval between storing cookies.
+	uint32_t		cookie_changes;			//!< Number of LDAP changes to process between
+								//!< each cookie store operation.
+
 	fr_schedule_t		*sc;
 
 	fr_listen_t		*listen;			//!< The listener structure which describes

--- a/src/listen/ldap_sync/proto_ldap_sync.h
+++ b/src/listen/ldap_sync/proto_ldap_sync.h
@@ -84,13 +84,14 @@ typedef struct sync_state_s sync_state_t;
  * controls for type of directory in use.
  *
  * @param[in] conn		to initialise the sync on
- * @param[in] config		for the sync
+ * @param[in] sync_no		number of the sync in the array of configs.
+ * @param[in] inst		instance of ldap_sync this query relates to
  * @param[in] cookie		to send with the query (RFC 4533 only)
  * @return
  *	- 0 on success.
  *	- -1 on error.
  */
- typedef int (*sync_init_t)(fr_ldap_connection_t *conn, size_t sync_no, sync_config_t const *config,
+ typedef int (*sync_init_t)(fr_ldap_connection_t *conn, size_t sync_no, proto_ldap_sync_t const *inst,
  			    uint8_t const *cookie);
 
 /** Received an LDAP message related to a sync

--- a/src/listen/ldap_sync/proto_ldap_sync_ldap.c
+++ b/src/listen/ldap_sync/proto_ldap_sync_ldap.c
@@ -170,6 +170,8 @@ sync_state_t *sync_state_alloc(TALLOC_CTX *ctx, fr_ldap_connection_t *conn, prot
 	sync->sync_no = sync_no;
 	sync->phase = SYNC_PHASE_INIT;
 
+	fr_dlist_talloc_init(&sync->pending, sync_packet_ctx_t, entry);
+
 	/*
 	 *	If the connection is freed, all the sync state is also freed
 	 */

--- a/src/listen/ldap_sync/proto_ldap_sync_ldap.c
+++ b/src/listen/ldap_sync/proto_ldap_sync_ldap.c
@@ -158,12 +158,14 @@ static int sync_state_free(sync_state_t *sync)
  * @param[in] config	for the sync.
  * @return new sync state.
  */
-sync_state_t *sync_state_alloc(TALLOC_CTX *ctx, fr_ldap_connection_t *conn, size_t sync_no, sync_config_t const *config)
+sync_state_t *sync_state_alloc(TALLOC_CTX *ctx, fr_ldap_connection_t *conn, proto_ldap_sync_t const *inst,
+			       size_t sync_no, sync_config_t const *config)
 {
 	sync_state_t	*sync;
 
 	MEM(sync = talloc_zero(ctx, sync_state_t));
 	sync->conn = conn;
+	sync->inst = inst;
 	sync->config = config;
 	sync->sync_no = sync_no;
 	sync->phase = SYNC_PHASE_INIT;
@@ -654,7 +656,7 @@ static ssize_t proto_ldap_child_mod_write(fr_listen_t *li, void *packet_ctx, UNU
 		vp = fr_pair_find_by_da_nested(&tmp, NULL, attr_ldap_sync_cookie);
 		if (vp) cookie = talloc_memdup(inst, vp->vp_octets, vp->vp_length);
 
-		inst->parent->sync_config[packet_id]->init(thread->conn->h, packet_id, inst->parent->sync_config[packet_id], cookie);
+		inst->parent->sync_config[packet_id]->init(thread->conn->h, packet_id, inst->parent, cookie);
 	}
 		break;
 
@@ -680,7 +682,7 @@ static ssize_t proto_ldap_child_mod_write(fr_listen_t *li, void *packet_ctx, UNU
 		sync_config = refresh_packet->sync->config;
 		DEBUG3("Restarting sync with base %s", sync_config->base_dn);
 		talloc_free(refresh_packet->sync);
-		inst->parent->sync_config[packet_id]->init(thread->conn->h, packet_id, sync_config, refresh_packet->refresh_cookie);
+		inst->parent->sync_config[packet_id]->init(thread->conn->h, packet_id, inst->parent, refresh_packet->refresh_cookie);
 
 		talloc_free(refresh_packet);
 	}

--- a/src/listen/ldap_sync/proto_ldap_sync_ldap.c
+++ b/src/listen/ldap_sync/proto_ldap_sync_ldap.c
@@ -183,13 +183,12 @@ sync_state_t *sync_state_alloc(TALLOC_CTX *ctx, fr_ldap_connection_t *conn, size
  * load Cookie.
  *
  * @param[in] sync	the cookie was received for.
- * @param[in] cookie	received from the LDAP server. Can be NULL to indicate the stored cookie should be cleared.
  * @param[in] refresh	the sync after storing this cookie.
  * @return
  *	- 0 on success.
  *	- -1 on failure
  */
-int ldap_sync_cookie_store(sync_state_t *sync, uint8_t const *cookie, bool refresh)
+int ldap_sync_cookie_store(sync_state_t *sync, bool refresh)
 {
 	proto_ldap_sync_ldap_thread_t	*thread = talloc_get_type_abort(sync->config->user_ctx, proto_ldap_sync_ldap_thread_t);
 	fr_dbuff_t			*dbuff;
@@ -197,6 +196,7 @@ int ldap_sync_cookie_store(sync_state_t *sync, uint8_t const *cookie, bool refre
 	fr_pair_list_t			pairs;
 	fr_pair_t			*vp;
 	TALLOC_CTX			*local = NULL;
+	uint8_t				*cookie = sync->cookie;
 
 	FR_DBUFF_TALLOC_THREAD_LOCAL(&dbuff, 1024, 4096);
 

--- a/src/listen/ldap_sync/proto_ldap_sync_ldap.h
+++ b/src/listen/ldap_sync/proto_ldap_sync_ldap.h
@@ -67,6 +67,8 @@ struct sync_state_s {
 	uint32_t			pending_cookies;	//!< How many cookies are in the pending heap
 	uint32_t			changes_since_cookie;	//!< How many changes have been added since
 								//!< the last cookie was stored.
+
+	fr_event_timer_t const		*cookie_ev;	//!< Timer event for sending cookies.
 };
 
 typedef struct sync_state_s sync_state_t;
@@ -148,6 +150,8 @@ sync_state_t *sync_state_alloc(TALLOC_CTX *ctx, fr_ldap_connection_t *conn, prot
 			       size_t sync_no, sync_config_t const *config);
 
 int ldap_sync_cookie_store(sync_state_t *sync, bool refresh);
+
+void ldap_sync_cookie_event(fr_event_list_t *el, fr_time_t now, void *uctx);
 
 int ldap_sync_cookie_send(sync_packet_ctx_t *sync_packet_ctx);
 

--- a/src/listen/ldap_sync/proto_ldap_sync_ldap.h
+++ b/src/listen/ldap_sync/proto_ldap_sync_ldap.h
@@ -121,7 +121,7 @@ int8_t sync_state_cmp(void const *one, void const *two);
 
 sync_state_t *sync_state_alloc(TALLOC_CTX *ctx, fr_ldap_connection_t *conn, size_t sync_no, sync_config_t const *config);
 
-int ldap_sync_cookie_store(sync_state_t *sync, uint8_t const *cookie, bool refresh);
+int ldap_sync_cookie_store(sync_state_t *sync, bool refresh);
 
 int ldap_sync_entry_send(sync_state_t *sync, uint8_t const uuid[SYNC_UUID_LENGTH], struct berval *orig_dn,
 			LDAPMessage *msg, sync_op_t op);

--- a/src/listen/ldap_sync/proto_ldap_sync_ldap.h
+++ b/src/listen/ldap_sync/proto_ldap_sync_ldap.h
@@ -106,6 +106,33 @@ typedef struct {
 	fr_connection_t			*conn;			//!< Our connection to the LDAP directory.
 } proto_ldap_sync_ldap_thread_t;
 
+typedef enum {
+	SYNC_PACKET_PENDING = 0,				//!< Packet not yet sent.
+	SYNC_PACKET_PREPARING,					//!< Packet being prepared.
+	SYNC_PACKET_PROCESSING,					//!< Packet sent to worker.
+	SYNC_PACKET_COMPLETE,					//!< Packet response received from worker.
+} sync_packet_status_t;
+
+typedef enum {
+	SYNC_PACKET_TYPE_CHANGE = 0,				//!< Packet is an entry change.
+	SYNC_PACKET_TYPE_COOKIE
+} sync_packet_type_t;
+
+/** Tracking structure for ldap sync packets
+ */
+struct sync_packet_ctx_s {
+	sync_packet_type_t		type;			//!< Type of packet.
+	sync_packet_status_t		status;			//!< Status of this packet.
+	sync_state_t			*sync;			//!< Sync packet relates to.
+
+	uint8_t				*cookie;		//!< Cookie to store - can be NULL.
+	bool				refresh;		//!< Does the sync require a refresh.
+
+	fr_dlist_t			entry;			//!< Entry in list of pending packets.
+};
+
+typedef struct sync_packet_ctx_s sync_packet_ctx_t;
+
 /** Tracking structure for connections requiring refresh
  */
 struct sync_refresh_packet_s {

--- a/src/listen/ldap_sync/proto_ldap_sync_ldap.h
+++ b/src/listen/ldap_sync/proto_ldap_sync_ldap.h
@@ -139,16 +139,6 @@ struct sync_packet_ctx_s {
 
 typedef struct sync_packet_ctx_s sync_packet_ctx_t;
 
-/** Tracking structure for connections requiring refresh
- */
-struct sync_refresh_packet_s {
-	sync_state_t			*sync;			//!< Sync requiring refresh
-
-	uint8_t				*refresh_cookie;	//!< Cookie provided by the server for the refresh.
-};
-
-typedef struct sync_refresh_packet_s sync_refresh_packet_t;
-
 extern fr_table_num_sorted_t const sync_op_table[];
 extern size_t sync_op_table_len;
 
@@ -158,6 +148,8 @@ sync_state_t *sync_state_alloc(TALLOC_CTX *ctx, fr_ldap_connection_t *conn, prot
 			       size_t sync_no, sync_config_t const *config);
 
 int ldap_sync_cookie_store(sync_state_t *sync, bool refresh);
+
+int ldap_sync_cookie_send(sync_packet_ctx_t *sync_packet_ctx);
 
 int ldap_sync_entry_send(sync_state_t *sync, uint8_t const uuid[SYNC_UUID_LENGTH], struct berval *orig_dn,
 			LDAPMessage *msg, sync_op_t op);

--- a/src/listen/ldap_sync/proto_ldap_sync_ldap.h
+++ b/src/listen/ldap_sync/proto_ldap_sync_ldap.h
@@ -61,6 +61,8 @@ struct sync_state_s {
 							//!< of filtering in persistent searches.
 
 	proto_ldap_sync_t const		*inst;		//!< Module instance for this sync.
+
+	fr_dlist_head_t			pending;	//!< List of pending changes in progress.
 };
 
 typedef struct sync_state_s sync_state_t;

--- a/src/listen/ldap_sync/proto_ldap_sync_ldap.h
+++ b/src/listen/ldap_sync/proto_ldap_sync_ldap.h
@@ -59,6 +59,8 @@ struct sync_state_s {
 							//!< before passing packets to the worker.
 							//!< Predominantly to overcome Active Directory's lack
 							//!< of filtering in persistent searches.
+
+	proto_ldap_sync_t const		*inst;		//!< Module instance for this sync.
 };
 
 typedef struct sync_state_s sync_state_t;
@@ -119,7 +121,8 @@ extern size_t sync_op_table_len;
 
 int8_t sync_state_cmp(void const *one, void const *two);
 
-sync_state_t *sync_state_alloc(TALLOC_CTX *ctx, fr_ldap_connection_t *conn, size_t sync_no, sync_config_t const *config);
+sync_state_t *sync_state_alloc(TALLOC_CTX *ctx, fr_ldap_connection_t *conn, proto_ldap_sync_t const *inst,
+			       size_t sync_no, sync_config_t const *config);
 
 int ldap_sync_cookie_store(sync_state_t *sync, bool refresh);
 

--- a/src/listen/ldap_sync/proto_ldap_sync_ldap.h
+++ b/src/listen/ldap_sync/proto_ldap_sync_ldap.h
@@ -63,6 +63,10 @@ struct sync_state_s {
 	proto_ldap_sync_t const		*inst;		//!< Module instance for this sync.
 
 	fr_dlist_head_t			pending;	//!< List of pending changes in progress.
+
+	uint32_t			pending_cookies;	//!< How many cookies are in the pending heap
+	uint32_t			changes_since_cookie;	//!< How many changes have been added since
+								//!< the last cookie was stored.
 };
 
 typedef struct sync_state_s sync_state_t;

--- a/src/listen/ldap_sync/rfc4533.c
+++ b/src/listen/ldap_sync/rfc4533.c
@@ -145,6 +145,11 @@ int rfc4533_sync_init(fr_ldap_connection_t *conn, size_t sync_no, proto_ldap_syn
 
 	DEBUG3("Sync created with msgid %i", sync->msgid);
 
+	/*
+	 *	Register event to store cookies at a regular interval
+	 */
+	fr_event_timer_in(sync, conn->conn->el, &sync->cookie_ev, inst->cookie_interval, ldap_sync_cookie_event, sync);
+
 	return 0;
 }
 

--- a/src/listen/ldap_sync/rfc4533.c
+++ b/src/listen/ldap_sync/rfc4533.c
@@ -394,7 +394,7 @@ int rfc4533_sync_search_entry(sync_state_t *sync, LDAPMessage *msg, LDAPControl 
 	 *	We have a new cookie - store it
 	 */
 	if ((ret == 0) && new_cookie) {
-		ret = ldap_sync_cookie_store(sync, sync->cookie, false);
+		ret = ldap_sync_cookie_store(sync, false);
 	}
 	ber_free(ber, 1);
 
@@ -674,7 +674,7 @@ int rfc4533_sync_intermediate(sync_state_t *sync, LDAPMessage *msg, UNUSED LDAPC
 	}
 
 	if (new_cookie) {
-		ret = ldap_sync_cookie_store(sync, sync->cookie, false);
+		ret = ldap_sync_cookie_store(sync, false);
 	}
 
 	if (ber) ber_free(ber, 1);
@@ -762,5 +762,5 @@ int rfc4533_sync_refresh_required(sync_state_t *sync, LDAPMessage *msg, LDAPCont
 		new_cookie = true;
 	}
 
-	return ldap_sync_cookie_store(sync, sync->cookie, true);
+	return ldap_sync_cookie_store(sync, true);
 }

--- a/src/listen/ldap_sync/rfc4533.c
+++ b/src/listen/ldap_sync/rfc4533.c
@@ -71,7 +71,7 @@ static size_t const sync_phase_table_len = NUM_ELEMENTS(sync_phase_table);
  *
  * The Sync Request Control is only applicable to the SearchRequest Message.
  */
-int rfc4533_sync_init(fr_ldap_connection_t *conn, size_t sync_no, sync_config_t const *config, uint8_t const *cookie)
+int rfc4533_sync_init(fr_ldap_connection_t *conn, size_t sync_no, proto_ldap_sync_t const *inst, uint8_t const *cookie)
 {
 	LDAPControl		ctrl = {0}, *ctrls[2] = { &ctrl, NULL };
 	BerElement		*ber = NULL;
@@ -79,6 +79,7 @@ int rfc4533_sync_init(fr_ldap_connection_t *conn, size_t sync_no, sync_config_t 
 	int			ret;
 	fr_rb_tree_t		*tree;
 	sync_state_t		*sync;
+	sync_config_t const 	*config = inst->sync_config[sync_no];
 
 	fr_assert(conn);
 	fr_assert(config);
@@ -96,7 +97,7 @@ int rfc4533_sync_init(fr_ldap_connection_t *conn, size_t sync_no, sync_config_t 
 		return -1;
 	}
 
-	sync = sync_state_alloc(tree, conn, sync_no, config);
+	sync = sync_state_alloc(tree, conn, inst, sync_no, config);
 
 	/*
 	 *	Might not necessarily have a cookie

--- a/src/listen/ldap_sync/rfc4533.h
+++ b/src/listen/ldap_sync/rfc4533.h
@@ -26,7 +26,8 @@
 #include <freeradius-devel/ldap/base.h>
 #include "proto_ldap_sync_ldap.h"
 
-int rfc4533_sync_init(fr_ldap_connection_t *conn, size_t sync_no, sync_config_t const *config, uint8_t const *cookie);
+int rfc4533_sync_init(fr_ldap_connection_t *conn, size_t sync_no,
+		      proto_ldap_sync_t const *inst, uint8_t const *cookie);
 
 int rfc4533_sync_search_entry(sync_state_t *sync, LDAPMessage *msg, LDAPControl **ctrls);
 


### PR DESCRIPTION
Two additional configuration items define when to store cookies
 - cookie_interval - maximum time between storing cookies
 - cookie_changes - maximum number of changes to be processed between storing cookies

Received cookies are stored in the list of packets being processed, in sequence, and are passed to a worker to run the `store Cookie` section if all preceding changes have been processed and either the time interval has passed or sufficient changes have been processed.