### PR TITLE
fr_sbuff_out_bstrncpy_until(): call fr_sbuff_extend_lowat() with proper sbuff

### DIFF
--- a/src/lib/util/sbuff.c
+++ b/src/lib/util/sbuff.c
@@ -846,7 +846,7 @@ size_t fr_sbuff_out_bstrncpy_until(fr_sbuff_t *out, fr_sbuff_t *in, size_t len,
 		char	*p;
 		char	*end;
 
-		if (fr_sbuff_extend_lowat(NULL, in, needle_len) == 0) break;
+		if (fr_sbuff_extend_lowat(NULL, &our_in, needle_len) == 0) break;
 
 		p = fr_sbuff_current(&our_in);
 		end = CONSTRAINED_END(&our_in, len, fr_sbuff_used_total(&our_in));

--- a/src/lib/util/sbuff_tests.c
+++ b/src/lib/util/sbuff_tests.c
@@ -1052,7 +1052,7 @@ static void test_file_extend(void)
 	fr_sbuff_uctx_file_t	fctx;
 	FILE		*fp;
 	char		buff[5];
-	char		out[16 + 1];
+	char		out[24];
 	char		fbuff[24];
 	const char	PATTERN[] = "xyzzy";
 #define PATTERN_LEN (sizeof(PATTERN) - 1)
@@ -1094,6 +1094,16 @@ static void test_file_extend(void)
 	TEST_CHECK_SLEN(slen, 0);
 	slen = fr_sbuff_out_bstrncpy_allowed(&FR_SBUFF_OUT(out, sizeof(out)), &our_sbuff, SIZE_MAX, allow_lowercase_and_space);
 	TEST_CHECK_SLEN(slen, 0);
+
+	fclose(fp);
+
+	TEST_CASE("Verify fr_sbuff_out_bstrncpy_until() extends from file properly");
+	fp = fmemopen(fbuff, sizeof(fbuff), "r");
+	TEST_CHECK(fp != NULL);
+	TEST_CHECK(fr_sbuff_init_file(&sbuff, &fctx, buff, sizeof(buff), fp, 128) == &sbuff);
+	our_sbuff = FR_SBUFF_BIND_CURRENT(&sbuff);
+	slen = fr_sbuff_out_bstrncpy_until(&FR_SBUFF_OUT(out, sizeof(out)), &our_sbuff, SIZE_MAX, &FR_SBUFF_TERM("x"), NULL);
+	TEST_CHECK_SLEN(slen, sizeof(fbuff) - PATTERN_LEN);
 
 	fclose(fp);
 }


### PR DESCRIPTION
Otherwise `our_in` is not shifted when `fr_sbuff_extend_file()` is called

The bug leads to yet another parsing bug when e.g. rlm_files policy file is parsed:
```
Reading file /etc/raddb/mods-config/files/ut_policies
/etc/raddb/mods-config/files/ut_policies[128]: test.viasat #Pool-Name := naw01_%{control.DHCP-Viasat-VASN-Stackid}_PERF-UT
/etc/raddb/mods-config/files/ut_policies[128]:              ^ Invalid operator
Failed reading /etc/raddb/mods-config/files/ut_policies
/etc/raddb/mods-enabled/files[1]: Instantiation failed for module "subscriber_ut_policy"
```

The file around line 128 is:

```
citests01:nos.biz.com #Pool-Name := naw01_%{control.DHCP-Viasat-VASN-Stackid}_MOB-UT
    dhcpv4.IP-Address-Lease-Time := "300",
    dhcpv4.Domain-Name-Server := "72.173.31.41",
    dhcpv4.Domain-Name-Server += "72.173.31.42",
    dhcpv4.NIS-Servers := "10.255.255.10"

citests01:perf.test.viasat #Pool-Name := naw01_%{control.DHCP-Viasat-VASN-Stackid}_PERF-UT
    dhcpv4.IP-Address-Lease-Time := "300",
    dhcpv4.Domain-Name-Server := "72.173.31.41",
    dhcpv4.Domain-Name-Server += "72.173.31.42",
    dhcpv4.NIS-Servers := "10.255.255.10"

citests01:si2.viasat.com #Pool-Name := naw01_%{control.DHCP-Viasat-VASN-Stackid}_VSAT-UT
    dhcpv4.IP-Address-Lease-Time := "300",
    dhcpv4.Domain-Name-Server := "72.173.31.41",
    dhcpv4.Domain-Name-Server += "72.173.31.42",
    dhcpv4.NIS-Servers := "10.255.255.10"
```

"citests01:perf.test.viasat" gets into 8192 I/O buffer boundary and "citests01:perf." is lost because the buffer is not shifted properly.