### PR TITLE
Annotate intentional writes of const-qualified data (CID #1508484, #1…

### DIFF
--- a/src/lib/util/pair.c
+++ b/src/lib/util/pair.c
@@ -188,12 +188,14 @@ static inline CC_HINT(always_inline) void pair_init_from_da(fr_pair_t *vp, fr_di
 		 *	Make it very obvious if we failed
 		 *	to initialise something.
 		 */
+		/* coverity[store_writes_const_field] */
 		memset(&vp->data, 0xff, sizeof(vp->data));
 #endif
 
 		/*
 		 *	Hack around const issues...
 		 */
+		/* coverity[store_writes_const_field] */
 		memcpy(UNCONST(fr_type_t *, &vp->vp_type), &da->type, sizeof(vp->vp_type));
 		fr_pair_list_init(&vp->vp_group);
 		vp->vp_group.is_child = true;

--- a/src/lib/util/value.h
+++ b/src/lib/util/value.h
@@ -452,6 +452,7 @@ int		fr_value_box_steal(TALLOC_CTX *ctx, fr_value_box_t *dst, fr_value_box_t *sr
 static inline CC_HINT(nonnull(1), always_inline)
 void fr_value_box_init(fr_value_box_t *vb, fr_type_t type, fr_dict_attr_t const *enumv, bool tainted)
 {
+	/* coverity[store_writes_const_field] */
 	memcpy(vb, &(fr_value_box_t){
 	       		.type = type,
 			.enumv = enumv,


### PR DESCRIPTION
…517674)

Certain members of fr_value_box_t and hence of fr_pair_t have const-qualified type, so pair_init_from_da() and fr_value_box_init(), which modify some of those members, coverity points them out. (UNCONST() placates the compiler, but not coverity.)

The coverity primitives that one might think would apply here, __coverity_write_buffer_{bytes, elements}__(), are said to relate mostly to checkers unrelated to writes to const-qualified fields, so we annotate.