### PR TITLE
Get rid of gratuitous assignment of NULL to uri_vb

### DIFF
--- a/src/modules/rlm_rest/rlm_rest.c
+++ b/src/modules/rlm_rest/rlm_rest.c
@@ -453,7 +453,6 @@ static xlat_action_t rest_xlat(UNUSED TALLOC_CTX *ctx, UNUSED fr_dcursor_t *out,
 		 *	Move to next argument
 		 */
 		in_vb = fr_value_box_list_pop_head(in);
-		uri_vb = NULL;
 	} else {
 		section->method = REST_HTTP_METHOD_GET;
 	}


### PR DESCRIPTION
The next use is an assignment, so there's no point.