### PR TITLE
redis_ippool: Do not die if call env initialization failed

### DIFF
--- a/src/modules/rlm_redis_ippool/rlm_redis_ippool.c
+++ b/src/modules/rlm_redis_ippool/rlm_redis_ippool.c
@@ -696,7 +696,7 @@ static ippool_rcode_t redis_ippool_allocate(rlm_redis_ippool_t const *inst, requ
 	/*
 	 *	Process IP address
 	 */
-	if (reply->elements > 1) {
+	if (env->allocated_address_attr && reply->elements > 1) {
 		tmpl_t ip_rhs;
 		map_t ip_map = {
 			.lhs = env->allocated_address_attr,
@@ -752,7 +752,7 @@ static ippool_rcode_t redis_ippool_allocate(rlm_redis_ippool_t const *inst, requ
 	/*
 	 *	Process Range identifier
 	 */
-	if (reply->elements > 2) {
+	if (env->range_attr && reply->elements > 2) {
 		switch (reply->element[2]->type) {
 		/*
 		 *	Add range ID to request


### PR DESCRIPTION
In our scenario `lease_time` is defined as

```
lease_time = &reply.IP-Address-Lease-Time
```

`reply.IP-Address-Lease-Time` can be undefined (due to misconfiguration or other reasons) and previously radiusd handled this case gracefully (did not die). Now it dies as follows:

```
(0)      ERROR: Failed to evaluate required module option lease_time
(0)      redis_ippool - Allocating lease from pool "naw01_healthcheck_VSAT-UT", to "01:01:bc:11:22:33_01:01:bc:11:22:33_0x0101bc112233", expires in 120s
(0)      redis_ippool - Reserved connection (0)
(0)      redis_ippool - [1] >>> Sending command(s) to 10.43.16.115:6379
(0)      redis_ippool - [1] <<< Returned: success
(0)      redis_ippool - Released connection (0)
CAUGHT SIGNAL: Segmentation fault
No panic action set
```

This happens due to call env not fully initialized (after ERROR:) but then `redis_ippool_allocate()` tries to use uninitialized (NULL) call env attribues (`allocated_address_attr` in this particular scenario) and dies.