### PR TITLE
Enable SASL for LDAP  in RPM builds

### DIFF
--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -165,7 +165,9 @@ SQL databases.
 Summary: LDAP support for FreeRADIUS
 Group: System Environment/Daemons
 Requires: %{name} = %{version}-%{release}
+Requires: cyrus-sasl
 Requires: openldap-ltb
+BuildRequires: cyrus-sasl-devel
 BuildRequires: openldap-ltb
 
 %description ldap


### PR DESCRIPTION
`cyrus-sasl-devel` needs to be available when building FreeRADIUS to ensure that rlm_ldap can use SASL when authenticating. Currently, if you try and use SASL you get the mildly incorrect error 'Configuration item 'sasl.mech' not supported.  Linked libldap does not provide ldap_sasl_interactive_bind function'.

The function is provided - however it's not linked because `sasl.h` was missing at build time.

Works fine on RHEL, not explicitly tested on SuSE, but `cyrus-sasl` and `cyrus-sasl-devel` are available there as packages in the default repo, same as RHEL.

This would be applicable to 3.2.x and 4.x.x as well, though I haven't tested those - upgrading to 3.2 is still on my to do list...

```
...
rlm_ldap: libldap vendor: OpenLDAP, version: 20459
rlm_ldap (ldap): Couldn't find configuration for accounting, will return NOOP for calls from this section
rlm_ldap (ldap): Couldn't find configuration for post-auth, will return NOOP for calls from this section
rlm_ldap (ldap): Initialising connection pool
   pool {
   	start = 5
   	min = 3
   	max = 32
   	spare = 10
   	uses = 0
   	lifetime = 0
   	cleanup_interval = 30
   	idle_timeout = 60
   	retry_delay = 30
   	spread = no
   }
rlm_ldap (ldap): Opening additional connection (0), 1 of 32 pending slots used
rlm_ldap (ldap): Connecting to ldapi://%2Fvar%2Frun%2Fslapd-REALM.socket
rlm_ldap (ldap): Starting SASL mech(s): GSSAPI
SASL/GSSAPI authentication started
SASL username: radius/host@REALM
SASL SSF: 256
SASL data security layer installed.
rlm_ldap (ldap): Bind successful
...
```