### PR TITLE
Fix pthread.h include

### DIFF
--- a/src/lib/event.c
+++ b/src/lib/event.c
@@ -28,13 +28,14 @@ RCSID("$Id$")
 #include <freeradius-devel/heap.h>
 #include <freeradius-devel/event.h>
 
+#include <pthread.h>
+
 #ifdef HAVE_KQUEUE
 #ifndef HAVE_SYS_EVENT_H
 #error kqueue requires <sys/event.h>
 
 #else
 #include <sys/event.h>
-#include <pthread.h>
 #endif
 #endif	/* HAVE_KQUEUE */
 


### PR DESCRIPTION
It needs to avoid:

```
src/lib/event.c:127:2: error: call to undeclared function 'pthread_mutex_destroy'; ISO C99 and later do not support implicit function declarations [-Werror,-Wimplicit-function-declaration] CC src/lib/getaddrinfo.c
        pthread_mutex_destroy(&el->mutex);
        ^
src/lib/event.c:162:9: error: call to undeclared function 'pthread_mutex_init'; ISO C99 and later do not support implicit function declarations [-Werror,-Wimplicit-function-declaration]
        pthread_mutex_init(&el->mutex, NULL);
        ^
src/lib/event.c:478:2: error: call to undeclared function 'pthread_mutex_lock'; ISO C99 and later do not support implicit function declarations [-Werror,-Wimplicit-function-declaration]
        pthread_mutex_lock(&el->mutex);
        ^
```

As can be seen in https://github.com/jpereira/freeradius-server/actions/runs/4538268322/jobs/7997013757#step:16:1777