### PR TITLE
Include libfreeradius-control.so

### DIFF
--- a/debian/libfreeradius4.install
+++ b/debian/libfreeradius4.install
@@ -1,3 +1,4 @@
+usr/lib/freeradius/libfreeradius-control.so
 usr/lib/freeradius/libfreeradius-eap.so
 usr/lib/freeradius/libfreeradius-eap-aka-sim.so
 usr/lib/freeradius/libfreeradius-radius.so


### PR DESCRIPTION
This fixes the following error when `control-socket` site is enabled:

```
Error : Failed to link to module "proto_control_unix": libfreeradius-control.so: cannot open shared object file: No such file or directory
Error : Make sure it (and all its dependent libraries!) are in the search path of your system's ld
```