### PR TITLE
Attempt at a simpler uninit local buffer workaround (CIDs below)

### DIFF
--- a/src/coverity-model/merged_model.c
+++ b/src/coverity-model/merged_model.c
@@ -209,52 +209,6 @@ static void fr_value_box_init(fr_value_box_t *vb, fr_type_t type, fr_dict_attr_t
 	__coverity_writeall__(vb);
 }
 
-ssize_t fr_sbuff_out_bstrncpy_exact(fr_sbuff_t *out, fr_sbuff_t *in, size_t len)
-{
-	ssize_t	result;
-
-	if (result >= 0) __coverity_write_buffer_bytes__(out->p, result);
-
-	return result;
-}
-
-size_t fr_sbuff_out_bstrncpy_allowed(fr_sbuff_t *out, fr_sbuff_t *in, size_t len,
-				     bool const allowed[static UINT8_MAX + 1])
-{
-	size_t	result;
-
-	__coverity_write_buffer_bytes__(out->p, result + 1);
-
-	return result;
-}
-
-typedef struct {
-} 	fr_sbuff_term_t;
-typedef struct {
-} 	fr_sbuff_unescape_rules_t;
-
-size_t fr_sbuff_out_bstrncpy_until(fr_sbuff_t *out, fr_sbuff_t *in, size_t len,
-				   fr_sbuff_term_t const *tt,
-				   fr_sbuff_unescape_rules_t const *u_rules)
-{
-	size_t	result;
-
-	__coverity_write_buffer_bytes__(out->p, result + 1);
-
-	return result;
-}
-
-size_t fr_sbuff_out_unescape_until(fr_sbuff_t *out, fr_sbuff_t *in, size_t len,
-				   fr_sbuff_term_t const *tt,
-				   fr_sbuff_unescape_rules_t const *u_rules)
-{
-	size_t	result;
-
-	__coverity_write_buffer_bytes__(out->p, result + 1);
-
-	return result;
-}
-
 ssize_t fr_dict_attr_oid_print(fr_sbuff_t *out,
 			       fr_dict_attr_t const *ancestor, fr_dict_attr_t const *da, bool numeric)
 {

--- a/src/lib/redis/redis.c
+++ b/src/lib/redis/redis.c
@@ -458,6 +458,7 @@ int fr_redis_tuple_from_map(TALLOC_CTX *pool, char const *out[], size_t out_len[
 	char		*new;
 
 	char		key_buf[256];
+	fr_sbuff_t	key_buf_sbuff = FR_SBUFF_OUT(key_buf, sizeof(key_buf));
 	char		*key;
 	size_t		key_len;
 	ssize_t		slen;
@@ -465,14 +466,14 @@ int fr_redis_tuple_from_map(TALLOC_CTX *pool, char const *out[], size_t out_len[
 	fr_assert(tmpl_is_attr(map->lhs));
 	fr_assert(tmpl_is_data(map->rhs));
 
-	slen = tmpl_print(&FR_SBUFF_OUT(key_buf, sizeof(key_buf)), map->lhs, TMPL_ATTR_REF_PREFIX_NO, NULL);
+	slen = tmpl_print(&key_buf_sbuff, map->lhs, TMPL_ATTR_REF_PREFIX_NO, NULL);
 	if (slen < 0) {
 		fr_strerror_printf("Key too long.  Must be < " STRINGIFY(sizeof(key_buf)) " "
 				   "bytes, got %zu bytes", (size_t)(slen * -1));
 		return -1;
 	}
 	key_len = (size_t)slen;
-	key = talloc_bstrndup(pool, key_buf, key_len);
+	key = talloc_bstrndup(pool, fr_sbuff_start(&key_buf_sbuff), key_len);
 	if (!key) return -1;
 
 	switch (tmpl_value_type(map->rhs)) {

--- a/src/lib/server/map.c
+++ b/src/lib/server/map.c
@@ -1314,6 +1314,7 @@ int map_afrom_attr_str(TALLOC_CTX *ctx, map_t **out, char const *vp_str,
 int map_afrom_vp(TALLOC_CTX *ctx, map_t **out, fr_pair_t *vp, tmpl_rules_t const *rules)
 {
 	char buffer[256];
+	fr_sbuff_t buffer_sbuff = FR_SBUFF_OUT(buffer, sizeof(buffer));
 
 	map_t *map;
 
@@ -1336,8 +1337,8 @@ int map_afrom_vp(TALLOC_CTX *ctx, map_t **out, fr_pair_t *vp, tmpl_rules_t const
 	tmpl_attr_set_request_ref(map->lhs, rules->attr.request_def);
 	tmpl_attr_set_list(map->lhs, rules->attr.list_def);
 
-	tmpl_print(&FR_SBUFF_OUT(buffer, sizeof(buffer)), map->lhs, TMPL_ATTR_REF_PREFIX_YES, NULL);
-	tmpl_set_name(map->lhs, T_BARE_WORD, buffer, -1);
+	tmpl_print(&buffer_sbuff, map->lhs, TMPL_ATTR_REF_PREFIX_YES, NULL);
+	tmpl_set_name(map->lhs, T_BARE_WORD, fr_sbuff_start(&buffer_sbuff), -1);
 
 	/*
 	 *	Allocate the RHS

--- a/src/modules/rlm_pap/rlm_pap.c
+++ b/src/modules/rlm_pap/rlm_pap.c
@@ -807,6 +807,7 @@ static unlang_action_t CC_HINT(nonnull) pap_auth_ns_mta_md5(rlm_rcode_t *p_resul
 	uint8_t digest[128];
 	uint8_t buff[FR_MAX_STRING_LEN];
 	uint8_t buff2[FR_MAX_STRING_LEN + 50];
+	fr_dbuff_t digest_dbuff = FR_DBUFF_TMP(digest, sizeof(digest));
 
 	RDEBUG2("Using Password.NT-MTA-MD5");
 
@@ -819,7 +820,7 @@ static unlang_action_t CC_HINT(nonnull) pap_auth_ns_mta_md5(rlm_rcode_t *p_resul
 	/*
 	 *	Sanity check the value of Password.NS-MTA-MD5
 	 */
-	if (fr_base16_decode(NULL, &FR_DBUFF_TMP(digest, sizeof(digest)),
+	if (fr_base16_decode(NULL, &digest_dbuff,
 		       &FR_SBUFF_IN(known_good->vp_strvalue, known_good->vp_length), false) != 16) {
 		REDEBUG("\"known good\" Password.NS-MTA-MD5 has invalid value");
 		RETURN_MODULE_INVALID;
@@ -853,7 +854,7 @@ static unlang_action_t CC_HINT(nonnull) pap_auth_ns_mta_md5(rlm_rcode_t *p_resul
 		fr_md5_calc(buff, (uint8_t *) buff2, p - buff2);
 	}
 
-	if (fr_digest_cmp(digest, buff, 16) != 0) {
+	if (fr_digest_cmp(fr_dbuff_start(&digest_dbuff), buff, 16) != 0) {
 		REDEBUG("NS-MTA-MD5 digest does not match \"known good\" digest");
 		RETURN_MODULE_REJECT;
 	}


### PR DESCRIPTION
CIDs: 1506690, 1506689, 1504436, 1504041, 1504020, 1503918

This doesn't name the uninitialized local array, but instead goes via the sbuff/dbuff API to get to the data.