### PR TITLE
Attempt to fix assert

### DIFF
--- a/src/main/threads.c
+++ b/src/main/threads.c
@@ -253,7 +253,7 @@ static pthread_mutex_t *ssl_mutexes = NULL;
 
 static void ssl_locking_function(int mode, int n, UNUSED char const *file, UNUSED int line)
 {
-	rad_assert(ssl_mutexes[n] != NULL);
+	rad_assert(&ssl_mutexes[n] != NULL);
 
 	if (mode & CRYPTO_LOCK) {
 		pthread_mutex_lock(&ssl_mutexes[n]);


### PR DESCRIPTION
Hello

I am trying to fix this error during compilation.

I guess the idea was to check that &ssl_mutexes[n] is initialized 

```
In file included from src/main/threads.c:34:0:
src/main/threads.c: In function 'ssl_locking_function':
src/main/threads.c:256:28: error: invalid operands to binary != (have
'pthread_mutex_t {aka union <anonymous>}' and 'void *')
  rad_assert(ssl_mutexes[n] != NULL);
             ~~~~~~~~~~~~~~ ^
src/freeradius-devel/rad_assert.h:38:13: note: in definition of macro
'rad_assert'
   ((void) ((expr) ? (void) 0 : \
             ^~~~
make: *** [build/objs/src/main/threads.lo] Error 1
```