### PR TITLE
Help coverity recognize the range check (CID #1503921)

### DIFF
--- a/src/protocols/dns/base.c
+++ b/src/protocols/dns/base.c
@@ -222,7 +222,7 @@ bool fr_dns_packet_ok(uint8_t const *packet, size_t packet_len, bool query, fr_d
 			 *	be at least somewhat sane.
 			 */
 			if (*p >= 0xc0) {
-				size_t offset;
+				ptrdiff_t offset;
 
 				if ((p + 2) > end) {
 					DECODE_FAIL(POINTER_OVERFLOWS_PACKET);
@@ -243,12 +243,11 @@ bool fr_dns_packet_ok(uint8_t const *packet, size_t packet_len, bool query, fr_d
 				/*
 				 *	Can't point to the current label.
 				 */
-				if ((packet + offset) >= start) {
+				if (offset >= (start - packet)) {
 					DECODE_FAIL(POINTER_LOOPS);
 					return false;
 				}
 
-				/* coverity[tainted_data] */
 				if (!fr_dns_marker[offset]) {
 					DECODE_FAIL(POINTER_TO_NON_LABEL);
 					return false;


### PR DESCRIPTION
The code checks that offset is in [12, start - packet), and coverity recognizes the lower bound check as constraining offset, but doesn't recognze the upper bound check, hence the TAINTED_SCALAR defect. We rewrite the check in an equivalent form with offset by itself on one side of the relational operator.