### PR TITLE
Fix memory-leak in "radiusd -XCM"

### DIFF
--- a/src/main/radiusd.c
+++ b/src/main/radiusd.c
@@ -717,6 +717,7 @@ cleanup:
 	if (main_config.memory_report) {
 		INFO("Allocated memory at time of report:");
 		fr_log_talloc_report(NULL);
+		talloc_disable_null_tracking();
 	}
 
 	return rcode;


### PR DESCRIPTION
Such error:

Current state of talloced memory:
full talloc report on 'null_context' (total      0 bytes in   1 blocks)

================================================================= ==85543==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 96 byte(s) in 1 object(s) allocated from:
    #0 0x5598fcd87f3e in malloc (/home/jpereira/Devel/FreeRADIUS/freeradius-server-v3.2.x.git-linux/build/bin/local/radiusd+0x20cf3e) (BuildId: 3bf5bfb4fd72e1e1112726414556f8a4f339789f)
    #1 0x7f1cc4453d7f in __talloc_with_prefix /build/talloc-NvEq5A/talloc-2.3.3/bin/default/../../talloc.c:783:9
    #2 0x7f1cc4455a5d in __talloc /build/talloc-NvEq5A/talloc-2.3.3/bin/default/../../talloc.c:825:9
    #3 0x7f1cc4455a5d in _talloc_named_const /build/talloc-NvEq5A/talloc-2.3.3/bin/default/../../talloc.c:982:8
    #4 0x7f1cc4455a5d in talloc_enable_null_tracking /build/talloc-NvEq5A/talloc-2.3.3/bin/default/../../talloc.c:2353:18
    #5 0x7f1cc4455a5d in talloc_enable_null_tracking /build/talloc-NvEq5A/talloc-2.3.3/bin/default/../../talloc.c:2350:15
    #6 0x5598fceb65b1 in main /home/jpereira/Devel/FreeRADIUS/freeradius-server-v3.2.x.git-linux/src/main/radiusd.c:313:3
    #7 0x7f1cc342350f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #8 0x7f1cc34235c8 in __libc_start_main csu/../csu/libc-start.c:381:3
    #9 0x5598fcd02514 in _start (/home/jpereira/Devel/FreeRADIUS/freeradius-server-v3.2.x.git-linux/build/bin/local/radiusd+0x187514) (BuildId: 3bf5bfb4fd72e1e1112726414556f8a4f339789f)

SUMMARY: AddressSanitizer: 96 byte(s) leaked in 1 allocation(s).