### PR TITLE
Make clear to fr_radius_ok() that totallen is validated (CID #1455247)

### DIFF
--- a/src/coverity-model/merged_model.c
+++ b/src/coverity-model/merged_model.c
@@ -328,32 +328,3 @@ void fr_md5_calc(uint8_t out[static MD5_DIGEST_LENGTH], uint8_t const *in, size_
 {
 	__coverity_write_buffer_bytes__(out, MD5_DIGEST_LENGTH);
 }
-
-typedef enum {
-	DECODE_FAIL_NONE = 0,
-	DECODE_FAIL_MIN_LENGTH_PACKET,
-	DECODE_FAIL_MIN_LENGTH_FIELD,
-	DECODE_FAIL_MIN_LENGTH_MISMATCH,
-	DECODE_FAIL_HEADER_OVERFLOW,
-	DECODE_FAIL_UNKNOWN_PACKET_CODE,
-	DECODE_FAIL_INVALID_ATTRIBUTE,
-	DECODE_FAIL_ATTRIBUTE_TOO_SHORT,
-	DECODE_FAIL_ATTRIBUTE_OVERFLOW,
-	DECODE_FAIL_MA_INVALID_LENGTH,
-	DECODE_FAIL_ATTRIBUTE_UNDERFLOW,
-	DECODE_FAIL_TOO_MANY_ATTRIBUTES,
-	DECODE_FAIL_MA_MISSING,
-	DECODE_FAIL_MA_INVALID,
-	DECODE_FAIL_UNKNOWN,
-	DECODE_FAIL_MAX
-} decode_fail_t;
-
-bool fr_radius_ok(uint8_t const *packet, size_t *packet_len_p,
-		  uint32_t max_attributes, bool require_ma, decode_fail_t *reason)
-{
-	bool result;
-
-	if (result) __coverity_mark_pointee_as_sanitized__(packet, TAINTED_SCALAR_GENERIC);
-
-	return result;
-}

--- a/src/protocols/radius/base.c
+++ b/src/protocols/radius/base.c
@@ -517,7 +517,7 @@ bool fr_radius_ok(uint8_t const *packet, size_t *packet_len_p,
 	 *
 	 *	i.e. No response to the NAS.
 	 */
-	if (packet_len < totallen) {
+	if (totallen > packet_len) {
 		FR_DEBUG_STRERROR_PRINTF("packet is truncated (received %zu <  packet header length of %zu)",
 					 packet_len, totallen);
 		failure = DECODE_FAIL_MIN_LENGTH_MISMATCH;
@@ -530,7 +530,7 @@ bool fr_radius_ok(uint8_t const *packet, size_t *packet_len_p,
 	 *	"Octets outside the range of the Length field MUST be
 	 *	treated as padding and ignored on reception."
 	 */
-	if (packet_len > totallen) {
+	if (totallen < packet_len) {
 		*packet_len_p = packet_len = totallen;
 	}
 

--- a/src/protocols/radius/decode.c
+++ b/src/protocols/radius/decode.c
@@ -2096,7 +2096,6 @@ static ssize_t fr_radius_decode_proto(TALLOC_CTX *ctx, fr_pair_list_t *out,
 	memcpy(original + 4, test_ctx->vector, sizeof(test_ctx->vector));
 	test_ctx->end = data + packet_len;
 
-	/* coverity[tainted_data] */
 	return fr_radius_decode(ctx, out, data, packet_len, original,
 				test_ctx->secret, talloc_array_length(test_ctx->secret) - 1);
 }


### PR DESCRIPTION
Coverity thinks that calculating totallen via byte-swapping taints the buffer holding the packet to be decoded. Modeling fr_radius_ok() doesn't seem to have worked, so we'll try making it clear to coverity that we validate totallen.