### PR TITLE
Include thread stats in Status-Server attributes

### DIFF
--- a/share/dictionary.freeradius
+++ b/share/dictionary.freeradius
@@ -192,4 +192,11 @@ ATTRIBUTE	FreeRADIUS-Stats-Server-IPv6-Address	189	ipv6addr
 ATTRIBUTE	FreeRADIUS-Total-Auth-Conflicts		191	integer
 ATTRIBUTE	FreeRADIUS-Total-Acct-Conflicts		192	integer
 
+#
+#  Worker thread activity
+#
+ATTRIBUTE	FreeRADIUS-Stats-Threads-Active		193	integer
+ATTRIBUTE	FreeRADIUS-Stats-Threads-Total		194	integer
+ATTRIBUTE	FreeRADIUS-Stats-Threads-Max		195	integer
+
 END-VENDOR FreeRADIUS

--- a/src/main/stats.c
+++ b/src/main/stats.c
@@ -565,9 +565,9 @@ void request_stats_reply(REQUEST *request)
 		if (vp) vp->vp_date = hup_time.tv_sec;
 
 #ifdef HAVE_PTHREAD_H
-		int i, array[RAD_LISTEN_MAX], pps[2];
+		int i, array[RAD_LISTEN_MAX], stats[3];
 
-		thread_pool_queue_stats(array, pps);
+		thread_pool_queue_stats(array, stats);
 
 		for (i = 0; i <= 4; i++) {
 			vp = radius_pair_create(request->reply, &request->reply->vps,
@@ -582,7 +582,17 @@ void request_stats_reply(REQUEST *request)
 					       PW_FREERADIUS_QUEUE_PPS_IN + i, VENDORPEC_FREERADIUS);
 
 			if (!vp) continue;
-			vp->vp_integer = pps[i];
+			vp->vp_integer = stats[i];
+		}
+
+		thread_pool_thread_stats(stats);
+
+		for (i = 0; i < 3; i++) {
+			vp = radius_pair_create(request->reply, &request->reply->vps,
+					       PW_FREERADIUS_STATS_THREADS_ACTIVE + i, VENDORPEC_FREERADIUS);
+
+			if (!vp) continue;
+			vp->vp_integer = stats[i];
 		}
 #endif
 	}


### PR DESCRIPTION
```
Sent Status-Server Id 63 from 0.0.0.0:59229 to 127.0.0.1:18121 length 50
	FreeRADIUS-Statistics-Type = 19
	Message-Authenticator = 0x00
Received Access-Accept Id 63 from 127.0.0.1:18121 to 127.0.0.1:59229 length 392
...
	FreeRADIUS-Stats-Threads-Active = 9
	FreeRADIUS-Stats-Threads-Total = 15
	FreeRADIUS-Stats-Threads-Max = 32
```