### PR TITLE
Annotate dead code false positive

### DIFF
--- a/src/modules/rlm_imap/rlm_imap.c
+++ b/src/modules/rlm_imap/rlm_imap.c
@@ -180,6 +180,7 @@ static unlang_action_t CC_HINT(nonnull(1,2)) mod_authenticate(rlm_rcode_t *p_res
 	randle = fr_imap_slab_reserve(t->slab);
 	if (!randle){
 	error:
+		/* coverity [dead_error_line] */
 		if (randle) fr_imap_slab_release(randle);
 		RETURN_MODULE_FAIL;
 	}


### PR DESCRIPTION
Coverity doesn't see the "goto error" hidden in the invocations of FR_CURL_REQUEST_SET_OPTION(), and hence thinks that at error, randle will always be NULL, making the fr_imap_slab_release() invocation dead code.