### PR TITLE
Added Brocade-Cmd attribute sent in command accounting messages

### DIFF
--- a/share/dictionary/radius/alias/brocade.txt
+++ b/share/dictionary/radius/alias/brocade.txt
@@ -5,3 +5,4 @@ ALIAS	Brocade-AVPairs3                        	26.1588.4
 ALIAS	Brocade-AVPairs4                        	26.1588.5
 ALIAS	Brocade-Passwd-ExpiryDate               	26.1588.6
 ALIAS	Brocade-Passwd-WarnPeriod               	26.1588.7
+ALIAS	Brocade-Cmd                             	26.1588.8

--- a/share/dictionary/radius/dictionary.brocade
+++ b/share/dictionary/radius/dictionary.brocade
@@ -21,5 +21,7 @@ ATTRIBUTE	AVPairs4				5	string
 ATTRIBUTE	Passwd-ExpiryDate			6	string # Format: MM/DD/YYYY
 ATTRIBUTE	Passwd-WarnPeriod			7	string # Format: integer in days
 
+ATTRIBUTE	Cmd					8	string
+
 END-VENDOR      Brocade
 


### PR DESCRIPTION
Extreme Networks, a vendor that still actively uses the enterprise number 1588 (Brocade) in their products, added the attribute 8 (Cmd) that contains a command line when command accounting is configured.

https://documentation.extremenetworks.com/slxos/sw/20xx/20.4.2/security/GUID-D8ACA260-DA62-4128-B443-44584AD90D96.shtml