### PR TITLE
Enclose explicit loop case of fr_memset_secure() in block

### DIFF
--- a/src/lib/util/misc.c
+++ b/src/lib/util/misc.c
@@ -481,11 +481,13 @@ void fr_memset_secure(void *ptr, size_t len)
 	explicit_bzero(ptr, len);
 
 #else
-	volatile unsigned char *volatile p =  (volatile unsigned char *volatile) ptr;
-	size_t i = len;
-	
-	while (i--) {
-		*(p++) = 0;
+	{
+		volatile unsigned char *volatile p =  (volatile unsigned char *volatile) ptr;
+		size_t i = len;
+
+		while (i--) {
+			*(p++) = 0;
+		}
 	}
 #endif
 }


### PR DESCRIPTION
Done because of the initial if statement, which makes the explicit loop declaratons not be at the start of a block.