### PR TITLE
Disable caller graphs for (some) functions with many callers

### DIFF
--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -2150,7 +2150,11 @@ PREDEFINED             = WITH_STATS \
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      = FR_DLIST_HEAD
+EXPAND_AS_DEFINED      = FR_DLIST_HEAD \
+                         fr_dbuff_set \
+                         FR_SBUFF_SET_RETURN \
+                         MEM \
+                         fr_assert
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have

--- a/src/lib/util/dcursor_tests.c
+++ b/src/lib/util/dcursor_tests.c
@@ -16,6 +16,7 @@ static void *test_iter(fr_dlist_head_t *list, void *current, UNUSED void *uctx)
 	return fr_dlist_next(list, current);
 }
 
+/** @hidecallergraph */
 static void test_list_init(test_item_list_t *list)
 {
 	fr_dlist_talloc_init(&list->head, test_item_t, entry);

--- a/src/lib/util/dlist.h
+++ b/src/lib/util/dlist.h
@@ -352,6 +352,8 @@ static inline CC_HINT(nonnull) int fr_dlist_insert_head(fr_dlist_head_t *list_he
  * @return
  * 	- 0 on success.
  *	- -1 on failure.
+ *
+ * @hidecallergraph
  */
 static inline CC_HINT(nonnull) int fr_dlist_insert_tail(fr_dlist_head_t *list_head, void *ptr)
 {
@@ -458,6 +460,8 @@ static inline CC_HINT(nonnull(1,3)) int fr_dlist_insert_before(fr_dlist_head_t *
  * @return
  *	- The HEAD item.
  *	- NULL if no items exist in the list.
+ *
+ * @hidecallergraph
  */
 static inline CC_HINT(nonnull) void *fr_dlist_head(fr_dlist_head_t const *list_head)
 {
@@ -526,6 +530,7 @@ static inline CC_HINT(nonnull) void *fr_dlist_tail(fr_dlist_head_t const *list_h
  *	- The next item in the list if ptr is not NULL.
  *	- The head of the list if ptr is NULL.
  *	- NULL if ptr is the tail of the list (no more items).
+ * @hidecallergraph
  */
 static inline CC_HINT(nonnull(1)) void *fr_dlist_next(fr_dlist_head_t const *list_head, void const *ptr)
 {
@@ -607,6 +612,8 @@ static inline CC_HINT(nonnull(1)) void *fr_dlist_prev(fr_dlist_head_t const *lis
  * @return
  *	- The previous item in the list (makes iteration easier).
  *	- NULL if we just removed the head of the list.
+ *
+ * @hidecallergraph
  */
 static inline CC_HINT(nonnull(1)) void *fr_dlist_remove(fr_dlist_head_t *list_head, void *ptr)
 {

--- a/src/lib/util/minmax_heap.c
+++ b/src/lib/util/minmax_heap.c
@@ -77,6 +77,9 @@ typedef struct fr_minmax_heap_s minmax_heap_t;
 #define HEAP_RIGHT(_x) (2 * (_x) + 1 )
 #define	HEAP_SWAP(_a, _b) { void *_tmp = _a; _a = _b; _b = _tmp; }
 
+/**
+ * @hidecallergraph
+ */
 static inline uint8_t depth(fr_minmax_heap_index_t i)
 {
 	return fr_high_bit_pos(i) - 1;

--- a/src/lib/util/pair.c
+++ b/src/lib/util/pair.c
@@ -40,6 +40,8 @@ FR_TLIST_FUNCS(fr_pair_order_list, fr_pair_t, order_entry)
 /** Initialise a pair list header
  *
  * @param[in,out] list to initialise
+ *
+ * @hidecallergraph
  */
 void fr_pair_list_init(fr_pair_list_t *list)
 {
@@ -1259,6 +1261,8 @@ int fr_pair_prepend(fr_pair_list_t *list, fr_pair_t *to_add)
  * @return
  *	- 0 on success.
  *	- -1 on failure (pair already in list).
+ *
+ * @hidecallergraph
  */
 int fr_pair_append(fr_pair_list_t *list, fr_pair_t *to_add)
 {

--- a/src/lib/util/pair.h
+++ b/src/lib/util/pair.h
@@ -89,7 +89,7 @@ struct value_pair_s {
 			 * fr_value_box_t which gives us much greater packing efficiency.
 			 */
 			uint8_t		pad[offsetof(fr_value_box_t, type) + sizeof(fr_type_t)];
-	
+
 			fr_pair_list_t	children;		//!< Nested attributes of this pair.
 		};
 	};
@@ -415,6 +415,7 @@ do { \
 } while (0)
 
 /* Initialisation */
+/** @hidecallergraph */
 void fr_pair_list_init(fr_pair_list_t *head) CC_HINT(nonnull);
 
 void fr_pair_init_null(fr_pair_t *vp) CC_HINT(nonnull);
@@ -454,6 +455,7 @@ bool		fr_pair_matches_da(void const *item, void const *uctx) CC_HINT(nonnull);
 unsigned int	fr_pair_count_by_da(fr_pair_list_t const *list, fr_dict_attr_t const *da)
 				    CC_HINT(nonnull);
 
+/** @hidecallergraph */
 fr_pair_t	*fr_pair_find_by_da(fr_pair_list_t const *list,
 				    fr_pair_t const *prev, fr_dict_attr_t const *da) CC_HINT(nonnull(1,3));
 
@@ -476,6 +478,7 @@ fr_pair_t	*fr_pair_find_by_child_num_idx(fr_pair_list_t const *list,
 					       fr_dict_attr_t const *parent, unsigned int attr,
 					       unsigned int idx) CC_HINT(nonnull);
 
+/** @hidecallergraph */
 int		fr_pair_append(fr_pair_list_t *list, fr_pair_t *vp) CC_HINT(nonnull);
 
 int		fr_pair_prepend(fr_pair_list_t *list, fr_pair_t *vp) CC_HINT(nonnull);

--- a/src/lib/util/rand.c
+++ b/src/lib/util/rand.c
@@ -95,6 +95,7 @@ void fr_rand_seed(void const *data, size_t size)
 
 /** Return a 32-bit random number
  *
+ * @hidecallergraph
  */
 uint32_t fr_rand(void)
 {

--- a/src/lib/util/rand.h
+++ b/src/lib/util/rand.h
@@ -57,6 +57,7 @@ typedef struct {
 
 void		fr_isaac(fr_randctx *ctx);
 void		fr_rand_init(fr_randctx *ctx, int flag);
+/** @hidecallergraph */
 uint32_t	fr_rand(void);	/* like rand(), but better. */
 void		fr_rand_buffer(void *start, size_t length) CC_HINT(nonnull);
 void		fr_rand_str(uint8_t *out, size_t len, char class);

--- a/src/lib/util/time.h
+++ b/src/lib/util/time.h
@@ -150,6 +150,7 @@ static inline int64_t fr_time_unwrap(fr_time_t time) { return time.value; }	/* f
 #define fr_time_delta_max() (fr_time_delta_t){ .value = INT64_MAX }
 #define fr_time_delta_min() (fr_time_delta_t){ .value = INT64_MIN }
 #define fr_time_delta_wrap(_time) (fr_time_delta_t){ .value = (_time) }
+/** @hidecallergraph */
 static inline int64_t fr_time_delta_unwrap(fr_time_delta_t time) { return time.value; }	/* func to stop mixing with fr_time_t */
 #define fr_time_delta_overflow_add(_a, _b) (fr_time_overflow_ispos(_a, true, _b) ? fr_time_delta_max() : fr_time_delta_min())
 #define fr_time_delta_overflow_sub(_a, _b) (fr_time_overflow_ispos(_a, false, _b) ? fr_time_delta_max() : fr_time_delta_min())
@@ -583,6 +584,7 @@ static inline fr_time_delta_t fr_time_delta_from_csec(int64_t csec)
 	return fr_time_delta_wrap(out);
 }
 
+/** @hidecallergraph */
 static inline fr_time_delta_t fr_time_delta_from_sec(int64_t sec)
 {
 	int64_t out;

--- a/src/lib/util/types.h
+++ b/src/lib/util/types.h
@@ -366,6 +366,8 @@ extern size_t fr_type_table_len;
  *
  * @param[in] type to return name for.
  * @return name of the type
+ *
+ * @hidecallergraph
  */
 static inline char const *fr_type_to_str(fr_type_t type)
 {

--- a/src/lib/util/value.h
+++ b/src/lib/util/value.h
@@ -449,6 +449,8 @@ int		fr_value_box_steal(TALLOC_CTX *ctx, fr_value_box_t *dst, fr_value_box_t *sr
  * @param[in] type	to set.
  * @param[in] enumv	Enumeration values.
  * @param[in] tainted	Whether data will come from an untrusted source.
+ *
+ * @hidecallergraph
  */
 static inline CC_HINT(nonnull(1), always_inline)
 void fr_value_box_init(fr_value_box_t *vb, fr_type_t type, fr_dict_attr_t const *enumv, bool tainted)
@@ -535,6 +537,8 @@ fr_value_box_t *fr_value_box_alloc(TALLOC_CTX *ctx, fr_type_t type, fr_dict_attr
  * @return
  *	- A new fr_value_box_t.
  *	- NULL on error.
+ *
+ *  @hidecallergraph
  */
 static inline CC_HINT(always_inline)
 fr_value_box_t *fr_value_box_alloc_null(TALLOC_CTX *ctx)


### PR DESCRIPTION
Some complaints about caller graphs involved macros; it sufficed to have them expanded as defined. For actual functions, it turns out that one has to specify @hidecallergraph twice for non-static functions: once where it's declared in a header and once where it's defined. This doesn't catch everything; there's still the matter of

1. Library functions. According to the doxygen-user mailing list, doxygen won't make *call* graphs for library functions... but what causes it to generate *caller* graphs for library functions, and if it does, why isn't it complaining about fprintf(), which FreeRADIUS code calls far more than fifty times?

2. xlat_init() and strlcpy(). (On Ubuntu, and probably other Linuxes, strlcpy() is in an optional libbsd package, and configure understandably doesn't check for that--hence we get the "missing" version.) For some still-unknown reason, two @hidecallergraphs doesn't do the trick.