### PR TITLE
Deal with dl_open_by_name() toctou (CIS #1400053)

### DIFF
--- a/src/lib/util/dl.c
+++ b/src/lib/util/dl.c
@@ -566,8 +566,12 @@ dl_t *dl_by_name(dl_loader_t *dl_loader, char const *name, void *uctx, bool uctx
 			 *	of  "path". Otherwise, stop looking for more libraries
 			 *	and instead complain about access permissions.
 			 */
-
 			dlerror_txt = dlerror();
+			
+			/*
+			 *	Yes, this really is the only way of getting the errno
+			 *	from the dlopen API.
+			 *
 			if (!strstr(dlerror_txt, fr_syserror(ENOENT))) {
 #ifndef __linux__
 				int access_mode = R_OK | X_OK;


### PR DESCRIPTION
dl_open_by_name() gives you the option of looking though a list of directories for a library, using the dlopen() function. If a dlopen() succeeds, dl_open_by_name() succeeds and all is well. If it fails, though, the question is why? If it doesn't exist in that directory, you want to try the next on the list. If it does, permissions are likely to be the problem, so report the issue and return failure.

The previous code uses access() on the path if the dlopen() fails, hence toctou.

Unfortunately, there's not a good way to deal with it.

There is no dlopenat(), so one can't avoid toctou with dlopenat() followed by accessat(). The only indication of why dlopen() failed is in the string returned by dlerror()... which only guarantees that the string is human-readable, NUL-terminated, and doesn't end with a newline.

Looking at the result of dlerror() when the dlopen() for the directory list fails suggests that it has the following format:

path COLON SPACE message COLON SPACE strerror_output

In the particular cases in the tests, that last part was always "No such file or directory", what strerror() returns for the ENOENT dl_open_by_name() is checking for.

As the least bad alternative, the code looks at the dlerror() output to determine whether to continue or get out of the loop.