### PR TITLE
Annotate coverity missing_unlock issues (CIDs below)

### DIFF
--- a/src/lib/server/pool.c
+++ b/src/lib/server/pool.c
@@ -295,6 +295,7 @@ static fr_pool_connection_t *connection_find(fr_pool_t *pool, void *conn)
 #endif
 
 			fr_assert(this->in_use == true);
+			/* coverity[missing_unlock] */
 			return this;
 		}
 	}
@@ -517,6 +518,7 @@ static fr_pool_connection_t *connection_spawn(fr_pool_t *pool, request_t *reques
 	pthread_cond_broadcast(&pool->done_spawn);
 	if (unlock) pthread_mutex_unlock(&pool->mutex);
 
+	/* coverity[missing_unlock] */
 	return this;
 }
 

--- a/src/modules/rlm_detail/rlm_detail.c
+++ b/src/modules/rlm_detail/rlm_detail.c
@@ -375,6 +375,7 @@ static unlang_action_t CC_HINT(nonnull) detail_do(rlm_rcode_t *p_result, module_
 	outfd = exfile_open(inst->ef, buffer, inst->perm, NULL);
 	if (outfd < 0) {
 		RPERROR("Couldn't open file %s", buffer);
+		/* coverity[missing_unlock] */
 		RETURN_MODULE_FAIL;
 	}
 

--- a/src/modules/rlm_linelog/rlm_linelog.c
+++ b/src/modules/rlm_linelog/rlm_linelog.c
@@ -821,6 +821,7 @@ finish:
 	talloc_free(vpt);
 	talloc_free(vector);
 
+	/* coverity[missing_unlock] */
 	RETURN_MODULE_RCODE(rcode);
 }
 

--- a/src/modules/rlm_sql/sql.c
+++ b/src/modules/rlm_sql/sql.c
@@ -612,6 +612,7 @@ void rlm_sql_query_log(rlm_sql_t const *inst, request_t *request, sql_acct_secti
 		ERROR("Couldn't open logfile '%s': %s", expanded, fr_syserror(errno));
 
 		talloc_free(expanded);
+		/* coverity[missing_unlock] */
 		return;
 	}
 


### PR DESCRIPTION
NOTE: It's unclear whether an annotation behind a macro
will have the desired effect.

1233595,
1206499,
1233595: coverity doesn't notice that all error returns
         from exfile_open() leave the mutex unlocked, and
         that exfile_close() unlocks the mutex
1414423: connection_find() intentionally leaves the mutex
         locked if it finds a connection
1414434: connection_spawn() intentionally leaves the mutex
         locked if the unlock parameter is false