### PR TITLE
v4: Use a thread specific trunk for LDAP bind auths

### DIFF
--- a/raddb/mods-available/ldap
+++ b/raddb/mods-available/ldap
@@ -815,6 +815,27 @@ ldap {
 #			free_delay = 10
 		}
 	}
+
+	#
+	#  ### Bind Connection Pool
+	#
+	#  This connection pool is used for LDAP binds used to authenticate requests when
+	#  calling the ldap module in authenticate context.  If passwords are retrieved
+	#  from the ldap directory and FreeRADIUS performs the authentication then this is
+	#  not used.
+	#
+	#  The options are essentially identical to the pool section above with certain
+	#  limitations.  Since only one bind operation can be in progress on a connection at
+	#  a time, `per_connection_max` and `per_connection_target` are always set to 1.
+	#
+	#  This limitation means that `max` represents the maximum number of in progress
+	#  binds which there can be on a single thread.
+	#
+	bind_pool {
+		start = 0
+		min = 1
+		max = 1000
+	}
 }
 
 #

--- a/src/lib/ldap/base.h
+++ b/src/lib/ldap/base.h
@@ -381,6 +381,7 @@ typedef struct {
 	fr_trunk_conf_t		*bind_trunk_conf;	//!< Trunk config for bind auth trunk
 	fr_event_list_t		*el;		//!< Thread event list for callbacks / timeouts
 	fr_connection_t		*conn;		//!< LDAP connection used for bind auths
+	fr_ldap_thread_trunk_t	*bind_trunk;	//!< LDAP trunk used for bind auths
 	fr_rb_tree_t		*binds;		//!< Tree of outstanding bind auths
 } fr_ldap_thread_t;
 
@@ -849,6 +850,8 @@ fr_ldap_thread_trunk_t	*fr_thread_ldap_trunk_get(fr_ldap_thread_t *thread, char 
 					       request_t *request, fr_ldap_config_t const *config);
 
 fr_trunk_state_t fr_thread_ldap_trunk_state(fr_ldap_thread_t *thread, char const *uri, char const *bind_dn);
+
+fr_ldap_thread_trunk_t	*fr_thread_ldap_bind_trunk_get(fr_ldap_thread_t *thread);
 
 /*
  *	state.c - Connection state machine

--- a/src/lib/ldap/base.h
+++ b/src/lib/ldap/base.h
@@ -378,6 +378,7 @@ typedef struct {
 	fr_rb_tree_t		*trunks;	//!< Tree of LDAP trunks used by this thread
 	fr_ldap_config_t	*config;	//!< Module instance config
 	fr_trunk_conf_t		*trunk_conf;	//!< Module trunk config
+	fr_trunk_conf_t		*bind_trunk_conf;	//!< Trunk config for bind auth trunk
 	fr_event_list_t		*el;		//!< Thread event list for callbacks / timeouts
 	fr_connection_t		*conn;		//!< LDAP connection used for bind auths
 	fr_rb_tree_t		*binds;		//!< Tree of outstanding bind auths

--- a/src/lib/ldap/base.h
+++ b/src/lib/ldap/base.h
@@ -483,20 +483,20 @@ typedef struct fr_ldap_referral_s {
  *
  */
 typedef struct {
-	fr_ldap_connection_t	*c;			//!< to bind.
+	fr_ldap_connection_t	*c;			//!< to bind.  Only used when binding as admin user.
 	char const		*bind_dn;		//!< of the user, may be NULL to bind anonymously.
 	char const		*password;		//!< of the user, may be NULL if no password is specified.
 	LDAPControl		**serverctrls;		//!< Controls to pass to the server.
 	LDAPControl		**clientctrls;		//!< Controls to pass to the client (library).
 
-	int			msgid;
+	int			msgid;			//!< Of the bind operation.  Only used when binding as admin.
 } fr_ldap_bind_ctx_t;
 
 /** Holds arguments for the async SASL bind operation
  *
  */
 typedef struct {
-	fr_ldap_connection_t	*c;			//!< to bind.
+	fr_ldap_connection_t	*c;			//!< to bind.  Only used when binding as admin user.
 	char const		*mechs;			//!< SASL mechanisms to run
 	char const		*dn;			//!< to bind as.
 	char const		*identity;		//!< of the user.
@@ -506,7 +506,7 @@ typedef struct {
 	LDAPControl		**serverctrls;		//!< Controls to pass to the server.
 	LDAPControl		**clientctrls;		//!< Controls to pass to the client (library).
 
-	int			msgid;			//!< Last msgid.
+	int			msgid;			//!< Last msgid.  Only used when binding as admin user.
 	LDAPMessage		*result;		//!< Previous result.
 	char const		*rmech;			//!< Mech we're continuing with.
 } fr_ldap_sasl_ctx_t;

--- a/src/lib/ldap/base.h
+++ b/src/lib/ldap/base.h
@@ -380,7 +380,6 @@ typedef struct {
 	fr_trunk_conf_t		*trunk_conf;	//!< Module trunk config
 	fr_trunk_conf_t		*bind_trunk_conf;	//!< Trunk config for bind auth trunk
 	fr_event_list_t		*el;		//!< Thread event list for callbacks / timeouts
-	fr_connection_t		*conn;		//!< LDAP connection used for bind auths
 	fr_ldap_thread_trunk_t	*bind_trunk;	//!< LDAP trunk used for bind auths
 	fr_rb_tree_t		*binds;		//!< Tree of outstanding bind auths
 } fr_ldap_thread_t;
@@ -605,6 +604,7 @@ typedef enum {
 typedef struct {
 	fr_rb_node_t		node;		//!< Entry in the tree of outstanding bind requests.
 	fr_ldap_thread_t	*thread;	//!< This bind is being run by.
+	fr_trunk_request_t	*treq;		//!< Trunk request this bind is associated with.
 	int			msgid;		//!< libldap msgid for this bind.
 	request_t		*request;	//!< this bind relates to.
 	fr_ldap_bind_type_t	type;		//!< type of bind.

--- a/src/lib/ldap/base.h
+++ b/src/lib/ldap/base.h
@@ -875,6 +875,10 @@ int		fr_ldap_sasl_bind_async(fr_ldap_connection_t *c,
 			    		char const *realm,
 			    		LDAPControl **serverctrls, LDAPControl **clientctrls);
 
+int		fr_ldap_sasl_bind_auth_send(fr_ldap_sasl_ctx_t *sasl_ctx,
+					    int *msgid,
+					    fr_ldap_connection_t *ldap_conn);
+
 int		fr_ldap_sasl_bind_auth_async(request_t *request,
 					     fr_ldap_thread_t *thread,
 					     char const *mechs,

--- a/src/lib/ldap/connection.c
+++ b/src/lib/ldap/connection.c
@@ -1016,6 +1016,266 @@ fr_trunk_state_t fr_thread_ldap_trunk_state(fr_ldap_thread_t *thread, char const
 	return (found) ? found->trunk->state : FR_TRUNK_STATE_MAX;
 }
 
+/** Free LDAP bind auth ctx when trunk request is "freed" with fr_trunk_request_free()
+ *
+ */
+static void ldap_trunk_bind_auth_free(UNUSED request_t *request, void *preq_to_free, UNUSED void *uctx)
+{
+	fr_ldap_bind_auth_ctx_t *bind = talloc_get_type_abort(preq_to_free, fr_ldap_bind_auth_ctx_t);
+
+	talloc_free(bind);
+}
+
+/** Take pending LDAP bind auths from the queue and send them.
+ *
+ * @param[in] el	Event list for timers.
+ * @param[in] tconn	Trunk handle.
+ * @param[in] conn	on which to send the queries
+ * @param[in] uctx	User context passed to fr_trunk_alloc
+ */
+static void ldap_trunk_bind_auth_mux(UNUSED fr_event_list_t *el, fr_trunk_connection_t *tconn,
+				   fr_connection_t *conn, void *uctx)
+{
+	fr_ldap_connection_t	*ldap_conn = talloc_get_type_abort(conn->h, fr_ldap_connection_t);
+	fr_ldap_thread_trunk_t	*ttrunk = talloc_get_type_abort(uctx, fr_ldap_thread_trunk_t);
+	fr_ldap_thread_t	*thread = ttrunk->t;
+	fr_trunk_request_t	*treq;
+
+	fr_ldap_bind_auth_ctx_t	*bind = NULL;
+	int			ret = 0;
+	struct berval		cred;
+	request_t		*request;
+
+	if (fr_trunk_connection_pop_request(&treq, tconn) != 0) return;
+
+	/* Pacify clang scan */
+	if (!treq) return;
+
+	bind = talloc_get_type_abort(treq->preq, fr_ldap_bind_auth_ctx_t);
+	request = bind->request;
+
+	switch (bind->type) {
+	case LDAP_BIND_SIMPLE:
+	{
+		fr_ldap_bind_ctx_t	*bind_ctx = bind->bind_ctx;
+
+		RDEBUG2("Starting bind auth operation as %s", bind_ctx->bind_dn);
+
+		if (bind_ctx->password) {
+			memcpy(&cred.bv_val, &bind_ctx->password, sizeof(cred.bv_val));
+			cred.bv_len = talloc_array_length(bind_ctx->password) - 1;
+		} else {
+			cred.bv_val = NULL;
+			cred.bv_len = 0;
+		}
+
+		ret = ldap_sasl_bind(ldap_conn->handle, bind_ctx->bind_dn, LDAP_SASL_SIMPLE,
+			     	     &cred, NULL, NULL, &bind->msgid);
+
+		switch (ret) {
+		case LDAP_SUCCESS:
+			fr_rb_insert(thread->binds, bind);
+			RDEBUG3("Bind auth sent as LDAP msgid %d", bind->msgid);
+			break;
+
+		default:
+			bind->ret = LDAP_PROC_ERROR;
+			unlang_interpret_mark_runnable(treq->request);
+			RERROR("Failed to send bind auth");
+			break;
+		}
+	}
+		break;
+
+	case LDAP_BIND_SASL:
+	{
+		fr_ldap_sasl_ctx_t	*sasl_ctx = bind->sasl_ctx;
+
+		RDEBUG2("%s SASL bind auth operation as %s", sasl_ctx->rmech ? "Continuing" : "Starting",
+			sasl_ctx->identity);
+
+		ret = fr_ldap_sasl_bind_auth_send(sasl_ctx, &bind->msgid, ldap_conn);
+
+		switch (ret) {
+		case LDAP_SASL_BIND_IN_PROGRESS:
+			/*
+			 *	Add the bind to the list of pending binds.
+			 */
+			fr_rb_insert(thread->binds, bind);
+			RDEBUG3("SASL bind auth sent as LDAP msgid %d", bind->msgid);
+			break;
+
+		case LDAP_SUCCESS:
+			bind->ret = LDAP_PROC_SUCCESS;
+			unlang_interpret_mark_runnable(treq->request);
+			break;
+
+		default:
+			bind->ret = LDAP_PROC_ERROR;
+			unlang_interpret_mark_runnable(treq->request);
+			RERROR("Failed to send SASL bind auth");
+			break;
+		}
+	}
+		break;
+	}
+	/*
+	 *	The request is marked as sent, to remove from the pending list.
+	 *	This is regardless of whether the sending was successful or not as
+	 *	the different states are handled by the resume function which then
+	 *	marks the request as complete triggering the tidy up.
+	 */
+	fr_trunk_request_signal_sent(treq);
+}
+
+/** Read LDAP bind auth responses
+ *
+ * @param[in] el	To insert timers into.
+ * @param[in] tconn	Trunk connection associated with these results.
+ * @param[in] conn	Connection handle for these results.
+ * @param[in] uctx	Thread specific trunk structure - contains tree of pending queries.
+ */
+static void ldap_trunk_bind_auth_demux(UNUSED fr_event_list_t *el, UNUSED fr_trunk_connection_t *tconn,
+				       fr_connection_t *conn, void *uctx)
+{
+	fr_ldap_connection_t	*ldap_conn = talloc_get_type_abort(conn->h, fr_ldap_connection_t);
+	fr_ldap_thread_trunk_t	*ttrunk = talloc_get_type_abort(uctx, fr_ldap_thread_trunk_t);
+	fr_ldap_thread_t	*thread = ttrunk->t;
+	fr_ldap_bind_auth_ctx_t	find = { .msgid = -1 }, *bind = NULL;
+
+	int 			ret = 0;
+	LDAPMessage		*result = NULL;
+	request_t		*request;
+	bool			really_no_result = false;
+
+	do {
+		/*
+		 *	The first time ldap_result is called when there's pending network
+		 *	data, it may read the data, but actually return a timeout.
+		 *
+		 *	In order to fix the spurious debugging messages and overhead,
+		 *	if this is the first iteration through the loop and fr_ldap_result
+		 *	returns a timeout, we call it again.
+		 */
+		ret = fr_ldap_result(&result, NULL, ldap_conn, LDAP_RES_ANY, LDAP_MSG_ALL, NULL, fr_time_delta_wrap(10));
+		if (ret == LDAP_PROC_TIMEOUT) {
+			if (really_no_result) return;
+			really_no_result = true;
+			continue;
+		}
+
+		if (!result) return;
+
+		really_no_result = true;
+		find.msgid = ldap_msgid(result);
+		bind = fr_rb_find(thread->binds, &find);
+
+		if (!bind) {
+			WARN("Ignoring bind result msgid %i - doesn't match any outstanding binds", find.msgid);
+			ldap_msgfree(result);
+			result = NULL;
+			continue;
+		}
+	} while (!bind);
+
+	/*
+	 *	There will only ever be one bind in flight at a time on a given
+	 *	connection - so having got a result, no need to loop.
+	 */
+
+	fr_rb_remove(thread->binds, bind);
+	request = bind->request;
+	bind->ret = ret;
+
+	switch (ret) {
+	/*
+	 *	Accept or reject will be SUCCESS, NOT_PERMITTED or REJECT
+	 */
+	case LDAP_PROC_NOT_PERMITTED:
+	case LDAP_PROC_REJECT:
+	case LDAP_PROC_BAD_DN:
+	case LDAP_PROC_NO_RESULT:
+		break;
+
+	case LDAP_PROC_SUCCESS:
+		if (bind->type == LDAP_BIND_SIMPLE) break;
+
+		/*
+		 *	With SASL binds, we will be here after ldap_sasl_interactive_bind
+		 *	returned LDAP_SASL_BIND_IN_PROGRESS.  That always requires a further
+		 *	call of ldap_sasl_interactive_bind to get the final result.
+		 */
+		bind->ret = LDAP_PROC_CONTINUE;
+		FALL_THROUGH;
+
+	case LDAP_PROC_CONTINUE:
+	{
+		fr_ldap_sasl_ctx_t	*sasl_ctx = bind->sasl_ctx;
+		struct berval		*srv_cred;
+
+		/*
+		 *	Free any previous result and track the new one.
+		 */
+		if (sasl_ctx->result) ldap_msgfree(sasl_ctx->result);
+		sasl_ctx->result = result;
+		result = NULL;
+
+		ret = ldap_parse_sasl_bind_result(ldap_conn->handle, sasl_ctx->result, &srv_cred, 0);
+		if (ret != LDAP_SUCCESS) {
+			RERROR("SASL decode failed (bind failed): %s", ldap_err2string(ret));
+			break;
+		}
+
+		if (srv_cred) {
+			RDEBUG3("SASL response  : %pV",
+				fr_box_strvalue_len(srv_cred->bv_val, srv_cred->bv_len));
+			ber_bvfree(srv_cred);
+		}
+
+		if (sasl_ctx->rmech) RDEBUG3("Continuing SASL mech %s...", sasl_ctx->rmech);
+	}
+		break;
+
+	default:
+		break;
+	}
+
+	ldap_msgfree(result);
+	unlang_interpret_mark_runnable(request);
+}
+
+/** Callback to cancel LDAP bind auth
+ *
+ * Inform the remote LDAP server that we no longer want responses to specific bind.
+ *
+ * @param[in] el	For timer management.
+ * @param[in] tconn	The trunk connection handle
+ * @param[in] conn	The specific connection binds will be cancelled on
+ * @param[in] uctx	Context provided to fr_trunk_alloc
+ */
+static void ldap_bind_auth_cancel_mux(UNUSED fr_event_list_t *el, fr_trunk_connection_t *tconn,
+				    fr_connection_t *conn, UNUSED void *uctx)
+{
+	fr_trunk_request_t	*treq;
+	fr_ldap_connection_t	*ldap_conn = talloc_get_type_abort(conn->h, fr_ldap_connection_t);
+	fr_ldap_bind_auth_ctx_t	*bind;
+
+	while ((fr_trunk_connection_pop_cancellation(&treq, tconn)) == 0) {
+		bind = talloc_get_type_abort(treq->preq, fr_ldap_bind_auth_ctx_t);
+		if (bind->type == LDAP_BIND_SASL) {
+			/*
+			 *	With SASL binds, abandoning the bind part way through
+			 *	seems to leave the connection in an unpredictable state
+			 *	so safer to restart.
+			 */
+			fr_trunk_connection_signal_reconnect(tconn, FR_CONNECTION_FAILED);
+		} else {
+			ldap_abandon_ext(ldap_conn->handle, bind->msgid, NULL, NULL);
+		}
+		fr_trunk_request_signal_cancel_complete(treq);
+	}
+}
+
 /** Find the thread specific trunk to use for LDAP bind auths
  *
  * If there is no current trunk then a new one is created.
@@ -1041,6 +1301,10 @@ fr_ldap_thread_trunk_t *fr_thread_ldap_bind_trunk_get(fr_ldap_thread_t *thread)
 				       &(fr_trunk_io_funcs_t){
 					      .connection_alloc = ldap_trunk_connection_alloc,
 					      .connection_notify = ldap_trunk_connection_notify,
+					      .request_mux = ldap_trunk_bind_auth_mux,
+					      .request_demux = ldap_trunk_bind_auth_demux,
+					      .request_cancel_mux = ldap_bind_auth_cancel_mux,
+					      .request_free = ldap_trunk_bind_auth_free
 					},
 				       thread->bind_trunk_conf,
 				       "rlm_ldap bind auth", ttrunk, false);

--- a/src/lib/ldap/connection.c
+++ b/src/lib/ldap/connection.c
@@ -1015,3 +1015,44 @@ fr_trunk_state_t fr_thread_ldap_trunk_state(fr_ldap_thread_t *thread, char const
 
 	return (found) ? found->trunk->state : FR_TRUNK_STATE_MAX;
 }
+
+/** Find the thread specific trunk to use for LDAP bind auths
+ *
+ * If there is no current trunk then a new one is created.
+ *
+ * @param[in] thread	to which the connection belongs
+ * @return
+ *	- an existing or new trunk.
+ *	- NULL on failure
+ */
+fr_ldap_thread_trunk_t *fr_thread_ldap_bind_trunk_get(fr_ldap_thread_t *thread)
+{
+	fr_ldap_thread_trunk_t	*ttrunk;
+
+	if (thread->bind_trunk) return (thread->bind_trunk);
+
+	MEM(ttrunk = talloc_zero(thread, fr_ldap_thread_trunk_t));
+	memcpy(&ttrunk->config, thread->config, sizeof(fr_ldap_config_t));
+
+	ttrunk->uri = ttrunk->config.server;
+	ttrunk->bind_dn = ttrunk->config.admin_identity;
+
+	ttrunk->trunk = fr_trunk_alloc(ttrunk, thread->el,
+				       &(fr_trunk_io_funcs_t){
+					      .connection_alloc = ldap_trunk_connection_alloc,
+					      .connection_notify = ldap_trunk_connection_notify,
+					},
+				       thread->bind_trunk_conf,
+				       "rlm_ldap bind auth", ttrunk, false);
+
+	if (!ttrunk->trunk) {
+		ERROR("Unable to create LDAP connection");
+		talloc_free(ttrunk);
+		return NULL;
+	}
+
+	ttrunk->t = thread;
+	thread->bind_trunk = ttrunk;
+
+	return ttrunk;
+}

--- a/src/lib/ldap/sasl.c
+++ b/src/lib/ldap/sasl.c
@@ -357,6 +357,23 @@ int fr_ldap_sasl_bind_async(fr_ldap_connection_t *c,
 }
 
 
+/** Send a SASL LDAP auth bind
+ *
+ * Shares the same callback as SASL admin binds
+ *
+ * @param[in] sasl_ctx	containing SASL parameters / state for the bind.
+ * @param[out] msgid	where to write the LDAP message ID.
+ * @param[in] ldap_conn	on which the message should be sent.
+ */
+int fr_ldap_sasl_bind_auth_send(fr_ldap_sasl_ctx_t *sasl_ctx, int *msgid,
+				 fr_ldap_connection_t *ldap_conn)
+{
+	return ldap_sasl_interactive_bind(ldap_conn->handle, NULL, sasl_ctx->mechs,
+					  NULL, NULL, LDAP_SASL_AUTOMATIC,
+					  _sasl_interact, sasl_ctx, sasl_ctx->result,
+					  &sasl_ctx->rmech, msgid);
+}
+
 /** Submit an async SASL LDAP auth bind
  *
  * @param[in] p_result	Unused.

--- a/src/lib/server/trunk.c
+++ b/src/lib/server/trunk.c
@@ -695,6 +695,7 @@ do { \
 #define IN_REQUEST_CANCEL_MUX(_trunk)	(((_trunk)->funcs.request_cancel_mux) && ((_trunk)->in_handler == (void *)(_trunk)->funcs.request_cancel_mux))
 
 #define IS_SERVICEABLE(_tconn)		((_tconn)->pub.state & FR_TRUNK_CONN_SERVICEABLE)
+#define IS_PROCESSING(_tconn)		((tconn)->pub.state & FR_TRUNK_CONN_PROCESSING)
 
 /** Remove the current request from the backlog
  *
@@ -1131,7 +1132,7 @@ static void trunk_request_enter_pending(fr_trunk_request_t *treq, fr_trunk_conne
 	fr_trunk_t		*trunk = treq->pub.trunk;
 
 	fr_assert(tconn->pub.trunk == trunk);
-	fr_assert(IS_SERVICEABLE(tconn));
+	fr_assert(IS_PROCESSING(tconn));
 
 	switch (treq->pub.state) {
 	case FR_TRUNK_REQUEST_STATE_INIT:
@@ -2570,7 +2571,7 @@ fr_trunk_enqueue_t fr_trunk_request_requeue(fr_trunk_request_t *treq)
 
 	if (!tconn) return FR_TRUNK_ENQUEUE_FAIL;
 
-	if (!IS_SERVICEABLE(tconn)) {
+	if (!IS_PROCESSING(tconn)) {
 		trunk_request_enter_failed(treq);
 		return FR_TRUNK_ENQUEUE_DST_UNAVAILABLE;
 	}

--- a/src/lib/server/trunk.c
+++ b/src/lib/server/trunk.c
@@ -989,8 +989,8 @@ static void trunk_request_remove_from_conn(fr_trunk_request_t *treq)
 	{
 		request_t *request = treq->pub.request;
 
-		ROPTIONAL(RDEBUG3, DEBUG3, "[%" PRIu64 "] Trunk connection released request %" PRIu64,
-			  tconn->pub.conn->id, treq->id);
+		ROPTIONAL(RDEBUG3, DEBUG3, "%s Trunk connection released request %" PRIu64,
+			  tconn->pub.conn->name, treq->id);
 	}
 	/*
 	 *	Release any connection specific resources the
@@ -1163,8 +1163,8 @@ static void trunk_request_enter_pending(fr_trunk_request_t *treq, fr_trunk_conne
 	{
 		request_t *request = treq->pub.request;
 
-		ROPTIONAL(RDEBUG, DEBUG3, "[%" PRIu64 "] Trunk connection assigned request %"PRIu64,
-			  tconn->pub.conn->id, treq->id);
+		ROPTIONAL(RDEBUG, DEBUG3, "%s Trunk connection assigned request %"PRIu64,
+			  tconn->pub.conn->name, treq->id);
 	}
 	fr_heap_insert(&tconn->pending, treq);
 

--- a/src/lib/server/trunk.h
+++ b/src/lib/server/trunk.h
@@ -132,6 +132,19 @@ typedef enum {
 	FR_TRUNK_CONN_DRAINING_TO_FREE \
 )
 
+/** States where the connection may be processing requests
+ *
+ */
+#define FR_TRUNK_CONN_PROCESSING \
+(\
+	FR_TRUNK_CONN_ACTIVE | \
+	FR_TRUNK_CONN_FULL | \
+	FR_TRUNK_CONN_INACTIVE | \
+	FR_TRUNK_CONN_DRAINING | \
+	FR_TRUNK_CONN_INACTIVE_DRAINING | \
+	FR_TRUNK_CONN_DRAINING_TO_FREE \
+)
+
 typedef enum {
 	FR_TRUNK_ENQUEUE_IN_BACKLOG = 1,		//!< Request should be enqueued in backlog
 	FR_TRUNK_ENQUEUE_OK = 0,			//!< Operation was successful.

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -2141,6 +2141,12 @@ static int mod_bootstrap(module_inst_ctx_t const *mctx)
 	inst->bind_trunk_conf.target_req_per_conn = 1;
 	inst->bind_trunk_conf.max_req_per_conn = 1;
 
+	/*
+	 *	Set sizes for trunk request pool.
+	 */
+	inst->bind_trunk_conf.req_pool_headers = 2;
+	inst->bind_trunk_conf.req_pool_size = sizeof(fr_ldap_bind_auth_ctx_t) + sizeof(fr_ldap_sasl_ctx_t);
+
 	xlat = xlat_func_register_module(NULL, mctx, mctx->inst->name, ldap_xlat, FR_TYPE_STRING);
 	xlat_func_mono_set(xlat, ldap_xlat_arg);
 

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -189,6 +189,9 @@ static const CONF_PARSER module_config[] = {
 
 	{ FR_CONF_OFFSET("pool", FR_TYPE_SUBSECTION, rlm_ldap_t, trunk_conf), .subcs = (void const *) fr_trunk_config },
 
+	{ FR_CONF_OFFSET("bind_pool", FR_TYPE_SUBSECTION, rlm_ldap_t, bind_trunk_conf),
+	  .subcs = (void const *) fr_trunk_config },
+
 	CONF_PARSER_TERMINATOR
 };
 
@@ -2035,6 +2038,7 @@ static int mod_thread_instatiate(module_thread_inst_ctx_t const *mctx)
 
 	t->config = &inst->handle_config;
 	t->trunk_conf = &inst->trunk_conf;
+	t->bind_trunk_conf = &inst->bind_trunk_conf;
 	t->el = mctx->el;
 
 	/*
@@ -2130,6 +2134,12 @@ static int mod_bootstrap(module_inst_ctx_t const *mctx)
 	} else {
 		inst->cache_da = inst->group_da;	/* Default to the group_da */
 	}
+
+	/*
+	 *	Trunks used for bind auth can only have one request in flight per connection.
+	 */
+	inst->bind_trunk_conf.target_req_per_conn = 1;
+	inst->bind_trunk_conf.max_req_per_conn = 1;
 
 	xlat = xlat_func_register_module(NULL, mctx, mctx->inst->name, ldap_xlat, FR_TYPE_STRING);
 	xlat_func_mono_set(xlat, ldap_xlat_arg);

--- a/src/modules/rlm_ldap/rlm_ldap.h
+++ b/src/modules/rlm_ldap/rlm_ldap.h
@@ -122,6 +122,7 @@ typedef struct {
 
 	fr_ldap_config_t handle_config;			//!< Connection configuration instance.
 	fr_trunk_conf_t	trunk_conf;			//!< Trunk configuration
+	fr_trunk_conf_t	bind_trunk_conf;		//!< Trunk configuration for trunk used for bind auths
 } rlm_ldap_t;
 
 /** Module environment used in LDAP authorization


### PR DESCRIPTION
Since only one bind can be in progress at a time on a given connect, use of a trunk allows the number of connections in use to scale with load.