### PR TITLE
Fix runtime LSAN/ASAN out of bound index

### DIFF
--- a/src/lib/event.c
+++ b/src/lib/event.c
@@ -779,7 +779,7 @@ static uint32_t event_rand(void)
 {
 	uint32_t num;
 
-	num = rand_pool.randrsl[rand_pool.randcnt++];
+	num = rand_pool.randrsl[rand_pool.randcnt++ & 0xff];
 	if (rand_pool.randcnt == 256) {
 		fr_isaac(&rand_pool);
 		rand_pool.randcnt = 0;

--- a/src/lib/radius.c
+++ b/src/lib/radius.c
@@ -5016,7 +5016,7 @@ void fr_rand_seed(void const *data, size_t size)
 	if (!hash) hash = fr_rand();
 	hash = fr_hash_update(data, size, hash);
 
-	fr_rand_pool.randmem[fr_rand_pool.randcnt] ^= hash;
+	fr_rand_pool.randmem[fr_rand_pool.randcnt & 0xff] ^= hash;
 }
 
 
@@ -5034,7 +5034,7 @@ uint32_t fr_rand(void)
 		fr_rand_seed(NULL, 0);
 	}
 
-	num = fr_rand_pool.randrsl[fr_rand_pool.randcnt++];
+	num = fr_rand_pool.randrsl[fr_rand_pool.randcnt++ & 0xff];
 	if (fr_rand_pool.randcnt >= 256) {
 		fr_rand_pool.randcnt = 0;
 		fr_isaac(&fr_rand_pool);


### PR DESCRIPTION
Such error:

Process 369882 stopped
* thread #4, name = 'radiusd', stop reason = Out of bounds index frame #0: 0x00005555556e7c10 radiusd`__ubsan_on_report radiusd`__ubsan_on_report:
->  0x5555556e7c10 <+0>: retq
    0x5555556e7c11:      nopw   %cs:(%rax,%rax)
    0x5555556e7c1b:      nopl   (%rax,%rax)
radiusd`__ubsan_get_current_report_data:
    0x5555556e7c20 <+0>: pushq  %rbx
lldb> vt
error: 'vt' is not a valid command.
lldb> bt
* thread #4, name = 'radiusd', stop reason = Out of bounds index
  * frame #0: 0x00005555556e7c10 radiusd`__ubsan_on_report
    frame #1: 0x00005555556e29c6 radiusd`__ubsan::Diag::~Diag() + 214
    frame #2: 0x00005555556e5814 radiusd`handleOutOfBoundsImpl(__ubsan::OutOfBoundsData*, unsigned long, __ubsan::ReportOptions) + 340
    frame #3: 0x00005555556e588e radiusd`__ubsan_handle_out_of_bounds_abort + 46
    frame #4: 0x00007ffff7e2fd5f libfreeradius-radius.so`fr_rand_seed(data=0x000062501c0aeae0, size=20) at radius.c:5019:45
    frame #5: 0x00007ffff7e2f865 libfreeradius-radius.so`rad_decode(packet=<unavailable>, original=<unavailable>, secret=<unavailable>) at radius.c:4551:2
    frame #6: 0x000055555571631d radiusd`client_socket_decode(listener=<unavailable>, request=<unavailable>) at listen.c:2404:9
    frame #7: 0x000055555575df97 radiusd`request_running [inlined] request_pre_handler(request=0x000062501c0aeb70, action=<unavailable>) at process.c:1379:11
    frame #8: 0x000055555575de92 radiusd`request_running(request=0x000062501c0aeb70, action=<unavailable>) at process.c:1676:8
    frame #9: 0x0000555555758f76 radiusd`request_handler_thread(arg=0x0000606000010880) at threads.c:826:3
    frame #10: 0x00007ffff7490402 libc.so.6`start_thread(arg=<unavailable>) at pthread_create.c:442:8
    frame #11: 0x00007ffff751f590 libc.so.6`__clone3 at clone3.S:81
lldb>