### PR TITLE
Remove unused variable

### DIFF
--- a/src/lib/tls/ctx.c
+++ b/src/lib/tls/ctx.c
@@ -612,7 +612,6 @@ SSL_CTX *fr_tls_ctx_alloc(fr_tls_conf_t const *conf, bool client)
 	SSL_CTX		*ctx;
 	X509_STORE	*cert_vpstore;
 	X509_STORE	*verify_store;
-	int		verify_mode = SSL_VERIFY_NONE;
 	int		ctx_options = 0;
 
 	ctx = SSL_CTX_new(TLS_method());


### PR DESCRIPTION
It fixes:

```
src/lib/tls/ctx.c:615:7: error: unused variable 'verify_mode' [-Werror,-Wunused-variable]
        int             verify_mode = SSL_VERIFY_NONE;
                        ^
1 error generated.
make: *** [scripts/boiler.mk:737: build/objs/src/lib/tls/ctx.lo] Error 1
```