### PR TITLE
Remove annotations of tainted data

### DIFF
--- a/src/bin/radsniff.c
+++ b/src/bin/radsniff.c
@@ -1373,7 +1373,6 @@ static void rs_packet_process(uint64_t count, rs_event_t *event, struct pcap_pkt
 		if ((version == 4) && conf->verify_udp_checksum) {
 			uint16_t expected;
 
-			/* coverity[tainted_data] */
 			expected = fr_udp_checksum((uint8_t const *) udp, udp_len, udp->checksum,
 						   ip->ip_src, ip->ip_dst);
 			if (udp->checksum != expected) {

--- a/src/lib/eap/session.c
+++ b/src/lib/eap/session.c
@@ -273,7 +273,6 @@ static char *eap_identity(request_t *request, eap_session_t *eap_session, eap_pa
 	 *	If the length is 5, then a buffer with a length of 1 is
 	 *	created with a \0 byte.
 	 */
-	/* coverity[tainted_data] */
 	return talloc_bstrndup(eap_session, (char *)&eap_packet->data[1], len - 5);
 }
 

--- a/src/lib/server/trunk_tests.c
+++ b/src/lib/server/trunk_tests.c
@@ -120,12 +120,10 @@ static void test_demux(UNUSED fr_event_list_t *el, UNUSED fr_trunk_connection_t 
 			break;		/* Hack - just ignore it */
 
 		case FR_TRUNK_REQUEST_STATE_CANCEL_SENT:
-			/* coverity[tainted_data] */
 			fr_trunk_request_signal_cancel_complete(preq->treq);
 			break;
 
 		case FR_TRUNK_REQUEST_STATE_SENT:
-			/* coverity[tainted_data] */
 			fr_trunk_request_signal_complete(preq->treq);
 			break;
 

--- a/src/lib/util/net.c
+++ b/src/lib/util/net.c
@@ -89,7 +89,6 @@ size_t fr_net_af_table_len = NUM_ELEMENTS(fr_net_af_table);
 		return -1;
 	}
 
-	/* coverity[tainted_data] */
 	expected = fr_udp_checksum((uint8_t const *) udp, udp_len, udp->checksum,
 				   ip->ip_src, ip->ip_dst);
 	if (udp->checksum != expected) {

--- a/src/lib/util/trie.c
+++ b/src/lib/util/trie.c
@@ -1147,7 +1147,6 @@ static void *trie_node_match(fr_trie_t *trie, uint8_t const *key, int start_bit,
 	fr_trie_node_t *node = (fr_trie_node_t *) trie;
 
 	chunk = get_chunk(key, start_bit, node->bits);
-	/* coverity[tainted_data] */
 	if (!node->trie[chunk]) {
 		MPRINT2("no match for node chunk %02x at %d\n", chunk, __LINE__);
 		return NULL;
@@ -1385,7 +1384,6 @@ static int trie_node_insert(TALLOC_CTX *ctx, fr_trie_t **trie_p, uint8_t const *
 	 *	No existing trie, create a brand new trie from
 	 *	the key.
 	 */
-	/* coverity[tainted_data] */
 	if (!node->trie[chunk]) {
 		node->trie[chunk] = trie_key_alloc(ctx, key, start_bit + node->bits, end_bit, data);
 		if (!node->trie[chunk]) {
@@ -1940,7 +1938,6 @@ static void *trie_node_remove(TALLOC_CTX *ctx, fr_trie_t **trie_p, uint8_t const
 	void *data;
 
 	chunk = get_chunk(key, start_bit, node->bits);
-	/* coverity[tainted_data] */
 	if (!node->trie[chunk]) return NULL;
 
 	data = trie_key_remove(ctx, &node->trie[chunk], key, start_bit + node->bits, end_bit);

--- a/src/listen/dhcpv6/proto_dhcpv6.c
+++ b/src/listen/dhcpv6/proto_dhcpv6.c
@@ -318,7 +318,6 @@ static ssize_t mod_encode(UNUSED void const *instance, request_t *request, uint8
 		if (client_id) {
 			size_t len = fr_nbo_to_uint16(client_id + 2);
 			if ((data_len + 4 + len) <= buffer_len) {
-				/* coverity[tainted_data] */
 				memcpy(buffer + data_len, client_id, 4 + len);
 				data_len += 4 + len;
 			}

--- a/src/listen/dhcpv6/proto_dhcpv6_udp.c
+++ b/src/listen/dhcpv6/proto_dhcpv6_udp.c
@@ -435,7 +435,6 @@ static void *mod_track_create(UNUSED void const *instance, UNUSED void *thread_i
 
 	memcpy(&t->header, packet, 4); /* packet code + 24-bit transaction ID */
 
-	/* coverity[tainted_data] */
 	memcpy(&t->client_id[0], option + 4, option_len);
 	t->client_id_len = option_len;
 

--- a/src/listen/radius/#proto_radius_tcp.c#
+++ b/src/listen/radius/#proto_radius_tcp.c#
@@ -192,7 +192,6 @@ static ssize_t mod_read(fr_listen_t *li, UNUSED void **packet_ctx, fr_time_t *re
 	/*
 	 *	Print out what we received.
 	 */
-	/* coverity[tainted_data] */
 	DEBUG2("proto_radius_tcp - Received %s ID %d length %d %s",
 	       fr_radius_packet_names[buffer[0]], buffer[1],
 	       (int) packet_len, thread->name);

--- a/src/listen/radius/proto_radius_tcp.c
+++ b/src/listen/radius/proto_radius_tcp.c
@@ -192,7 +192,6 @@ static ssize_t mod_read(fr_listen_t *li, UNUSED void **packet_ctx, fr_time_t *re
 	/*
 	 *	Print out what we received.
 	 */
-	/* coverity[tainted_data] */
 	DEBUG2("proto_radius_tcp - Received %s ID %d length %d %s",
 	       fr_radius_packet_names[buffer[0]], buffer[1],
 	       (int) packet_len, thread->name);

--- a/src/modules/rlm_tacacs/rlm_tacacs_tcp.c
+++ b/src/modules/rlm_tacacs/rlm_tacacs_tcp.c
@@ -1144,7 +1144,6 @@ static void request_demux(UNUSED fr_event_list_t *el, fr_trunk_connection_t *tco
 		 *	TACACS+ doesn't care about packet codes.  All packet of the codes share the same ID
 		 *	space.
 		 */
-		/* coverity[tainted_data] */
 		treq = h->tracking[h->recv.read[1]];
 		if (!treq) {
 			WARN("%s - Ignoring reply with ID %i that arrived too late",

--- a/src/protocols/bfd/decode.c
+++ b/src/protocols/bfd/decode.c
@@ -202,7 +202,6 @@ static ssize_t fr_bfd_decode_proto(TALLOC_CTX *ctx, fr_pair_list_t *out,
 	fr_pair_append(out, vp);
 #endif
 
-	/* coverity[tainted_data] */
 	return fr_bfd_decode(ctx, out, data, data_len,
 			     test_ctx->secret, talloc_array_length(test_ctx->secret) - 1);
 }

--- a/src/protocols/dhcpv4/decode.c
+++ b/src/protocols/dhcpv4/decode.c
@@ -403,7 +403,6 @@ next:
 	}
 	p++;
 
-	/* coverity[tainted_data] */
 	len = fr_pair_tlvs_from_network(ctx, out, vendor, p, option_len, decode_ctx, decode_option, verify_tlvs, false);
 	if (len <= 0) return len;
 

--- a/src/protocols/dhcpv4/pcap.c
+++ b/src/protocols/dhcpv4/pcap.c
@@ -188,7 +188,6 @@ fr_radius_packet_t *fr_dhcpv4_pcap_recv(fr_pcap_t *pcap)
 	/*
 	 *	UDP header validation.
 	 */
-	/* coverity[tainted_data] */
 	ret = fr_udp_header_check(p, (header->caplen - (p - data)), ip);
 	if (ret < 0) return NULL;
 

--- a/src/protocols/dhcpv4/raw.c
+++ b/src/protocols/dhcpv4/raw.c
@@ -319,7 +319,6 @@ fr_radius_packet_t *fr_dhcv4_raw_packet_recv(int sockfd, struct sockaddr_ll *lin
 	 *      and use that, too?
 	 */
 	memset(packet->vector, 0, sizeof(packet->vector));
-	/* coverity[tainted_data] */
 	memcpy(packet->vector, packet->data + 28, packet->data[2]);
 	packet->vector[packet->data[2]] = packet->code & 0xff;
 

--- a/src/protocols/dhcpv6/base.c
+++ b/src/protocols/dhcpv6/base.c
@@ -886,7 +886,6 @@ static void dhcpv6_print_hex(FILE *fp, uint8_t const *packet, size_t packet_len,
 			break;
 		}
 
-		/* coverity[tainted_data] */
 		print_hex_data(fp, option + 4, length, depth + 3);
 		if ((option[0] == 0) && (option[1] == attr_relay_message->attr)) {
 			dhcpv6_print_hex(fp, option + 4, length, depth + 2);

--- a/src/protocols/dns/base.c
+++ b/src/protocols/dns/base.c
@@ -248,7 +248,6 @@ bool fr_dns_packet_ok(uint8_t const *packet, size_t packet_len, bool query, fr_d
 					return false;
 				}
 
-				/* coverity[tainted_data] */
 				if (!fr_dns_marker[offset]) {
 					DECODE_FAIL(POINTER_TO_NON_LABEL);
 					return false;

--- a/src/protocols/dns/decode.c
+++ b/src/protocols/dns/decode.c
@@ -236,7 +236,6 @@ static ssize_t decode_record(TALLOC_CTX *ctx, fr_pair_list_t *out, fr_dict_attr_
 
 	count = fr_nbo_to_uint16(counter);
 	FR_PROTO_TRACE("Decoding %u of %s", count, attr->name);
-	/* coverity[tainted_data] */
 	for (i = 0; i < count; i++) {
 		ssize_t slen;
 

--- a/src/protocols/radius/decode.c
+++ b/src/protocols/radius/decode.c
@@ -2096,7 +2096,6 @@ static ssize_t fr_radius_decode_proto(TALLOC_CTX *ctx, fr_pair_list_t *out,
 	memcpy(original + 4, test_ctx->vector, sizeof(test_ctx->vector));
 	test_ctx->end = data + packet_len;
 
-	/* coverity[tainted_data] */
 	return fr_radius_decode(ctx, out, data, packet_len, original,
 				test_ctx->secret, talloc_array_length(test_ctx->secret) - 1);
 }

--- a/src/protocols/radius/packet.c
+++ b/src/protocols/radius/packet.c
@@ -190,7 +190,6 @@ int fr_radius_packet_decode(TALLOC_CTX *ctx, fr_pair_list_t *out,
 		 *	This may return many VPs
 		 */
 		fr_assert(ptr != NULL);
-		/* coverity[tainted_data] */
 		my_len = fr_radius_decode_pair(ctx, &tmp_list, ptr, packet_length, &packet_ctx);
 		if (my_len < 0) {
 		fail:

--- a/src/protocols/tacacs/base.c
+++ b/src/protocols/tacacs/base.c
@@ -485,7 +485,6 @@ void _fr_tacacs_packet_log_hex(fr_log_t const *log, fr_tacacs_packet_t const *pa
 			print_ascii(log, file, line, "      rem_addr       ", p, hdr[6], end);
 			p += hdr[6];
 
-			/* coverity[tainted_data] */
 			print_hex(log, file, line, "      data           ", p, hdr[7], end); /* common auth flows */
 
 		} else if (packet_is_authen_continue(packet)) {

--- a/src/protocols/vmps/vmps.c
+++ b/src/protocols/vmps/vmps.c
@@ -495,7 +495,6 @@ void fr_vmps_print_hex(FILE *fp, uint8_t const *packet, size_t packet_len)
 
 		fprintf(fp, "\t\t%08x  %04x  ", id, length);
 
-		/* coverity[tainted_data] */
 		print_hex_data(attr + 6, length - 6, 3);
 	}
 }


### PR DESCRIPTION
We do this so we can get back the details of why coverity thinks these issues arise to aid in modeling.