### PR TITLE
Fix debian package build, fix RPM build version string

### DIFF
--- a/configure
+++ b/configure
@@ -3264,7 +3264,7 @@ then :
 fi
 
 
-if test "x$GIT" = "xyes" && git --git-dir=.git status 2>&1 > /dev/null; then
+if test "x$GIT" = "xyes" && git status 2>&1 > /dev/null; then
   if test "x$RADIUSD_VERSION_COMMIT" = "x"; then
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking build commit" >&5
 printf %s "checking build commit... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -154,12 +154,7 @@ AC_ARG_ENABLE(developer,
 dnl #
 dnl #  Turn on the developer flag when taken from a git checkout (not a release)
 dnl #
-dnl #  Passing --git-dir explicitly limits the search to the CWD.  Without it
-dnl #  git will search back up the directory tree for a git repository.
-dnl #  This can cause the configure script to erroneously determine that it's
-dnl #  running in a git repo.
-dnl #
-if test "x$GIT" = "xyes" && git --git-dir=.git status 2>&1 > /dev/null; then
+if test "x$GIT" = "xyes" && git status 2>&1 > /dev/null; then
   if test "x$RADIUSD_VERSION_COMMIT" = "x"; then
     AC_MSG_CHECKING([build commit])
     RADIUSD_VERSION_COMMIT=`git rev-parse --short=8 HEAD`
@@ -2650,8 +2645,8 @@ dnl #
 case "$target" in
   *-darwin*)
     echo "Please be sure to use 'xcrun gmake' or 'xcrun lldb' in order to build and run the server from the source tree"
-    ;;
+    ;;	
 
   *)
     ;;
-esac
+esac 

--- a/debian/rules
+++ b/debian/rules
@@ -91,6 +91,7 @@ endif
 
 	./configure $(confflags) \
 		--config-cache \
+		--disable-developer \
 		--disable-openssl-version-check \
 		--prefix=/usr \
 		--exec-prefix=/usr \

--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -661,6 +661,8 @@ export RADIUSD_VERSION_RELEASE="%{release}"
 %if %{with developer}
         --enable-developer=yes \
         --with-gperftools \
+%else
+	--disable-developer \
 %endif
 %if %{with address_sanitizer}
         --enable-address-sanitizer \


### PR DESCRIPTION
After these two commits:
b97ee714bf22e08aff4c405f8f33a97885fe0a6b
d39744650b7606bdad80e050556cfa279594efcd

1) debian package build (which runs just from current directory and not from "git archive" output) now has developer mode implicitly enabled:

```
ubuntu@primary:~/freeradius-server-upstream$ make deb
/usr/bin/fakeroot
EMAIL="packages@freeradius.org" fakeroot dch -b -v4.0~25868+git ""
dch warning: new version (4.0~25868+git) is less than
the current version number (4.0~25870+git).
fakeroot debian/rules debian/control # Clean
make[1]: Entering directory '/home/ubuntu/freeradius-server-upstream'
make[1]: 'debian/control' is up to date.
make[1]: Leaving directory '/home/ubuntu/freeradius-server-upstream'
fakeroot dpkg-buildpackage -b -uc
dpkg-buildpackage: info: source package freeradius
dpkg-buildpackage: info: source version 4.0~25868+git
dpkg-buildpackage: info: source distribution UNRELEASED
dpkg-buildpackage: info: source changed by root <packages@freeradius.org>
dpkg-buildpackage: info: host architecture amd64
 dpkg-source --before-build .
 debian/rules clean
make[1]: Entering directory '/home/ubuntu/freeradius-server-upstream'
QUILT_PATCHES=debian/patches \
	quilt --quiltrc /dev/null pop -a -R || test $? = 2
Removing patch radiusd-to-freeradius.diff
Restoring scripts/monit/freeradius.monitrc
Restoring src/bin/radiusd.c
Restoring Make.inc.in
Restoring raddb/sites-available/control-socket
Restoring raddb/radiusd.conf.in

No patches applied
rm -rf .pc debian/stamp-patched
dh_testdir
dh_testroot
rm -f build-arch-stamp build-indep-stamp
rm -f config.cache config.log
rm -f src/freeradius-devel
[ ! -d src/modules/lib ] || rm -fr src/modules/lib || true
[ ! -d src/binary ] || rm -fr src/binary || true
# Add here commands to clean up after the build process.
rm -f config.sub
mv config.sub.dist config.sub
rm -f config.guess
mv config.guess.dist config.guess
#distclean destroys debian/control, however we need it for dh_clean
/usr/bin/make -f debian/rules debian/control
make[2]: Entering directory '/home/ubuntu/freeradius-server-upstream'
make[2]: 'debian/control' is up to date.
make[2]: Leaving directory '/home/ubuntu/freeradius-server-upstream'
dh_clean
	rm -f debian/debhelper-build-stamp
	rm -rf debian/.debhelper/
dh_clean: warning: Compatibility levels before 10 are deprecated (level 9 in use)
	rm -f -- debian/freeradius.substvars debian/freeradius-common.substvars debian/freeradius-config.substvars debian/freeradius-utils.substvars debian/freeradius-perl-util.substvars debian/freeradius-snmp.substvars debian/libfreeradius4.substvars debian/libfreeradius-dev.substvars debian/freeradius-dhcp.substvars debian/freeradius-krb5.substvars debian/freeradius-kafka.substvars debian/freeradius-ldap.substvars debian/freeradius-rest.substvars debian/freeradius-postgresql.substvars debian/freeradius-mysql.substvars debian/freeradius-unixodbc.substvars debian/freeradius-redis.substvars debian/freeradius-freetds.substvars debian/freeradius-memcached.substvars debian/freeradius-yubikey.substvars debian/freeradius-dbg.substvars debian/files
	rm -fr -- debian/freeradius/ debian/tmp/ debian/freeradius-common/ debian/freeradius-config/ debian/freeradius-utils/ debian/freeradius-perl-util/ debian/freeradius-snmp/ debian/libfreeradius4/ debian/libfreeradius-dev/ debian/freeradius-dhcp/ debian/freeradius-krb5/ debian/freeradius-kafka/ debian/freeradius-ldap/ debian/freeradius-rest/ debian/freeradius-postgresql/ debian/freeradius-mysql/ debian/freeradius-unixodbc/ debian/freeradius-redis/ debian/freeradius-freetds/ debian/freeradius-memcached/ debian/freeradius-yubikey/ debian/freeradius-dbg/
	find .  \( \( \
		\( -path .\*/.git -o -path .\*/.svn -o -path .\*/.bzr -o -path .\*/.hg -o -path .\*/CVS -o -path .\*/.pc -o -path .\*/_darcs \) -prune -o -type f -a \
	        \( -name '#*#' -o -name '.*~' -o -name '*~' -o -name DEADJOE \
		 -o -name '*.orig' -o -name '*.rej' -o -name '*.bak' \
		 -o -name '.*.orig' -o -name .*.rej -o -name '.SUMS' \
		 -o -name TAGS -o \( -path '*/.deps/*' -a -name '*.P' \) \
		\) -exec rm -f {} + \) -o \
		\( -type d -a -name autom4te.cache -prune -exec rm -rf {} + \) \)
make[1]: Leaving directory '/home/ubuntu/freeradius-server-upstream'
 debian/rules build
make[1]: Entering directory '/home/ubuntu/freeradius-server-upstream'
QUILT_PATCHES=debian/patches \
	quilt --quiltrc /dev/null push -a || test $? = 2
Applying patch radiusd-to-freeradius.diff
patching file Make.inc.in
Hunk #1 succeeded at 127 (offset 22 lines).
patching file raddb/radiusd.conf.in
Hunk #2 succeeded at 447 (offset 18 lines).
patching file scripts/monit/freeradius.monitrc
patching file raddb/sites-available/control-socket
Hunk #1 succeeded at 82 with fuzz 1.
patching file src/bin/radiusd.c
Hunk #1 succeeded at 308 (offset 78 lines).

Now at patch radiusd-to-freeradius.diff
touch debian/stamp-patched
dh_testdir
mv config.sub config.sub.dist
mv config.guess config.guess.dist
ln -s /usr/share/misc/config.sub config.sub
ln -s /usr/share/misc/config.guess config.guess
./configure --build x86_64-linux-gnu \
	--config-cache \
	--disable-openssl-version-check \
	--prefix=/usr \
	--exec-prefix=/usr \
	--mandir=/usr/share/man \
	--sysconfdir=/etc \
	--libdir=/usr/lib/freeradius \
	--datadir=/usr/share \
	--localstatedir=/var \
	--with-raddbdir=/etc/freeradius \
	--with-logdir=/var/log/freeradius \
	--with-large-files \
	--with-udpfromto \
	--without-rlm_eap_tnc \
	--with-rlm_sql_postgresql_lib_dir=`pg_config --libdir` \
	--with-rlm_sql_postgresql_include_dir=`pg_config --includedir` \
	--without-rlm_eap_ikev2 \
	--without-rlm_sql_oracle \
	--without-rlm_sql_unixodbc \
	--with-systemd \
	--enable-reproducible-builds
configure: creating cache config.cache
checking build version... 0400650c
checking for git... yes
checking for asciidoctor... /usr/bin/asciidoctor
checking for pandoc... /usr/bin/pandoc
checking for perl... perl
checking for perl module JSON... ok
checking for doxygen... no
configure: WARNING: doxygen not found - Please install if you want build the docs/source
checking for antora... no
configure: WARNING: antora not found - Please install if you want build the site
checking build commit... 69a3945f
configure: in git repository, enabling developer build implicitly, disable with --disable-developer
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking target system type... x86_64-pc-linux-gnu
...
```

2) RPM build (when run from git clone) no longer has RADIUSD_VERSION_COMMIT_STRING in the version output so version string is not in sync with .deb builds

@mcnewton can you please review this