### PR TITLE
Add new unit load tests for dhcpv4

### DIFF
--- a/src/tests/unit/protocols/dhcpv4/PRIV_bootp-both_overload.txt
+++ b/src/tests/unit/protocols/dhcpv4/PRIV_bootp-both_overload.txt
@@ -1,0 +1,39 @@
+#  -*- text -*-
+#
+#  Based on PRIV_bootp-both_overload.pcap from Wireshark
+#
+#  $ wget https://wiki.wireshark.org/uploads/__moin_import__/attachments/SampleCaptures/PRIV_bootp-both_overload_empty-no_end.pcap
+#  $ ./scripts//util/pcap2decode-proto.py  -f PRIV_bootp-both_overload.pcap -p dhcpv4 > src/tests/unit/protocols/dhcpv4/PRIV_bootp-both_overload.txt
+#
+
+proto dhcpv4
+proto-dictionary dhcpv4
+
+#
+#  1.
+#
+# [ BOOTP ]
+#   op        = BOOTREQUEST
+#   htype     = Ethernet (10Mb)
+#   hlen      = 6
+#   hops      = 0
+#   xid       = 0xac2effff
+#   secs      = 0
+#   flags     =
+#   ciaddr    = 0.0.0.0
+#   yiaddr    = 0.0.0.0
+#   siaddr    = 0.0.0.0
+#   giaddr    = 0.0.0.0
+#   chaddr    = 00:00:6c:82:dc:4e (+ 10 nul pad)
+#   sname     = '8\x14sname field overload\\xff'
+#   file      = '8\x18file name field overload\\xff'
+#   options   = b'c\x82Sc' (DHCP magic)
+# [ DHCP options ]
+#    options   = [message-type=discover max_dhcp_size=590 param_req_list=[1, 28, 3, 43] lease_time=3600 dhcp-option-overload=3 error_message=b'Padding' pad client_id='\x01\x00\x00l\\x82\\xdcN' end]
+#
+decode-proto 01 01 06 00 ac 2e ff ff 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 6c 82 dc 4e 00 00 00 00 00 00 00 00 00 00 38 14 73 6e 61 6d 65 20 66 69 65 6c 64 20 6f 76 65 72 6c 6f 61 64 ff 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 38 18 66 69 6c 65 20 6e 61 6d 65 20 66 69 65 6c 64 20 6f 76 65 72 6c 6f 61 64 ff 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 63 82 53 63 35 01 01 39 02 02 4e 37 04 01 1c 03 2b 33 04 00 00 0e 10 34 01 03 38 07 50 61 64 64 69 6e 67 00 3d 07 01 00 00 6c 82 dc 4e ff
+match Opcode = Client-Message, Hardware-Type = Ethernet, Hardware-Address-Length = 6, Hop-Count = 0, Transaction-Id = 2888761343, Number-of-Seconds = 0, Flags = 0, Client-IP-Address = 0.0.0.0, Your-IP-Address = 0.0.0.0, Server-IP-Address = 0.0.0.0, Gateway-IP-Address = 0.0.0.0, Client-Hardware-Address = 00:00:6c:82:dc:4e, Message-Type = Discover, Maximum-Msg-Size = 590, Parameter-Request-List = Subnet-Mask, Parameter-Request-List = Broadcast-Address, Parameter-Request-List = Router-Address, Parameter-Request-List = Vendor, IP-Address-Lease-Time = 3600, Overload = 3, Error-Message = "Padding", Error-Message = "sname field overload", Error-Message = "file name field overload", Network-Subnet = 0.0.0.0/32
+
+count
+match 4
+

--- a/src/tests/unit/protocols/dhcpv4/PRIV_bootp-both_overload_empty-no_end.txt
+++ b/src/tests/unit/protocols/dhcpv4/PRIV_bootp-both_overload_empty-no_end.txt
@@ -1,0 +1,39 @@
+#  -*- text -*-
+#
+#  Based on PRIV_bootp-both_overload_empty-no_end.pcap from Wireshark
+#
+#  $ wget https://wiki.wireshark.org/uploads/__moin_import__/attachments/SampleCaptures/PRIV_bootp-both_overload_empty-no_end.pcap
+#  $ ./scripts//util/pcap2decode-proto.py  -f PRIV_bootp-both_overload_empty-no_end.pcap -p dhcpv4 > src/tests/unit/protocols/dhcpv4/PRIV_bootp-both_overload_empty-no_end.txt
+#
+
+proto dhcpv4
+proto-dictionary dhcpv4
+
+#
+#  1.
+#
+# [ BOOTP ]
+#   op        = BOOTREQUEST
+#   htype     = Ethernet (10Mb)
+#   hlen      = 6
+#   hops      = 0
+#   xid       = 0xac2effff
+#   secs      = 0
+#   flags     =
+#   ciaddr    = 0.0.0.0
+#   yiaddr    = 0.0.0.0
+#   siaddr    = 0.0.0.0
+#   giaddr    = 0.0.0.0
+#   chaddr    = 00:00:6c:82:dc:4e (+ 10 nul pad)
+#   sname     = ''
+#   file      = ''
+#   options   = b'c\x82Sc' (DHCP magic)
+# [ DHCP options ]
+#    options   = [message-type=discover max_dhcp_size=590 param_req_list=[1, 28, 3, 43] lease_time=3600 dhcp-option-overload=3 error_message=b'Padding' pad client_id='\x01\x00\x00l\\x82\\xdcN' pad]
+#
+decode-proto 01 01 06 00 ac 2e ff ff 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 6c 82 dc 4e 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 63 82 53 63 35 01 01 39 02 02 4e 37 04 01 1c 03 2b 33 04 00 00 0e 10 34 01 03 38 07 50 61 64 64 69 6e 67 00 3d 07 01 00 00 6c 82 dc 4e 00
+match Opcode = Client-Message, Hardware-Type = Ethernet, Hardware-Address-Length = 6, Hop-Count = 0, Transaction-Id = 2888761343, Number-of-Seconds = 0, Flags = 0, Client-IP-Address = 0.0.0.0, Your-IP-Address = 0.0.0.0, Server-IP-Address = 0.0.0.0, Gateway-IP-Address = 0.0.0.0, Client-Hardware-Address = 00:00:6c:82:dc:4e, Message-Type = Discover, Maximum-Msg-Size = 590, Parameter-Request-List = Subnet-Mask, Parameter-Request-List = Broadcast-Address, Parameter-Request-List = Router-Address, Parameter-Request-List = Vendor, IP-Address-Lease-Time = 3600, Overload = 3, Error-Message = "Padding", Network-Subnet = 0.0.0.0/32
+
+count
+match 4
+

--- a/src/tests/unit/protocols/dhcpv4/client-server.txt
+++ b/src/tests/unit/protocols/dhcpv4/client-server.txt
@@ -1,0 +1,114 @@
+#  -*- text -*-
+#
+#  Based on dhcp.pcap from Wireshark
+#
+#  $ wget https://wiki.wireshark.org/uploads/__moin_import__/attachments/SampleCaptures/dhcp.pcap
+#  $ ./scripts//util/pcap2decode-proto.py  -f dhcp.pcap -p dhcpv4 > src/tests/unit/protocols/dhcpv4/client-server.txt
+#
+
+proto dhcpv4
+proto-dictionary dhcpv4
+
+#
+#  1.
+#
+# [ BOOTP ]
+#   op        = BOOTREQUEST
+#   htype     = Ethernet (10Mb)
+#   hlen      = 6
+#   hops      = 0
+#   xid       = 0x3d1d
+#   secs      = 0
+#   flags     =
+#   ciaddr    = 0.0.0.0
+#   yiaddr    = 0.0.0.0
+#   siaddr    = 0.0.0.0
+#   giaddr    = 0.0.0.0
+#   chaddr    = 00:0b:82:01:fc:42 (+ 10 nul pad)
+#   sname     = ''
+#   file      = ''
+#   options   = b'c\x82Sc' (DHCP magic)
+# [ DHCP options ]
+#    options   = [message-type=discover client_id='\x01\x00\x0b\\x82\x01\\xfcB' requested_addr=0.0.0.0 param_req_list=[1, 3, 6, 42] end pad pad pad pad pad pad pad]
+#
+decode-proto 01 01 06 00 00 00 3d 1d 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 0b 82 01 fc 42 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 63 82 53 63 35 01 01 3d 07 01 00 0b 82 01 fc 42 32 04 00 00 00 00 37 04 01 03 06 2a ff 00 00 00 00 00 00 00
+match Opcode = Client-Message, Hardware-Type = Ethernet, Hardware-Address-Length = 6, Hop-Count = 0, Transaction-Id = 15645, Number-of-Seconds = 0, Flags = 0, Client-IP-Address = 0.0.0.0, Your-IP-Address = 0.0.0.0, Server-IP-Address = 0.0.0.0, Gateway-IP-Address = 0.0.0.0, Client-Hardware-Address = 00:0b:82:01:fc:42, Message-Type = Discover, Client-Identifier = 0x01000b8201fc42, Requested-IP-Address = 0.0.0.0, Parameter-Request-List = Subnet-Mask, Parameter-Request-List = Router-Address, Parameter-Request-List = Domain-Name-Server, Parameter-Request-List = NTP-Servers, Network-Subnet = 0.0.0.0/32
+
+#
+#  2.
+#
+# [ BOOTP ]
+#   op        = BOOTREPLY
+#   htype     = Ethernet (10Mb)
+#   hlen      = 6
+#   hops      = 0
+#   xid       = 0x3d1d
+#   secs      = 0
+#   flags     =
+#   ciaddr    = 0.0.0.0
+#   yiaddr    = 192.168.0.10
+#   siaddr    = 192.168.0.1
+#   giaddr    = 0.0.0.0
+#   chaddr    = 00:0b:82:01:fc:42 (+ 10 nul pad)
+#   sname     = ''
+#   file      = ''
+#   options   = b'c\x82Sc' (DHCP magic)
+# [ DHCP options ]
+#    options   = [message-type=offer subnet_mask=255.255.255.0 renewal_time=1800 rebinding_time=3150 lease_time=3600 server_id=192.168.0.1 end pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad]
+#
+decode-proto 02 01 06 00 00 00 3d 1d 00 00 00 00 00 00 00 00 c0 a8 00 0a c0 a8 00 01 00 00 00 00 00 0b 82 01 fc 42 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 63 82 53 63 35 01 02 01 04 ff ff ff 00 3a 04 00 00 07 08 3b 04 00 00 0c 4e 33 04 00 00 0e 10 36 04 c0 a8 00 01 ff 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+match Opcode = Server-Message, Hardware-Type = Ethernet, Hardware-Address-Length = 6, Hop-Count = 0, Transaction-Id = 15645, Number-of-Seconds = 0, Flags = 0, Client-IP-Address = 0.0.0.0, Your-IP-Address = 192.168.0.10, Server-IP-Address = 192.168.0.1, Gateway-IP-Address = 0.0.0.0, Client-Hardware-Address = 00:0b:82:01:fc:42, Message-Type = Offer, Subnet-Mask = 255.255.255.0, Renewal-Time = 1800, Rebinding-Time = 3150, IP-Address-Lease-Time = 3600, Server-Identifier = 192.168.0.1, Network-Subnet = 0.0.0.0/32
+
+#
+#  3.
+#
+# [ BOOTP ]
+#   op        = BOOTREQUEST
+#   htype     = Ethernet (10Mb)
+#   hlen      = 6
+#   hops      = 0
+#   xid       = 0x3d1e
+#   secs      = 0
+#   flags     =
+#   ciaddr    = 0.0.0.0
+#   yiaddr    = 0.0.0.0
+#   siaddr    = 0.0.0.0
+#   giaddr    = 0.0.0.0
+#   chaddr    = 00:0b:82:01:fc:42 (+ 10 nul pad)
+#   sname     = ''
+#   file      = ''
+#   options   = b'c\x82Sc' (DHCP magic)
+# [ DHCP options ]
+#    options   = [message-type=request client_id='\x01\x00\x0b\\x82\x01\\xfcB' requested_addr=192.168.0.10 server_id=192.168.0.1 param_req_list=[1, 3, 6, 42] end pad]
+#
+decode-proto 01 01 06 00 00 00 3d 1e 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 0b 82 01 fc 42 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 63 82 53 63 35 01 03 3d 07 01 00 0b 82 01 fc 42 32 04 c0 a8 00 0a 36 04 c0 a8 00 01 37 04 01 03 06 2a ff 00
+match Opcode = Client-Message, Hardware-Type = Ethernet, Hardware-Address-Length = 6, Hop-Count = 0, Transaction-Id = 15646, Number-of-Seconds = 0, Flags = 0, Client-IP-Address = 0.0.0.0, Your-IP-Address = 0.0.0.0, Server-IP-Address = 0.0.0.0, Gateway-IP-Address = 0.0.0.0, Client-Hardware-Address = 00:0b:82:01:fc:42, Message-Type = Request, Client-Identifier = 0x01000b8201fc42, Requested-IP-Address = 192.168.0.10, Server-Identifier = 192.168.0.1, Parameter-Request-List = Subnet-Mask, Parameter-Request-List = Router-Address, Parameter-Request-List = Domain-Name-Server, Parameter-Request-List = NTP-Servers, Network-Subnet = 0.0.0.0/32
+
+#
+#  4.
+#
+# [ BOOTP ]
+#   op        = BOOTREPLY
+#   htype     = Ethernet (10Mb)
+#   hlen      = 6
+#   hops      = 0
+#   xid       = 0x3d1e
+#   secs      = 0
+#   flags     =
+#   ciaddr    = 0.0.0.0
+#   yiaddr    = 192.168.0.10
+#   siaddr    = 0.0.0.0
+#   giaddr    = 0.0.0.0
+#   chaddr    = 00:0b:82:01:fc:42 (+ 10 nul pad)
+#   sname     = ''
+#   file      = ''
+#   options   = b'c\x82Sc' (DHCP magic)
+# [ DHCP options ]
+#    options   = [message-type=ack renewal_time=1800 rebinding_time=3150 lease_time=3600 server_id=192.168.0.1 subnet_mask=255.255.255.0 end pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad]
+#
+decode-proto 02 01 06 00 00 00 3d 1e 00 00 00 00 00 00 00 00 c0 a8 00 0a 00 00 00 00 00 00 00 00 00 0b 82 01 fc 42 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 63 82 53 63 35 01 05 3a 04 00 00 07 08 3b 04 00 00 0c 4e 33 04 00 00 0e 10 36 04 c0 a8 00 01 01 04 ff ff ff 00 ff 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+match Opcode = Server-Message, Hardware-Type = Ethernet, Hardware-Address-Length = 6, Hop-Count = 0, Transaction-Id = 15646, Number-of-Seconds = 0, Flags = 0, Client-IP-Address = 0.0.0.0, Your-IP-Address = 192.168.0.10, Server-IP-Address = 0.0.0.0, Gateway-IP-Address = 0.0.0.0, Client-Hardware-Address = 00:0b:82:01:fc:42, Message-Type = Ack, Renewal-Time = 1800, Rebinding-Time = 3150, IP-Address-Lease-Time = 3600, Server-Identifier = 192.168.0.1, Subnet-Mask = 255.255.255.0, Network-Subnet = 0.0.0.0/32
+
+count
+match 10
+

--- a/src/tests/unit/protocols/dhcpv4/dhcp-auth.txt
+++ b/src/tests/unit/protocols/dhcpv4/dhcp-auth.txt
@@ -1,0 +1,39 @@
+#  -*- text -*-
+#
+#  Based on dhcp-auth.pcap from Wireshark
+#
+#  $ wget https://wiki.wireshark.org/uploads/__moin_import__/attachments/SampleCaptures/dhcp-auth.pcap
+#  $ ./scripts//util/pcap2decode-proto.py  -f dhcp-auth.pcap -p dhcpv4 > src/tests/unit/protocols/dhcpv4/dhcp-auth.txt
+#
+
+proto dhcpv4
+proto-dictionary dhcpv4
+
+#
+#  1.
+#
+# [ BOOTP ]
+#   op        = BOOTREPLY
+#   htype     = Ethernet (10Mb)
+#   hlen      = 6
+#   hops      = 1
+#   xid       = 0x7771cf85
+#   secs      = 10
+#   flags     =
+#   ciaddr    = 0.0.0.0
+#   yiaddr    = 10.10.8.235
+#   siaddr    = 172.22.178.234
+#   giaddr    = 10.10.8.240
+#   chaddr    = 00:0e:86:11:c0:75 (+ 10 nul pad)
+#   sname     = ''
+#   file      = ''
+#   options   = b'c\x82Sc' (DHCP magic)
+# [ DHCP options ]
+#    options   = [message-type=offer subnet_mask=255.255.255.0 server_id=172.22.178.234 lease_time=43200 router=10.10.8.254 name_server=143.209.4.1,143.209.5.1 tftp_server_name=b'172.22.178.234' 120=b'\x01\xac\x16\xb2\xea' client_id='\x00nathan1clientid' 90=b'\x01\x01\x00\xc8x\xc4RV@ \x811234\x8f\xe0\xcc\xe2\xee\x85\x96\xab\xb2X\x17\xc4\x80\xb2\xfd0' relay_agent_information=b'\x01\x14 PON 1/1/07/01:1.0.1' end]
+#
+decode-proto 02 01 06 01 77 71 cf 85 00 0a 00 00 00 00 00 00 0a 0a 08 eb ac 16 b2 ea 0a 0a 08 f0 00 0e 86 11 c0 75 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 63 82 53 63 35 01 02 01 04 ff ff ff 00 36 04 ac 16 b2 ea 33 04 00 00 a8 c0 03 04 0a 0a 08 fe 06 08 8f d1 04 01 8f d1 05 01 42 0e 31 37 32 2e 32 32 2e 31 37 38 2e 32 33 34 78 05 01 ac 16 b2 ea 3d 10 00 6e 61 74 68 61 6e 31 63 6c 69 65 6e 74 69 64 5a 1f 01 01 00 c8 78 c4 52 56 40 20 81 31 32 33 34 8f e0 cc e2 ee 85 96 ab b2 58 17 c4 80 b2 fd 30 52 16 01 14 20 50 4f 4e 20 31 2f 31 2f 30 37 2f 30 31 3a 31 2e 30 2e 31 ff
+match Opcode = Server-Message, Hardware-Type = Ethernet, Hardware-Address-Length = 6, Hop-Count = 1, Transaction-Id = 2003947397, Number-of-Seconds = 10, Flags = 0, Client-IP-Address = 0.0.0.0, Your-IP-Address = 10.10.8.235, Server-IP-Address = 172.22.178.234, Gateway-IP-Address = 10.10.8.240, Client-Hardware-Address = 00:0e:86:11:c0:75, Message-Type = Offer, Subnet-Mask = 255.255.255.0, Server-Identifier = 172.22.178.234, IP-Address-Lease-Time = 43200, Router-Address = 10.10.8.254, Domain-Name-Server = 143.209.4.1, Domain-Name-Server = 143.209.5.1, TFTP-Server-Name = "172.22.178.234", raw.SIP-Servers-Option = 0x01ac16b2ea, Client-Identifier = 0x006e617468616e31636c69656e746964, Authentication = { protocol = delayed-authentication, algorithm = HMAC-SHA1-keyed-hash, RDM = 0, replay-detection = 14445511662704271489, raw.algorithm.HMAC-SHA1-keyed-hash = 0x313233348fe0cce2ee8596abb25817c480b2fd30 }, Relay-Agent-Information.Circuit-Id = 0x20504f4e20312f312f30372f30313a312e302e31, Network-Subnet = 10.10.8.240/32
+
+count
+match 4
+


### PR DESCRIPTION
It's based on Wireshark .pcap tests
from https://wiki.wireshark.org/DHCP

e.g:
```
$ wget https://wiki.wireshark.org/uploads/__moin_import__/attachments/SampleCaptures/dhcp.pcap
$ ./scripts//util/pcap2decode-proto.py  -f dhcp.pcap -p dhcpv4 > src/tests/unit/protocols/dhcpv4/client-server.txt
```