### PR TITLE
Remove what we believe to be unnecessary alloc_strlen annotations

### DIFF
--- a/src/lib/util/pair_legacy_tests.c
+++ b/src/lib/util/pair_legacy_tests.c
@@ -166,7 +166,6 @@ static void test_fr_pair_list_move_op(void)
 	fr_pair_list_t old_list, new_list;
 	bool           pfiledone;
 	char const     *fake_file = "Test-Uint32-0 = 123\nTest-String-0 = \"Testing123\"\n";
-	/* coverity[alloc_strlen] */
 	FILE           *fp = open_buffer_as_file((uint8_t const *)fake_file, strlen(fake_file));
 
 	fr_pair_list_init(&old_list);

--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -2168,7 +2168,6 @@ size_t rest_uri_escape(UNUSED request_t *request, char *out, size_t outlen, char
 {
 	char *escaped;
 
-	/* coverity[alloc_strlen] */
 	escaped = curl_escape(raw, 0);
 	strlcpy(out, escaped, outlen);
 	curl_free(escaped);


### PR DESCRIPTION
1. Either coverity has changed or pen_buffer_as_file() has, because an essentially identical use of it isn't annotated and doesn't register a defect, so the annotaion can go.
2. The curl_escape() call now just passes 0 and lets the function itself call strlen(), so that annotation should be unneccessary.