### PR TITLE
pap: Hoist &control:User-Password check so that it can be found

### DIFF
--- a/src/lib/server/password.c
+++ b/src/lib/server/password.c
@@ -964,22 +964,21 @@ fr_pair_t *password_find(bool *ephemeral, TALLOC_CTX *ctx, request_t *request,
 	fr_dcursor_t	cursor;
 	fr_pair_t	*known_good;
 
+	if (fr_pair_find_by_da(&request->control_pairs, NULL, attr_user) != NULL) {
+		RWDEBUG("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+		RWDEBUG("!!! Ignoring control.User-Password.  Update your        !!!");
+		RWDEBUG("!!! configuration so that the \"known good\" clear text   !!!");
+		RWDEBUG("!!! password is in Password.Cleartext and NOT in        !!!");
+		RWDEBUG("!!! User-Password.                                      !!!");
+		RWDEBUG("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+	}
+
 	for (known_good = fr_pair_dcursor_by_ancestor_init(&cursor, &request->control_pairs, attr_root);
 	     known_good;
 	     known_good = fr_dcursor_next(&cursor)) {
 		password_info_t		*info;
 		fr_pair_t		*out;
 		size_t			i;
-
-		if (known_good->da == attr_user) {
-			RWDEBUG("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-			RWDEBUG("!!! Ignoring control.User-Password.  Update your        !!!");
-			RWDEBUG("!!! configuration so that the \"known good\" clear text !!!");
-			RWDEBUG("!!! password is in Password.Cleartext and NOT in        !!!");
-			RWDEBUG("!!! User-Password.                                      !!!");
-			RWDEBUG("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-			continue;
-		}
 
 		if (known_good->da->attr >= NUM_ELEMENTS(password_info)) continue;
 


### PR DESCRIPTION
Since loop is rooted at &Password.

(Maybe the check isn't needed nowadays?)