### PR TITLE
fix compiler warnings when WITH_TCP id not defined

### DIFF
--- a/src/main/listen.c
+++ b/src/main/listen.c
@@ -3205,7 +3205,9 @@ static rad_listen_t *listen_parse(CONF_SECTION *cs, char const *server)
 	char const	*value;
 	fr_dlhandle	handle;
 	CONF_SECTION	*server_cs;
+#ifdef WITH_TCP
 	char const	*p;
+#endif
 	char		buffer[32];
 
 	cp = cf_pair_find(cs, "type");

--- a/src/main/process.c
+++ b/src/main/process.c
@@ -5394,7 +5394,9 @@ static void event_new_fd(rad_listen_t *this)
 		this->print(this, buffer, sizeof(buffer));
 		ERROR("Failed adding event handler for socket %s: %s", buffer, fr_strerror());
 		this->status = RAD_LISTEN_STATUS_EOL;
+	#ifdef WITH_TCP
 		goto listener_is_eol;
+	#endif
 	} /* end of INIT */
 
 	if (this->status == RAD_LISTEN_STATUS_PAUSE) {


### PR DESCRIPTION
Fix some compiler warnings here.