### PR TITLE
Alternative TLS Load Test

### DIFF
--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -336,7 +336,11 @@ tests.runtests:  test.conf | radiusd.kill radiusd.pid
 	${Q}BIN_PATH="$(BIN_PATH)" PORT="$(PORT)" ./runtests.sh $(TESTS)
 
 # probably not the best way to do this
-tests.load: $(RADDB_PATH)certs/ca.pem $(RADDB_PATH)certs/server.pem $(RADDB_PATH)certs/client.pem
-	${Q}(cd tls-load && BUILD_DIR=${BUILD_PATH} LIB_DIR=${LIB_PATH} DICT_DIR=${top_builddir}/share RADDB_DIR=${top_builddir}/raddb ./run_test.sh -o output 10)
+.PHONY: $(BUILD_PATH)/tests/tls-load
+$(BUILD_PATH)/tests/tls-load:
+	${Q}mkdir -p $@
+
+tests.load: $(BUILD_PATH)/tests/tls-load $(RADDB_PATH)certs/ca.pem $(RADDB_PATH)certs/server.pem $(RADDB_PATH)certs/client.pem
+	${Q}(cd tls-load && BUILD_DIR=${BUILD_PATH} LIB_DIR=${LIB_PATH} DICT_DIR=${top_builddir}/share RADDB_DIR=${top_builddir}/raddb ./run_test.sh -o $(BUILD_PATH)/tests/tls-load 10)
 
 tests: tests.runtests tests.eap

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -3,7 +3,7 @@
 ## Makefile -- Build and run tests for the server.
 ##
 ##	http://www.freeradius.org/
-##	$Id: f7ab1f9b400f3e3bee1d80ba97ae24b4c6bd7f2a $
+##	$Id$
 ##
 #
 include ../../Make.inc
@@ -115,7 +115,7 @@ SECRET	= testing123
 #
 #	Build the directory for testing the server
 #
-all: tests
+all: tests tests.load
 
 clean:
 	@rm -f test.conf dictionary *.ok *.log $(BUILD_DIR)/tests/eap
@@ -188,6 +188,7 @@ config/eap-test: $(RADDB_PATH)mods-available/eap config/eap-test-inner-tunnel
 radiusd.pid: test.conf $(RADDB_PATH)certs/ca.pem $(RADDB_PATH)certs/server.pem
 	${Q}rm -rf $(TEST_PATH)/gdb.log $(TEST_PATH)/radius.log $(TEST_PATH)/tlscache
 	${Q}mkdir -p $(TEST_PATH)/tlscache
+	$(info ${RADIUSD_BIN} -Pxxxxml ${TEST_PATH}/radius.log -d ${top_builddir}/src/tests -n test -i 127.0.0.1 -p ${PORT} -D ${DICT_PATH})
 	${Q}printf "Starting server... "
 	${Q}if ! $(RADIUSD_BIN) -Pxxxxml $(TEST_PATH)/radius.log -d ${top_builddir}/src/tests -n test -i 127.0.0.1 -p $(PORT) -D $(DICT_PATH); then \
 		echo "failed"; \
@@ -335,5 +336,9 @@ endif # we have eapol_test built
 tests.runtests:  test.conf | radiusd.kill radiusd.pid
 	${Q}chmod a+x runtests.sh
 	${Q}BIN_PATH="$(BIN_PATH)" PORT="$(PORT)" ./runtests.sh $(TESTS)
+
+# probably not the best way to do this
+tests.load:
+	${Q}(cd tls-load && BUILD_DIR=${BUILD_PATH} LIB_DIR=${LIB_PATH} DICT_DIR=${top_builddir}/share RADDB_DIR=${top_builddir}/raddb ./run_test.sh -o output 10)
 
 tests: tests.runtests tests.eap

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -3,7 +3,7 @@
 ## Makefile -- Build and run tests for the server.
 ##
 ##	http://www.freeradius.org/
-##	$Id$
+##	$Id: f7ab1f9b400f3e3bee1d80ba97ae24b4c6bd7f2a $
 ##
 #
 include ../../Make.inc
@@ -136,7 +136,7 @@ test.conf: dictionary config/eap-test
 	fi
 	${Q}echo "testdir =" $(TEST_PATH) >> $@
 	${Q}echo 'logdir = $${testdir}' >> $@
-	${Q}echo "maindir =" $(RADDB_PATH) >> $@
+	${Q}echo "maindir =" $(RADDB_PATH:/=) >> $@
 	${Q}echo 'radacctdir = $${testdir}' >> $@
 	${Q}echo 'pidfile = $${testdir}/radiusd.pid' >> $@
 	${Q}echo 'panic_action = "gdb -batch -x $${testdir}/panic.gdb %e %p > $${testdir}/gdb.log 2>&1; cat $${testdir}/gdb.log"' >> $@
@@ -144,11 +144,21 @@ test.conf: dictionary config/eap-test
 	${Q}echo '        allow_vulnerable_openssl = yes' >> $@
 	${Q}echo '}' >> $@
 	${Q}echo >> $@
-	${Q}echo 'modconfdir = $${maindir}mods-config' >> $@
+	${Q}echo 'modconfdir = $${maindir}/mods-config' >> $@
 	${Q}echo 'certdir = $${maindir}/certs' >> $@
 	${Q}echo 'cadir   = $${maindir}/certs' >> $@
 	${Q}echo '$$INCLUDE $${testdir}/config/' >> $@
 	${Q}echo '$$INCLUDE $${maindir}/radiusd.conf' >> $@
+
+$(RADDB_PATH)certs/server.pem:
+	${Q}openssl genrsa -out test.key 2048
+	${Q}openssl req -x509 -sha256 -new -nodes -key test.key -days 3650 -subj "/C=--/ST=--/L=--/O=--/CN=--" -out test.crt
+	${Q}cat test.key test.crt > $(RADDB_PATH)certs/server.pem
+
+$(RADDB_PATH)certs/ca.pem:
+	${Q}openssl genrsa -out test.key 2048
+	${Q}openssl req -x509 -sha256 -new -nodes -key test.key -days 3650 -subj "/C=--/ST=--/L=--/O=--/CN=--" -out test.crt
+	${Q}cat test.key test.crt > $(RADDB_PATH)certs/ca.pem
 
 #
 #  Rename "inner-tunnel", and ensure that it only uses the "eap-test" module.
@@ -175,7 +185,7 @@ config/eap-test: $(RADDB_PATH)mods-available/eap config/eap-test-inner-tunnel
 	     -e 's/cipher_list = "DEFAULT"/cipher_list = "DEFAULT${SECLEVEL}"/' \
 		 < $< > $@
 
-radiusd.pid: test.conf
+radiusd.pid: test.conf $(RADDB_PATH)certs/ca.pem $(RADDB_PATH)certs/server.pem
 	${Q}rm -rf $(TEST_PATH)/gdb.log $(TEST_PATH)/radius.log $(TEST_PATH)/tlscache
 	${Q}mkdir -p $(TEST_PATH)/tlscache
 	${Q}printf "Starting server... "

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -150,15 +150,14 @@ test.conf: dictionary config/eap-test
 	${Q}echo '$$INCLUDE $${testdir}/config/' >> $@
 	${Q}echo '$$INCLUDE $${maindir}/radiusd.conf' >> $@
 
-$(RADDB_PATH)certs/server.pem:
-	${Q}openssl genrsa -out test.key 2048
-	${Q}openssl req -x509 -sha256 -new -nodes -key test.key -days 3650 -subj "/C=--/ST=--/L=--/O=--/CN=--" -out test.crt
-	${Q}cat test.key test.crt > $(RADDB_PATH)certs/server.pem
-
 $(RADDB_PATH)certs/ca.pem:
-	${Q}openssl genrsa -out test.key 2048
-	${Q}openssl req -x509 -sha256 -new -nodes -key test.key -days 3650 -subj "/C=--/ST=--/L=--/O=--/CN=--" -out test.crt
-	${Q}cat test.key test.crt > $(RADDB_PATH)certs/ca.pem
+	${Q}make -C $(RADDB_PATH)certs ca.pem
+
+$(RADDB_PATH)certs/server.pem:
+	${Q}make -C $(RADDB_PATH)certs server.pem
+
+$(RADDB_PATH)certs/client.pem:
+	${Q}make -C $(RADDB_PATH)certs client.pem
 
 #
 #  Rename "inner-tunnel", and ensure that it only uses the "eap-test" module.
@@ -188,7 +187,6 @@ config/eap-test: $(RADDB_PATH)mods-available/eap config/eap-test-inner-tunnel
 radiusd.pid: test.conf $(RADDB_PATH)certs/ca.pem $(RADDB_PATH)certs/server.pem
 	${Q}rm -rf $(TEST_PATH)/gdb.log $(TEST_PATH)/radius.log $(TEST_PATH)/tlscache
 	${Q}mkdir -p $(TEST_PATH)/tlscache
-	$(info ${RADIUSD_BIN} -Pxxxxml ${TEST_PATH}/radius.log -d ${top_builddir}/src/tests -n test -i 127.0.0.1 -p ${PORT} -D ${DICT_PATH})
 	${Q}printf "Starting server... "
 	${Q}if ! $(RADIUSD_BIN) -Pxxxxml $(TEST_PATH)/radius.log -d ${top_builddir}/src/tests -n test -i 127.0.0.1 -p $(PORT) -D $(DICT_PATH); then \
 		echo "failed"; \
@@ -338,7 +336,7 @@ tests.runtests:  test.conf | radiusd.kill radiusd.pid
 	${Q}BIN_PATH="$(BIN_PATH)" PORT="$(PORT)" ./runtests.sh $(TESTS)
 
 # probably not the best way to do this
-tests.load:
+tests.load: $(RADDB_PATH)certs/ca.pem $(RADDB_PATH)certs/server.pem $(RADDB_PATH)certs/client.pem
 	${Q}(cd tls-load && BUILD_DIR=${BUILD_PATH} LIB_DIR=${LIB_PATH} DICT_DIR=${top_builddir}/share RADDB_DIR=${top_builddir}/raddb ./run_test.sh -o output 10)
 
 tests: tests.runtests tests.eap

--- a/src/tests/tls-load/Dockerfile
+++ b/src/tests/tls-load/Dockerfile
@@ -1,0 +1,6 @@
+ARG from=ubuntu:latest
+FROM ${from} as build
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+RUN apt-get install -y libtalloc-dev

--- a/src/tests/tls-load/README.md
+++ b/src/tests/tls-load/README.md
@@ -1,0 +1,18 @@
+# TLS Load Testing
+
+Runs local radiusd load testing for TLS using docker compose.  
+Requires Docker.  
+### Usage:  
+`./run_test.sh -o output (number of concurrent clients/servers running)`  
+### Options:  
+- `-n`: number of messages to send per client (default is 1000)
+- `-l`: log level for home/proxy servers (default is 1, 1=`radiusd -f`, 2=`radiusd -fx`, 3=`radiusd -fxx`, other=no log files generated)
+- `-o`: where to put log files after running (if left empty, output will not be generated)
+ 
+### Output:  
+- `client_*.log`: Output of radclient for each running client
+- `home_*.log`: Output from radiusd of home servers
+- `proxy.log`: Output from radiusd of proxy server
+
+### Result:
+The script will exit 0 if all clients succeed or 1 if any client fails, and will print a corresponding message.  

--- a/src/tests/tls-load/docker-compose.yml
+++ b/src/tests/tls-load/docker-compose.yml
@@ -1,0 +1,79 @@
+version: "3"
+
+name: test-container
+
+networks:
+  test-net: 
+
+services:
+  tasks:
+    image: radius_libraries
+    build:
+      context: .
+      args:
+        from: ${BASE_IMAGE}
+    entrypoint: bash -c "mkdir /test/containers ; rm /test/containers/*"
+    volumes:
+      - ./test:/test
+  
+  proxy:
+    depends_on:
+      - home
+      - client
+    image: radius_libraries
+    build:
+      context: .
+      args:
+        from: ${BASE_IMAGE}
+    entrypoint: /test/proxy-entrypoint.sh
+    environment:
+      - LOG_LEVEL
+    networks:
+      - test-net
+    volumes:
+      - ./test:/test
+      - ${BUILD_DIR}:/etc/freeradius
+      - ${DICT_DIR}:/dict
+      - ${LIB_DIR}:/usr/lib/freeradius
+      - ${RADDB_DIR}:/raddb
+      - ./certs:/certs
+
+  home:
+    depends_on:
+      - tasks
+    image: radius_libraries
+    build:
+      context: .
+      args:
+        from: ${BASE_IMAGE}
+    entrypoint: bash /test/home-entrypoint.sh
+    environment:
+      - LOG_LEVEL
+    networks:
+      - test-net
+    volumes:
+      - ./test:/test
+      - ${BUILD_DIR}:/etc/freeradius
+      - ${DICT_DIR}:/dict
+      - ${LIB_DIR}:/usr/lib/freeradius
+      - ${RADDB_DIR}:/raddb
+      - ./certs:/certs
+
+  client:
+    depends_on:
+      - tasks
+    image: radius_libraries
+    build:
+      context: .
+      args:
+        from: ${BASE_IMAGE}
+    entrypoint: /test/client-entrypoint.sh
+    environment:
+      - NUM_REQUESTS
+    networks:
+      - test-net
+    volumes:
+      - ./test:/test
+      - ${BUILD_DIR}:/etc/freeradius
+      - ${DICT_DIR}:/dict
+      - ${LIB_DIR}:/usr/lib/freeradius

--- a/src/tests/tls-load/docker-compose.yml
+++ b/src/tests/tls-load/docker-compose.yml
@@ -32,11 +32,10 @@ services:
       - test-net
     volumes:
       - ./test:/test
-      - ${BUILD_DIR}:/etc/freeradius
+      - ${BUILD_DIR}:/build
       - ${DICT_DIR}:/dict
       - ${LIB_DIR}:/usr/lib/freeradius
-      - ${RADDB_DIR}:/raddb
-      - ./certs:/certs
+      - ${RADDB_DIR}:/etc/freeradius
 
   home:
     depends_on:
@@ -53,11 +52,10 @@ services:
       - test-net
     volumes:
       - ./test:/test
-      - ${BUILD_DIR}:/etc/freeradius
+      - ${BUILD_DIR}:/build
       - ${DICT_DIR}:/dict
       - ${LIB_DIR}:/usr/lib/freeradius
-      - ${RADDB_DIR}:/raddb
-      - ./certs:/certs
+      - ${RADDB_DIR}:/etc/freeradius
 
   client:
     depends_on:
@@ -74,6 +72,7 @@ services:
       - test-net
     volumes:
       - ./test:/test
-      - ${BUILD_DIR}:/etc/freeradius
+      - ${BUILD_DIR}:/build
       - ${DICT_DIR}:/dict
       - ${LIB_DIR}:/usr/lib/freeradius
+      - ${RADDB_DIR}:/etc/freeradius

--- a/src/tests/tls-load/docker-compose.yml
+++ b/src/tests/tls-load/docker-compose.yml
@@ -32,10 +32,10 @@ services:
       - test-net
     volumes:
       - ./test:/test
+      - ${JLIBTOOL_DIR}:/fbin
       - ${BUILD_DIR}:/build
-      - ${DICT_DIR}:/dict
-      - ${LIB_DIR}:/usr/lib/freeradius
-      - ${RADDB_DIR}:/etc/freeradius
+      - ${DICT_DIR}:/share
+      - ${RADDB_DIR}:/raddb
 
   home:
     depends_on:
@@ -45,17 +45,17 @@ services:
       context: .
       args:
         from: ${BASE_IMAGE}
-    entrypoint: bash /test/home-entrypoint.sh
+    entrypoint: /test/home-entrypoint.sh
     environment:
       - LOG_LEVEL
     networks:
       - test-net
     volumes:
       - ./test:/test
+      - ${JLIBTOOL_DIR}:/fbin
       - ${BUILD_DIR}:/build
-      - ${DICT_DIR}:/dict
-      - ${LIB_DIR}:/usr/lib/freeradius
-      - ${RADDB_DIR}:/etc/freeradius
+      - ${DICT_DIR}:/share
+      - ${RADDB_DIR}:/raddb
 
   client:
     depends_on:
@@ -72,7 +72,7 @@ services:
       - test-net
     volumes:
       - ./test:/test
+      - ${JLIBTOOL_DIR}:/fbin
       - ${BUILD_DIR}:/build
-      - ${DICT_DIR}:/dict
-      - ${LIB_DIR}:/usr/lib/freeradius
-      - ${RADDB_DIR}:/etc/freeradius
+      - ${DICT_DIR}:/share
+      - ${RADDB_DIR}:/raddb

--- a/src/tests/tls-load/run_test.sh
+++ b/src/tests/tls-load/run_test.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Other shells not tested
+# Arguments in caps are exported to containers or relevant in docker-compose.yml
+
+export BASE_IMAGE=${BASE_IMAGE:-ubuntu:latest}
+export BUILD_DIR=${BUILD_DIR:-../../../build}
+export DICT_DIR=${DICT_DIR:-../../../share}
+export LIB_DIR=${LIB_DIR:-../../../build/lib/.libs}
+export RADDB_DIR=${RADDB_DIR:-../../../raddb}
+yes | docker compose rm
+if ! [ "$?" -eq 0 ]; then
+  echo "Docker failed"
+  exit 1
+fi
+
+### ARGUMENT PARSING ###
+# Note -s and -b require the freeradius docker image to be rebuilt, meaning it must be removed, or renamed with -i.
+while getopts ':n:l:d:r:o:bm' OPTION; do
+  case "$OPTION" in
+    n)
+      NUM_REQUESTS="$OPTARG"
+      ;;
+    l)
+      LOG_LEVEL="$OPTARG"
+      ;;
+    o)
+      output_dir="$OPTARG"
+      ;;
+    ?)
+      echo "Usage: $0 [-n number_of_requests_per_realm] [-l log_level (0=none, 1,2,3=radiusd -f, -fx, -fxx)] [-o output_log_dir] number_of_realms"
+      exit 1
+      ;;
+  esac
+done
+shift "$(($OPTIND-1))"
+
+max_container_num=100
+num_realms="$1"
+if [[ "/$num_realms" = "/" ]]; then
+  echo "No container num given"
+  exit 1
+fi
+if [ "$num_realms" -gt "$max_container_num" ]; then
+  echo "You have tried to create more than $max_container_num docker containers, exiting load testing script without running"
+  exit 1
+fi
+export NUM_REQUESTS=${NUM_REQUESTS:-5000}
+export LOG_LEVEL=${LOG_LEVEL:-1}
+
+### DOCKER ###
+docker compose up -d --scale home="$num_realms" --scale client="$num_realms"
+if ! [ "$?" -eq 0 ]; then
+  echo "Docker failed"
+  exit 1
+fi
+
+# Check for when all of the client containers have exited
+while docker compose ps | grep client; do
+  sleep 3
+done
+
+docker compose stop
+
+# Move all the output to an external directory if specified
+if [[ "/$output_dir" != "/" ]]; then
+  docker logs test-container-proxy-1 > "$output_dir"/proxy.log
+  i=1
+  while [ "$i" -le $num_realms ]; do
+    docker logs test-container-client-"$i" > "$output_dir"/client_"$i".log&
+    docker logs test-container-home-"$i" > "$output_dir"/home_"$i".log&
+    i=$((i+1))
+  done
+fi
+
+# Check that the number of clients that were created is the same as the number of clients that were created and exited successfully
+if [ $(docker compose ps --all | grep -c client) -eq $(docker compose ps --all | grep -c "client.*Exited (0)") ]; then
+  echo "TLS load test succeeded"
+  yes | docker compose rm &> /dev/null
+  exit 0
+else
+  echo "TLS load test failed"
+  yes | docker compose rm &> /dev/null
+  exit 1
+fi

--- a/src/tests/tls-load/run_test.sh
+++ b/src/tests/tls-load/run_test.sh
@@ -3,9 +3,9 @@
 # Arguments in caps are exported to containers or relevant in docker-compose.yml
 
 export BASE_IMAGE=${BASE_IMAGE:-ubuntu:latest}
+export JLIBTOOL_DIR=${JLIBTOOL_DIR:-../../../scripts/bin}
 export BUILD_DIR=${BUILD_DIR:-../../../build}
 export DICT_DIR=${DICT_DIR:-../../../share}
-export LIB_DIR=${LIB_DIR:-../../../build/lib/.libs}
 export RADDB_DIR=${RADDB_DIR:-../../../raddb}
 yes | docker compose rm
 if ! [ "$?" -eq 0 ]; then
@@ -59,7 +59,8 @@ while docker compose ps | grep client; do
   sleep 3
 done
 
-docker compose stop
+# We don't care about the processes now, and we need to send a SIGKILL because of zombie processes spawned by jlibtool.
+docker compose kill
 
 # Move all the output to an external directory if specified
 if [[ "/$output_dir" != "/" ]]; then

--- a/src/tests/tls-load/test/client-entrypoint.sh
+++ b/src/tests/tls-load/test/client-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+touch /test/containers/realm_"$HOSTNAME"
+# Unfortunately, I don't really know a better way to synchronize the clients than a short sleep length 
+# and a sufficient number of requests.
+# It still seems like sometimes one can start inordinately later than the others.
+while ! [ -f "/test/containers/proxy-running" ]; do
+  sleep 0.1
+done
+rm /test/containers/realm_"$HOSTNAME"
+echo /etc/freeradius/lib/local/.libs >> /etc/ld.so.conf
+ldconfig
+echo User-Name="bob@realm_$HOSTNAME",User-Password="bob",Message-Authenticator=0x00 | /etc/freeradius/bin/local/radclient -D /dict -c "$NUM_REQUESTS" test-container-proxy-1 auth testing123
+if [ "$?" -ne 0 ] ; then
+  echo "This container failed"
+  exit 1
+else
+  echo "This container succeeded"
+fi

--- a/src/tests/tls-load/test/client-entrypoint.sh
+++ b/src/tests/tls-load/test/client-entrypoint.sh
@@ -7,9 +7,9 @@ while ! [ -f "/test/containers/proxy-running" ]; do
   sleep 0.1
 done
 rm /test/containers/realm_"$HOSTNAME"
-echo /etc/freeradius/lib/local/.libs >> /etc/ld.so.conf
+echo /build/lib/local/.libs >> /etc/ld.so.conf
 ldconfig
-echo User-Name="bob@realm_$HOSTNAME",User-Password="bob",Message-Authenticator=0x00 | /etc/freeradius/bin/local/radclient -D /dict -c "$NUM_REQUESTS" test-container-proxy-1 auth testing123
+echo User-Name="bob@realm_$HOSTNAME",User-Password="bob",Message-Authenticator=0x00 | /build/bin/local/radclient -D /dict -c "$NUM_REQUESTS" test-container-proxy-1 auth testing123
 if [ "$?" -ne 0 ] ; then
   echo "This container failed"
   exit 1

--- a/src/tests/tls-load/test/client-entrypoint.sh
+++ b/src/tests/tls-load/test/client-entrypoint.sh
@@ -7,9 +7,7 @@ while ! [ -f "/test/containers/proxy-running" ]; do
   sleep 0.1
 done
 rm /test/containers/realm_"$HOSTNAME"
-echo /build/lib/local/.libs >> /etc/ld.so.conf
-ldconfig
-echo User-Name="bob@realm_$HOSTNAME",User-Password="bob",Message-Authenticator=0x00 | /build/bin/local/radclient -D /dict -c "$NUM_REQUESTS" test-container-proxy-1 auth testing123
+echo User-Name="bob@realm_$HOSTNAME",User-Password="bob",Message-Authenticator=0x00 | /fbin/radclient -c "$NUM_REQUESTS" test-container-proxy-1 auth testing123
 if [ "$?" -ne 0 ] ; then
   echo "This container failed"
   exit 1

--- a/src/tests/tls-load/test/home-entrypoint.sh
+++ b/src/tests/tls-load/test/home-entrypoint.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
-echo /build/lib/local/.libs >> /etc/ld.so.conf
-ldconfig
 if [ "$LOG_LEVEL" -eq 2 ]; then
-  exec /build/bin/local/radiusd -D /dict -d /test/home -fx -l stdout
+  exec /fbin/radiusd -d /test/home -fx -l stdout
 elif [ "$LOG_LEVEL" -eq 3 ]; then
-  exec /build/bin/local/radiusd -D /dict -d /test/home -fxx -l stdout
+  exec /fbin/radiusd -d /test/home -fxx -l stdout
 else
-  exec /build/bin/local/radiusd -D /dict -d /test/home -f -l stdout
+  exec /fbin/radiusd -d /test/home -f -l stdout
 fi

--- a/src/tests/tls-load/test/home-entrypoint.sh
+++ b/src/tests/tls-load/test/home-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+echo /etc/freeradius/lib/local/.libs >> /etc/ld.so.conf
+ldconfig
+if [ "$LOG_LEVEL" -eq 2 ]; then
+  exec /etc/freeradius/bin/local/radiusd -D /dict -d /test/home -fx -l stdout
+elif [ "$LOG_LEVEL" -eq 3 ]; then
+  exec /etc/freeradius/bin/local/radiusd -D /dict -d /test/home -fxx -l stdout
+else
+  exec /etc/freeradius/bin/local/radiusd -D /dict -d /test/home -f -l stdout
+fi

--- a/src/tests/tls-load/test/home-entrypoint.sh
+++ b/src/tests/tls-load/test/home-entrypoint.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-echo /etc/freeradius/lib/local/.libs >> /etc/ld.so.conf
+echo /build/lib/local/.libs >> /etc/ld.so.conf
 ldconfig
 if [ "$LOG_LEVEL" -eq 2 ]; then
-  exec /etc/freeradius/bin/local/radiusd -D /dict -d /test/home -fx -l stdout
+  exec /build/bin/local/radiusd -D /dict -d /test/home -fx -l stdout
 elif [ "$LOG_LEVEL" -eq 3 ]; then
-  exec /etc/freeradius/bin/local/radiusd -D /dict -d /test/home -fxx -l stdout
+  exec /build/bin/local/radiusd -D /dict -d /test/home -fxx -l stdout
 else
-  exec /etc/freeradius/bin/local/radiusd -D /dict -d /test/home -f -l stdout
+  exec /build/bin/local/radiusd -D /dict -d /test/home -f -l stdout
 fi

--- a/src/tests/tls-load/test/home/radiusd.conf
+++ b/src/tests/tls-load/test/home/radiusd.conf
@@ -1,13 +1,13 @@
 #
 #  Minimal radiusd.conf for testing
 #
-raddb        = /raddb
+raddb        = /etc/freeradius
 modconfdir   = ${raddb}/mods-config
 testdir      = /test
 pidfile      = ${testdir}/radiusd.pid
 panic_action = "gdb -batch -x ${raddb}/panic.gdb %e %p > ${testdir}/gdb-radiusd.log 2>&1; cat ${testdir}/gdb-radiusd.log"
-certdir      = /certs
-cadir        = /certs
+certdir      = ${raddb}/certs
+cadir        = ${raddb}/certs
 libdir       = /usr/lib/freeradius
 
 max_requests = 1048576

--- a/src/tests/tls-load/test/home/radiusd.conf
+++ b/src/tests/tls-load/test/home/radiusd.conf
@@ -1,7 +1,7 @@
 #
 #  Minimal radiusd.conf for testing
 #
-raddb        = /etc/freeradius
+raddb        = /raddb
 modconfdir   = ${raddb}/mods-config
 testdir      = /test
 pidfile      = ${testdir}/radiusd.pid
@@ -13,14 +13,14 @@ libdir       = /usr/lib/freeradius
 max_requests = 1048576
 
 thread pool {
-	start_servers = 5
-	max_servers = 32
-	min_spare_servers = 3
-	max_spare_servers = 10
-	max_requests_per_server = 0
-	cleanup_delay = 5
-	max_queue_size = 65536
-	auto_limit_acct = no
+  start_servers = 5
+  max_servers = 32
+  min_spare_servers = 3
+  max_spare_servers = 10
+  max_requests_per_server = 0
+  cleanup_delay = 5
+  max_queue_size = 65536
+  auto_limit_acct = no
 }
 
 #
@@ -31,74 +31,74 @@ modules {
 }
 
 clients radsec {
-	client all {
-		ipaddr = 0.0.0.0/0
-		proto = tls
-	}
+  client all {
+    ipaddr = 0.0.0.0/0
+    proto = tls
+  }
 }
 
 listen {
-	type = auth
+  type = auth
 
-	ipaddr = *
-	port = 1812
-	proto = tcp
+  ipaddr = *
+  port = 1812
+  proto = tcp
 
-	clients = radsec
+  clients = radsec
 
-	virtual_server = default
+  virtual_server = default
 
-	tls {
-		private_key_password = whatever
-		private_key_file = ${certdir}/server.pem
-		certificate_file = ${certdir}/server.pem
-		ca_file = ${cadir}/ca.pem
-		fragment_size = 8192
-		ca_path = ${cadir}
-		cipher_list = "DEFAULT"
-		tls_min_version = "1.2"
-		tls_max_version = "1.2"
-	}
+  tls {
+    private_key_password = whatever
+    private_key_file = ${certdir}/server.pem
+    certificate_file = ${certdir}/server.pem
+    ca_file = ${cadir}/ca.pem
+    fragment_size = 8192
+    ca_path = ${cadir}
+    cipher_list = "DEFAULT"
+    tls_min_version = "1.2"
+    tls_max_version = "1.2"
+  }
 }
 
 listen {
-	type = acct
+  type = acct
 
-	ipaddr = *
-	port = 1813
-	proto = tcp
+  ipaddr = *
+  port = 1813
+  proto = tcp
 
-	clients = radsec
+  clients = radsec
 
-	virtual_server = default
+  virtual_server = default
 
-	tls {
-		private_key_password = whatever
-		private_key_file = ${certdir}/server.pem
-		certificate_file = ${certdir}/server.pem
-		ca_file = ${cadir}/ca.pem
-		fragment_size = 8192
-		ca_path = ${cadir}
-		cipher_list = "DEFAULT"
-		tls_min_version = "1.3"
-		tls_max_version = "1.3"
-	}
+  tls {
+    private_key_password = whatever
+    private_key_file = ${certdir}/server.pem
+    certificate_file = ${certdir}/server.pem
+    ca_file = ${cadir}/ca.pem
+    fragment_size = 8192
+    ca_path = ${cadir}
+    cipher_list = "DEFAULT"
+    tls_min_version = "1.3"
+    tls_max_version = "1.3"
+  }
 }
 
 server default {
-	authorize {
-		update control {
-			Auth-Type := accept
-		}
-	}
+  authorize {
+    update control {
+      Auth-Type := accept
+    }
+  }
 
-	preacct {
-		update control {
-			Response-Packet-Type := Accounting-Response
-		}
-	}
+  preacct {
+    update control {
+      Response-Packet-Type := Accounting-Response
+    }
+  }
 
-	acct {
-		ok
-	}
+  acct {
+    ok
+  }
 }

--- a/src/tests/tls-load/test/home/radiusd.conf
+++ b/src/tests/tls-load/test/home/radiusd.conf
@@ -1,0 +1,104 @@
+#
+#  Minimal radiusd.conf for testing
+#
+raddb        = /raddb
+modconfdir   = ${raddb}/mods-config
+testdir      = /test
+pidfile      = ${testdir}/radiusd.pid
+panic_action = "gdb -batch -x ${raddb}/panic.gdb %e %p > ${testdir}/gdb-radiusd.log 2>&1; cat ${testdir}/gdb-radiusd.log"
+certdir      = /certs
+cadir        = /certs
+libdir       = /usr/lib/freeradius
+
+max_requests = 1048576
+
+thread pool {
+	start_servers = 5
+	max_servers = 32
+	min_spare_servers = 3
+	max_spare_servers = 10
+	max_requests_per_server = 0
+	cleanup_delay = 5
+	max_queue_size = 65536
+	auto_limit_acct = no
+}
+
+#
+#  Referenced by some modules for default thread pool configuration
+#
+modules {
+  $INCLUDE ${raddb}/mods-available/always
+}
+
+clients radsec {
+	client all {
+		ipaddr = 0.0.0.0/0
+		proto = tls
+	}
+}
+
+listen {
+	type = auth
+
+	ipaddr = *
+	port = 1812
+	proto = tcp
+
+	clients = radsec
+
+	virtual_server = default
+
+	tls {
+		private_key_password = whatever
+		private_key_file = ${certdir}/server.pem
+		certificate_file = ${certdir}/server.pem
+		ca_file = ${cadir}/ca.pem
+		fragment_size = 8192
+		ca_path = ${cadir}
+		cipher_list = "DEFAULT"
+		tls_min_version = "1.2"
+		tls_max_version = "1.2"
+	}
+}
+
+listen {
+	type = acct
+
+	ipaddr = *
+	port = 1813
+	proto = tcp
+
+	clients = radsec
+
+	virtual_server = default
+
+	tls {
+		private_key_password = whatever
+		private_key_file = ${certdir}/server.pem
+		certificate_file = ${certdir}/server.pem
+		ca_file = ${cadir}/ca.pem
+		fragment_size = 8192
+		ca_path = ${cadir}
+		cipher_list = "DEFAULT"
+		tls_min_version = "1.3"
+		tls_max_version = "1.3"
+	}
+}
+
+server default {
+	authorize {
+		update control {
+			Auth-Type := accept
+		}
+	}
+
+	preacct {
+		update control {
+			Response-Packet-Type := Accounting-Response
+		}
+	}
+
+	acct {
+		ok
+	}
+}

--- a/src/tests/tls-load/test/home/radiusd.conf
+++ b/src/tests/tls-load/test/home/radiusd.conf
@@ -8,7 +8,7 @@ pidfile      = ${testdir}/radiusd.pid
 panic_action = "gdb -batch -x ${raddb}/panic.gdb %e %p > ${testdir}/gdb-radiusd.log 2>&1; cat ${testdir}/gdb-radiusd.log"
 certdir      = ${raddb}/certs
 cadir        = ${raddb}/certs
-libdir       = /usr/lib/freeradius
+libdir       = /build/objs/src/modules
 
 max_requests = 1048576
 

--- a/src/tests/tls-load/test/proxy-entrypoint.sh
+++ b/src/tests/tls-load/test/proxy-entrypoint.sh
@@ -17,12 +17,10 @@ done 3<"/client-hostnames.txt"
 
 # This file is so the clients know the proxy is starting the server soon; checking at an earlier point is possible to fail if hostname resolution is very slow
 touch /test/containers/proxy-running
-echo /build/lib/local/.libs >> /etc/ld.so.conf
-ldconfig
 if [ "$LOG_LEVEL" -eq 2 ]; then
-  exec /build/bin/local/radiusd -D /dict -d /eqx -fx -l stdout
+  exec /fbin/radiusd -d /eqx -fx -l stdout
 elif [ "$LOG_LEVEL" -eq 3 ]; then
-  exec /build/bin/local/radiusd -D /dict -d /eqx -fxx -l stdout
+  exec /fbin/radiusd -d /eqx -fxx -l stdout
 else
-  exec /build/bin/local/radiusd -D /dict -d /eqx -f -l stdout
+  exec /fbin/radiusd -d /eqx -f -l stdout
 fi

--- a/src/tests/tls-load/test/proxy-entrypoint.sh
+++ b/src/tests/tls-load/test/proxy-entrypoint.sh
@@ -17,12 +17,12 @@ done 3<"/client-hostnames.txt"
 
 # This file is so the clients know the proxy is starting the server soon; checking at an earlier point is possible to fail if hostname resolution is very slow
 touch /test/containers/proxy-running
-echo /etc/freeradius/lib/local/.libs >> /etc/ld.so.conf
+echo /build/lib/local/.libs >> /etc/ld.so.conf
 ldconfig
 if [ "$LOG_LEVEL" -eq 2 ]; then
-  exec /etc/freeradius/bin/local/radiusd -D /dict -d /eqx -fx -l stdout
+  exec /build/bin/local/radiusd -D /dict -d /eqx -fx -l stdout
 elif [ "$LOG_LEVEL" -eq 3 ]; then
-  exec /etc/freeradius/bin/local/radiusd -D /dict -d /eqx -fxx -l stdout
+  exec /build/bin/local/radiusd -D /dict -d /eqx -fxx -l stdout
 else
-  exec /etc/freeradius/bin/local/radiusd -D /dict -d /eqx -f -l stdout
+  exec /build/bin/local/radiusd -D /dict -d /eqx -f -l stdout
 fi

--- a/src/tests/tls-load/test/proxy-entrypoint.sh
+++ b/src/tests/tls-load/test/proxy-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Unfortunately, our clients do not know their own human readable name as far as I can tell, so the proxy must know their HOSTNAME to have information in common for realms
+ls /test/containers | grep realm_ > /client-hostnames.txt
+
+# We will generate the proxy.conf file that will be used in a separate directory
+mkdir /eqx
+touch /eqx/proxy.conf
+cp /test/proxy/radiusd.conf /eqx/radiusd.conf
+
+i=1
+while read -r -u 3 c_name
+do
+  cat /test/proxy/proxy.PART | sed -e "s/##C_NAME##/$c_name/g" -e "s/##H_IP##/test-container-home-$i/g" >> /eqx/proxy.conf
+  i=$((i+1))
+done 3<"/client-hostnames.txt"
+
+# This file is so the clients know the proxy is starting the server soon; checking at an earlier point is possible to fail if hostname resolution is very slow
+touch /test/containers/proxy-running
+echo /etc/freeradius/lib/local/.libs >> /etc/ld.so.conf
+ldconfig
+if [ "$LOG_LEVEL" -eq 2 ]; then
+  exec /etc/freeradius/bin/local/radiusd -D /dict -d /eqx -fx -l stdout
+elif [ "$LOG_LEVEL" -eq 3 ]; then
+  exec /etc/freeradius/bin/local/radiusd -D /dict -d /eqx -fxx -l stdout
+else
+  exec /etc/freeradius/bin/local/radiusd -D /dict -d /eqx -f -l stdout
+fi

--- a/src/tests/tls-load/test/proxy/proxy.PART
+++ b/src/tests/tls-load/test/proxy/proxy.PART
@@ -1,0 +1,34 @@
+home_server ##C_NAME## {
+	ipaddr = ##H_IP##
+	port = 1812
+	type = auth+acct
+	secret = radsec
+	proto = tcp
+	status_check = none
+
+	nonblock = yes
+
+	revive_interval = 10
+
+	tls {
+		private_key_password = whatever
+	  private_key_file = ${certdir}/client.pem
+	  certificate_file = ${certdir}/client.pem
+	  ca_file = ${cadir}/ca.pem
+	  fragment_size = 8192
+	  ca_path = ${cadir}
+	  cipher_list = "DEFAULT"
+	  tls_min_version = "1.2"
+	  tls_max_version = "1.2"
+	}
+}
+
+home_server_pool ##C_NAME## {
+	type = fail-over
+	home_server = ##C_NAME##
+}
+
+realm "##C_NAME##" {
+  pool = ##C_NAME##
+  nostrip
+}

--- a/src/tests/tls-load/test/proxy/proxy.PART
+++ b/src/tests/tls-load/test/proxy/proxy.PART
@@ -1,31 +1,31 @@
 home_server ##C_NAME## {
-	ipaddr = ##H_IP##
-	port = 1812
-	type = auth+acct
-	secret = radsec
-	proto = tcp
-	status_check = none
+  ipaddr = ##H_IP##
+  port = 1812
+  type = auth+acct
+  secret = radsec
+  proto = tcp
+  status_check = none
 
-	nonblock = yes
+  nonblock = yes
 
-	revive_interval = 10
+  revive_interval = 10
 
-	tls {
-		private_key_password = whatever
-	  private_key_file = ${certdir}/client.pem
-	  certificate_file = ${certdir}/client.pem
-	  ca_file = ${cadir}/ca.pem
-	  fragment_size = 8192
-	  ca_path = ${cadir}
-	  cipher_list = "DEFAULT"
-	  tls_min_version = "1.2"
-	  tls_max_version = "1.2"
-	}
+  tls {
+    private_key_password = whatever
+    private_key_file = ${certdir}/client.pem
+    certificate_file = ${certdir}/client.pem
+    ca_file = ${cadir}/ca.pem
+    fragment_size = 8192
+    ca_path = ${cadir}
+    cipher_list = "DEFAULT"
+    tls_min_version = "1.2"
+    tls_max_version = "1.2"
+  }
 }
 
 home_server_pool ##C_NAME## {
-	type = fail-over
-	home_server = ##C_NAME##
+  type = fail-over
+  home_server = ##C_NAME##
 }
 
 realm "##C_NAME##" {

--- a/src/tests/tls-load/test/proxy/radiusd.conf
+++ b/src/tests/tls-load/test/proxy/radiusd.conf
@@ -1,10 +1,10 @@
-raddb        = /raddb
+raddb        = /etc/freeradius
 modconfdir   = ${raddb}/mods-config
 testdir      = /test
 pidfile      = ${testdir}/radiusd.pid
 panic_action = "gdb -batch -x ${raddb}/panic.gdb %e %p > ${testdir}/gdb-radiusd.log 2>&1; cat ${testdir}/gdb-radiusd.log"
-certdir      = /certs
-cadir        = /certs
+certdir      = ${raddb}/certs
+cadir        = ${raddb}/certs
 libdir       = /usr/lib/freeradius
 
 max_requests = 1048576

--- a/src/tests/tls-load/test/proxy/radiusd.conf
+++ b/src/tests/tls-load/test/proxy/radiusd.conf
@@ -1,4 +1,4 @@
-raddb        = /etc/freeradius
+raddb        = /raddb
 modconfdir   = ${raddb}/mods-config
 testdir      = /test
 pidfile      = ${testdir}/radiusd.pid
@@ -10,14 +10,14 @@ libdir       = /usr/lib/freeradius
 max_requests = 1048576
 
 thread pool {
-	start_servers = 5
-	max_servers = 32
-	min_spare_servers = 3
-	max_spare_servers = 10
-	max_requests_per_server = 0
-	cleanup_delay = 5
-	max_queue_size = 65536
-	auto_limit_acct = no
+  start_servers = 5
+  max_servers = 32
+  min_spare_servers = 3
+  max_spare_servers = 10
+  max_requests_per_server = 0
+  cleanup_delay = 5
+  max_queue_size = 65536
+  auto_limit_acct = no
 }
 
 #
@@ -30,38 +30,38 @@ modules {
 }
 
 clients indocker {
-	client all {
-		ipaddr = 0.0.0.0/0
-		secret = testing123
-		proto = *
-	}
+  client all {
+    ipaddr = 0.0.0.0/0
+    secret = testing123
+    proto = *
+  }
 }
 
 listen {
-	type = auth
-	ipaddr = *
-	port = 1812
-	proto = udp
-	clients = indocker
-	virtual_server = default
+  type = auth
+  ipaddr = *
+  port = 1812
+  proto = udp
+  clients = indocker
+  virtual_server = default
 }
 
 listen {
-	type = acct
-	ipaddr = *
-	port = 1813
-	proto = udp
-	clients = indocker
-	virtual_server = default
+  type = acct
+  ipaddr = *
+  port = 1813
+  proto = udp
+  clients = indocker
+  virtual_server = default
 }
 
 
 server default {
-	authorize {
-	  suffix
-	}
+  authorize {
+    suffix
+  }
 
-	preacct {
-	  suffix
-	}
+  preacct {
+    suffix
+  }
 }

--- a/src/tests/tls-load/test/proxy/radiusd.conf
+++ b/src/tests/tls-load/test/proxy/radiusd.conf
@@ -1,0 +1,67 @@
+raddb        = /raddb
+modconfdir   = ${raddb}/mods-config
+testdir      = /test
+pidfile      = ${testdir}/radiusd.pid
+panic_action = "gdb -batch -x ${raddb}/panic.gdb %e %p > ${testdir}/gdb-radiusd.log 2>&1; cat ${testdir}/gdb-radiusd.log"
+certdir      = /certs
+cadir        = /certs
+libdir       = /usr/lib/freeradius
+
+max_requests = 1048576
+
+thread pool {
+	start_servers = 5
+	max_servers = 32
+	min_spare_servers = 3
+	max_spare_servers = 10
+	max_requests_per_server = 0
+	cleanup_delay = 5
+	max_queue_size = 65536
+	auto_limit_acct = no
+}
+
+#
+# Minimum configuration for Proxy Server -> SRADIUSD
+#
+$INCLUDE proxy.conf
+
+modules {
+  $INCLUDE ${raddb}/mods-available/realm
+}
+
+clients indocker {
+	client all {
+		ipaddr = 0.0.0.0/0
+		secret = testing123
+		proto = *
+	}
+}
+
+listen {
+	type = auth
+	ipaddr = *
+	port = 1812
+	proto = udp
+	clients = indocker
+	virtual_server = default
+}
+
+listen {
+	type = acct
+	ipaddr = *
+	port = 1813
+	proto = udp
+	clients = indocker
+	virtual_server = default
+}
+
+
+server default {
+	authorize {
+	  suffix
+	}
+
+	preacct {
+	  suffix
+	}
+}

--- a/src/tests/tls-load/test/proxy/radiusd.conf
+++ b/src/tests/tls-load/test/proxy/radiusd.conf
@@ -5,7 +5,7 @@ pidfile      = ${testdir}/radiusd.pid
 panic_action = "gdb -batch -x ${raddb}/panic.gdb %e %p > ${testdir}/gdb-radiusd.log 2>&1; cat ${testdir}/gdb-radiusd.log"
 certdir      = ${raddb}/certs
 cadir        = ${raddb}/certs
-libdir       = /usr/lib/freeradius
+libdir       = /build/objs/src/modules
 
 max_requests = 1048576
 


### PR DESCRIPTION
- I changed src/tests/Makefile because it did not run. First, I fixed an apparent error in generating test.conf (two /s are generated in a directory path). Second, I changed it so that certs/server.pem and certs/ca.pem are generated before the server is started (this may not be desirable behavior). I would recommend looking over the Makefile to see if it's acceptable.
- I do not know the 'proper way' to add this test to the Makefile, because it seems very different from existing tests. I set it to run under 'all' but not under 'tests' in the testing Makefile.
- Docker generates an excessive amount of output, which may not be desirable when also running many other tests in a Makefile.
- I created a different pull request because this is a significantly different, and I think superior, strategy towards using Docker than what I had before.