### PR TITLE
Rewrite udp_len check in fr_udp_header_check() for coverity (CID #150…

### DIFF
--- a/src/lib/util/net.c
+++ b/src/lib/util/net.c
@@ -70,22 +70,22 @@ size_t fr_net_af_table_len = NUM_ELEMENTS(fr_net_af_table);
 	 *	UDP header validation.
 	 */
 	uint16_t udp_len;
-	ssize_t diff;
+	ssize_t actual_len;
 	uint16_t expected;
 
 	udp = (udp_header_t const *)data;
 	udp_len = ntohs(udp->len);
-	diff = udp_len - remaining;
+	actual_len = remaining;
 	/* Truncated data */
-	if (diff > 0) {
+	if (udp_len > actual_len) {
 		fr_strerror_printf("packet too small by %zi bytes, UDP header + Payload should be %hu bytes",
-				   diff, udp_len);
+				   (udp_len - actual_len), udp_len);
 		return -1;
 	}
 	/* Trailing data */
-	else if (diff < 0) {
+	else if (udp_len < actual_len) {
 		fr_strerror_printf("Packet too big by %zi bytes, UDP header + Payload should be %hu bytes",
-				   diff * -1, udp_len);
+				   (actual_len - udp_len), udp_len);
 		return -1;
 	}
 


### PR DESCRIPTION
…4068)

It wasn't practical to write a single UDP header check function, so the change to make coverity see that udp_len is valid has to be there twice.