### PR TITLE
v4: Add limit for number of outstanding ldap sync packets

### DIFF
--- a/raddb/sites-available/ldap_sync
+++ b/raddb/sites-available/ldap_sync
@@ -154,6 +154,14 @@ server ldap_sync {
 			#  How big the kernel's receive buffer should be.
 			#
 #			recv_buff = 1048576
+
+			#
+			#  Maximum number of updates to have outstanding
+			#  When this number is reached, no more are read, potentially
+			#  causing the receive buffer to fill which will cause the
+			#  change notifications to queue up on the LDAP server
+			#
+#			max_outstanding = 65536
 		}
 
 		#

--- a/src/lib/io/network.c
+++ b/src/lib/io/network.c
@@ -764,6 +764,25 @@ int fr_network_listen_send_packet(fr_network_t *nr, fr_listen_t *parent, fr_list
 	return 0;
 }
 
+/** Get the number of outstanding packets
+ *
+ * @param nr the network
+ * @param li the listener that the packet was "read" from
+ * @return
+ *	- <0 on error
+ *	- the number of outstanding packets
+*/
+size_t fr_network_listen_outstanding(fr_network_t *nr, fr_listen_t *li) {
+	fr_network_socket_t *s;
+
+	(void) talloc_get_type_abort(nr, fr_network_t);
+	(void) talloc_get_type_abort_const(li, fr_listen_t);
+
+	s = fr_rb_find(nr->sockets, &(fr_network_socket_t){ .listen = li });
+	if (!s) return -1;
+
+	return s->outstanding;
+}
 
 /*
  *	Mark it as dead, but DON'T free it until all of the replies

--- a/src/lib/io/network.h
+++ b/src/lib/io/network.h
@@ -64,6 +64,8 @@ int		fr_network_listen_inject(fr_network_t *nr, fr_listen_t *li, uint8_t const *
 int		fr_network_listen_send_packet(fr_network_t *nr, fr_listen_t *parent, fr_listen_t *li,
 					      const uint8_t *buffer, size_t buflen, fr_time_t recv_time, void *packet_ctx) CC_HINT(nonnull(1,2,3,4));
 
+size_t		fr_network_listen_outstanding(fr_network_t *nr, fr_listen_t *li);
+
 fr_network_t	*fr_network_create(TALLOC_CTX *ctx, fr_event_list_t *el,
 				   char const *nr, fr_log_t const *logger, fr_log_lvl_t lvl,
 				   fr_network_config_t const *config) CC_HINT(nonnull(2,4));

--- a/src/listen/ldap_sync/proto_ldap_sync_ldap.h
+++ b/src/listen/ldap_sync/proto_ldap_sync_ldap.h
@@ -103,6 +103,8 @@ typedef struct {
 
 	uint32_t			recv_buff;		//!< How big the kernel's recive buffer should be
 	bool				recv_buff_is_set;	//!< Whether we were provided with a recv_buff
+
+	uint32_t			max_outstanding;	//!< Maximun number of outstanding packets.
 } proto_ldap_sync_ldap_t;
 
 typedef struct {


### PR DESCRIPTION
To push back pressure to the LDAP server when processing is lagging