### PR TITLE
v4: Use PyConfig structure to initialise Python interpreter

### DIFF
--- a/raddb/global.d/python
+++ b/raddb/global.d/python
@@ -1,0 +1,17 @@
+python {
+	#
+	#  path::
+	#
+	#  The search path for Python modules.  It must include the path to your
+	#  Python module.
+	#
+#	path = ${modconfdir}/${.:name}
+
+	#
+	#  path_include_default::
+	#
+	#  If "yes", retain the default search path.  Any additional search
+	#  path components will be prepended to the the default search path.
+	#
+#	path_include_default = "yes"
+}

--- a/raddb/mods-available/python
+++ b/raddb/mods-available/python
@@ -33,34 +33,6 @@ python {
 	module = example
 
 	#
-	#  cext_compat::
-	#
-	#  Uncomment the following line (and set to true) if you need
-	#  to call Python C extensions that acquire the GIL.
-	#
-	#  This will use the first Python interpreter (*not a sub-interpreter*)
-	#  to provide the execution environment for this module instance.
-	#
-	#  The tradeoff is, that any module instance with `cext_compat = true`,
-	#  will share the same environment, and will use the same user
-	#  configurable configuration items, and `python_path`, as the first
-	#  instance of `rlm_python` to be loaded with `cext_compat` enabled.
-	#
-	#  Not all Python functions use the GIL as it prevents parallel
-	#  execution.  A good indication of whether `cext_compat` is needed
-	#  is whether your script locks up or crashes when calling a
-	#  Python C extension.
-	#
-	#  [NOTE]
-	#  ====
-	#  This functionality is only available when building with Python 2.7
-	#  or below.  For Python 3 you should build against Python 3.8 which
-	#  has a proper fix for this issue (per interpreter GILs)
-	#  ====
-	#
-#	cext_compat = false
-
-	#
 	#  [NOTE]
 	#  ====
 	#  * You may set `mod_<section>` for any of the section to module

--- a/raddb/mods-available/python
+++ b/raddb/mods-available/python
@@ -61,29 +61,6 @@ python {
 #	cext_compat = false
 
 	#
-	#  python_path::
-	#
-	#  The search path for Python modules.  It must include the path to your
-	#  Python module.
-	#
-#	python_path = ${modconfdir}/${.:name}
-
-	#
-	#  python_path_include_conf_dir::
-	#
-	#  If "yes", include the directory containing this file in Python's
-	#  module search path.
-	#
-#	python_path_include_conf_dir = "yes"
-
-	#
-	#  python_path_include_default::
-	#
-	#  If "yes", retain the default search path.  Any additional search
-	#  path components will be prepended to the the default search path.
-	#
-#	python_path_include_default = "yes"
-	#
 	#  [NOTE]
 	#  ====
 	#  * You may set `mod_<section>` for any of the section to module

--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -364,8 +364,13 @@ This plugin provides Perl support for the FreeRADIUS server project.
 Summary: Python support for FreeRADIUS
 Group: System Environment/Daemons
 Requires: %{name}%{?_isa} = %{version}-%{release}
+%if 0%{?rhel} < 9
+Requires: python38
+BuildRequires: python38-devel
+%else
 Requires: python3
 BuildRequires: python3-devel
+%endif
 
 %description python
 This plugin provides Python support for the FreeRADIUS server project.

--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -94,7 +94,6 @@ static PyThreadState		*global_interpreter;	//!< Our first interpreter.
 
 static module_ctx_t const	*current_mctx;		//!< Used for communication with inittab functions.
 static CONF_SECTION		*current_conf;		//!< Used for communication with inittab functions.
-static char			*default_path;		//!< The default python path.
 
 static libpython_global_config_t libpython_global_config = {
 	.path = NULL,
@@ -1065,6 +1064,7 @@ static int libpython_init(void)
 	PyConfig	config;
 	PyStatus	status;
 	wchar_t		*wide_name;
+	char		*path;
 
 	fr_assert(!Py_IsInitialized());
 
@@ -1133,10 +1133,11 @@ static int libpython_init(void)
 	PyConfig_Clear(&config);
 
 	/*
-	 *	Get the default search path so we can append to it.
+	 *	Report the path
 	 */
-	default_path = Py_EncodeLocale(Py_GetPath(), NULL);
-	LOAD_INFO("Python path set to \"%s\"", default_path);
+	path = Py_EncodeLocale(Py_GetPath(), NULL);
+	LOAD_INFO("Python path set to \"%s\"", path);
+	PyMem_Free(path);
 
 	global_interpreter = PyEval_SaveThread();	/* Store reference to the main interpreter and release the GIL */
 
@@ -1146,7 +1147,6 @@ static int libpython_init(void)
 static void libpython_free(void)
 {
 	PyThreadState_Swap(global_interpreter); /* Swap to the main thread */
-	if (default_path) PyMem_Free(default_path);
 
 	/*
 	 *	PyImport_Cleanup - Leaks memory in python 3.6

--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -57,11 +57,6 @@ typedef struct {
 typedef struct {
 	char const	*name;			//!< Name of the module instance
 	PyThreadState	*interpreter;		//!< The interpreter used for this instance of rlm_python.
-	char const	*python_path;		//!< Path to search for python files in.
-	bool		python_path_include_conf_dir;	//!< Include the directory of the current
-							///< rlm_python module config in the python path.
-	bool		python_path_include_default;	//!< Include the default python path
-							///< in the python path.
 	PyObject	*module;		//!< Local, interpreter specific module.
 
 	python_func_def_t
@@ -164,10 +159,6 @@ static CONF_PARSER module_config[] = {
 	A(detach)
 
 #undef A
-
-	{ FR_CONF_OFFSET("python_path", FR_TYPE_STRING, rlm_python_t, python_path) },
-	{ FR_CONF_OFFSET("python_path_include_conf_dir", FR_TYPE_BOOL, rlm_python_t, python_path_include_conf_dir), .dflt = "yes" },
-	{ FR_CONF_OFFSET("python_path_include_default", FR_TYPE_BOOL, rlm_python_t, python_path_include_default), .dflt = "yes" },
 
 	CONF_PARSER_TERMINATOR
 };

--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -1094,13 +1094,6 @@ static int mod_load(void)
 	default_path = Py_EncodeLocale(Py_GetPath(), NULL);
 
 	/*
-	 *	As of 3.7 this is called by Py_Initialize
-	 */
-#if PY_VERSION_HEX < 0x03070000
-	PyEval_InitThreads(); 			/* This also grabs a lock (which we then need to release) */
-#endif
-
-	/*
 	 *	Set program name (i.e. the software calling the interpreter)
 	 */
 	{

--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -112,9 +112,14 @@ static CONF_PARSER const python_global_config[] = {
 	CONF_PARSER_TERMINATOR
 };
 
+static int libpython_init(void);
+static void libpython_free(void);
+
 global_lib_autoinst_t rlm_python_autoinst = {
 	.name = "python",
 	.config = python_global_config,
+	.init = libpython_init,
+	.free = libpython_free,
 	.inst = &libpython_global_config
 };
 
@@ -1087,7 +1092,7 @@ static int mod_thread_detach(module_thread_inst_ctx_t const *mctx)
 	return 0;
 }
 
-static int mod_load(void)
+static int libpython_init(void)
 {
 #define LOAD_INFO(_fmt, ...) fr_log(LOG_DST, L_INFO, __FILE__, __LINE__, "rlm_python - " _fmt,  ## __VA_ARGS__)
 #define LOAD_WARN(_fmt, ...) fr_log_perror(LOG_DST, L_WARN, __FILE__, __LINE__, \
@@ -1138,7 +1143,7 @@ static int mod_load(void)
 	return 0;
 }
 
-static void mod_unload(void)
+static void libpython_free(void)
 {
 	PyThreadState_Swap(global_interpreter); /* Swap to the main thread */
 	if (default_path) PyMem_Free(default_path);
@@ -1172,8 +1177,6 @@ module_rlm_t rlm_python = {
 		.thread_inst_size	= sizeof(rlm_python_thread_t),
 
 		.config			= module_config,
-		.onload			= mod_load,
-		.unload			= mod_unload,
 
 		.instantiate		= mod_instantiate,
 		.detach			= mod_detach,

--- a/src/modules/rlm_python/rlm_python.c
+++ b/src/modules/rlm_python/rlm_python.c
@@ -77,6 +77,14 @@ typedef struct {
 						//!< made available to the python script.
 } rlm_python_t;
 
+/** Global config for python library
+ *
+ */
+typedef struct {
+	char const	*path;			//!< Path to search for python files in.
+	bool		path_include_default;	//!< Include the default python path in `path`
+} libpython_global_config_t;
+
 /** Tracks a python module inst/thread state pair
  *
  * Multiple instances of python create multiple interpreters and each
@@ -92,6 +100,29 @@ static PyThreadState		*global_interpreter;	//!< Our first interpreter.
 static module_ctx_t const	*current_mctx;		//!< Used for communication with inittab functions.
 static CONF_SECTION		*current_conf;		//!< Used for communication with inittab functions.
 static char			*default_path;		//!< The default python path.
+
+static libpython_global_config_t libpython_global_config = {
+	.path = NULL,
+	.path_include_default = true
+};
+
+static CONF_PARSER const python_global_config[] = {
+	{ FR_CONF_OFFSET("path", FR_TYPE_STRING, libpython_global_config_t, path) },
+	{ FR_CONF_OFFSET("path_include_default", FR_TYPE_BOOL, libpython_global_config_t, path_include_default) },
+	CONF_PARSER_TERMINATOR
+};
+
+global_lib_autoinst_t rlm_python_autoinst = {
+	.name = "python",
+	.config = python_global_config,
+	.inst = &libpython_global_config
+};
+
+extern global_lib_autoinst_t const * const rlm_python_lib[];
+global_lib_autoinst_t const * const rlm_python_lib[] = {
+	&rlm_python_autoinst,
+	GLOBAL_LIB_TERMINATOR
+};
 
 /*
  *	As of Python 3.8 the GIL will be per-interpreter


### PR DESCRIPTION
Makes minimum Python version 3.8

Path setting becomes part of a global library setting rather than per module instance.
This also deals with the functions (PySys_SetPath and Py_SetProgramName) being deprecated in Python 3.11