### PR TITLE
Get rid of missing unlock (CID #1518998)

### DIFF
--- a/src/lib/util/atexit.h
+++ b/src/lib/util/atexit.h
@@ -132,14 +132,10 @@ static inline int fr_atexit_talloc_free(void *to_free)
 	if (unlikely(!atomic_load(&_init_done))) { \
 		pthread_mutex_lock(&_init_mutex); \
 		if (!atomic_load(&_init_done)) { \
-			if (_fr_atexit_global_once_funcs(_init, _free, _our_uctx) < 0) { \
-				*(_ret) = -1; \
-				pthread_mutex_unlock(&_init_mutex); \
-			} \
+			if (_fr_atexit_global_once_funcs(_init, _free, _our_uctx) < 0) *(_ret) = -1; \
 			atomic_store(&_init_done, true); \
-		} else { \
-		    pthread_mutex_unlock(&_init_mutex); \
 		} \
+		pthread_mutex_unlock(&_init_mutex); \
 	} \
 	*(_ret) = 0; \
 }


### PR DESCRIPTION
Attempt to get rid of duplicate unlock left a gap for a missing unlock, namely if _fr_atexit_global_once_funcs() succeeded.