### PR TITLE
Fix _ldap_connection_close_watch panic

### DIFF
--- a/src/lib/ldap/connection.c
+++ b/src/lib/ldap/connection.c
@@ -342,8 +342,6 @@ static fr_connection_state_t _ldap_connection_init(void **h, fr_connection_t *co
 	c = fr_ldap_connection_alloc(conn);
 	c->conn = conn;
 
-	fr_connection_add_watch_pre(conn, FR_CONNECTION_STATE_CLOSED, _ldap_connection_close_watch, true, c);
-
 	/*
 	 *	Configure/allocate the libldap handle
 	 */
@@ -365,6 +363,7 @@ static fr_connection_state_t _ldap_connection_init(void **h, fr_connection_t *co
 	 */
 	MEM(c->queries = fr_rb_inline_talloc_alloc(c, fr_ldap_query_t, node, fr_ldap_query_cmp, NULL));
 	fr_dlist_init(&c->refs, fr_ldap_query_t, entry);
+	fr_connection_add_watch_pre(conn, FR_CONNECTION_STATE_CLOSED, _ldap_connection_close_watch, true, c);
 
 	*h = c;	/* Set the handle */
 


### PR DESCRIPTION
Add `_ldap_connection_close_watch` only after `queries' have been
initialized and after the connection is known to be correctly initialized (and not free'd after being added to close watch list).