### PR TITLE
Hide CC_HINT() from doxygen

### DIFF
--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -2104,7 +2104,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -2112,7 +2112,7 @@ MACRO_EXPANSION        = NO
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -2145,7 +2145,8 @@ INCLUDE_FILE_PATTERNS  = *.h
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 PREDEFINED             = WITH_STATS \
-                         HAVE_JSON
+                         HAVE_JSON \
+                         CC_HINT(x)=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
doxygen documentation mentions that it doesn't know about __attribute()__, and recommends making it expand to the empty string for doxygen using PREDEFINED. Letting CC_HINT() through to doxygen confuses it, in particular about function definitions/declarations. In src/lib/util/strerror.h it was not recognizing the parameters of the functions therein as such and therefore giving multiple "member <parameter> belongs to two different groups" warnings.