### PR TITLE
Rename fr_equality_op to reflect its actual meaning

### DIFF
--- a/src/lib/server/cf_util.c
+++ b/src/lib/server/cf_util.c
@@ -1212,7 +1212,7 @@ CONF_PAIR *cf_pair_alloc(CONF_SECTION *parent, char const *attr, char const *val
 {
 	CONF_PAIR *cp;
 
-	fr_assert(fr_equality_op[op] || fr_assignment_op[op]);
+	fr_assert(fr_comparison_op[op] || fr_assignment_op[op]);
 	if (!attr) return NULL;
 
 	cp = talloc_zero(parent, CONF_PAIR);

--- a/src/lib/unlang/compile.c
+++ b/src/lib/unlang/compile.c
@@ -807,7 +807,7 @@ static int unlang_fixup_map(map_t *map, UNUSED void *ctx)
 		return -1;
 	}
 
-	if (!fr_assignment_op[map->op] && !fr_equality_op[map->op]) {
+	if (!fr_assignment_op[map->op] && !fr_comparison_op[map->op]) {
 		cf_log_err(map->ci, "Invalid operator \"%s\" in map section.  "
 			   "Only assignment or filter operators are allowed",
 			   fr_table_str_by_value(fr_tokens_table, map->op, "<INVALID>"));
@@ -906,14 +906,14 @@ int unlang_fixup_update(map_t *map, void *ctx)
 	 *	Depending on the attribute type, some operators are disallowed.
 	 */
 	if (tmpl_is_attr(map->lhs)) {
-		if (!fr_assignment_op[map->op] && !fr_equality_op[map->op]) {
+		if (!fr_assignment_op[map->op] && !fr_comparison_op[map->op]) {
 			cf_log_err(map->ci, "Invalid operator \"%s\" in update section.  "
 				   "Only assignment or filter operators are allowed",
 				   fr_table_str_by_value(fr_tokens_table, map->op, "<INVALID>"));
 			return -1;
 		}
 
-		if (fr_equality_op[map->op] && (map->op != T_OP_CMP_FALSE)) {
+		if (fr_comparison_op[map->op] && (map->op != T_OP_CMP_FALSE)) {
 			cf_log_warn(cp, "Please use the 'filter' keyword for attribute filtering");
 		}
 	}
@@ -1362,7 +1362,7 @@ static unlang_t *compile_update_to_edit(unlang_t *parent, unlang_compile_t *unla
 	 *	Hoist this out of the loop, and make sure it always has a '&' prefix.
 	 */
 	if (name2) {
-		snprintf(list_buffer, sizeof(list_buffer), "&%s", name2);		
+		snprintf(list_buffer, sizeof(list_buffer), "&%s", name2);
 	} else {
 		snprintf(list_buffer, sizeof(list_buffer), "&%s", fr_table_str_by_value(pair_list_table, unlang_ctx->rules->attr.list_def, "???"));
 	}

--- a/src/lib/unlang/xlat_expr.c
+++ b/src/lib/unlang/xlat_expr.c
@@ -383,7 +383,9 @@ static xlat_action_t xlat_binary_op(TALLOC_CTX *ctx, fr_dcursor_t *out,
 	fr_assert(a->type == FR_TYPE_GROUP);
 	fr_assert(b->type == FR_TYPE_GROUP);
 
-	if (!fr_equality_op[op]) {
+	if (fr_comparison_op[op]) {
+		rcode = fr_value_calc_list_cmp(dst, dst, &a->vb_group, op, &b->vb_group);
+	} else {
 		if (fr_value_box_list_num_elements(&a->vb_group) != 1) {
 			REDEBUG("Expected one value as the first argument, got %d",
 				fr_value_box_list_num_elements(&a->vb_group));
@@ -400,8 +402,6 @@ static xlat_action_t xlat_binary_op(TALLOC_CTX *ctx, fr_dcursor_t *out,
 						fr_value_box_list_head(&a->vb_group),
 						op,
 						fr_value_box_list_head(&b->vb_group));
-	} else {
-		rcode = fr_value_calc_list_cmp(dst, dst, &a->vb_group, op, &b->vb_group);
 	}
 	if (rcode < 0) {
 		RPEDEBUG("Failed calculating result, returning NULL");
@@ -2675,7 +2675,7 @@ redo:
 	 *
 	 *	as special cases, so we can check lists for emptiness.
 	 */
-	if (fr_equality_op[op]) {
+	if (fr_comparison_op[op]) {
 		if (!valid_type(lhs)) goto fail_lhs;
 		if (!valid_type(rhs)) goto fail_rhs;
 

--- a/src/lib/util/token.c
+++ b/src/lib/util/token.c
@@ -193,7 +193,7 @@ const bool fr_list_assignment_op[T_TOKEN_LAST] = {
 	T(PREPEND),		/* prepend */
 };
 
-const bool fr_equality_op[T_TOKEN_LAST] = {
+const bool fr_comparison_op[T_TOKEN_LAST] = {
 	T(NE),
 	T(GE),
 	T(GT),
@@ -456,7 +456,7 @@ fr_token_t getop(char const **ptr)
 	fr_token_t token;
 
 	token = getthing(ptr, op, sizeof(op), true, fr_tokens_table, fr_tokens_table_len, false);
-	if (!fr_assignment_op[token] && !fr_equality_op[token]) {
+	if (!fr_assignment_op[token] && !fr_comparison_op[token]) {
 		fr_strerror_const("Expected operator");
 		return T_INVALID;
 	}

--- a/src/lib/util/token.h
+++ b/src/lib/util/token.h
@@ -143,7 +143,7 @@ extern size_t fr_token_quotes_table_len;
 extern const char *fr_tokens[T_TOKEN_LAST];
 extern const char fr_token_quote[T_TOKEN_LAST];
 extern const bool fr_assignment_op[T_TOKEN_LAST];
-extern const bool fr_equality_op[T_TOKEN_LAST];
+extern const bool fr_comparison_op[T_TOKEN_LAST];
 extern const bool fr_binary_op[T_TOKEN_LAST];
 extern const bool fr_str_tok[T_TOKEN_LAST];
 extern const bool fr_list_assignment_op[T_TOKEN_LAST];

--- a/src/modules/rlm_couchbase/mod.c
+++ b/src/modules/rlm_couchbase/mod.c
@@ -445,7 +445,7 @@ int mod_json_object_to_map(TALLOC_CTX *ctx, fr_dcursor_t *out, request_t *reques
 			}
 
 			op = fr_table_value_by_str(fr_tokens_table, op_str, T_INVALID);
-			if (!fr_assignment_op[op] && !fr_equality_op[op]) goto bad_op;
+			if (!fr_assignment_op[op] && !fr_comparison_op[op]) goto bad_op;
 		} else {
 			op = T_OP_SET;	/* The default */
 		}

--- a/src/modules/rlm_sql/sql.c
+++ b/src/modules/rlm_sql/sql.c
@@ -136,7 +136,7 @@ static int sql_pair_afrom_row(TALLOC_CTX *ctx, request_t *request, fr_pair_list_
 	if (row[4] != NULL && row[4][0] != '\0') {
 		ptr = row[4];
 		op = gettoken(&ptr, buf, sizeof(buf), false);
-		if (!fr_assignment_op[op] && !fr_equality_op[op]) {
+		if (!fr_assignment_op[op] && !fr_comparison_op[op]) {
 			REDEBUG("Invalid op \"%s\" for attribute %s", row[4], row[2]);
 			return -1;
 		}


### PR DESCRIPTION
The array contains true values for comparison operators, not just equals and not equals. A rename to fr_comparison_op makes a positive logic version of the distinction between comparisons (which will compare any number of values) and other binary operators (which only do one value) clearer.