### PR TITLE
Add IGNORE() macro to let us avoid some identical branch annotations

### DIFF
--- a/src/include/build.h
+++ b/src/include/build.h
@@ -452,3 +452,20 @@ do { \
  *	For closing macros which open a code block e.g. fr_rb_inorder_foreach
  */
 #define endforeach }
+
+/* Explicitly evaluate and ignore an expression
+ *
+ * Why this macro?
+ * 1. gcc will warn about unused return values, even with the traditional cast to void.
+ * 2. There are cases in which an error case wants to clean up, but the function to
+ *    clean up itself returns a status. In this context you don't care, but then you
+ *    have the Scylla of unused return value and the Charybdis of Coverity complaining
+ *    about an if that doesn't affect control flow. The following evaluates _expr and
+ *    stores it in a variable marked as unused
+ * @param _expr		The expression to be evaluated and ignored
+ * @param _type		The type of the expression
+ */
+#define IGNORE(_expr, _type) \
+	do { \
+		_type ignored UNUSED = (_expr); \
+	} while (0)

--- a/src/lib/tls/session.c
+++ b/src/lib/tls/session.c
@@ -1449,8 +1449,7 @@ DIAG_ON(DIAG_UNKNOWN_PRAGMAS)
 		ua = fr_tls_cache_pending_push(request, tls_session);
 		switch (ua) {
 		case UNLANG_ACTION_FAIL:
-			/* coverity[identical_branches] */
-			if (unlang_function_clear(request) < 0) goto error;
+			IGNORE(unlang_function_clear(request), int);
 			goto error;
 
 		case UNLANG_ACTION_PUSHED_CHILD:
@@ -1467,8 +1466,7 @@ DIAG_ON(DIAG_UNKNOWN_PRAGMAS)
 		ua = fr_tls_verify_cert_pending_push(request, tls_session);
 		switch (ua) {
 		case UNLANG_ACTION_FAIL:
-			/* coverity[identical_branches] */
-			if (unlang_function_clear(request) < 0) goto error;
+			IGNORE(unlang_function_clear(request), int);
 			goto error;
 
 		default:


### PR DESCRIPTION
If the unused-return warning is set, gcc will complain even in the presence of an explicit cast to void. This lets us avoid that warning in an error handling case that would otherwise be written

	if (cleanup() < 0) goto error;
	goto error;

about which Coverity complains.