### PR TITLE
Add ocspd verifycert boolean

### DIFF
--- a/src/modules/rlm_ocsp/conf.c
+++ b/src/modules/rlm_ocsp/conf.c
@@ -9,6 +9,7 @@ static CONF_PARSER ocsp_config[] = {
 	{ FR_CONF_OFFSET("use_nonce", FR_TYPE_BOOL, fr_tls_ocsp_conf_t, use_nonce), .dflt = "yes" },
 	{ FR_CONF_OFFSET("timeout", FR_TYPE_UINT32, fr_tls_ocsp_conf_t, timeout), .dflt = "yes" },
 	{ FR_CONF_OFFSET("softfail", FR_TYPE_BOOL, fr_tls_ocsp_conf_t, softfail), .dflt = "no" },
+	{ FR_CONF_OFFSET("verifycert", FR_TYPE_BOOL, fr_tls_ocsp_conf_t, vertifycert), .dflt = "yes" },
 
 	CONF_PARSER_TERMINATOR
 };

--- a/src/modules/rlm_ocsp/conf.c
+++ b/src/modules/rlm_ocsp/conf.c
@@ -9,7 +9,7 @@ static CONF_PARSER ocsp_config[] = {
 	{ FR_CONF_OFFSET("use_nonce", FR_TYPE_BOOL, fr_tls_ocsp_conf_t, use_nonce), .dflt = "yes" },
 	{ FR_CONF_OFFSET("timeout", FR_TYPE_UINT32, fr_tls_ocsp_conf_t, timeout), .dflt = "yes" },
 	{ FR_CONF_OFFSET("softfail", FR_TYPE_BOOL, fr_tls_ocsp_conf_t, softfail), .dflt = "no" },
-	{ FR_CONF_OFFSET("verifycert", FR_TYPE_BOOL, fr_tls_ocsp_conf_t, vertifycert), .dflt = "yes" },
+	{ FR_CONF_OFFSET("verifycert", FR_TYPE_BOOL, fr_tls_ocsp_conf_t, verifycert), .dflt = "yes" },
 
 	CONF_PARSER_TERMINATOR
 };

--- a/src/modules/rlm_ocsp/ocsp.c
+++ b/src/modules/rlm_ocsp/ocsp.c
@@ -564,10 +564,13 @@ int fr_tls_ocsp_check(request_t *request, SSL *ssl,
 		REDEBUG("Response has wrong nonce value");
 		goto finish;
 	}
-	if (OCSP_basic_verify(bresp, NULL, store, 0) != 1){
-		REDEBUG("Couldn't verify OCSP basic response");
-		goto finish;
-	}
+       
+	if (conf->verifycert) {
+		if (OCSP_basic_verify(bresp, NULL, store, 0) != 1){
+			REDEBUG("Couldn't verify OCSP basic response");
+			goto finish;
+		}
+        }
 
 	/*	Verify OCSP cert status */
 	if (!OCSP_resp_find_status(bresp, certid, (int *)&status, &reason, &rev, &this_update, &next_update)) {

--- a/src/modules/rlm_ocsp/ocsp.h
+++ b/src/modules/rlm_ocsp/ocsp.h
@@ -11,6 +11,7 @@ typedef struct {
 	X509_STORE	*store;
 	uint32_t	timeout;
 	bool		softfail;
+	bool		verifycert;
 
 
 	fr_tls_cache_t	cache;				//!< Cached cache section pointers.  Means we don't have


### PR DESCRIPTION
This is a patch based on a similar boolean for Apache that allows the OCSP_basic_verify step to be skipped.  This is a convienient way to test the server against a non-production OCSP server that may not have an official OCSP certificate (i.e. one with the required OIDs for OCSP signing)
