### PR TITLE
Fix the use of the ctype classification and mapping functions.

### DIFF
--- a/scripts/build/dlopen.c
+++ b/scripts/build/dlopen.c
@@ -597,7 +597,7 @@ static void ad_have_feature(char const *symbol)
 
 	for (p = def->name + 5; *p != '\0'; p++) {
 		if (islower((int) *p)) {
-			*p = toupper((int) *p);
+			*p = toupper((u_char) *p);
 
 		} else if ((*p == '/') || (*p == '.')) {
 			*p = '_';
@@ -667,7 +667,7 @@ static void ad_update_variable(char const *name, char *value)
 
 	p = strstr(old, value);
 	if (p) {
-		if (!p[value_len] || isspace((int) p[value_len])) {
+		if (!p[value_len] || isspace((u_char) p[value_len])) {
 			gmk_free(old);
 			return;
 		}
@@ -1007,7 +1007,7 @@ static char *make_ad_dump_defines(__attribute__((unused)) char const *nm, unsign
 	FILE *fp;
 	unsigned int i;
 
-	if ((argc == 0) || !*argv[0] || isspace((int) *argv[0])) {
+	if ((argc == 0) || !*argv[0] || isspace((u_char) *argv[0])) {
 		/*
 		 *	Print Makefile rules to redefine the variables we've created.
 		 */

--- a/scripts/jlibtool.c
+++ b/scripts/jlibtool.c
@@ -1062,7 +1062,7 @@ static int parse_long_opt(char const *arg, command_t *cmd)
 		/*
 		 *	Smash the target to lower case
 		 */
-		for (i = 0; i < len; i++) value[i] = tolower(value[i]);
+		for (i = 0; i < len; i++) value[i] = tolower((u_char)value[i]);
 
 		for (p = target_map, end = target_map + (sizeof(target_map) / sizeof(*target_map));
 		     p < end;

--- a/src/bin/collectd.c
+++ b/src/bin/collectd.c
@@ -267,7 +267,7 @@ rs_stats_tmpl_t *rs_stats_collectd_init_latency(TALLOC_CTX *ctx, rs_stats_tmpl_t
 
 #define INIT_STATS(_ti, _v) do {\
 		strlcpy(buffer, fr_packet_codes[code], sizeof(buffer)); \
-		for (p = buffer; *p; ++p) *p = tolower(*p);\
+		for (p = buffer; *p; ++p) *p = tolower((u_char)*p);\
 		last = *tmpl = rs_stats_collectd_init(ctx, conf, type, _ti, buffer, stats, _v);\
 		if (!*tmpl) {\
 			TALLOC_FREE(*out);\

--- a/src/bin/unit_test_attribute.c
+++ b/src/bin/unit_test_attribute.c
@@ -564,14 +564,14 @@ static ssize_t hex_to_bin(uint8_t *out, size_t outlen, char *in, size_t inlen)
 
 		if (!*p) break;
 
-		c1 = memchr(hextab, tolower((int) *p++), sizeof(hextab));
+		c1 = memchr(hextab, tolower((u_char) *p++), sizeof(hextab));
 		if (!c1) {
 		bad_input:
 			fr_strerror_printf("Invalid hex data starting at \"%s\"", p);
 			return -(p - in);
 		}
 
-		c2 = memchr(hextab, tolower((int)*p++), sizeof(hextab));
+		c2 = memchr(hextab, tolower((u_char)*p++), sizeof(hextab));
 		if (!c2) goto bad_input;
 
 		*out_p++ = ((c1 - hextab) << 4) + (c2 - hextab);

--- a/src/lib/ldap/filter.c
+++ b/src/lib/ldap/filter.c
@@ -491,9 +491,9 @@ static bool ldap_filter_node_eval(ldap_filter_t *node, fr_ldap_connection_t *con
 						continue;
 					}
 					if (skip) {
-						while ((tolower(*t) != tolower(*v)) && (v <= v_end)) v++;
+						while ((tolower((u_char)*t) != tolower((u_char)*v)) && (v <= v_end)) v++;
 					}
-					if (tolower(*t) != tolower(*v)) break;
+					if (tolower((u_char)*t) != tolower((u_char)*v)) break;
 					skip = false;
 					t++;
 					v++;

--- a/src/lib/ldap/util.c
+++ b/src/lib/ldap/util.c
@@ -148,8 +148,8 @@ size_t fr_ldap_unescape_func(UNUSED request_t *request, char *out, size_t outlen
 		}
 
 		/* Is a hex sequence */
-		if (!(c1 = memchr(hextab, tolower(p[0]), 16)) ||
-		    !(c2 = memchr(hextab, tolower(p[1]), 16))) goto next;
+		if (!(c1 = memchr(hextab, tolower((u_char)p[0]), 16)) ||
+		    !(c2 = memchr(hextab, tolower((u_char)p[1]), 16))) goto next;
 		c3 = ((c1 - hextab) << 4) + (c2 - hextab);
 
 		*out++ = c3;

--- a/src/lib/server/cf_file.c
+++ b/src/lib/server/cf_file.c
@@ -1046,8 +1046,8 @@ static int process_include(cf_stack_t *stack, CONF_SECTION *parent, char const *
 			 *	Check for valid characters
 			 */
 			for (p = dp->d_name; *p != '\0'; p++) {
-				if (isalpha((int)*p) ||
-				    isdigit((int)*p) ||
+				if (isalpha((u_char)*p) ||
+				    isdigit((u_char)*p) ||
 				    (*p == '-') ||
 				    (*p == '_') ||
 				    (*p == '.')) continue;
@@ -2016,7 +2016,7 @@ static int parse_input(cf_stack_t *stack)
 	 *	it, so oh well.
 	 */
 	if ((*ptr == '"') || (*ptr == '`') || (*ptr == '\'') || ((*ptr == '&') && (ptr[1] != '=')) ||
-	    ((*((uint8_t const *) ptr) & 0x80) != 0) || isalpha((int) *ptr)) {
+	    ((*((uint8_t const *) ptr) & 0x80) != 0) || isalpha((u_char) *ptr)) {
 		if (cf_get_token(parent, &ptr, &name2_token, buff[2], stack->bufsize,
 				 frame->filename, frame->lineno) < 0) {
 			return -1;

--- a/src/lib/server/command.c
+++ b/src/lib/server/command.c
@@ -1359,7 +1359,7 @@ int fr_command_tab_expand(TALLOC_CTX *ctx, fr_cmd_t *head, fr_cmd_info_t *info, 
 				p++; \
 				q++; \
 			} } while (0)
-#define MATCHED_NAME	((!*p || isspace((int) *p)) && !*q)
+#define MATCHED_NAME	((!*p || isspace((u_char) *p)) && !*q)
 #define TOO_FAR		(*p && (*q > *p))
 #define MATCHED_START	((text + start) >= word) && ((text + start) <= p)
 
@@ -2173,7 +2173,7 @@ int fr_command_str_to_argv(fr_cmd_t *head, fr_cmd_info_t *info, char const *text
 
 		fr_skip_whitespace(word);
 
-		if ((word[0] == '*') && isspace(word[1]) && cmd->added_name) {
+		if ((word[0] == '*') && isspace((u_char)word[1]) && cmd->added_name) {
 			p = word + 1;
 			goto skip_matched;
 		}
@@ -2242,7 +2242,7 @@ skip_matched:
 		 *	Allow wildcards as a primitive "for" loop in
 		 *	some special circumstances.
 		 */
-		if ((word[0] == '*') && isspace(word[1]) && cmd->added_name) {
+		if ((word[0] == '*') && isspace((u_char)word[1]) && cmd->added_name) {
 			fr_assert(cmd->intermediate);
 			fr_assert(cmd->child != NULL);
 
@@ -2622,7 +2622,7 @@ static int expand_syntax(fr_cmd_t *cmd, fr_cmd_info_t *info, fr_cmd_argv_t *argv
 		 *	matching all of the name.  The input is a
 		 *	PARTIAL match.  Go fill it in.
 		 */
-		if (!*p || isspace((int) *p)) {
+		if (!*p || isspace((u_char) *p)) {
 			goto expand_name;
 		}
 
@@ -2697,7 +2697,7 @@ int fr_command_complete(fr_cmd_t *head, char const *text, int start,
 				 *	Matched all of the input to
 				 *	part of cmd->name.
 				 */
-				if (!*p || isspace((int) *p)) {
+				if (!*p || isspace((u_char) *p)) {
 					expansions[count] = strdup(cmd->name);
 					count++;
 				}

--- a/src/lib/server/dl_module.c
+++ b/src/lib/server/dl_module.c
@@ -402,7 +402,7 @@ dl_module_t const *dl_module(dl_module_t const *parent, char const *name, dl_mod
 
 	if (!module_name) return NULL;
 
-	for (p = module_name, q = p + talloc_array_length(p) - 1; p < q; p++) *p = tolower(*p);
+	for (p = module_name, q = p + talloc_array_length(p) - 1; p < q; p++) *p = tolower((u_char)*p);
 
 	/*
 	 *	If the module's already been loaded, increment the reference count.

--- a/src/lib/server/exec.c
+++ b/src/lib/server/exec.c
@@ -125,7 +125,7 @@ static CC_HINT(nonnull(1,3,4,5)) int exec_pair_to_env(char **env_p, size_t env_l
 		p = fr_sbuff_current(&env_m[i]);
 		if (isdigit((int)*p)) *p++ = '_';
 		for (; p < fr_sbuff_current(&sbuff); p++) {
-			if (isalpha((int)*p)) *p = toupper(*p);
+			if (isalpha((u_char)*p)) *p = toupper((u_char)*p);
 			else if (*p == '-') *p = '_';
 			else if (isdigit((int)*p)) continue;
 			else *p = '_';

--- a/src/lib/server/exec_legacy.c
+++ b/src/lib/server/exec_legacy.c
@@ -63,8 +63,8 @@ static void exec_pair_to_env_legacy(request_t *request, fr_pair_list_t *input_pa
 			for (p = buffer; *p != '='; p++) {
 				if (*p == '-') {
 					*p = '_';
-				} else if (isalpha((int) *p)) {
-					*p = toupper(*p);
+				} else if (isalpha((u_char) *p)) {
+					*p = toupper((u_char)*p);
 				}
 			}
 		}

--- a/src/lib/sim/comp128.c
+++ b/src/lib/sim/comp128.c
@@ -389,7 +389,7 @@ void comp128v23(uint8_t sres[static 4], uint8_t kc[static 8],
 #include <ctype.h>
 static int hextoint(char x)
 {
-	x = toupper(x);
+	x = toupper((u_char)x);
 	if (x >= 'A' && x <= 'F') {
 		return x-'A' + 10;
 	} else if (x >= '0' && x <= '9') {

--- a/src/lib/tls/session.c
+++ b/src/lib/tls/session.c
@@ -292,7 +292,7 @@ static bool session_psk_identity_is_safe(const char *identity)
 	if (!identity) return true;
 
 	while ((c = *(identity++)) != '\0') {
-		if (isalpha((int) c) || isdigit((int) c) || isspace((int) c) ||
+		if (isalpha((u_char) c) || isdigit((u_char) c) || isspace((u_char) c) ||
 		    (c == '@') || (c == '-') || (c == '_') || (c == '.')) {
 			continue;
 		}

--- a/src/lib/unlang/xlat_builtin.c
+++ b/src/lib/unlang/xlat_builtin.c
@@ -3468,7 +3468,7 @@ static xlat_action_t xlat_change_case(UNUSED TALLOC_CTX *ctx, fr_dcursor_t *out,
 	end = p + vb->vb_length;
 
 	while (p < end) {
-		*(p) = upper ? toupper ((int) *(p)) : tolower((int) *(p));
+		*(p) = upper ? toupper ((u_char) *(p)) : tolower((u_char) *(p));
 		p++;
 	}
 
@@ -3659,8 +3659,8 @@ static xlat_action_t xlat_func_urlunquote(TALLOC_CTX *ctx, fr_dcursor_t *out,
 		/* Is a % char */
 
 		/* Don't need \0 check, as it won't be in the hextab */
-		if (!(c1 = memchr(hextab, tolower(*++p), 16)) ||
-		    !(c2 = memchr(hextab, tolower(*++p), 16))) {
+		if (!(c1 = memchr(hextab, tolower((u_char)*++p), 16)) ||
+		    !(c2 = memchr(hextab, tolower((u_char)*++p), 16))) {
 			REMARKER(in_head->vb_strvalue, p - in_head->vb_strvalue, "Non-hex char in %% sequence");
 			talloc_free(vb);
 
@@ -3853,7 +3853,7 @@ static int xlat_protocol_register(fr_dict_t const *dict)
 
 	strlcpy(name, fr_dict_root(dict)->name, sizeof(name));
 	for (p = name; *p != '\0'; p++) {
-		*p = tolower((int) *p);
+		*p = tolower((u_char) *p);
 	}
 
 	/*

--- a/src/lib/util/dict_tokenize.c
+++ b/src/lib/util/dict_tokenize.c
@@ -125,7 +125,7 @@ static int dict_read_sscanf_i(unsigned int *pvalue, char const *str)
 
 		if (*str == '.') break;
 
-		c = memchr(tab, tolower((int)*str), base);
+		c = memchr(tab, tolower((u_char)*str), base);
 		if (!c) return 0;
 
 		ret *= base;

--- a/src/lib/util/dict_util.c
+++ b/src/lib/util/dict_util.c
@@ -109,7 +109,7 @@ static uint32_t dict_hash_name(char const *name, size_t len)
 
 	while (p < q) {
 		int c = *(unsigned char const *)p;
-		if (isalpha(c)) c = tolower(c);
+		if (isalpha((u_char)c)) c = tolower((u_char)c);
 
 		hash *= FNV_MAGIC_PRIME;
 		hash ^= (uint32_t)(c & 0xff);

--- a/src/lib/util/inet.c
+++ b/src/lib/util/inet.c
@@ -479,7 +479,7 @@ int fr_inet_pton4(fr_ipaddr_t *out, char const *value, ssize_t inlen, bool resol
 	memset(out, 0, sizeof(*out));
 
 	end = value + inlen;
-	while ((value < end) && isspace((int) *value)) value++;
+	while ((value < end) && isspace((u_char) *value)) value++;
 	if (value == end) {
 		fr_strerror_const("Empty IPv4 address string is invalid");
 		return -1;
@@ -630,7 +630,7 @@ int fr_inet_pton6(fr_ipaddr_t *out, char const *value, ssize_t inlen, bool resol
 	if (inlen < 0) inlen = strlen(value);
 
 	end = value + inlen;
-	while ((value < end) && isspace((int) *value)) value++;
+	while ((value < end) && isspace((u_char) *value)) value++;
 	if (value == end) {
 		fr_strerror_const("Empty IPv6 address string is invalid");
 		return -1;
@@ -770,7 +770,7 @@ int fr_inet_pton(fr_ipaddr_t *out, char const *value, ssize_t inlen, int af, boo
 	char const *end;
 
 	end = value + inlen;
-	while ((value < end) && isspace((int) *value)) value++;
+	while ((value < end) && isspace((u_char) *value)) value++;
 	if (value == end) {
 		fr_strerror_const("Empty IPv4 address string is invalid");
 		return -1;
@@ -1125,7 +1125,7 @@ uint8_t *fr_inet_ifid_pton(uint8_t out[static 8], char const *ifid_str)
 			num_id = 0;
 			if ((idx += 2) > 6)
 				return NULL;
-		} else if ((pch = strchr(xdigits, tolower(*p))) != NULL) {
+		} else if ((pch = strchr(xdigits, tolower((u_char)*p))) != NULL) {
 			if (++num_id > 4)
 				return NULL;
 			/*

--- a/src/lib/util/misc.c
+++ b/src/lib/util/misc.c
@@ -217,7 +217,7 @@ char *fr_trim(char const *str, size_t size)
 	if (!str || !size) return NULL;
 
 	memcpy(&q, &str, sizeof(q));
-	for (q = q + size; q > str && isspace(*q); q--);
+	for (q = q + size; q > str && isspace((u_char)*q); q--);
 
 	return q;
 }

--- a/src/lib/util/misc.h
+++ b/src/lib/util/misc.h
@@ -63,7 +63,7 @@ void		fr_talloc_verify_cb(const void *ptr, int depth,
  * @param[in,out] _p	string to skip over.
  * @param[in] _e	pointer to end of string.
  */
-#define fr_bskip_whitespace(_p, _e) while((_p < _e) && isspace((int)*(_p))) _p++
+#define fr_bskip_whitespace(_p, _e) while((_p < _e) && isspace((u_char)*(_p))) _p++
 
 /** Skip everything that's not whitespace ('\\t', '\\n', '\\v', '\\f', '\\r', ' ')
  *

--- a/src/lib/util/missing.c
+++ b/src/lib/util/missing.c
@@ -49,8 +49,8 @@ int strncasecmp(char *s1, char *s2, int n)
 		c1 = *p1;
 		c2 = *p2;
 
-		if (islower(c1)) c1 = toupper(c1);
-		if (islower(c2)) c2 = toupper(c2);
+		if (islower((u_char)c1)) c1 = toupper((u_char)c1);
+		if (islower((u_char)c2)) c2 = toupper((u_char)c2);
 
 		if ((dif = c1 - c2) != 0)
 			break;

--- a/src/lib/util/print.c
+++ b/src/lib/util/print.c
@@ -494,7 +494,7 @@ char *fr_vasprintf(TALLOC_CTX *ctx, char const *fmt, va_list ap)
 		/*
 		 *	Check for parameter field
 		 */
-		for (q = p; isdigit(*q); q++);
+		for (q = p; isdigit((u_char)*q); q++);
 		if ((q != p) && (*q == '$')) {
 			p = q + 1;
 		}
@@ -536,7 +536,7 @@ char *fr_vasprintf(TALLOC_CTX *ctx, char const *fmt, va_list ap)
 			(void) va_arg(ap_q, int);
 			p++;
 		} else {
-			for (q = p; isdigit(*q); q++);
+			for (q = p; isdigit((u_char)*q); q++);
 			p = q;
 		}
 

--- a/src/lib/util/sbuff.c
+++ b/src/lib/util/sbuff.c
@@ -1068,7 +1068,7 @@ fr_slen_t fr_sbuff_out_bool(bool *out, fr_sbuff_t *in)
 	};
 
 	if (fr_sbuff_is_in_charset(&our_in, bool_prefix)) {
-		switch (tolower(fr_sbuff_char(&our_in, '\0'))) {
+		switch (tolower((u_char)fr_sbuff_char(&our_in, '\0'))) {
 		default:
 			break;
 
@@ -1153,7 +1153,7 @@ fr_slen_t fr_sbuff_out_##_name(fr_sbuff_parse_error_t *err, _type *out, fr_sbuff
 		return -1; \
 	} else if (no_trailing && (((a_end = in->p + (end - buff)) + 1) < in->end)) { \
 		if (isdigit(*a_end) || (((_base > 10) || ((_base == 0) && (len > 2) && (buff[0] == '0') && (buff[1] == 'x'))) && \
-		    ((tolower(*a_end) >= 'a') && (tolower(*a_end) <= 'f')))) { \
+		    ((tolower((u_char)*a_end) >= 'a') && (tolower((u_char)*a_end) <= 'f')))) { \
 			if (err) *err = FR_SBUFF_PARSE_ERROR_TRAILING; \
 			*out = (_type)(_max); \
 			FR_SBUFF_ERROR_RETURN(&our_in); \
@@ -1213,7 +1213,7 @@ fr_slen_t fr_sbuff_out_##_name(fr_sbuff_parse_error_t *err, _type *out, fr_sbuff
 		return -1; \
 	} else if (no_trailing && (((a_end = in->p + (end - buff)) + 1) < in->end)) { \
 		if (isdigit(*a_end) || (((_base > 10) || ((_base == 0) && (len > 2) && (buff[0] == '0') && (buff[1] == 'x'))) && \
-		    ((tolower(*a_end) >= 'a') && (tolower(*a_end) <= 'f')))) { \
+		    ((tolower((u_char)*a_end) >= 'a') && (tolower((u_char)*a_end) <= 'f')))) { \
 			if (err) *err = FR_SBUFF_PARSE_ERROR_TRAILING; \
 			*out = (_type)(_max); \
 			FR_SBUFF_ERROR_RETURN(&our_in); \
@@ -1695,7 +1695,7 @@ size_t fr_sbuff_adv_past_strcase(fr_sbuff_t *sbuff, char const *needle, size_t n
 	end = p + needle_len;
 
 	for (p = sbuff->p, n_p = needle; p < end; p++, n_p++) {
-		if (tolower(*p) != tolower(*n_p)) return 0;
+		if (tolower((u_char)*p) != tolower((u_char)*n_p)) return 0;
 	}
 
 	return fr_sbuff_advance(sbuff, needle_len);
@@ -1999,7 +1999,7 @@ char *fr_sbuff_adv_to_strcase(fr_sbuff_t *sbuff, size_t len, char const *needle,
 		if (fr_sbuff_extend_lowat(NULL, &our_sbuff, needle_len) < needle_len) break;
 
 		for (p = our_sbuff.p, n_p = needle, end = our_sbuff.p + needle_len;
-		     (p < end) && (tolower(*p) == tolower(*n_p));
+		     (p < end) && (tolower((u_char)*p) == tolower((u_char)*n_p));
 		     p++, n_p++);
 		if (p == end) {
 			(void)fr_sbuff_set(sbuff, our_sbuff.p);

--- a/src/lib/util/sbuff.h
+++ b/src/lib/util/sbuff.h
@@ -1734,42 +1734,42 @@ static inline bool _fr_sbuff_is_char(fr_sbuff_t *sbuff, char *p, char c)
 static inline bool _fr_sbuff_is_digit(fr_sbuff_t *sbuff, char *p)
 {
 	if (!fr_sbuff_extend(sbuff)) return false;
-	return isdigit(*p);
+	return isdigit((u_char)*p);
 }
 #define fr_sbuff_is_digit(_sbuff_or_marker) _fr_sbuff_is_digit(fr_sbuff_ptr(_sbuff_or_marker), fr_sbuff_current(_sbuff_or_marker))
 
 static inline bool _fr_sbuff_is_upper(fr_sbuff_t *sbuff, char const *p)
 {
 	if (!fr_sbuff_extend(sbuff)) return false;
-	return isupper(*p);
+	return isupper((u_char)*p);
 }
 #define fr_sbuff_is_upper(_sbuff_or_marker) _fr_sbuff_is_upper(fr_sbuff_ptr(_sbuff_or_marker), fr_sbuff_current(_sbuff_or_marker))
 
 static inline bool _fr_sbuff_is_lower(fr_sbuff_t *sbuff, char const *p)
 {
 	if (!fr_sbuff_extend(sbuff)) return false;
-	return islower(*p);
+	return islower((u_char)*p);
 }
 #define fr_sbuff_is_lower(_sbuff_or_marker) _fr_sbuff_is_lower(fr_sbuff_ptr(_sbuff_or_marker), fr_sbuff_current(_sbuff_or_marker))
 
 static inline bool _fr_sbuff_is_alpha(fr_sbuff_t *sbuff, char const *p)
 {
 	if (!fr_sbuff_extend(sbuff)) return false;
-	return isalpha(*p);
+	return isalpha((u_char)*p);
 }
 #define fr_sbuff_is_alpha(_sbuff_or_marker) _fr_sbuff_is_alpha(fr_sbuff_ptr(_sbuff_or_marker), fr_sbuff_current(_sbuff_or_marker))
 
 static inline bool _fr_sbuff_is_space(fr_sbuff_t *sbuff, char const *p)
 {
 	if (!fr_sbuff_extend(sbuff)) return false;
-	return isspace(*p);
+	return isspace((u_char)*p);
 }
 #define fr_sbuff_is_space(_sbuff_or_marker) _fr_sbuff_is_space(fr_sbuff_ptr(_sbuff_or_marker), fr_sbuff_current(_sbuff_or_marker))
 
 static inline bool _fr_sbuff_is_hex(fr_sbuff_t *sbuff, char const *p)
 {
 	if (!fr_sbuff_extend(sbuff)) return false;
-	return isxdigit(*p);
+	return isxdigit((u_char)*p);
 }
 #define fr_sbuff_is_hex(_sbuff_or_marker) _fr_sbuff_is_hex(fr_sbuff_ptr(_sbuff_or_marker), fr_sbuff_current(_sbuff_or_marker))
 

--- a/src/lib/util/size.c
+++ b/src/lib/util/size.c
@@ -68,7 +68,7 @@ fr_slen_t fr_size_from_str(size_t *out, fr_sbuff_t *in)
 	if (fr_sbuff_out(NULL, &size, &our_in) < 0) FR_SBUFF_ERROR_RETURN(&our_in);
 	if (!fr_sbuff_extend(&our_in)) goto done;
 
-	c = tolower(fr_sbuff_char(&our_in, '\0'));
+	c = tolower((u_char)fr_sbuff_char(&our_in, '\0'));
 
 	/*
 	 *	Special cases first...

--- a/src/lib/util/snprintf.c
+++ b/src/lib/util/snprintf.c
@@ -210,7 +210,7 @@ char ** fract;
 			fp = integral(number, &ip);
 			ch = (int)((fp + PRECISION)*base); /* force to round */
 			integral_part[i] = (ch <= 9) ? ch + '0' : ch + 'a' - 10;
-			if (! isxdigit(integral_part[i])) /* bail out overflow !! */
+			if (! isxdigit((u_char)integral_part[i])) /* bail out overflow !! */
 	break;
 			number = ip;
 		 }
@@ -234,7 +234,7 @@ char ** fract;
 /* the fractionnal part */
 	for (i=0, fp=fraction; precision > 0 && i < MAX_FRACT ; i++, precision--	) {
 		fraction_part[i] = (int)((fp + PRECISION)*10. + '0');
-		if (! isdigit(fraction_part[i])) /* underflow ? */
+		if (! isdigit((u_char)fraction_part[i])) /* underflow ? */
 			break;
 		fp = (fp*10.0) - (double)(long)((fp + PRECISION)*10.);
 	}
@@ -316,7 +316,7 @@ double d;
 		PUT_CHAR('0', p); PUT_CHAR(*p->pf, p);
 	}
 	while (*tmp) { /* hexa */
-		PUT_CHAR((*p->pf == 'X' ? toupper(*tmp) : *tmp), p);
+		PUT_CHAR((*p->pf == 'X' ? toupper((u_char)*tmp) : *tmp), p);
 		tmp++;
 	}
 	PAD_LEFT(p);
@@ -485,7 +485,7 @@ struct DATA * p;
 			case '1': case '2': case '3':
 			case '4': case '5': case '6':
 			case '7': case '8': case '9':		 /* gob all the digits */
-	for (i = 0; isdigit(*s); i++, s++)
+	for (i = 0; isdigit((u_char)*s); i++, s++)
 		if (i < MAX_FIELD/2 - 1)
 			number[i] = *s;
 	number[i] = '\0';

--- a/src/lib/util/snprintf.h
+++ b/src/lib/util/snprintf.h
@@ -171,7 +171,7 @@ struct DATA {
 #define isflag(c) ((c) == '#' || (c) == ' ' || \
 		   (c) == '*' || (c) == '+' || \
 		   (c) == '-' || (c) == '.' || \
-		   isdigit(c))
+		   isdigit((u_char)c))
 
 /* round off to the precision */
 #define ROUND(d, p) \

--- a/src/lib/util/table.c
+++ b/src/lib/util/table.c
@@ -424,7 +424,7 @@ static void const *table_ordered_value_by_longest_prefix(size_t *match_len,
 		offset = TABLE_IDX(table, i, element_size);
 
 		for (j = 0; (j < (size_t)name_len) && (j < ELEM_LEN(offset)) &&
-			    (tolower(name[j]) == tolower((ELEM_STR(offset))[j])); j++);
+			    (tolower((u_char)name[j]) == tolower((u_char)(ELEM_STR(offset))[j])); j++);
 
 		/*
 		 *	If we didn't get to the end of the

--- a/src/listen/cron/proto_cron_crontab.c
+++ b/src/listen/cron/proto_cron_crontab.c
@@ -226,7 +226,7 @@ static int parse_field(CONF_ITEM *ci, char const **start, char const *name,
 		/*
 		 *	EOS or space is end of field.
 		 */
-		if (!(!*end || isspace((int) *end))) {
+		if (!(!*end || isspace((u_char) *end))) {
 			cf_log_err(ci, "Unexpected text for %s at %s", name, end);
 			return -1;
 		}

--- a/src/modules/rlm_escape/rlm_escape.c
+++ b/src/modules/rlm_escape/rlm_escape.c
@@ -159,8 +159,8 @@ static xlat_action_t unescape_xlat(TALLOC_CTX *ctx, fr_dcursor_t *out,
 		/* Is a = char */
 
 		if (((end - p) < 2) ||
-		    !(c1 = memchr(hextab, tolower(*(p + 1)), 16)) ||
-		    !(c2 = memchr(hextab, tolower(*(p + 2)), 16))) goto next;
+		    !(c1 = memchr(hextab, tolower((u_char)*(p + 1)), 16)) ||
+		    !(c2 = memchr(hextab, tolower((u_char)*(p + 2)), 16))) goto next;
 		c3 = ((c1 - hextab) << 4) + (c2 - hextab);
 
 		(void) fr_sbuff_in_char(&sbuff, c3);

--- a/src/modules/rlm_isc_dhcp/rlm_isc_dhcp.c
+++ b/src/modules/rlm_isc_dhcp/rlm_isc_dhcp.c
@@ -622,7 +622,7 @@ static int match_subword(rlm_isc_dhcp_tokenizer_t *state, char const *cmd, rlm_i
 	p = type_name;
 	while (*q && !isspace((int) *q) && (*q != ',')) {
 		if ((p - type_name) >= (int) sizeof(type_name)) return -1; /* internal error */
-		*(p++) = tolower((int) *(q++));
+		*(p++) = tolower((u_char) *(q++));
 	}
 	*p = '\0';
 
@@ -1199,7 +1199,7 @@ static int match_keyword(rlm_isc_dhcp_info_t *parent, rlm_isc_dhcp_tokenizer_t *
 			/*
 			 *	The token exactly matches the command.
 			 */
-			if (!c || isspace((int) c)) {
+			if (!c || isspace((u_char) c)) {
 				q = &(tokens[half].name[state->token_len]);
 				break;
 			}

--- a/src/modules/rlm_ldap/groups.c
+++ b/src/modules/rlm_ldap/groups.c
@@ -744,7 +744,7 @@ unlang_action_t rlm_ldap_check_userobj_dynamic(rlm_rcode_t *p_result, rlm_ldap_t
 				int j;
 
 				for (j = 0; j < (int)values[i]->bv_len; j++) {
-					if (tolower(values[i]->bv_val[j]) != tolower(check->vp_strvalue[j])) break;
+					if (tolower((u_char)values[i]->bv_val[j]) != tolower((u_char)check->vp_strvalue[j])) break;
 				}
 				if (j == (int)values[i]->bv_len) {
 					RDEBUG2("User found in group DN \"%s\". "

--- a/src/modules/rlm_logintime/timestr.c
+++ b/src/modules/rlm_logintime/timestr.c
@@ -181,7 +181,7 @@ static int week_fill(char *bitmap, char const *tm)
 
 	strlcpy(tmp, tm, sizeof(tmp));
 	for (s = tmp; *s; s++)
-		if (isupper(*s)) *s = tolower(*s);
+		if (isupper((u_char)*s)) *s = tolower((u_char)*s);
 
 	s = strtok(tmp, ",|");
 	while (s) {

--- a/src/modules/rlm_mschap/smbdes.c
+++ b/src/modules/rlm_mschap/smbdes.c
@@ -324,7 +324,7 @@ void smbdes_lmpwdhash(char const *password, uint8_t *lmhash)
 
 	memset(p14, 0, sizeof(p14));
 	for (i = 0; i < 14 && password[i]; i++) {
-		p14[i] = toupper((int) password[i]);
+		p14[i] = toupper((u_char) password[i]);
 	}
 
 	smbhash(lmhash, sp8, p14);

--- a/src/modules/rlm_yubikey/rlm_yubikey.c
+++ b/src/modules/rlm_yubikey/rlm_yubikey.c
@@ -84,7 +84,7 @@ fr_dict_attr_autoload_t rlm_yubikey_dict_attr[] = {
 static char const modhextab[] = "cbdefghijklnrtuv";
 static char const hextab[] = "0123456789abcdef";
 
-#define is_modhex(x) (memchr(modhextab, tolower(x), 16))
+#define is_modhex(x) (memchr(modhextab, tolower((u_char)x), 16))
 
 /** Convert yubikey modhex to normal hex
  *
@@ -115,8 +115,8 @@ static ssize_t modhex2hex(char const *modhex, char *hex, size_t len)
 		if (modhex[i + 1] == '\0')
 			return -1;
 
-		if (!(c1 = memchr(modhextab, tolower((int) modhex[i]), 16)) ||
-		    !(c2 = memchr(modhextab, tolower((int) modhex[i + 1]), 16)))
+		if (!(c1 = memchr(modhextab, tolower((u_char) modhex[i]), 16)) ||
+		    !(c2 = memchr(modhextab, tolower((u_char) modhex[i + 1]), 16)))
 			return -1;
 
 		hex[i] = hextab[c1 - modhextab];


### PR DESCRIPTION
Even though the argument type for these functions is `int`, there is only a restricted subset of values which are actually valid. The values are either EOF (which is negative) or the values representable as an `unsigned char`, says the standard.

On NetBSD with pkgsrc, where we typically build with -Wchar-subscripts, the existing use (without casts of arguments) typically gets us
   warning: array subscript has type 'char'

Someone has apparently been in here before to silence warnings and added casts to int, which will invoke undefined behaviour for half of the values of a `signed char` argument, as a negative `signed char` will be sign-extended to a negative `int` by the cast, and most probably not to the EOF value.

I could not offhand see any use which would deal with EOF, so added casts to `u_char` to make the behaviour well-defined, and this should both properly get rid of the warnings and the undefined behaviour.