### PR TITLE
amending thread_pool_stop() to free a TALLOC_CTX blob/chunk

### DIFF
--- a/src/include/atomic_queue.h
+++ b/src/include/atomic_queue.h
@@ -60,7 +60,7 @@ extern "C" {
 typedef struct fr_atomic_queue_s fr_atomic_queue_t;
 
 fr_atomic_queue_t	*fr_atomic_queue_alloc(TALLOC_CTX *ctx, size_t size);
-void			fr_atomic_queue_free(fr_atomic_queue_t **aq);
+void			fr_atomic_queue_free(fr_atomic_queue_t *aq);
 bool			fr_atomic_queue_push(fr_atomic_queue_t *aq, void *data);
 bool			fr_atomic_queue_pop(fr_atomic_queue_t *aq, void **p_data);
 size_t			fr_atomic_queue_size(fr_atomic_queue_t *aq);

--- a/src/lib/atomic_queue.c
+++ b/src/lib/atomic_queue.c
@@ -136,7 +136,7 @@ void fr_atomic_queue_free(fr_atomic_queue_t *aq)
 {
 	if (!aq) return;
 
-	talloc_free((aq->chunk);
+	talloc_free(aq->chunk);
 	aq = NULL;
 }
 

--- a/src/lib/atomic_queue.c
+++ b/src/lib/atomic_queue.c
@@ -132,12 +132,12 @@ fr_atomic_queue_t *fr_atomic_queue_alloc(TALLOC_CTX *ctx, size_t size)
  * This function is needed because the atomic queue memory
  * must be cache line aligned.
  */
-void fr_atomic_queue_free(fr_atomic_queue_t **aq)
+void fr_atomic_queue_free(fr_atomic_queue_t *aq)
 {
-	if (!*aq) return;
+	if (!aq) return;
 
-	talloc_free((*aq)->chunk);
-	*aq = NULL;
+	talloc_free((aq->chunk);
+	aq = NULL;
 }
 
 /** Push a pointer into the atomic queue

--- a/src/main/threads.c
+++ b/src/main/threads.c
@@ -1238,7 +1238,7 @@ void thread_pool_stop(void)
 
 	for (i = 0; i < NUM_FIFOS; i++) {
 #ifdef HAVE_STDATOMIC_H
-		talloc_free(thread_pool.queue[i]);
+		fr_atomic_queue_free(thread_pool.queue[i]);
 #else
 		fr_fifo_free(thread_pool.fifo[i]);
 #endif


### PR DESCRIPTION
thread_pool_stop() will free a TALLOC_CTX blob/chunk via fr_atomic_queue_free()