### PR TITLE
Fixed misplaced bash syntax when adding the debug flag to CFLAGS in d…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -178,7 +178,7 @@ dnl #  -g3 so nice things like macro values are included. Other arguments are
 dnl #  added later when we know what compiler were using.
 dnl #
 if test "x$developer" = "xyes"; then
-  : ${CFLAGS="$CFLAGS -g3"}
+  CFLAGS="$CFLAGS -g3"
 fi
 
 dnl #


### PR DESCRIPTION
…eveloper mode

This is a one line change to remove bash syntax from the configure.ac file.