### PR TITLE
Skip fr_assert() for static analysis (CID #1414423)

### DIFF
--- a/src/lib/server/pool.c
+++ b/src/lib/server/pool.c
@@ -306,7 +306,13 @@ static fr_pool_connection_t *connection_find(fr_pool_t *pool, void *conn)
 			fr_assert(pthread_equal(this->pthread_id, pthread_id) != 0);
 #endif
 
+#ifndef STATIC_ANALYZER
+			/*
+			 *	For static analyzers, fr_assert() is assert(),
+			 * 	changing semantics so the mutex is not released.
+			 */
 			fr_assert(this->in_use == true);
+#endif
 			return this;
 		}
 	}


### PR DESCRIPTION
For static analysis, fr_assert() is plain assert...but otherwise, for non-debugging versions, it just logs. That means that to coverity, the mutex won't be unlocked, while in production it will always be unlocked.