### PR TITLE
Fix wrong ifdef

### DIFF
--- a/src/lib/util/event.c
+++ b/src/lib/util/event.c
@@ -92,7 +92,7 @@ static fr_table_num_sorted_t const kevent_filter_table[] = {
 };
 static size_t kevent_filter_table_len = NUM_ELEMENTS(kevent_filter_table);
 
-#ifdef __linux__
+#ifdef EVFILT_LIBKQUEUE
 static int log_conf_kq;
 #endif
 


### PR DESCRIPTION
... It should be only when build with EVFILT_LIBKQUEUE

Fixing the below _unused_ warning on Linux

```
src/lib/util/event.c:96:12: error: unused variable 'log_conf_kq' [-Werror,-Wunused-variable]
static int log_conf_kq;
           ^
1 error generated.
make: *** [scripts/boiler.mk:737: build/objs/src/lib/util/event.lo] Error 1
```