### PR TITLE
md5 xlat: Destroy MD context, causing leaks with OpenSSL >= 3.0 (#4893)

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -5,6 +5,7 @@ FreeRADIUS 3.0.27 Tue 20 Sep 2022 12:00:00 EDT urgency=low
 	Bug fixes
 	* Fix rlm_python3 build with python >= 3.10. Fixes #4441
 	* The DS-Lite-Tunnel-Name data type should be 'octets'.
+	* Fix rlm_expr destroying MD context, causing leaks with OpenSSL >= 3.0 #4893
 
 FreeRADIUS 3.0.26 Tue 20 Sep 2022 12:00:00 EDT urgency=low
 	Feature improvements

--- a/src/modules/rlm_expr/rlm_expr.c
+++ b/src/modules/rlm_expr/rlm_expr.c
@@ -955,6 +955,7 @@ static ssize_t md5_xlat(UNUSED void *instance, REQUEST *request,
 	fr_md5_init(&ctx);
 	fr_md5_update(&ctx, p, inlen);
 	fr_md5_final(digest, &ctx);
+	fr_md5_destroy(&ctx);
 
 	/*
 	 *	Each digest octet takes two hex digits, plus one for
@@ -998,6 +999,7 @@ static ssize_t md4_xlat(UNUSED void *instance, REQUEST *request,
 	fr_md4_init(&ctx);
 	fr_md4_update(&ctx, p, inlen);
 	fr_md4_final(digest, &ctx);
+	fr_md4_destroy(&ctx);
 
 	/*
 	 *	Each digest octet takes two hex digits, plus one for


### PR DESCRIPTION
Backporting #4893 for v3.0.x