### PR TITLE
Fixes #4790 on v3.0.x

### DIFF
--- a/src/main/process.c
+++ b/src/main/process.c
@@ -3123,7 +3123,7 @@ static int request_will_proxy(REQUEST *request)
 		 *	The home server is alive (or may be alive).
 		 *	Send the packet to the IP.
 		 */
-		if (home->state < HOME_STATE_IS_DEAD) goto do_home;
+		if (home->state != HOME_STATE_IS_DEAD) goto do_home;
 
 		/*
 		 *	The home server is dead.  If you wanted
@@ -3171,7 +3171,7 @@ static int request_will_proxy(REQUEST *request)
 		 *	The home server is alive (or may be alive).
 		 *	Send the packet to the IP.
 		 */
-		if (home->state < HOME_STATE_IS_DEAD) goto do_home;
+		if (home->state != HOME_STATE_IS_DEAD) goto do_home;
 
 		/*
 		 *	The home server is dead.  If you wanted
@@ -3658,7 +3658,7 @@ static void request_ping(REQUEST *request, int action)
 		 *
 		 *	If it's zombie, we mark it alive immediately.
 		 */
-		if ((home->state >= HOME_STATE_IS_DEAD) &&
+		if ((home->state == HOME_STATE_IS_DEAD) &&
 		    (home->num_received_pings < home->num_pings_to_alive)) {
 			return;
 		}
@@ -4079,7 +4079,7 @@ static void proxy_wait_for_reply(REQUEST *request, int action)
 		 *	If the listener is known or frozen, use it for
 		 *	retransmits.
 		 */
-		if ((home->state >= HOME_STATE_IS_DEAD) ||
+		if ((home->state == HOME_STATE_IS_DEAD) ||
 		    !request->proxy_listener ||
 		    (request->proxy_listener->status >= RAD_LISTEN_STATUS_EOL)) {
 			request_proxy_anew(request);
@@ -4559,7 +4559,7 @@ static void coa_retransmit(REQUEST *request)
 	 *	Don't do fail-over.  This is a 3.1 feature.
 	 */
 	if (!request->home_server ||
-	    (request->home_server->state >= HOME_STATE_IS_DEAD) ||
+	    (request->home_server->state == HOME_STATE_IS_DEAD) ||
 	    request->proxy_reply ||
 	    !request->proxy_listener ||
 	    (request->proxy_listener->status >= RAD_LISTEN_STATUS_EOL)) {

--- a/src/main/realms.c
+++ b/src/main/realms.c
@@ -2647,7 +2647,7 @@ home_server_t *home_server_ldb(char const *realmname,
 		 *	Home servers that are unknown, alive, or zombie
 		 *	are used for proxying.
 		 */
-		if (home->state >= HOME_STATE_IS_DEAD) {
+		if (home->state == HOME_STATE_IS_DEAD) {
 			continue;
 		}
 
@@ -2812,7 +2812,7 @@ home_server_t *home_server_ldb(char const *realmname,
 
 			if (!home) continue;
 
-			if ((home->state >= HOME_STATE_IS_DEAD) &&
+			if ((home->state == HOME_STATE_IS_DEAD) &&
 			    (home->ping_check == HOME_PING_CHECK_NONE)) {
 				home->state = HOME_STATE_ALIVE;
 				home->response_timeouts = 0;


### PR DESCRIPTION
Maintains the behaviour prior to reversion of home_state_t enum order in 70cf14154d161ed11ee99c39eddc103b626726b6 by explicit chained equality operators rather than comparison operators.