### PR TITLE
Get rid of unresolved explicit link request warning

### DIFF
--- a/src/lib/util/pair.c
+++ b/src/lib/util/pair.c
@@ -1335,7 +1335,7 @@ int fr_pair_insert_before(fr_pair_list_t *list, fr_pair_t *pos, fr_pair_t *to_ad
  * @note Memory used by the VP being replaced will be freed.
  *
  * @param[in,out] list		pair list
- * @param[in] to_replace	pair to replace and free, on #list
+ * @param[in] to_replace	pair to replace and free, on list
  * @param[in] vp		New pair to insert.
  */
 void fr_pair_replace(fr_pair_list_t *list, fr_pair_t *to_replace, fr_pair_t *vp)


### PR DESCRIPTION
It turns out that the link requests we use that work are to types, values, and functions known at the time of the link request. This doesn't work for not-yet-seen function parameters.