### PR TITLE
Get rid of "explicit link to foo could not be resolved" warnings

### DIFF
--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -2146,6 +2146,7 @@ INCLUDE_FILE_PATTERNS  = *.h
 
 PREDEFINED             = WITH_STATS \
                          HAVE_JSON \
+                         STATE \
                          CC_HINT(x)=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this

--- a/src/lib/util/pair.c
+++ b/src/lib/util/pair.c
@@ -1334,8 +1334,8 @@ int fr_pair_insert_before(fr_pair_list_t *list, fr_pair_t *pos, fr_pair_t *to_ad
  *
  * @note Memory used by the VP being replaced will be freed.
  *
- * @param[in,out] list		pair list containing #to_replace.
- * @param[in] to_replace	pair to replace and free
+ * @param[in,out] list		pair list
+ * @param[in] to_replace	pair to replace and free, on #list
  * @param[in] vp		New pair to insert.
  */
 void fr_pair_replace(fr_pair_list_t *list, fr_pair_t *to_replace, fr_pair_t *vp)


### PR DESCRIPTION
These turned up for a couple of reasons:
1. Macros expanding to variable declarations (here STATE()); doxygen needs it expaded to see the declaration.
2. Forward references in @param