### PR TITLE
rlm_redis_ippool: Fix lua_alloc_cmd

### DIFF
--- a/src/modules/rlm_redis_ippool/rlm_redis_ippool.c
+++ b/src/modules/rlm_redis_ippool/rlm_redis_ippool.c
@@ -215,9 +215,9 @@ static char lua_alloc_cmd[] =
 	"  if expires_in > 0 then" EOL									/* 11 */
 	"    ip = redis.call('HMGET', '{' .. KEYS[1] .. '}:"IPPOOL_ADDRESS_KEY":' .. exists, 'device', 'range', 'counter')" EOL	/* 12 */
 	"    if ip and (ip[1] == ARGV[3]) then" EOL							/* 13 */
-	"      if expires_in < ARGV[2] then" EOL							/* 14 */
-	"        redis.call('ZADD', pool_key, 'XX', ARGV[1] + ARGV[2], ip[1])" EOL			/* 15 */
-	"        expires_in = ARGV[2]" EOL								/* 16 */
+	"      if expires_in < tonumber(ARGV[2]) then" EOL						/* 14 */
+	"        redis.call('ZADD', pool_key, 'XX', ARGV[1] + ARGV[2], exists)" EOL			/* 15 */
+	"        expires_in = tonumber(ARGV[2])" EOL							/* 16 */
 	"      end" EOL											/* 17 */
 	"      return {" STRINGIFY(_IPPOOL_RCODE_SUCCESS) ", exists, ip[2], expires_in, ip[3] }" EOL	/* 18 */
 	"    end" EOL											/* 19 */


### PR DESCRIPTION
This fixes the following error:

```
(0)      redis_ippool - ERROR: (0) error   : ERR Error running script (call to f_555f9a10a670669b1725edfc4b558c4c5eb3f9ad): @user_script:14: user_script:14: attempt to compare number with string
```

which appeared after 587fcafdcd3350cba4319cbc3c5f2ce9fc8ec2f4
Looks like rlm_redis_ippool.c change in this commit was accidental (and thus not tested)