### PR TITLE
Attempt to placate coverity about fr_value_box_init() (CID #1508484)

### DIFF
--- a/src/lib/util/value.h
+++ b/src/lib/util/value.h
@@ -411,11 +411,11 @@ static inline CC_HINT(nonnull(1), always_inline)
 void fr_value_box_init(fr_value_box_t *vb, fr_type_t type, fr_dict_attr_t const *enumv, bool tainted)
 {
 	/* coverity[store_writes_const_field] */
-	memcpy(vb, &(fr_value_box_t){
+	memcpy((void *) vb, &(fr_value_box_t){
 	       		.type = type,
 			.enumv = enumv,
 			.tainted = tainted
-	       }, sizeof(*vb));
+		}, sizeof(*vb));
 	fr_value_box_list_entry_init(vb);
 
 	/*


### PR DESCRIPTION
An fr_value_box_t has some members with const-qualified type. The only way one can assign to it in this context is with an initializer, which doesn't make sense here, hence the memcpy(). That makes the compilers happy, but coverity notices that vp points at an fr_value_box_t and considers it a defect, even though it's all we can do.

In a similar situation elsewhere, coverity notices a parameter cast from void * to pointer to some structure type. It notices it, calls it "downcasting" (odd for a non-OOP language) and considers the allegedly pointed-at structure as tainted--perhaps alignment issues? We'll attempt a cast to void *,  and see whether coverity will notice how it started out and still complain.