### PR TITLE
Prevent overrun of fr_tacacs_packet_codes[] (CID #1520416)

### DIFF
--- a/src/protocols/tacacs/base.c
+++ b/src/protocols/tacacs/base.c
@@ -99,7 +99,7 @@ fr_dict_attr_autoload_t libfreeradius_tacacs_dict_attr[] = {
 	{ NULL }
 };
 
-char const *fr_tacacs_packet_codes[FR_TACACS_CODE_MAX] = {
+char const *fr_tacacs_packet_codes[FR_TACACS_CODE_MAX + 1] = {
 	[FR_PACKET_TYPE_VALUE_AUTHENTICATION_START] = "Authentication-Start",
 	[FR_PACKET_TYPE_VALUE_AUTHENTICATION_START_REPLY] = "Authentication-Start-Reply",
 
@@ -111,6 +111,8 @@ char const *fr_tacacs_packet_codes[FR_TACACS_CODE_MAX] = {
 
 	[FR_PACKET_TYPE_VALUE_ACCOUNTING_REQUEST] = "Accounting-Request",
 	[FR_PACKET_TYPE_VALUE_ACCOUNTING_REPLY] = "Accounting-Reply",
+
+	[FR_PACKET_TYPE_VALUE_DO_NOT_RESPOND] = "Do-Not-Respond",
 };
 
 

--- a/src/protocols/tacacs/tacacs.h
+++ b/src/protocols/tacacs/tacacs.h
@@ -286,7 +286,7 @@ typedef enum {
 
 #define FR_TACACS_PACKET_CODE_VALID(_code) (((_code) > 0) && ((_code) < FR_TACACS_CODE_MAX))
 
-extern char const *fr_tacacs_packet_codes[FR_TACACS_CODE_MAX];
+extern char const *fr_tacacs_packet_codes[FR_TACACS_CODE_MAX + 1];
 
 /** Used as the decoder ctx
  *


### PR DESCRIPTION
In mod_process(), request->packet->code is constrained to [1, FR_TACACS_PACKET_TYPE_MAX)... but FR_TACACS_PACKET_TYPE_MAX - 1 is equal to FR_TACACS_CODE_MAX, and hence if the code is not allowed, it will fall off the end of fr_tacacs_packet_codes[] in the REDEBUG() invocation.

We therefore add an element to fr_tacacs_packet_codes[].