### PR TITLE
Add src/modules/rlm_ocsp/oscp.c to EXCLUDE

### DIFF
--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -878,7 +878,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                =
+EXCLUDE                = ../../src/modules/rlm_ocsp/ocsp.c
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded


### PR DESCRIPTION
That file currently isn't compiled, so there's no point in having it in doxygen generated documentation.