### PR TITLE
v4: Fix up module boostrap sequence

### DIFF
--- a/src/lib/server/module.c
+++ b/src/lib/server/module.c
@@ -342,16 +342,10 @@ int module_submodule_parse(UNUSED TALLOC_CTX *ctx, void *out, void *parent,
 
 	if (unlikely(module_conf_parse(mi, submodule_cs) < 0)) {
 		cf_log_err(submodule_cs, "Failed parsing submodule config");
-	error:
 		talloc_free(mi);
 		return -1;
 	}
 
-	if (unlikely(module_bootstrap(mi) < 0)) {
-		cf_log_err(submodule_cs, "Failed bootstrapping submodule");
-		goto error;
-
-	}
 	*((module_instance_t **)out) = mi;
 
 	return 0;

--- a/src/lib/server/module_rlm.c
+++ b/src/lib/server/module_rlm.c
@@ -1051,11 +1051,6 @@ int modules_rlm_bootstrap(CONF_SECTION *root)
 			return -1;
 		}
 
-		if (module_bootstrap(mi) < 0) {
-			cf_log_perr(subcs, "Failed bootstrapping module");
-			goto error;
-		}
-
 		/*
 		 *	Compile the default "actions" subsection, which includes retries.
 		 */
@@ -1065,6 +1060,13 @@ int modules_rlm_bootstrap(CONF_SECTION *root)
 			goto error;
 		}
 	}
+
+	/*
+	 *	Having parsed all the modules, bootstrap them.
+	 *	This needs to be after parsing so that submodules can access
+	 *	their parent's fully parsed data.
+	 */
+	modules_bootstrap(rlm_modules);
 
 	cf_log_debug(modules, " } # modules");
 

--- a/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c
@@ -167,7 +167,7 @@ static int _sql_socket_destructor(rlm_sql_mysql_conn_t *conn)
 	return 0;
 }
 
-static int mod_instantiate(module_inst_ctx_t const *mctx)
+static int mod_bootstrap(module_inst_ctx_t const *mctx)
 {
 	rlm_sql_mysql_t		*inst = talloc_get_type_abort(mctx->inst->data, rlm_sql_mysql_t);
 	int			warnings;
@@ -851,7 +851,7 @@ rlm_sql_driver_t rlm_sql_mysql = {
 		.onload				= mod_load,
 		.unload				= mod_unload,
 		.config				= driver_config,
-		.instantiate			= mod_instantiate
+		.bootstrap			= mod_bootstrap
 	},
 	.flags				= RLM_SQL_RCODE_FLAGS_ALT_QUERY,
 	.sql_socket_init		= sql_socket_init,

--- a/src/modules/rlm_sql/drivers/rlm_sql_oracle/rlm_sql_oracle.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_oracle/rlm_sql_oracle.c
@@ -153,7 +153,7 @@ static int mod_detach(module_detach_ctx_t const *mctx)
 	return 0;
 }
 
-static int mod_instantiate(module_inst_ctx_t const *mctx)
+static int mod_bootstrap(module_inst_ctx_t const *mctx)
 {
 	rlm_sql_t const		*parent = talloc_get_type_abort(mctx->inst->parent->data, rlm_sql_t);
 	rlm_sql_config_t const	*config = &parent->config;
@@ -617,7 +617,7 @@ rlm_sql_driver_t rlm_sql_oracle = {
 		.magic				= MODULE_MAGIC_INIT,
 		.inst_size			= sizeof(rlm_sql_oracle_t),
 		.config				= driver_config,
-		.instantiate			= mod_instantiate,
+		.bootstrap			= mod_bootstrap,
 		.detach				= mod_detach
 	},
 	.sql_socket_init		= sql_socket_init,

--- a/src/modules/rlm_sql/drivers/rlm_sql_postgresql/rlm_sql_postgresql.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_postgresql/rlm_sql_postgresql.c
@@ -544,7 +544,7 @@ static size_t sql_escape_func(request_t *request, char *out, size_t outlen, char
 	return ret;
 }
 
-static int mod_instantiate(module_inst_ctx_t const *mctx)
+static int mod_bootstrap(module_inst_ctx_t const *mctx)
 {
 	rlm_sql_t const		*parent = talloc_get_type_abort(mctx->inst->parent->data, rlm_sql_t);
 	rlm_sql_config_t const	*config = &parent->config;
@@ -675,7 +675,7 @@ rlm_sql_driver_t rlm_sql_postgresql = {
 		.inst_size			= sizeof(rlm_sql_postgresql_t),
 		.onload				= mod_load,
 		.config				= driver_config,
-		.instantiate			= mod_instantiate
+		.bootstrap			= mod_bootstrap
 	},
 	.flags				= RLM_SQL_RCODE_FLAGS_ALT_QUERY,
 	.sql_socket_init		= sql_socket_init,

--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -1150,14 +1150,6 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 	}
 
 	/*
-	 *	Ensure the driver is instantiated before attempting connections
-	 */
-	if (module_instantiate(inst->driver_submodule) < 0) {
-		cf_log_err(conf, "Failed instantiating SQL driver");
-		return -1;
-	}
-
-	/*
 	 *	Initialise the connection pool for this instance
 	 */
 	INFO("Attempting to connect to database \"%s\"", inst->config.sql_db);


### PR DESCRIPTION
This ensures all module config is parsed before bootstrapping, allowing submodules to use the results of parent module config parsing.