### PR TITLE
Initialize sbuff_tests output buffers for now

### DIFF
--- a/src/lib/util/sbuff_tests.c
+++ b/src/lib/util/sbuff_tests.c
@@ -105,7 +105,7 @@ static void test_bstrncpy_exact(void)
 {
 	char const	in[] = "i am a test string";
 	char const	in_long[] = "i am a longer test string";
-	char		out[18 + 1];
+	char		out[18 + 1] = " ";
 	fr_sbuff_t	sbuff;
 	ssize_t		slen;
 
@@ -227,7 +227,7 @@ static void test_bstrncpy_allowed(void)
 {
 	char const	in[] = "i am a test string";
 	char const	in_long[] = "i am a longer test string";
-	char		out[18 + 1];
+	char		out[18 + 1] = " ";
 	fr_sbuff_t	sbuff;
 	ssize_t		slen;
 
@@ -409,7 +409,7 @@ static void test_unescape_until(void)
 	char const		in_long[] = "i am a longer test string";
 	char const		in_escapes[] = "i am a |t|est strin|g";
 	char const		in_escapes_seq[] = "i |x|0am a |t|est strin|g|x20|040";
-	char			out[18 + 1];
+	char			out[18 + 1] = " ";
 	char			escape_out[20 + 1];
 
 	fr_sbuff_t		sbuff;
@@ -827,7 +827,7 @@ static void test_terminal_merge(void)
 static void test_no_advance(void)
 {
 	char const	*in = "i am a test string";
-	char		out[18 + 1];
+	char		out[18 + 1] = " ";
 	fr_sbuff_t	sbuff;
 	ssize_t		slen;
 


### PR DESCRIPTION
CID #1503912, #1503930, #1503945, #1503930, #1503945

This should quiet coverity while we figure out why the sbuff function models don't communicate to coverity that on success, they really do write to the output sbuff.