### PR TITLE
Ensure service user has stable uid/gid between Docker distro versions

### DIFF
--- a/scripts/docker/debian11/Dockerfile
+++ b/scripts/docker/debian11/Dockerfile
@@ -44,7 +44,12 @@ RUN make -j2 deb
 FROM ${from}
 COPY --from=build /usr/local/src/repositories/*.deb /tmp/
 
-RUN apt-get update \
+ARG freerad_uid=101
+ARG freerad_gid=101
+
+RUN groupadd -g ${freerad_gid} -r freerad \
+    && useradd -u ${freerad_uid} -g freerad -r -M -d /etc/freeradius -s /usr/sbin/nologin freerad \
+    && apt-get update \
     && apt-get install -y /tmp/*.deb \
     && apt-get clean \
     && rm -r /var/lib/apt/lists/* /tmp/*.deb \

--- a/scripts/docker/debiansid/Dockerfile
+++ b/scripts/docker/debiansid/Dockerfile
@@ -44,7 +44,12 @@ RUN make -j2 deb
 FROM ${from}
 COPY --from=build /usr/local/src/repositories/*.deb /tmp/
 
-RUN apt-get update \
+ARG freerad_uid=101
+ARG freerad_gid=101
+
+RUN groupadd -g ${freerad_gid} -r freerad \
+    && useradd -u ${freerad_uid} -g freerad -r -M -d /etc/freeradius -s /usr/sbin/nologin freerad \
+    && apt-get update \
     && apt-get install -y /tmp/*.deb \
     && apt-get clean \
     && rm -r /var/lib/apt/lists/* /tmp/*.deb \

--- a/scripts/docker/rocky8/Dockerfile
+++ b/scripts/docker/rocky8/Dockerfile
@@ -93,7 +93,12 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-LTB-project'\
     && yum install -y dnf-utils \
     && yum config-manager --enable epel-testing
 
-RUN yum install -y /tmp/*.rpm
+ARG radiusd_uid=95
+ARG radiusd_gid=95
+
+RUN groupadd -g ${radiusd_gid} -r radiusd \
+    && useradd -u ${radiusd_uid} -g radiusd -r -M -d /home/radiusd -s /sbin/nologin radiusd \
+    && yum install -y /tmp/*.rpm
 
 COPY docker-entrypoint.sh /
 RUN chmod +x /docker-entrypoint.sh

--- a/scripts/docker/ubuntu22/Dockerfile
+++ b/scripts/docker/ubuntu22/Dockerfile
@@ -44,9 +44,14 @@ RUN make -j2 deb
 FROM ${from}
 COPY --from=build /usr/local/src/repositories/*.deb /tmp/
 
+ARG freerad_uid=101
+ARG freerad_gid=101
+
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update \
+RUN groupadd -g ${freerad_gid} -r freerad \
+    && useradd -u ${freerad_uid} -g freerad -r -M -d /etc/freeradius -s /usr/sbin/nologin freerad \
+    && apt-get update \
     && apt-get install -y /tmp/*.deb \
     && apt-get clean \
     && rm -r /var/lib/apt/lists/* /tmp/*.deb \


### PR DESCRIPTION
Changing UID between image versions is deprecated because modern container workflows involve automated image upgrade / rollback using the same mounted-in volume (i.e. with persistent filesystem permissions).