### PR TITLE
Allow using clang 15 with -Werror and -Wunreachable-code-generic-assoc

### DIFF
--- a/src/lib/server/cf_util.h
+++ b/src/lib/server/cf_util.h
@@ -66,13 +66,10 @@ typedef struct cf_data CONF_DATA;	//!< #CONF_ITEM used to associate arbitrary da
 _Generic((_cf), \
 	CONF_SECTION *			: cf_section_to_item((CONF_SECTION const *)_cf), \
 	CONF_SECTION const *		: cf_section_to_item((CONF_SECTION const *)_cf), \
-	CONF_SECTION const * const	: cf_section_to_item((CONF_SECTION const * const)_cf), \
 	CONF_PAIR *			: cf_pair_to_item((CONF_PAIR const *)_cf), \
 	CONF_PAIR const *		: cf_pair_to_item((CONF_PAIR const *)_cf), \
-	CONF_PAIR const * const		: cf_pair_to_item((CONF_PAIR const * const)_cf), \
 	CONF_DATA *			: cf_data_to_item((CONF_DATA const *)_cf), \
 	CONF_DATA const *		: cf_data_to_item((CONF_DATA const *)_cf), \
-	CONF_DATA const * const		: cf_data_to_item((CONF_DATA const * const)_cf), \
 	default: _cf \
 )
 

--- a/src/lib/util/value.h
+++ b/src/lib/util/value.h
@@ -687,25 +687,15 @@ _Generic((_var), \
 	fr_ethernet_t const *	: fr_value_box_ethernet_addr, \
 	bool			: fr_value_box_bool, \
 	uint8_t			: fr_value_box_uint8, \
-	uint8_t const		: fr_value_box_uint8, \
 	uint16_t		: fr_value_box_uint16, \
-	uint16_t const		: fr_value_box_uint16, \
 	uint32_t		: fr_value_box_uint32, \
-	uint32_t const		: fr_value_box_uint32, \
 	uint64_t		: fr_value_box_uint64, \
-	uint64_t const		: fr_value_box_uint64, \
 	int8_t			: fr_value_box_int8, \
-	int8_t const		: fr_value_box_int8, \
 	int16_t			: fr_value_box_int16, \
-	int16_t const		: fr_value_box_int16, \
 	int32_t			: fr_value_box_int32, \
-	int32_t	const		: fr_value_box_int32, \
 	int64_t			: fr_value_box_int64, \
-	int64_t	const		: fr_value_box_int64, \
 	float			: fr_value_box_float32, \
-	float const		: fr_value_box_float32, \
-	double			: fr_value_box_float64, \
-	double const		: fr_value_box_float64 \
+	double			: fr_value_box_float64 \
 )(_box, NULL, _var, _tainted)
 
 /** Automagically fill in a box, for types with length


### PR DESCRIPTION
Pre C17, there was ambiguity about the type of the controlling expression in __Generic(). C17 explicitly states that it is subject to rvalue promotions, which removes qualification from the outermost (or is that deepest?) type modifier (or the base type if there are no modifiers).

(To clarify with an example, a FOO const * const will become FOO const * as far as __Generic() is concerned.)

clang 15, perhaps anticipating C17, has -Wunreachabale-code-generic-assoc, which warns if a __Generic() alternative type is unreachable, e.g. FOO const * const. This change gets rid of such alternatives in a couple of macros.

This builds and passes such tests as I can do compiling with gcc, clang 14, and clang 15.