### PR TITLE
Fix remaining uninitialized scalar values (CID #1503958, #1504020)

### DIFF
--- a/src/lib/util/value.c
+++ b/src/lib/util/value.c
@@ -4978,7 +4978,7 @@ parse:
 		fr_base16_decode(&err, &dbuff, &our_in, true);
 		if (err != FR_SBUFF_PARSE_OK) goto ether_error;
 
-		fr_value_box_ethernet_addr(dst, dst_enumv, &ether, tainted);
+		fr_value_box_ethernet_addr(dst, dst_enumv, (fr_ethernet_t * const)fr_dbuff_start(&dbuff), tainted);
 
 		FR_SBUFF_SET_RETURN(in, &our_in);
 	}


### PR DESCRIPTION
The latter issue was interesting; the dbuff is set to use ether.addr, but fr_value_box_ethernet_addr() is passed &ether, which looks like it will put random garbage in the value box until you notice that the address is the only member of the type. We'll see whether coverity considers (fr_ethernet_t * const) fr_dbuff_start(&dbuff) a dangerous downcast (whatever that means in C) and still complains. I hope not, because the only reason that comes to mind for it is alignment issues, which shouldn't happen here.