### PR TITLE
Fix git revision versioning for package builds

### DIFF
--- a/configure
+++ b/configure
@@ -3264,7 +3264,7 @@ then :
 fi
 
 
-if test "x$GIT" = "xyes" && git --git-dir=.git status 2>&1 > /dev/null; then
+if test "x$GIT" = "xyes" && git status 2>&1 > /dev/null; then
   if test "x$RADIUSD_VERSION_COMMIT" = "x"; then
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking build commit" >&5
 printf %s "checking build commit... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -154,12 +154,7 @@ AC_ARG_ENABLE(developer,
 dnl #
 dnl #  Turn on the developer flag when taken from a git checkout (not a release)
 dnl #
-dnl #  Passing --git-dir explicitly limits the search to the CWD.  Without it
-dnl #  git will search back up the directory tree for a git repository.
-dnl #  This can cause the configure script to erroneously determine that it's
-dnl #  running in a git repo.
-dnl #
-if test "x$GIT" = "xyes" && git --git-dir=.git status 2>&1 > /dev/null; then
+if test "x$GIT" = "xyes" && git status 2>&1 > /dev/null; then
   if test "x$RADIUSD_VERSION_COMMIT" = "x"; then
     AC_MSG_CHECKING([build commit])
     RADIUSD_VERSION_COMMIT=`git rev-parse --short=8 HEAD`
@@ -2650,8 +2645,8 @@ dnl #
 case "$target" in
   *-darwin*)
     echo "Please be sure to use 'xcrun gmake' or 'xcrun lldb' in order to build and run the server from the source tree"
-    ;;
+    ;;	
 
   *)
     ;;
-esac
+esac 

--- a/debian/rules
+++ b/debian/rules
@@ -91,6 +91,7 @@ endif
 
 	./configure $(confflags) \
 		--config-cache \
+		--disable-developer \
 		--disable-openssl-version-check \
 		--prefix=/usr \
 		--exec-prefix=/usr \

--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -661,6 +661,8 @@ export RADIUSD_VERSION_RELEASE="%{release}"
 %if %{with developer}
         --enable-developer=yes \
         --with-gperftools \
+%else
+	--disable-developer \
 %endif
 %if %{with address_sanitizer}
         --enable-address-sanitizer \


### PR DESCRIPTION
Before these two commits:
d39744650b7606bdad80e050556cfa279594efcd
b97ee714bf22e08aff4c405f8f33a97885fe0a6b

package builds (when run from a git clone) had git revision in the package version so it was rather easy to differentiate between different package builds and also upgrade packages properly. Now this very nice feature is broken.

@mcnewton JFYI