### PR TITLE
Don't pass NULL buffer to _fr_syserror()

### DIFF
--- a/src/lib/util/syserror.c
+++ b/src/lib/util/syserror.c
@@ -260,6 +260,7 @@ char const *fr_syserror(int num)
 	 *	Grab our thread local buffer
 	 */
 	buffer = _fr_syserror_buffer();
+	if (!buffer) goto error;
 
 	p = buffer;
 	end = p + FR_SYSERROR_BUFSIZE;
@@ -297,7 +298,7 @@ char const *fr_syserror_simple(int num)
 	 *	Grab our thread local buffer
 	 */
 	buffer = _fr_syserror_buffer();
-	if (_fr_syserror(num, buffer, FR_SYSERROR_BUFSIZE) < 0) return "Failed retrieving error";
+	if (!buffer || (_fr_syserror(num, buffer, FR_SYSERROR_BUFSIZE) < 0)) return "Failed retrieving error";
 
 	return buffer;
 }


### PR DESCRIPTION
The issue turns up if _fr_syserror_buffer() returns NULL.