### PR TITLE
TCP based connections have two (parent where server is listening and …

### DIFF
--- a/src/include/stats.h
+++ b/src/include/stats.h
@@ -80,7 +80,8 @@ void request_stats_reply(REQUEST *request);
 void radius_stats_ema(fr_stats_ema_t *ema,
 		      struct timeval *start, struct timeval *end);
 
-#define FR_STATS_INC(_x, _y) radius_ ## _x ## _stats._y++;if (listener) listener->stats._y++;if (client) client->_x._y++;
+#define FR_STATS_INC(_x, _y) radius_ ## _x ## _stats._y++;if (listener) listener->stats._y++;if (client) client->_x._y++;\
+	 if (listener && listener->parent) listener->parent->stats._y++;
 #define FR_STATS_TYPE_INC(_x) _x++
 
 #else  /* WITH_STATS */

--- a/src/main/stats.c
+++ b/src/main/stats.c
@@ -109,25 +109,29 @@ void request_stats_final(REQUEST *request)
 		return;
 
 #undef INC_AUTH
-#define INC_AUTH(_x) radius_auth_stats._x++;request->listener->stats._x++;request->client->auth._x++;
+#define INC_AUTH(_x) radius_auth_stats._x++;request->listener->stats._x++;request->client->auth._x++;\
+	if (request->listener->parent) {request->listener->parent->stats._x++;}
 
 #undef INC_ACCT
 #ifdef WITH_ACCOUNTING
-#define INC_ACCT(_x) radius_acct_stats._x++;request->listener->stats._x++;request->client->acct._x++
+#define INC_ACCT(_x) radius_acct_stats._x++;request->listener->stats._x++;request->client->acct._x++;\
+	if (request->listener->parent) {request->listener->parent->stats._x++;}
 #else
 #define INC_ACCT(_x)
 #endif
 
 #undef INC_COA
 #ifdef WITH_COA
-#define INC_COA(_x) radius_coa_stats._x++;request->listener->stats._x++;request->client->coa._x++
+#define INC_COA(_x) radius_coa_stats._x++;request->listener->stats._x++;request->client->coa._x++;\
+	if (request->listener->parent) {request->listener->parent->stats._x++;}
 #else
 #define INC_COA(_x)
 #endif
 
 #undef INC_DSC
 #ifdef WITH_DSC
-#define INC_DSC(_x) radius_dsc_stats._x++;request->listener->stats._x++;request->client->dsc._x++
+#define INC_DSC(_x) radius_dsc_stats._x++;request->listener->stats._x++;request->client->dsc._x++;\
+	if (request->listener->parent) {request->listener->parent->stats._x++;}
 #else
 #define INC_DSC(_x)
 #endif
@@ -745,6 +749,13 @@ void request_stats_reply(REQUEST *request)
 		 *	Not found: don't do anything
 		 */
 		this = listener_find_byipaddr(&ipaddr, server_port->vp_integer, IPPROTO_UDP);
+
+#ifdef WITH_TCP
+		if (!this) {
+		this = listener_find_byipaddr(&ipaddr, server_port->vp_integer, IPPROTO_TCP);
+		}
+#endif
+
 		if (!this) {
 			stats_error(request, "No such listener");
 			return;
@@ -819,6 +830,13 @@ void request_stats_reply(REQUEST *request)
 		 *	Not found: don't do anything
 		 */
 		home = home_server_find(&ipaddr, server_port->vp_integer, IPPROTO_UDP);
+
+#ifdef WITH_TCP
+		if (!home) {
+			home = home_server_find(&ipaddr, server_port->vp_integer, IPPROTO_TCP);
+		}
+#endif
+
 		if (!home) {
 			stats_error(request, "Failed to find home server IP");
 			return;


### PR DESCRIPTION
TCP based connections have two (parent where server is listening and ephemeral child were actual processing happens) unlike UDP. Stats need to update parent incase of TCP and also find socket to update didn't look  for TCP sockets. Addressed both these.