### PR TITLE
v3.2: Define max_retries for pool connections

### DIFF
--- a/raddb/mods-available/ldap
+++ b/raddb/mods-available/ldap
@@ -696,5 +696,10 @@ ldap {
 		#
 		#  The solution is to either lower the 'min' connections,
 		#  or increase lifetime/idle_timeout.
+
+		#  Maximum number of times an operation can be retried
+		#  if it returns an error which indicates the connection
+		#  needs to be restarted.  This includes timeouts.
+		max_retries = 5
 	}
 }

--- a/raddb/mods-available/sql
+++ b/raddb/mods-available/sql
@@ -325,6 +325,11 @@ sql {
 		#
 		#  The solution is to either lower the "min" connections,
 		#  or increase lifetime/idle_timeout.
+
+		#  Maximum number of times an operation can be retried
+		#  if it returns an error which indicates the connection
+		#  needs to be restarted.  This includes timeouts.
+		max_retries = 5
 	}
 
 	# Set to 'yes' to read radius clients from the database ('nas' table)

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -84,6 +84,8 @@ fr_connection_pool_t	*fr_connection_pool_module_init(CONF_SECTION *module,
  */
 int	fr_connection_pool_get_num(fr_connection_pool_t *pool);
 
+int	fr_connection_pool_get_retries(fr_connection_pool_t *pool);
+
 /*
  *	Pool management
  */

--- a/src/modules/rlm_ldap/ldap.c
+++ b/src/modules/rlm_ldap/ldap.c
@@ -717,7 +717,7 @@ ldap_rcode_t rlm_ldap_bind(rlm_ldap_t const *inst, REQUEST *request, ldap_handle
 	 *	For sanity, for when no connections are viable,
 	 *	and we can't make a new one.
 	 */
-	num = retry ? fr_connection_pool_get_num(inst->pool) : 0;
+	num = retry ? fr_connection_pool_get_retries(inst->pool) : 0;
 	for (i = num; i >= 0; i--) {
 #ifdef WITH_SASL
 		if (sasl && sasl->mech) {
@@ -877,7 +877,7 @@ ldap_rcode_t rlm_ldap_search(LDAPMessage **result, rlm_ldap_t const *inst, REQUE
 	 *	For sanity, for when no connections are viable,
 	 *	and we can't make a new one.
 	 */
-	for (i = fr_connection_pool_get_num(inst->pool); i >= 0; i--) {
+	for (i = fr_connection_pool_get_retries(inst->pool); i >= 0; i--) {
 		(void) ldap_search_ext((*pconn)->handle, dn, scope, filter, search_attrs,
 				       0, serverctrls, clientctrls, &tv, 0, &msgid);
 
@@ -1004,7 +1004,7 @@ ldap_rcode_t rlm_ldap_modify(rlm_ldap_t const *inst, REQUEST *request, ldap_hand
 	 *	For sanity, for when no connections are viable,
 	 *	and we can't make a new one.
 	 */
-	for (i = fr_connection_pool_get_num(inst->pool); i >= 0; i--) {
+	for (i = fr_connection_pool_get_retries(inst->pool); i >= 0; i--) {
 		RDEBUG2("Modifying object with DN \"%s\"", dn);
 		(void) ldap_modify_ext((*pconn)->handle, dn, mods, NULL, NULL, &msgid);
 

--- a/src/modules/rlm_sql/sql.c
+++ b/src/modules/rlm_sql/sql.c
@@ -292,7 +292,7 @@ sql_rcode_t rlm_sql_query(rlm_sql_t *inst, REQUEST *request, rlm_sql_handle_t **
 	/*
 	 *  inst->pool may be NULL is this function is called by mod_conn_create.
 	 */
-	count = inst->pool ? fr_connection_pool_get_num(inst->pool) : 0;
+	count = inst->pool ? fr_connection_pool_get_retries(inst->pool) : 0;
 
 	/*
 	 *  Here we try with each of the existing connections, then try to create
@@ -392,7 +392,7 @@ sql_rcode_t rlm_sql_select_query(rlm_sql_t *inst, REQUEST *request, rlm_sql_hand
 	/*
 	 *  inst->pool may be NULL is this function is called by mod_conn_create.
 	 */
-	count = inst->pool ? fr_connection_pool_get_num(inst->pool) : 0;
+	count = inst->pool ? fr_connection_pool_get_retries(inst->pool) : 0;
 
 	/*
 	 *  For sanity, for when no connections are viable, and we can't make a new one


### PR DESCRIPTION
Allows control over the number of times a connection operation can be retried before the module call fails.

Previously this was always set to the number of connections in the pool
- so on a system with a large number of open connections, and a remote server going slow, this would easily block threads.