### PR TITLE
Remove dead code

### DIFF
--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -437,7 +437,6 @@ static unlang_action_t mod_map_proc(rlm_rcode_t *p_result, void *mod_inst, UNUSE
 	handle = fr_pool_connection_get(inst->pool, request);		/* connection pool should produce error */
 	if (!handle) {
 		RETURN_MODULE_FAIL;
-		goto finish;
 	}
 
 	rlm_sql_query_log(inst, request, NULL, query_str);


### PR DESCRIPTION
This particular case happens if fr_pool_connection_get() fails and is before (inst->driver->sql_fields)() makes fields point at allocated space, so it needn't goto finish.