### PR TITLE
We don't need scripts/build/lsan_leaks_osx as we have all suppression in __lsan_default_suppressions()

### DIFF
--- a/src/lib/util/debug.c
+++ b/src/lib/util/debug.c
@@ -155,22 +155,22 @@ char const CC_HINT(used) *__lsan_default_suppressions(void)
 	return
 		"leak:CRYPTO_THREAD_lock_new\n"		/* OpenSSL init leak - reported by heaptrack */
 #if defined(__APPLE__)
+		"leak:*gmtsub*\n"
+		"leak:ImageLoaderMachO::doImageInit\n"
+		"leak:_st_tzset_basic\n"
+		"leak:attachCategories\n"
+		"leak:fork\n"
 		"leak:getaddrinfo\n"
 		"leak:getpwuid_r\n"
-		"leak:*gmtsub*\n"
-		"leak:tzsetwall_basic\n"
-		"leak:ImageLoaderMachO::doImageInit\n"
 		"leak:libSystem_atfork_child\n"
-		"leak:fork\n"
-		"leak:tzset\n"
-		"leak:_st_tzset_basic\n"
-		"leak:newlocale\n"
 		"leak:libsystem_notify\n"
-		"leak:attachCategories\n"
 		"leak:load_images\n"
-		"leak:realizeClassWithoutSwift\n"
 		/* Perl >= 5.32.0 - Upstream bug, tracked by https://github.com/Perl/perl5/issues/18108 */
 		"leak:perl_construct"
+		"leak:newlocale\n"
+		"leak:realizeClassWithoutSwift\n"
+		"leak:tzset\n"
+		"leak:tzsetwall_basic\n"
 #elif defined(__linux__)
 		"leak:kqueue\n"
 		"leak:*getpwnam_r*\n"			/* libc startup leak - reported by heaptrack */

--- a/src/tests/all.mk
+++ b/src/tests/all.mk
@@ -92,11 +92,7 @@ ifneq "$(findstring test,$(MAKECMDGOALS))$(findstring clean,$(MAKECMDGOALS))" ""
 ifneq "$(findstring leak,$(CFLAGS))" ""
 export ASAN_SYMBOLIZER_PATH=$(shell which llvm-symbolizer)
 export ASAN_OPTIONS=malloc_context_size=50 detect_leaks=1 symbolize=1
-ifneq "$(findstring apple,$(AC_HOSTINFO))" ""
-export LSAN_OPTIONS=print_suppressions=0 fast_unwind_on_malloc=0 suppressions=${top_srcdir}/scripts/build/lsan_leaks_osx
-else
 export LSAN_OPTIONS=print_suppressions=0 fast_unwind_on_malloc=0
-endif
 endif
 
 SUBMAKEFILES := rbmonkey.mk $(subst src/tests/,,$(wildcard src/tests/*/all.mk))


### PR DESCRIPTION
* we don't need scripts/build/lsan_leaks_osx as we have all suppression in __lsan_default_suppressions()
* sorted in alphabetic order.