### PR TITLE
Turn off caller graph for strlcpy()

### DIFF
--- a/src/include/missing-h
+++ b/src/include/missing-h
@@ -368,8 +368,10 @@ int vsnprintf(char *str, size_t count, char const *fmt, va_list arg);
 int snprintf(char *str, size_t count, char const *fmt, ...);
 #endif
 
-/*
+/**
  *	Functions from strl{cat,cpy}.c
+ *
+ * @hidecallergraph
  */
 #ifndef HAVE_STRLCPY
 size_t strlcpy(char *dst, char const *src, size_t siz);

--- a/src/lib/util/strlcpy.c
+++ b/src/lib/util/strlcpy.c
@@ -29,6 +29,7 @@ RCSID("$Id$")
  * will be copied.  Always NUL terminates (unless siz == 0).
  * Returns strlen(src); if retval >= siz, truncation occurred.
  */
+/** @hidecallergraph */
 size_t
 strlcpy(char *dst, char const *src, size_t siz)
 {


### PR DESCRIPTION
We get the "missing" version of strlcpy() on Linux, which means the other @hidecallergraph has to be in src/include/missing-h, from which src/include/missing.h, which doxygen looks at, is generated.