### PR TITLE
rlm_sql_mysql: Check if the 'result' pointer is valid in both cases

### DIFF
--- a/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_mysql/rlm_sql_mysql.c
@@ -475,6 +475,7 @@ static int sql_num_fields(rlm_sql_handle_t *handle, UNUSED rlm_sql_config_t cons
 	rlm_sql_mysql_conn_t *conn = handle->conn;
 
 #if MYSQL_VERSION_ID >= 32224
+	if (!conn->sock) return 0;
 	/*
 	 *	Count takes a connection handle
 	 */


### PR DESCRIPTION
It should be verified before, then it will be possible to avoid
calling `mysql_field_count` with an invalid pointer.