### PR TITLE
v4: Add libcurl tuneables to control open / cached connection counts

### DIFF
--- a/raddb/mods-available/imap
+++ b/raddb/mods-available/imap
@@ -230,5 +230,38 @@ imap {
 			cleanup_interval = 30s
 
 		}
+
+		#
+		# curl_opts { .. }:: Options for resource limiting connections
+		# handled by libcurl.  These represent per thread limits.
+		#
+		curl_opts {
+			#
+			#  max_connects:: The libcurl option CURLMOPT_MAXCONNECTS.
+			#
+			#  Sets the maximum number of connections to maintain in
+			#  the connection cache.  If this number is exceeded, then
+			#  the oldest connection is closed when a new one is
+			#  requested.
+			#
+			max_connects = 100
+
+			#
+			#  max_host_connections:: The libcurl option CURLMOPT_MAX_HOST_CONNECTIONS.
+			#
+			#  Sets the maximum number of currently open connections
+			#  to a given host and port combination.  Requests beyond
+			#  this limit will be queued by libcurl.
+			#
+		#	max_host_connections = 0
+
+			#
+			#  max_total_connections:  The libcurl option CURLMOPT_MAX_TOTAL_CONNECTIONS.
+			#
+			#  Sets the maximum total number of open connections.
+			#  Requests beyond this limit will be queued by libcurl.
+			#
+		#	max_total_connections = 0
+		}
 	}
 }

--- a/src/lib/curl/base.c
+++ b/src/lib/curl/base.c
@@ -79,8 +79,16 @@ static CONF_PARSER reuse_curl_conn_config[] = {
 	CONF_PARSER_TERMINATOR
 };
 
+static CONF_PARSER curl_opts_config[] = {
+	{ FR_CONF_OFFSET("max_connects", FR_TYPE_UINT32, fr_curl_mhandle_opts_t, max_connects) },
+	{ FR_CONF_OFFSET("max_host_connections", FR_TYPE_UINT32, fr_curl_mhandle_opts_t, max_host_connections) },
+	{ FR_CONF_OFFSET("max_total_connections", FR_TYPE_UINT32, fr_curl_mhandle_opts_t, max_total_connections) },
+	CONF_PARSER_TERMINATOR
+};
+
 CONF_PARSER fr_curl_conn_config[] = {
 	{ FR_CONF_OFFSET("reuse", FR_TYPE_SUBSECTION, fr_curl_conn_config_t, reuse), .subcs = (void const *) reuse_curl_conn_config },
+	{ FR_CONF_OFFSET("curl_opts", FR_TYPE_SUBSECTION, fr_curl_conn_config_t, curl_opts), .subcs = (void const *) curl_opts_config },
 	{ FR_CONF_OFFSET("connect_timeout", FR_TYPE_TIME_DELTA, fr_curl_conn_config_t, connect_timeout), .dflt = "3.0" },
 	CONF_PARSER_TERMINATOR
 };

--- a/src/lib/curl/base.h
+++ b/src/lib/curl/base.h
@@ -82,6 +82,18 @@ do {\
 #  define CURL_AT_LEAST_VERSION(x, y, z) (LIBCURL_VERSION_NUM >= CURL_VERSION_BITS(x, y, z))
 #endif
 
+/** Structure for optional CURL multi handle config options
+ *
+ */
+typedef struct {
+	uint32_t		max_connects;		//!< Setting for CURLMOPT_MAXCONNECTS - maximum number of
+							///< connections to maintain in the connection cache
+	uint32_t		max_host_connections;	//!< Setting for CURLMOPT_MAX_HOST_CONNECTIONS - maximum
+							///< number of open connections for a given host and port
+	uint32_t		max_total_connections;	//!< Setting for CURLMOPT_MAX_TOTAL_CONNECTIONS - maximum
+							///< total number of open connections.
+} fr_curl_mhandle_opts_t;
+
 /** Uctx data for timer and I/O functions
  *
  * Seems like overkill for a single field, but I'm sure we'll need to
@@ -121,6 +133,7 @@ typedef struct {
 typedef struct {
 	fr_slab_config_t	reuse;
 	fr_time_delta_t		connect_timeout;
+	fr_curl_mhandle_opts_t	curl_opts;
 } fr_curl_conn_config_t;
 
 extern CONF_PARSER	 	fr_curl_tls_config[];

--- a/src/lib/curl/base.h
+++ b/src/lib/curl/base.h
@@ -145,7 +145,8 @@ int			fr_curl_io_request_enqueue(fr_curl_handle_t *mhandle,
 
 fr_curl_io_request_t	*fr_curl_io_request_alloc(TALLOC_CTX *ctx);
 
-fr_curl_handle_t	*fr_curl_io_init(TALLOC_CTX *ctx, fr_event_list_t *el, bool multiplex);
+fr_curl_handle_t	*fr_curl_io_init(TALLOC_CTX *ctx, fr_event_list_t *el, bool multiplex,
+					 fr_curl_mhandle_opts_t const *curl_opts);
 
 int			fr_curl_response_certinfo(request_t *request, fr_curl_io_request_t *randle);
 

--- a/src/lib/curl/io.c
+++ b/src/lib/curl/io.c
@@ -570,7 +570,8 @@ fr_curl_handle_t *fr_curl_io_init(TALLOC_CTX *ctx,
 #ifndef CURLPIPE_MULTIPLEX
 				   UNUSED
 #endif
-				   bool multiplex)
+				   bool multiplex,
+				   fr_curl_mhandle_opts_t const *curl_opts)
 {
 	CURLMcode		ret;
 	CURLM			*mandle;
@@ -604,6 +605,14 @@ fr_curl_handle_t *fr_curl_io_init(TALLOC_CTX *ctx,
 #ifdef CURLPIPE_MULTIPLEX
 	SET_MOPTION(mandle, CURLMOPT_PIPELINING, multiplex ? CURLPIPE_MULTIPLEX : CURLPIPE_NOTHING);
 #endif
+
+	if (!curl_opts) return mhandle;
+
+	if (curl_opts->max_host_connections) SET_MOPTION(mandle, CURLMOPT_MAX_HOST_CONNECTIONS,
+							 (long)curl_opts->max_host_connections);
+	if (curl_opts->max_total_connections) SET_MOPTION(mandle, CURLMOPT_MAX_TOTAL_CONNECTIONS,
+							 (long)curl_opts->max_host_connections);
+	if (curl_opts->max_connects) SET_MOPTION(mandle, CURLMOPT_MAXCONNECTS, (long)curl_opts->max_connects);
 
 	return mhandle;
 

--- a/src/modules/rlm_imap/rlm_imap.c
+++ b/src/modules/rlm_imap/rlm_imap.c
@@ -255,7 +255,7 @@ static int mod_thread_instantiate(module_thread_inst_ctx_t const *mctx)
 		return -1;
 	}
 
-	mhandle = fr_curl_io_init(t, mctx->el, false);
+	mhandle = fr_curl_io_init(t, mctx->el, false, &inst->conn_config.curl_opts);
 	if (!mhandle) return -1;
 
 	t->mhandle = mhandle;

--- a/src/modules/rlm_rest/rlm_rest.c
+++ b/src/modules/rlm_rest/rlm_rest.c
@@ -1170,7 +1170,7 @@ static int mod_thread_instantiate(module_thread_inst_ctx_t const *mctx)
 		return -1;
 	}
 
-	mhandle = fr_curl_io_init(t, mctx->el, inst->multiplex);
+	mhandle = fr_curl_io_init(t, mctx->el, inst->multiplex, &inst->conn_config.curl_opts);
 	if (!mhandle) return -1;
 
 	t->mhandle = mhandle;

--- a/src/modules/rlm_smtp/rlm_smtp.c
+++ b/src/modules/rlm_smtp/rlm_smtp.c
@@ -1093,7 +1093,7 @@ static int mod_thread_instantiate(module_thread_inst_ctx_t const *mctx)
 	rlm_smtp_thread_t    		*t = talloc_get_type_abort(mctx->thread, rlm_smtp_thread_t);
 	fr_curl_handle_t    		*mhandle;
 
-	mhandle = fr_curl_io_init(t, mctx->el, false);
+	mhandle = fr_curl_io_init(t, mctx->el, false, NULL);
 	if (!mhandle) return -1;
 
 	t->mhandle = mhandle;


### PR DESCRIPTION
These libcurl multi handle options allow admins to avoid having too many connections open to remote servers at the same time.  Especially beneficial for rlm_imap where it appears that even a curl_easy_cleanup() doesn't cause the session to log out of the IMAP server.