### PR TITLE
Pull check for non-NULL randle after check for NULL randle

### DIFF
--- a/src/modules/rlm_imap/rlm_imap.c
+++ b/src/modules/rlm_imap/rlm_imap.c
@@ -177,7 +177,6 @@ static unlang_action_t CC_HINT(nonnull(1,2)) mod_authenticate(rlm_rcode_t *p_res
 
 	randle = imap_slab_reserve(t->slab);
 	if (!randle){
-		if (randle) imap_slab_release(randle);
 		RETURN_MODULE_FAIL;
 	}
 


### PR DESCRIPTION
randle is local to mod_authenticate(), so in the then clause of an if checking for randle being NULL, randle won't be non-NULL.