### PR TITLE
Skip recursive _raddict_export() call if children == NULL

### DIFF
--- a/src/bin/radict.c
+++ b/src/bin/radict.c
@@ -263,11 +263,12 @@ static void _raddict_export(fr_dict_t const *dict, uint64_t *count, uintptr_t *l
 	 *	Todo - Should be fixed to use attribute walking API
 	 */
 	children = dict_attr_children(da);
-	len = talloc_array_length(children);
-	for (i = 0; i < len; i++) {
-		/* coverity[dereference] */
-		for (p = children[i]; p; p = p->next) {
-			_raddict_export(dict, count, low, high, p, lvl + 1);
+	if (children) {
+		len = talloc_array_length(children);
+		for (i = 0; i < len; i++) {
+			for (p = children[i]; p; p = p->next) {
+				_raddict_export(dict, count, low, high, p, lvl + 1);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Arguably a redundant test, but the alternative would be to model talloc_array_length() to make clear to coverity that it returns zero if handed NULL, and we're not sure that modeling functions can check their parameters.