### PR TITLE
v4: Use async LDAP queries for user, group and profile object lookups

### DIFF
--- a/raddb/mods-available/ldap
+++ b/raddb/mods-available/ldap
@@ -275,6 +275,12 @@ ldap {
 #			mech = 'PLAIN'
 
 			#
+			#  authname:: SASL authentication name.  Mechanism specific value
+			#  to use when prompted for the client authentication name.
+			#
+#			authname = &User-Name
+
+			#
 			#  proxy:: SASL authorisation identity to proxy.
 			#
 #			proxy = &User-Name

--- a/src/lib/ldap/base.c
+++ b/src/lib/ldap/base.c
@@ -737,7 +737,7 @@ unlang_action_t fr_ldap_trunk_search(rlm_rcode_t *p_result,
 		return UNLANG_ACTION_CALCULATE_RESULT;
 	}
 
-	return UNLANG_ACTION_YIELD;
+	return UNLANG_ACTION_PUSHED_CHILD;
 }
 
 /** Run an async or sync modification LDAP query on a trunk connection
@@ -801,7 +801,7 @@ unlang_action_t fr_ldap_trunk_modify(rlm_rcode_t *p_result,
 		return UNLANG_ACTION_CALCULATE_RESULT;
 	}
 
-	return UNLANG_ACTION_YIELD;
+	return UNLANG_ACTION_PUSHED_CHILD;
 }
 
 /** Modify something in the LDAP directory

--- a/src/lib/ldap/base.h
+++ b/src/lib/ldap/base.h
@@ -486,6 +486,29 @@ typedef struct {
 	int			msgid;
 } fr_ldap_bind_ctx_t;
 
+/** Holds arguments for the async SASL bind operation
+ *
+ */
+typedef struct {
+	fr_ldap_connection_t	*c;			//!< to bind.
+	char const		*mechs;			//!< SASL mechanisms to run
+	char const		*dn;			//!< to bind as.
+	char const		*identity;		//!< of the user.
+	char const		*password;		//!< of the user, may be NULL if no password is specified.
+	char const		*proxy;			//!< Proxy identity, may be NULL in which case identity is used.
+	char const		*realm;			//!< SASL realm (may be NULL).
+	LDAPControl		**serverctrls;		//!< Controls to pass to the server.
+	LDAPControl		**clientctrls;		//!< Controls to pass to the client (library).
+
+	int			msgid;			//!< Last msgid.
+	LDAPMessage		*result;		//!< Previous result.
+	char const		*rmech;			//!< Mech we're continuing with.
+} fr_ldap_sasl_ctx_t;
+
+typedef enum {
+	LDAP_BIND_SIMPLE		= 0,
+	LDAP_BIND_SASL
+} fr_ldap_bind_type_t;
 
 /** Holds arguments for async bind auth requests
  *
@@ -497,7 +520,11 @@ typedef struct {
 	fr_ldap_thread_t	*thread;	//!< This bind is being run by.
 	int			msgid;		//!< libldap msgid for this bind.
 	request_t		*request;	//!< this bind relates to.
-	fr_ldap_bind_ctx_t	*bind_ctx;	//!< Data relating to the user being bound.
+	fr_ldap_bind_type_t	type;		//!< type of bind.
+	union {
+		fr_ldap_bind_ctx_t	*bind_ctx;	//!< User data for simple binds.
+		fr_ldap_sasl_ctx_t	*sasl_ctx;	//!< User data for SASL binds.
+	};
 	fr_ldap_result_code_t	ret;		//!< Return code of bind operation.
 } fr_ldap_bind_auth_ctx_t;
 

--- a/src/lib/ldap/base.h
+++ b/src/lib/ldap/base.h
@@ -711,8 +711,7 @@ unlang_action_t fr_ldap_trunk_modify(rlm_rcode_t *p_result,
 				     TALLOC_CTX *ctx,
 				     fr_ldap_query_t **out, request_t *request, fr_ldap_thread_trunk_t *ttrunk,
 				     char const *dn, LDAPMod *mods[],
-				     LDAPControl **serverctrls, LDAPControl **clientctrls,
-				     bool is_async);
+				     LDAPControl **serverctrls, LDAPControl **clientctrls);
 
 /*
  *	base.c - Wrappers arounds OpenLDAP functions.

--- a/src/lib/ldap/base.h
+++ b/src/lib/ldap/base.h
@@ -14,6 +14,7 @@
 #include <freeradius-devel/server/global_lib.h>
 #include <freeradius-devel/server/map.h>
 #include <freeradius-devel/server/trunk.h>
+#include <freeradius-devel/unlang/function.h>
 #include <freeradius-devel/util/dlist.h>
 
 #define LDAP_DEPRECATED 0	/* Quiet warnings about LDAP_DEPRECATED not being defined */

--- a/src/lib/ldap/base.h
+++ b/src/lib/ldap/base.h
@@ -856,6 +856,14 @@ int		fr_ldap_sasl_bind_async(fr_ldap_connection_t *c,
 			    		char const *proxy,
 			    		char const *realm,
 			    		LDAPControl **serverctrls, LDAPControl **clientctrls);
+
+int		fr_ldap_sasl_bind_auth_async(request_t *request,
+					     fr_ldap_thread_t *thread,
+					     char const *mechs,
+					     char const *dn,
+					     char const *identity,
+					     char const *password,
+					     char const *proxy, char const *realm);
 #endif
 
 /*

--- a/src/lib/ldap/bind.c
+++ b/src/lib/ldap/bind.c
@@ -27,7 +27,6 @@ USES_APPLE_DEPRECATED_API
 
 #include <freeradius-devel/ldap/base.h>
 #include <freeradius-devel/util/debug.h>
-#include <freeradius-devel/unlang/function.h>
 
 /** Error reading from or writing to the file descriptor
  *

--- a/src/lib/ldap/sasl.c
+++ b/src/lib/ldap/sasl.c
@@ -29,24 +29,6 @@ USES_APPLE_DEPRECATED_API
 #include <freeradius-devel/util/debug.h>
 #include <sasl/sasl.h>
 
-/** Holds arguments for the bind operation
- *
- */
-typedef struct {
-	fr_ldap_connection_t	*c;			//!< to bind.
-	char const		*mechs;			//!< SASL mechanisms to run
-	char const		*identity;		//!< of the user.
-	char const		*password;		//!< of the user, may be NULL if no password is specified.
-	char const		*proxy;			//!< Proxy identity, may be NULL in which case identity is used.
-	char const		*realm;			//!< SASL realm (may be NULL).
-	LDAPControl		**serverctrls;		//!< Controls to pass to the server.
-	LDAPControl		**clientctrls;		//!< Controls to pass to the client (library).
-
-	int			msgid;			//!< Last msgid.
-	LDAPMessage		*result;		//!< Previous result.
-	char const		*rmech;			//!< Mech we're continuing with.
-} fr_ldap_sasl_ctx_t;
-
 static void _ldap_sasl_bind_io_write(fr_event_list_t *el, int fd, UNUSED int flags, void *uctx);
 
 /** Error reading from or writing to the file descriptor

--- a/src/lib/server/module.h
+++ b/src/lib/server/module.h
@@ -376,6 +376,12 @@ _Generic((((_s *)NULL)->_f), \
 		  .type_name = FR_MODULE_ENV_DST_TYPE_NAME(_struct, _field), \
 		  .tmpl_offset = offsetof(_struct, _tmpl_field) }
 
+#define FR_MODULE_ENV_SUBSECTION(_name, _ident2, _subcs ) \
+	.name = _name, \
+	.type = FR_TYPE_SUBSECTION, \
+	.section = { .ident2 = _ident2, \
+		     .subcs = _subcs }
+
 /** A list of modules
  *
  * This allows modules to be instantiated and freed in phases,

--- a/src/modules/rlm_ldap/groups.c
+++ b/src/modules/rlm_ldap/groups.c
@@ -31,7 +31,7 @@ USES_APPLE_DEPRECATED_API
 #include <freeradius-devel/util/debug.h>
 #include <ctype.h>
 
-#define LOG_PREFIX inst->name
+#define LOG_PREFIX "rlm_ldap groups"
 
 #include "rlm_ldap.h"
 

--- a/src/modules/rlm_ldap/groups.c
+++ b/src/modules/rlm_ldap/groups.c
@@ -35,6 +35,23 @@ USES_APPLE_DEPRECATED_API
 
 #include "rlm_ldap.h"
 
+/** Context to use when resolving group membership from the user object.
+ *
+ */
+typedef struct {
+	rlm_ldap_t const	*inst;					//!< Module instance.
+	fr_value_box_t		*base_dn;				//!< The base DN to search for groups in.
+	fr_ldap_thread_trunk_t	*ttrunk;				//!< Trunk on which to perform additional queries.
+	fr_pair_list_t		groups;					//!< Temporary list to hold pairs.
+	TALLOC_CTX		*list_ctx;				//!< In which to allocate pairs.
+	char			*group_name[LDAP_MAX_CACHEABLE + 1];	//!< List of group names which need resolving.
+	unsigned int		name_cnt;				//!< How many names need resolving.
+	char			*group_dn[LDAP_MAX_CACHEABLE + 1];	//!< List of group DNs which need resolving.
+	char			**dn;					//!< Current DN being resolved.
+	char const		*attrs[2];				//!< For resolving name from DN.
+	fr_ldap_query_t		*query;					//!< Current query performing group resolution.
+} ldap_group_userobj_ctx_t;
+
 /** Convert multiple group names into a DNs
  *
  * Given an array of group names, builds a filter matching all names, then retrieves all group objects

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -1721,7 +1721,7 @@ static unlang_action_t user_modify_resume(rlm_rcode_t *p_result, UNUSED int *pri
 				 UNLANG_SUB_FRAME, usermod_ctx) < 0) goto fail;
 
 	return fr_ldap_trunk_modify(p_result, usermod_ctx, &usermod_ctx->query, request, usermod_ctx->ttrunk,
-				    usermod_ctx->dn, modify, NULL, NULL, true);
+				    usermod_ctx->dn, modify, NULL, NULL);
 }
 
 /** Modify user's object in LDAP

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -1526,6 +1526,7 @@ static unlang_action_t CC_HINT(nonnull) mod_authorize(rlm_rcode_t *p_result, mod
 	autz_ctx->dlinst = mctx->inst;
 	autz_ctx->inst = inst;
 	autz_ctx->mod_env = mod_env;
+	autz_ctx->status = LDAP_AUTZ_FIND;
 
 	if (unlang_function_push(request, mod_authorize_start, mod_authorize_resume, mod_authorize_cancel,
 				 ~FR_SIGNAL_CANCEL, UNLANG_SUB_FRAME, autz_ctx) < 0) RETURN_MODULE_FAIL;

--- a/src/modules/rlm_ldap/rlm_ldap.h
+++ b/src/modules/rlm_ldap/rlm_ldap.h
@@ -166,6 +166,9 @@ typedef struct {
 	ldap_autz_mod_env_t	*mod_env;
 	LDAPMessage		*entry;
 	ldap_autz_status_t	status;
+	struct berval		**profile_values;
+	int			value_idx;
+	char			*profile_value;
 } ldap_autz_ctx_t;
 
 extern HIDDEN fr_dict_attr_t const *attr_cleartext_password;

--- a/src/modules/rlm_ldap/rlm_ldap.h
+++ b/src/modules/rlm_ldap/rlm_ldap.h
@@ -18,12 +18,6 @@
 #include <freeradius-devel/ldap/base.h>
 
 typedef struct {
-	tmpl_t	*mech;				//!< SASL mech(s) to try.
-	tmpl_t	*proxy;				//!< Identity to proxy.
-	tmpl_t	*realm;				//!< Kerberos realm.
-} fr_ldap_sasl_t_dynamic_t;
-
-typedef struct {
 	CONF_SECTION	*cs;				//!< Section configuration.
 
 	char const	*reference;			//!< Configuration reference string.
@@ -62,8 +56,6 @@ typedef struct {
 	char const	*userobj_access_attr;		//!< Attribute to check to see if the user should be locked out.
 	bool		access_positive;		//!< If true the presence of the attribute will allow access,
 							//!< else it will deny access.
-
-	fr_ldap_sasl_t_dynamic_t user_sasl;			//!< SASL parameters used when binding as the user.
 
 	char const	*valuepair_attr;		//!< Generic dynamic mapping attribute, contains a RADIUS
 							//!< attribute and value.
@@ -109,13 +101,8 @@ typedef struct {
 	/*
 	 *	Profiles
 	 */
-	tmpl_t	*default_profile;		//!< If this is set, we will search for a profile object
-							//!< with this name, and map any attributes it contains.
-							//!< No value should be set if profiles are not being used
-							//!< as there is an associated performance penalty.
 	char const	*profile_attr;			//!< Attribute that identifies profiles to apply. May appear
 							//!< in userobj or groupobj.
-	tmpl_t	*profile_filter;		//!< Filter to retrieve only retrieve group objects.
 
 	/*
 	 *	Accounting

--- a/src/modules/rlm_ldap/rlm_ldap.h
+++ b/src/modules/rlm_ldap/rlm_ldap.h
@@ -161,6 +161,10 @@ static inline char const *rlm_find_user_dn_cached(request_t *request)
 	return vp->vp_strvalue;
 }
 
+int rlm_ldap_find_user_async(TALLOC_CTX *ctx, rlm_ldap_t const *inst, request_t *request, fr_value_box_t *base,
+			     fr_value_box_t *filter_box, fr_ldap_thread_trunk_t *ttrunk, char const *attrs[],
+			     fr_ldap_query_t **query_out);
+
 char const *rlm_ldap_find_user(rlm_ldap_t const *inst, request_t *request, fr_ldap_thread_trunk_t *tconn,
 			       char const *attrs[], bool force, LDAPMessage **result, LDAP **handle, rlm_rcode_t *rcode);
 

--- a/src/modules/rlm_ldap/rlm_ldap.h
+++ b/src/modules/rlm_ldap/rlm_ldap.h
@@ -208,8 +208,7 @@ void rlm_ldap_check_reply(module_ctx_t const *mctx, request_t *request, fr_ldap_
 unlang_action_t rlm_ldap_cacheable_userobj(rlm_rcode_t *p_result, request_t *request, ldap_autz_ctx_t *autz_ctx,
 					   char const *attr);
 
-unlang_action_t rlm_ldap_cacheable_groupobj(rlm_rcode_t *p_result,
-					    rlm_ldap_t const *inst, request_t *request, fr_ldap_thread_trunk_t *ttrunk);
+unlang_action_t rlm_ldap_cacheable_groupobj(rlm_rcode_t *p_result, request_t *request, ldap_autz_ctx_t *autz_ctx);
 
 unlang_action_t rlm_ldap_check_groupobj_dynamic(rlm_rcode_t *p_result,
 						rlm_ldap_t const *inst, request_t *request, fr_ldap_thread_trunk_t *ttrunk,

--- a/src/modules/rlm_ldap/rlm_ldap.h
+++ b/src/modules/rlm_ldap/rlm_ldap.h
@@ -138,6 +138,20 @@ typedef struct {
 	fr_trunk_conf_t	trunk_conf;			//!< Trunk configuration
 } rlm_ldap_t;
 
+/** Module environment used in LDAP authorization
+ *
+ */
+typedef struct {
+	fr_value_box_t	user_base;			//!< Base DN in which to search for users.
+	fr_value_box_t	user_filter;			//!< Filter to use when searching for users.
+	fr_value_box_t 	group_base;			//!< Base DN in which to search for groups.
+	fr_value_box_t	default_profile;		//!< If this is set, we will search for a profile object
+							//!< with this name, and map any attributes it contains.
+							//!< No value should be set if profiles are not being used
+							//!< as there is an associated performance penalty.
+	fr_value_box_t	profile_filter;			//!< Filter to use when searching for profiles.
+} ldap_autz_mod_env_t;
+
 extern HIDDEN fr_dict_attr_t const *attr_cleartext_password;
 extern HIDDEN fr_dict_attr_t const *attr_crypt_password;
 extern HIDDEN fr_dict_attr_t const *attr_ldap_userdn;

--- a/src/modules/rlm_ldap/rlm_ldap.h
+++ b/src/modules/rlm_ldap/rlm_ldap.h
@@ -205,9 +205,8 @@ void rlm_ldap_check_reply(module_ctx_t const *mctx, request_t *request, fr_ldap_
 /*
  *	groups.c - Group membership functions.
  */
-unlang_action_t rlm_ldap_cacheable_userobj(rlm_rcode_t *p_result, rlm_ldap_t const *inst,
-					   request_t *request, fr_ldap_thread_trunk_t *ttrunk,
-					   LDAPMessage *entry, char const *attr);
+unlang_action_t rlm_ldap_cacheable_userobj(rlm_rcode_t *p_result, request_t *request, ldap_autz_ctx_t *autz_ctx,
+					   char const *attr);
 
 unlang_action_t rlm_ldap_cacheable_groupobj(rlm_rcode_t *p_result,
 					    rlm_ldap_t const *inst, request_t *request, fr_ldap_thread_trunk_t *ttrunk);

--- a/src/modules/rlm_ldap/rlm_ldap.h
+++ b/src/modules/rlm_ldap/rlm_ldap.h
@@ -150,6 +150,17 @@ extern HIDDEN fr_dict_attr_t const *attr_user_name;
 /*
  *	user.c - User lookup functions
  */
+static inline char const *rlm_find_user_dn_cached(request_t *request)
+{
+	fr_pair_t	*vp;
+
+	vp = fr_pair_find_by_da(&request->control_pairs, NULL, attr_ldap_userdn);
+	if (!vp) return NULL;
+
+	RDEBUG2("Using user DN from request \"%pV\"", &vp->data);
+	return vp->vp_strvalue;
+}
+
 char const *rlm_ldap_find_user(rlm_ldap_t const *inst, request_t *request, fr_ldap_thread_trunk_t *tconn,
 			       char const *attrs[], bool force, LDAPMessage **result, LDAP **handle, rlm_rcode_t *rcode);
 

--- a/src/modules/rlm_ldap/rlm_ldap.h
+++ b/src/modules/rlm_ldap/rlm_ldap.h
@@ -152,6 +152,19 @@ typedef struct {
 	fr_value_box_t	profile_filter;			//!< Filter to use when searching for profiles.
 } ldap_autz_mod_env_t;
 
+/** Holds state of in progress async authorization
+ *
+ */
+typedef struct {
+	dl_module_inst_t const	*dlinst;
+	rlm_ldap_t const	*inst;
+	fr_ldap_map_exp_t	expanded;
+	fr_ldap_query_t		*query;
+	fr_ldap_thread_trunk_t	*ttrunk;
+	ldap_autz_mod_env_t	*mod_env;
+	LDAPMessage		*entry;
+} ldap_autz_ctx_t;
+
 extern HIDDEN fr_dict_attr_t const *attr_cleartext_password;
 extern HIDDEN fr_dict_attr_t const *attr_crypt_password;
 extern HIDDEN fr_dict_attr_t const *attr_ldap_userdn;

--- a/src/modules/rlm_ldap/rlm_ldap.h
+++ b/src/modules/rlm_ldap/rlm_ldap.h
@@ -152,6 +152,21 @@ typedef struct {
 	fr_value_box_t	profile_filter;			//!< Filter to use when searching for profiles.
 } ldap_autz_mod_env_t;
 
+/** State list for resumption of authorization
+ *
+ */
+typedef enum {
+	LDAP_AUTZ_FIND = 0,
+	LDAP_AUTZ_GROUP,
+	LDAP_AUTZ_POST_GROUP,
+#ifdef WITH_EDIR
+	LDAP_AUTZ_POST_EDIR,
+#endif
+	LDAP_AUTZ_POST_DEFAULT_PROFILE,
+	LDAP_AUTZ_USER_PROFILE,
+	LDAP_AUTZ_MAP
+} ldap_autz_status_t;
+
 /** Holds state of in progress async authorization
  *
  */
@@ -163,6 +178,7 @@ typedef struct {
 	fr_ldap_thread_trunk_t	*ttrunk;
 	ldap_autz_mod_env_t	*mod_env;
 	LDAPMessage		*entry;
+	ldap_autz_status_t	status;
 } ldap_autz_ctx_t;
 
 extern HIDDEN fr_dict_attr_t const *attr_cleartext_password;


### PR DESCRIPTION
Partial conversion of rlm_ldap mod_authorize and mod_authenticate to use async LDAP queries.

In addition, use module environment for tmpl expansion and restore user SASL binds