### PR TITLE
Fix rlm_unbound build

### DIFF
--- a/src/modules/rlm_unbound/configure
+++ b/src/modules/rlm_unbound/configure
@@ -3005,7 +3005,7 @@ rm "config.report.tmp"
 
 
 mod_ldflags="${SMART_LIBS}"
-mod_cflags="${SMART_CFLAGS}"
+mod_cflags="${SMART_CPPFLAGS}"
 
 
 

--- a/src/modules/rlm_unbound/configure.ac
+++ b/src/modules/rlm_unbound/configure.ac
@@ -6,6 +6,9 @@ FR_INIT_MODULE([rlm_unbound])
 
 FR_MODULE_START_TESTS
 
+AC_PROG_CC
+AC_PROG_CPP
+
 dnl extra argument: --with-rlm-unbound-lib-dir
 rlm_unbound_lib_dir=
 AC_ARG_WITH(rlm-unbound-lib-dir,
@@ -53,7 +56,7 @@ fi
 FR_MODULE_END_TESTS
 
 mod_ldflags="${SMART_LIBS}"
-mod_cflags="${SMART_CFLAGS}"
+mod_cflags="${SMART_CPPFLAGS}"
 
 AC_SUBST(mod_cflags)
 AC_SUBST(mod_ldflags)


### PR DESCRIPTION
As all the others `configure.ac`, the *FR_SMART_CHECK_INCLUDE* set the FLAGS inside `${SMART_CPPFLAGS}`

e.g:

```
grep -E "(C|CPP)FLAGS" -r m4/fr_smart_check_include.m4
m4/fr_smart_check_include.m4:old_CPPFLAGS="$CPPFLAGS"
m4/fr_smart_check_include.m4:    CPPFLAGS="-isystem $try $old_CPPFLAGS"
m4/fr_smart_check_include.m4:  CPPFLAGS="$old_CPPFLAGS"
m4/fr_smart_check_include.m4:    CPPFLAGS="-isystem $try $old_CPPFLAGS"
m4/fr_smart_check_include.m4:  CPPFLAGS="$old_CPPFLAGS"
m4/fr_smart_check_include.m4:  CPPFLAGS="$smart_include $old_CPPFLAGS"
m4/fr_smart_check_include.m4:  SMART_CPPFLAGS="$smart_include $SMART_CPPFLAGS"
$
```