### PR TITLE
add Calix-Role in Calix Dictionary

### DIFF
--- a/share/dictionary.calix
+++ b/share/dictionary.calix
@@ -12,6 +12,7 @@
 
 VENDOR		Calix				6321
 
+ATTRIBUTE	Calix-Role			1 string
 ATTRIBUTE	Calix-CMS-User-Group			220	string
 ATTRIBUTE	Calix-CMS-Alarm-Filter			221	integer
 


### PR DESCRIPTION
Some customers uses Calix-Role attribute and when the Calix dictionary was added to the v3.2.x branch it created a conflict error on our end and with lacking Calix-Role attribute.

Same scenario on this PR for v3.2.x

https://github.com/FreeRADIUS/freeradius-server/pull/5121