### PR TITLE
fr_time_elapsed_fprint(): Fix tab space calculation

### DIFF
--- a/src/lib/util/time.c
+++ b/src/lib/util/time.c
@@ -681,7 +681,7 @@ void fr_time_elapsed_fprint(FILE *fp, fr_time_elapsed_t const *elapsed, char con
 
 		if (!elapsed->array[i]) continue;
 
-		len = prefix_len + strlen(names[i]);
+		len = prefix_len + 1 + strlen(names[i]);
 
 		if (len >= (size_t) (tab_offset * 8)) {
 			fprintf(fp, "%s.%s %" PRIu64 "\n",


### PR DESCRIPTION
Without the fix the output sometimes is improperly indented:
```
time.requests.100ms             28
time.requests.1s                        918
time.requests.10s               2408
```