### PR TITLE
Disable developer build explicitly when building without _with_developer as it is implicitly enabled when building from git

### DIFF
--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -596,6 +596,8 @@ export RADIUSD_VERSION_RELEASE="%{release}"
 %if %{?_with_developer:1}%{!?_with_developer:0}
         --enable-developer=yes \
         --with-gperftools \
+%else
+	--disable-developer \
 %endif
 %if %{?_with_address_sanitizer:1}%{!?_with_address_sanitizer:0}
         --enable-address-sanitizer \


### PR DESCRIPTION
debian build does not have this problem as it uses --disable-developer explicitly