### PR TITLE
Enable hostname resolution: AWS ElastiCache returns hostnames in MOVED response

### DIFF
--- a/src/lib/redis/cluster.c
+++ b/src/lib/redis/cluster.c
@@ -470,7 +470,7 @@ static fr_redis_cluster_rcode_t cluster_node_conf_from_redirect(uint16_t *key_sl
 	}
 	p++;			/* Skip the ' ' */
 
-	if (fr_inet_pton_port(&ipaddr, &port, p, redirect->len - (p - redirect->str), AF_UNSPEC, false, true) < 0) {
+	if (fr_inet_pton_port(&ipaddr, &port, p, redirect->len - (p - redirect->str), AF_UNSPEC, true, true) < 0) {
 		return FR_REDIS_CLUSTER_RCODE_BAD_INPUT;
 	}
 	fr_assert(ipaddr.af);
@@ -536,14 +536,14 @@ static fr_redis_cluster_rcode_t cluster_map_apply(fr_redis_cluster_t *cluster, r
 #  define SET_ADDR(_addr, _map) \
 do { \
 	int _ret; \
-	_ret = fr_inet_pton(&_addr.inet.dst_ipaddr, _map->element[0]->str, _map->element[0]->len, AF_UNSPEC, false, true);\
+	_ret = fr_inet_pton(&_addr.inet.dst_ipaddr, _map->element[0]->str, _map->element[0]->len, AF_UNSPEC, true, true);\
 	fr_assert(_ret == 0);\
 	_addr.inet.dst_port = _map->element[1]->integer; \
 } while (0)
 #else
 #  define SET_ADDR(_addr, _map) \
 do { \
-	fr_inet_pton(&_addr.inet.dst_ipaddr, _map->element[0]->str, _map->element[0]->len, AF_UNSPEC, false, true);\
+	fr_inet_pton(&_addr.inet.dst_ipaddr, _map->element[0]->str, _map->element[0]->len, AF_UNSPEC, true, true);\
 	_addr.inet.dst_port = _map->element[1]->integer; \
 } while (0)
 #endif


### PR DESCRIPTION
Error is:

```
Debug : (0)      redis_ippool - Allocating lease from pool "naw01_citests01_VSAT-UT", to "00:a0:bd:11:22:33_00:a0:bd:11:22:33_0x00a0bd112233", expires in 120s
Debug : (0)      redis_ippool - Reserved connection (0)
Debug : (0)      redis_ippool - [1] >>> Sending command(s) to 127.0.0.1:6379
ERROR : (0)      redis_ippool - ERROR: (0) error   : MOVED 352 dev-citests01-dhcpdb-0001-001.dev-citests01-dhcpdb.oovb0g.usw2.cache.amazonaws.com:6379
Debug : (0)      redis_ippool - [1] <<< Returned: move
Info  : (0)      redis_ippool - Initiating cluster remap
Debug : (0)      redis_ippool - : Not IPv4/6 address, and asked not to resolve
Debug : (0)      redis_ippool - Released connection (0)
Info  : (0)      redis_ippool - Need 3 more connections to reach min connections (4)
Debug : (0)      redis_ippool - Opening additional connection (1), 1 of 3 pending slots used
Debug : rlm_redis (redis) - [1] Connecting to node 127.0.0.1:6379
Debug : (0)      redis_ippool - [1] Processing redirect "MOVED 352 dev-citests01-dhcpdb-0001-001.dev-citests01-dhcpdb.oovb0g.usw2.cache.amazonaws.com:6379"
Debug : (0)      redis_ippool (fail)
```