### PR TITLE
Check returns (CID #1538387)

### DIFF
--- a/src/protocols/dhcpv4/encode.c
+++ b/src/protocols/dhcpv4/encode.c
@@ -582,10 +582,9 @@ static ssize_t encode_vsio_data(fr_dbuff_t *dbuff,
 	 *
 	 *	And leave room for data-len1
 	 */
-	fr_dbuff_in_bytes(&work_dbuff, (uint8_t) da->attr, 0x00);
-	/* coverity[check_return] */
-	fr_dbuff_in(&work_dbuff, dv->attr);
-	fr_dbuff_in_bytes(&work_dbuff, (uint8_t) 0x00);
+	FR_DBUFF_IN_BYTES_RETURN(&work_dbuff, (uint8_t) da->attr, 0x00);
+	FR_DBUFF_IN_RETURN(&work_dbuff, dv->attr);
+	FR_DBUFF_IN_BYTES_RETURN(&work_dbuff, (uint8_t) 0x00);
 
 	/*
 	 *	https://tools.ietf.org/html/rfc3925#section-4


### PR DESCRIPTION
Humans can figure out that
        FR_DBUFF_REMAINING_RETURN(&foo, bar);
implies that one can safely write bar bytes to the dbuff foo, but coverity can't. There's another use, in fr_tacacs_encode(), but the following operations using the dbuff are checked there.