### PR TITLE
Dictionaries prefix are not longer used

### DIFF
--- a/share/dictionary/radius/dictionary.broadsoft
+++ b/share/dictionary/radius/dictionary.broadsoft
@@ -1,5 +1,5 @@
 # -*- text -*-
-# Copyright (C) 2022 The FreeRADIUS Server project and contributors
+# Copyright (C) 2023 The FreeRADIUS Server project and contributors
 # This work is licensed under CC-BY version 4.0 https://creativecommons.org/licenses/by/4.0
 # Version $Id$
 #

--- a/share/dictionary/radius/dictionary.chillispot
+++ b/share/dictionary/radius/dictionary.chillispot
@@ -1,5 +1,5 @@
 # -*- text -*-
-# Copyright (C) 2022 The FreeRADIUS Server project and contributors
+# Copyright (C) 2023 The FreeRADIUS Server project and contributors
 # This work is licensed under CC-BY version 4.0 https://creativecommons.org/licenses/by/4.0
 # Version $Id$
 ##############################################################################

--- a/share/dictionary/radius/dictionary.cisco.vpn3000
+++ b/share/dictionary/radius/dictionary.cisco.vpn3000
@@ -1,5 +1,5 @@
 # -*- text -*-
-# Copyright (C) 2022 The FreeRADIUS Server project and contributors
+# Copyright (C) 2023 The FreeRADIUS Server project and contributors
 # This work is licensed under CC-BY version 4.0 https://creativecommons.org/licenses/by/4.0
 # Version $Id$
 #
@@ -92,26 +92,26 @@ ATTRIBUTE	IE-Proxy-Exception-List			82	string
 ATTRIBUTE	IE-Proxy-Bypass-Local			83	integer
 ATTRIBUTE	IKE-Keepalive-Retry-Interval		84	integer
 ATTRIBUTE	Tunnel-Group-Lock			85	string
-ATTRIBUTE	Cisco-VPN3000-Access-List-Inbound	86	string
-ATTRIBUTE	Cisco-VPN3000-Access-List-Outbound	87	string
-ATTRIBUTE	Cisco-VPN3000-Perfect-Forward-Secrecy-Enable 88	integer
-ATTRIBUTE	Cisco-VPN3000-NAC-Enable		89	integer
-ATTRIBUTE	Cisco-VPN3000-NAC-Status-Query-Timer	90	integer
-ATTRIBUTE	Cisco-VPN3000-NAC-Revalidation-Timer	91	integer
-ATTRIBUTE	Cisco-VPN3000-NAC-Default-ACL		92	integer
-ATTRIBUTE	Cisco-VPN3000-WebVPN-URL-Entry-Enable	93	integer
-ATTRIBUTE	Cisco-VPN3000-WebVPN-File-Access-Enable	94	integer
-ATTRIBUTE	Cisco-VPN3000-WebVPN-File-Server-Entry-Enable 95	integer
-ATTRIBUTE	Cisco-VPN3000-WebVPN-File-Server-Browsing-Enable 96	integer
-ATTRIBUTE	Cisco-VPN3000-WebVPN-Port-Forwarding-Enable 97	integer
-ATTRIBUTE	Cisco-VPN3000-WebVPN-Outlook-Exchange-Proxy-Enable 98	integer
-ATTRIBUTE	Cisco-VPN3000-WebVPN-HTTP-Proxy-Enable	99	integer
-ATTRIBUTE	Cisco-VPN3000-WebVPN-Auto-Applet-Download-Enable 100	integer
-ATTRIBUTE	Cisco-VPN3000-WebVPN-Citrix-MetaFrame-Enable 101	integer
-ATTRIBUTE	Cisco-VPN3000-WebVPN-Apply-ACL		102	integer
-ATTRIBUTE	Cisco-VPN3000-WebVPN-SSL-VPN-Client-Enable 103	integer
-ATTRIBUTE	Cisco-VPN3000-WebVPN-SSL-VPN-Client-Required 104	integer
-ATTRIBUTE	Cisco-VPN3000-WebVPN-SSL-VPN-Client-Keep-Installation 105	integer
+ATTRIBUTE	Access-List-Inbound			86	string
+ATTRIBUTE	Access-List-Outbound			87	string
+ATTRIBUTE	Perfect-Forward-Secrecy-Enable		88	integer
+ATTRIBUTE	NAC-Enable				89	integer
+ATTRIBUTE	NAC-Status-Query-Timer			90	integer
+ATTRIBUTE	NAC-Revalidation-Timer			91	integer
+ATTRIBUTE	NAC-Default-ACL				92	integer
+ATTRIBUTE	WebVPN-URL-Entry-Enable			93	integer
+ATTRIBUTE	WebVPN-File-Access-Enable		94	integer
+ATTRIBUTE	WebVPN-File-Server-Entry-Enable		95	integer
+ATTRIBUTE	WebVPN-File-Server-Browsing-Enable	96	integer
+ATTRIBUTE	WebVPN-Port-Forwarding-Enable		97	integer
+ATTRIBUTE	WebVPN-Outlook-Exchange-Proxy-Enable	98	integer
+ATTRIBUTE	WebVPN-HTTP-Proxy-Enable		99	integer
+ATTRIBUTE	WebVPN-Auto-Applet-Download-Enable	100	integer
+ATTRIBUTE	WebVPN-Citrix-MetaFrame-Enable		101	integer
+ATTRIBUTE	WebVPN-Apply-ACL			102	integer
+ATTRIBUTE	WebVPN-SSL-VPN-Client-Enable		103	integer
+ATTRIBUTE	WebVPN-SSL-VPN-Client-Required		104	integer
+ATTRIBUTE	WebVPN-SSL-VPN-Client-Keep-Installation	105	integer
 
 ATTRIBUTE	Partition-Primary-DHCP			128	ipaddr
 ATTRIBUTE	Partition-Secondary-DHCP		129	ipaddr

--- a/share/dictionary/radius/dictionary.erx
+++ b/share/dictionary/radius/dictionary.erx
@@ -1,5 +1,5 @@
 # -*- text -*-
-# Copyright (C) 2022 The FreeRADIUS Server project and contributors
+# Copyright (C) 2023 The FreeRADIUS Server project and contributors
 # This work is licensed under CC-BY version 4.0 https://creativecommons.org/licenses/by/4.0
 # Version $Id$
 #
@@ -55,379 +55,379 @@ VENDOR		ERX				4874
 
 BEGIN-VENDOR	ERX
 
-ATTRIBUTE	ERX-Virtual-Router-Name			1	string
-ATTRIBUTE	ERX-Address-Pool-Name			2	string
-ATTRIBUTE	ERX-Local-Loopback-Interface		3	string
-ATTRIBUTE	ERX-Primary-Dns				4	ipaddr
-ATTRIBUTE	ERX-Secondary-Dns			5	ipaddr
-ATTRIBUTE	ERX-Primary-Wins			6	ipaddr
-ATTRIBUTE	ERX-Secondary-Wins			7	ipaddr
-ATTRIBUTE	ERX-Tunnel-Virtual-Router		8	string	has_tag
-ATTRIBUTE	ERX-Tunnel-Password			9	string	has_tag
-ATTRIBUTE	ERX-Ingress-Policy-Name			10	string
-ATTRIBUTE	ERX-Egress-Policy-Name			11	string
-ATTRIBUTE	ERX-Ingress-Statistics			12	integer
-ATTRIBUTE	ERX-Egress-Statistics			13	integer
-ATTRIBUTE	ERX-Atm-Service-Category		14	integer
-ATTRIBUTE	ERX-Atm-PCR				15	integer
-ATTRIBUTE	ERX-Atm-SCR				16	integer
-ATTRIBUTE	ERX-Atm-MBS				17	integer
-ATTRIBUTE	ERX-Cli-Initial-Access-Level		18	string
-ATTRIBUTE	ERX-Cli-Allow-All-VR-Access		19	integer
-ATTRIBUTE	ERX-Alternate-Cli-Access-Level		20	string
-ATTRIBUTE	ERX-Alternate-Cli-Vrouter-Name		21	string
-ATTRIBUTE	ERX-Sa-Validate				22	integer
-ATTRIBUTE	ERX-Igmp-Enable				23	integer
-ATTRIBUTE	ERX-Pppoe-Description			24	string
-ATTRIBUTE	ERX-Redirect-VR-Name			25	string
-ATTRIBUTE	ERX-Qos-Profile-Name			26	string
-ATTRIBUTE	ERX-Pppoe-Max-Sessions			27	integer
-ATTRIBUTE	ERX-Pppoe-Url				28	string
-ATTRIBUTE	ERX-Qos-Profile-Interface-Type		29	integer
-ATTRIBUTE	ERX-Tunnel-Nas-Port-Method		30	integer
-ATTRIBUTE	ERX-Service-Bundle			31	string
-ATTRIBUTE	ERX-Tunnel-Tos				32	integer
-ATTRIBUTE	ERX-Tunnel-Maximum-Sessions		33	integer
-ATTRIBUTE	ERX-Framed-Ip-Route-Tag			34	string
-ATTRIBUTE	ERX-Dial-Out-Number			35	string
-ATTRIBUTE	ERX-PPP-Username			36	string
-ATTRIBUTE	ERX-PPP-Password			37	string
-ATTRIBUTE	ERX-PPP-Auth-Protocol			38	integer
-ATTRIBUTE	ERX-Minimum-BPS				39	integer
-ATTRIBUTE	ERX-Maximum-BPS				40	integer
-ATTRIBUTE	ERX-Bearer-Type				41	integer
-ATTRIBUTE	ERX-Input-Gigapkts			42	integer
-ATTRIBUTE	ERX-Output-Gigapkts			43	integer
-ATTRIBUTE	ERX-Tunnel-Interface-Id			44	string
-ATTRIBUTE	ERX-IpV6-Virtual-Router			45	string
-ATTRIBUTE	ERX-IpV6-Local-Interface		46	string
-ATTRIBUTE	ERX-Ipv6-Primary-Dns			47	ipv6addr
-ATTRIBUTE	ERX-Ipv6-Secondary-Dns			48	ipv6addr
+ATTRIBUTE	Virtual-Router-Name			1	string
+ATTRIBUTE	Address-Pool-Name			2	string
+ATTRIBUTE	Local-Loopback-Interface		3	string
+ATTRIBUTE	Primary-Dns				4	ipaddr
+ATTRIBUTE	Secondary-Dns				5	ipaddr
+ATTRIBUTE	Primary-Wins				6	ipaddr
+ATTRIBUTE	Secondary-Wins				7	ipaddr
+ATTRIBUTE	Tunnel-Virtual-Router			8	string	has_tag
+ATTRIBUTE	Tunnel-Password				9	string	has_tag
+ATTRIBUTE	Ingress-Policy-Name			10	string
+ATTRIBUTE	Egress-Policy-Name			11	string
+ATTRIBUTE	Ingress-Statistics			12	integer
+ATTRIBUTE	Egress-Statistics			13	integer
+ATTRIBUTE	Atm-Service-Category			14	integer
+ATTRIBUTE	Atm-PCR					15	integer
+ATTRIBUTE	Atm-SCR					16	integer
+ATTRIBUTE	Atm-MBS					17	integer
+ATTRIBUTE	Cli-Initial-Access-Level		18	string
+ATTRIBUTE	Cli-Allow-All-VR-Access			19	integer
+ATTRIBUTE	Alternate-Cli-Access-Level		20	string
+ATTRIBUTE	Alternate-Cli-Vrouter-Name		21	string
+ATTRIBUTE	Sa-Validate				22	integer
+ATTRIBUTE	Igmp-Enable				23	integer
+ATTRIBUTE	Pppoe-Description			24	string
+ATTRIBUTE	Redirect-VR-Name			25	string
+ATTRIBUTE	Qos-Profile-Name			26	string
+ATTRIBUTE	Pppoe-Max-Sessions			27	integer
+ATTRIBUTE	Pppoe-Url				28	string
+ATTRIBUTE	Qos-Profile-Interface-Type		29	integer
+ATTRIBUTE	Tunnel-Nas-Port-Method			30	integer
+ATTRIBUTE	Service-Bundle				31	string
+ATTRIBUTE	Tunnel-Tos				32	integer
+ATTRIBUTE	Tunnel-Maximum-Sessions			33	integer
+ATTRIBUTE	Framed-Ip-Route-Tag			34	string
+ATTRIBUTE	Dial-Out-Number				35	string
+ATTRIBUTE	PPP-Username				36	string
+ATTRIBUTE	PPP-Password				37	string
+ATTRIBUTE	PPP-Auth-Protocol			38	integer
+ATTRIBUTE	Minimum-BPS				39	integer
+ATTRIBUTE	Maximum-BPS				40	integer
+ATTRIBUTE	Bearer-Type				41	integer
+ATTRIBUTE	Input-Gigapkts				42	integer
+ATTRIBUTE	Output-Gigapkts				43	integer
+ATTRIBUTE	Tunnel-Interface-Id			44	string
+ATTRIBUTE	IpV6-Virtual-Router			45	string
+ATTRIBUTE	IpV6-Local-Interface			46	string
+ATTRIBUTE	Ipv6-Primary-Dns			47	ipv6addr
+ATTRIBUTE	Ipv6-Secondary-Dns			48	ipv6addr
 ATTRIBUTE	Sdx-Service-Name			49	string
 ATTRIBUTE	Sdx-Session-Volume-Quota		50	string
 ATTRIBUTE	Sdx-Tunnel-Disconnect-Cause-Info	51	string
-ATTRIBUTE	ERX-Radius-Client-Address		52	ipaddr
-ATTRIBUTE	ERX-Service-Description			53	string
-ATTRIBUTE	ERX-L2tp-Recv-Window-Size		54	integer
-ATTRIBUTE	ERX-Dhcp-Options			55	octets
-ATTRIBUTE	ERX-Dhcp-Mac-Addr			56	string
-ATTRIBUTE	ERX-Dhcp-Gi-Address			57	ipaddr
-ATTRIBUTE	ERX-LI-Action				58	integer	encrypt=2
-ATTRIBUTE	ERX-Med-Dev-Handle			59	octets	encrypt=2
-ATTRIBUTE	ERX-Med-Ip-Address			60	ipaddr	encrypt=2
-ATTRIBUTE	ERX-Med-Port-Number			61	integer	encrypt=2
-ATTRIBUTE	ERX-MLPPP-Bundle-Name			62	string
-ATTRIBUTE	ERX-Interface-Desc			63	string
-ATTRIBUTE	ERX-Tunnel-Group			64	string
-ATTRIBUTE	ERX-Service-Activate			65	string	has_tag
-ATTRIBUTE	ERX-Service-Deactivate			66	string
-ATTRIBUTE	ERX-Service-Volume			67	integer	has_tag
-ATTRIBUTE	ERX-Service-Timeout			68	integer	has_tag
-ATTRIBUTE	ERX-Service-Statistics			69	integer	has_tag
+ATTRIBUTE	Radius-Client-Address			52	ipaddr
+ATTRIBUTE	Service-Description			53	string
+ATTRIBUTE	L2tp-Recv-Window-Size			54	integer
+ATTRIBUTE	Dhcp-Options				55	octets
+ATTRIBUTE	Dhcp-Mac-Addr				56	string
+ATTRIBUTE	Dhcp-Gi-Address				57	ipaddr
+ATTRIBUTE	LI-Action				58	integer	encrypt=2
+ATTRIBUTE	Med-Dev-Handle				59	octets	encrypt=2
+ATTRIBUTE	Med-Ip-Address				60	ipaddr	encrypt=2
+ATTRIBUTE	Med-Port-Number				61	integer	encrypt=2
+ATTRIBUTE	MLPPP-Bundle-Name			62	string
+ATTRIBUTE	Interface-Desc				63	string
+ATTRIBUTE	Tunnel-Group				64	string
+ATTRIBUTE	Service-Activate			65	string	has_tag
+ATTRIBUTE	Service-Deactivate			66	string
+ATTRIBUTE	Service-Volume				67	integer	has_tag
+ATTRIBUTE	Service-Timeout				68	integer	has_tag
+ATTRIBUTE	Service-Statistics			69	integer	has_tag
 
-ATTRIBUTE	ERX-DF-Bit				70	integer
+ATTRIBUTE	DF-Bit					70	integer
 
-ATTRIBUTE	ERX-IGMP-Access-Name			71	string
-ATTRIBUTE	ERX-IGMP-Access-Src-Name		72	string
-ATTRIBUTE	ERX-IGMP-OIF-Map-Name			73	string
+ATTRIBUTE	IGMP-Access-Name			71	string
+ATTRIBUTE	IGMP-Access-Src-Name			72	string
+ATTRIBUTE	IGMP-OIF-Map-Name			73	string
 
-ATTRIBUTE	ERX-MLD-Access-Name			74	string
-ATTRIBUTE	ERX-MLD-Access-Src-Name			75	string
-ATTRIBUTE	ERX-MLD-OIF-Map-Name			76	string
-ATTRIBUTE	ERX-MLD-Version				77	integer
-ATTRIBUTE	ERX-IGMP-Version			78	integer
-ATTRIBUTE	ERX-IP-Mcast-Adm-Bw-Limit		79	integer
-ATTRIBUTE	ERX-IPv6-Mcast-Adm-Bw-Limit		80	integer
-ATTRIBUTE	ERX-Qos-Parameters			82	string
-ATTRIBUTE	ERX-Service-Session			83	string
+ATTRIBUTE	MLD-Access-Name				74	string
+ATTRIBUTE	MLD-Access-Src-Name			75	string
+ATTRIBUTE	MLD-OIF-Map-Name			76	string
+ATTRIBUTE	MLD-Version				77	integer
+ATTRIBUTE	IGMP-Version				78	integer
+ATTRIBUTE	IP-Mcast-Adm-Bw-Limit			79	integer
+ATTRIBUTE	IPv6-Mcast-Adm-Bw-Limit			80	integer
+ATTRIBUTE	Qos-Parameters				82	string
+ATTRIBUTE	Service-Session				83	string
 
-ATTRIBUTE	ERX-Mobile-IP-Algorithm			84	integer
-ATTRIBUTE	ERX-Mobile-IP-SPI			85	integer
-ATTRIBUTE	ERX-Mobile-IP-Key			86	string
-ATTRIBUTE	ERX-Mobile-IP-Replay			87	integer
-ATTRIBUTE	ERX-Mobile-IP-Access-Control		88	string
-ATTRIBUTE	ERX-Mobile-IP-Lifetime			89	integer
+ATTRIBUTE	Mobile-IP-Algorithm			84	integer
+ATTRIBUTE	Mobile-IP-SPI				85	integer
+ATTRIBUTE	Mobile-IP-Key				86	string
+ATTRIBUTE	Mobile-IP-Replay			87	integer
+ATTRIBUTE	Mobile-IP-Access-Control		88	string
+ATTRIBUTE	Mobile-IP-Lifetime			89	integer
 
-ATTRIBUTE	ERX-L2TP-Resynch-Method			90	integer
+ATTRIBUTE	L2TP-Resynch-Method			90	integer
 
-ATTRIBUTE	ERX-Tunnel-Switch-Profile		91	string
+ATTRIBUTE	Tunnel-Switch-Profile			91	string
 
-ATTRIBUTE	ERX-L2c-Up-Stream-Data			92	string
-ATTRIBUTE	ERX-L2c-Down-Stream-Data		93	string
+ATTRIBUTE	L2c-Up-Stream-Data			92	string
+ATTRIBUTE	L2c-Down-Stream-Data			93	string
 
-ATTRIBUTE	ERX-Tunnel-Tx-Speed-Method		94	integer
+ATTRIBUTE	Tunnel-Tx-Speed-Method			94	integer
 
-ATTRIBUTE	ERX-IGMP-Query-Interval			95	integer
-ATTRIBUTE	ERX-IGMP-Max-Resp-Time			96	integer
-ATTRIBUTE	ERX-IGMP-Immediate-Leave		97	integer
-ATTRIBUTE	ERX-MLD-Query-Interval			98	integer
-ATTRIBUTE	ERX-MLD-Max-Resp-Time			99	integer
-ATTRIBUTE	ERX-MLD-Immediate-Leave			100	integer
-ATTRIBUTE	ERX-IP-Block-Multicast			101	integer
+ATTRIBUTE	IGMP-Query-Interval			95	integer
+ATTRIBUTE	IGMP-Max-Resp-Time			96	integer
+ATTRIBUTE	IGMP-Immediate-Leave			97	integer
+ATTRIBUTE	MLD-Query-Interval			98	integer
+ATTRIBUTE	MLD-Max-Resp-Time			99	integer
+ATTRIBUTE	MLD-Immediate-Leave			100	integer
+ATTRIBUTE	IP-Block-Multicast			101	integer
 
-ATTRIBUTE	ERX-IGMP-Explicit-Tracking		102	integer
-ATTRIBUTE	ERX-IGMP-No-Tracking-V2-Grps		103	integer
-ATTRIBUTE	ERX-MLD-Explicit-Tracking		104	integer
-ATTRIBUTE	ERX-MLD-No-Tracking-V1-Grps		105	integer
+ATTRIBUTE	IGMP-Explicit-Tracking			102	integer
+ATTRIBUTE	IGMP-No-Tracking-V2-Grps		103	integer
+ATTRIBUTE	MLD-Explicit-Tracking			104	integer
+ATTRIBUTE	MLD-No-Tracking-V1-Grps			105	integer
 
-ATTRIBUTE	ERX-IPv6-Ingress-Policy-Name		106	string
-ATTRIBUTE	ERX-IPv6-Egress-Policy-Name		107	string
-ATTRIBUTE	ERX-CoS-Shaping-Pmt-Type		108	string
-ATTRIBUTE	ERX-DHCP-Guided-Relay-Server		109	ipaddr
+ATTRIBUTE	IPv6-Ingress-Policy-Name		106	string
+ATTRIBUTE	IPv6-Egress-Policy-Name			107	string
+ATTRIBUTE	CoS-Shaping-Pmt-Type			108	string
+ATTRIBUTE	DHCP-Guided-Relay-Server		109	ipaddr
 
-ATTRIBUTE	ERX-Acc-Loop-Cir-Id			110	string
-ATTRIBUTE	ERX-Acc-Aggr-Cir-Id-Bin			111	octets
-ATTRIBUTE	ERX-Acc-Aggr-Cir-Id-Asc			112	string
-ATTRIBUTE	ERX-Act-Data-Rate-Up			113	integer
-ATTRIBUTE	ERX-Act-Data-Rate-Dn			114	integer
-ATTRIBUTE	ERX-Min-Data-Rate-Up			115	integer
-ATTRIBUTE	ERX-Min-Data-Rate-Dn			116	integer
-ATTRIBUTE	ERX-Att-Data-Rate-Up			117	integer
-ATTRIBUTE	ERX-Att-Data-Rate-Dn			118	integer
-ATTRIBUTE	ERX-Max-Data-Rate-Up			119	integer
-ATTRIBUTE	ERX-Max-Data-Rate-Dn			120	integer
-ATTRIBUTE	ERX-Min-LP-Data-Rate-Up			121	integer
-ATTRIBUTE	ERX-Min-LP-Data-Rate-Dn			122	integer
-ATTRIBUTE	ERX-Max-Interlv-Delay-Up		123	integer
-ATTRIBUTE	ERX-Act-Interlv-Delay-Up		124	integer
-ATTRIBUTE	ERX-Max-Interlv-Delay-Dn		125	integer
-ATTRIBUTE	ERX-Act-Interlv-Delay-Dn		126	integer
-ATTRIBUTE	ERX-DSL-Line-State			127	integer
-ATTRIBUTE	ERX-DSL-Type				128	integer
+ATTRIBUTE	Acc-Loop-Cir-Id				110	string
+ATTRIBUTE	Acc-Aggr-Cir-Id-Bin			111	octets
+ATTRIBUTE	Acc-Aggr-Cir-Id-Asc			112	string
+ATTRIBUTE	Act-Data-Rate-Up			113	integer
+ATTRIBUTE	Act-Data-Rate-Dn			114	integer
+ATTRIBUTE	Min-Data-Rate-Up			115	integer
+ATTRIBUTE	Min-Data-Rate-Dn			116	integer
+ATTRIBUTE	Att-Data-Rate-Up			117	integer
+ATTRIBUTE	Att-Data-Rate-Dn			118	integer
+ATTRIBUTE	Max-Data-Rate-Up			119	integer
+ATTRIBUTE	Max-Data-Rate-Dn			120	integer
+ATTRIBUTE	Min-LP-Data-Rate-Up			121	integer
+ATTRIBUTE	Min-LP-Data-Rate-Dn			122	integer
+ATTRIBUTE	Max-Interlv-Delay-Up			123	integer
+ATTRIBUTE	Act-Interlv-Delay-Up			124	integer
+ATTRIBUTE	Max-Interlv-Delay-Dn			125	integer
+ATTRIBUTE	Act-Interlv-Delay-Dn			126	integer
+ATTRIBUTE	DSL-Line-State				127	integer
+ATTRIBUTE	DSL-Type				128	integer
 
-ATTRIBUTE	ERX-IPv6-NdRa-Prefix			129	ipv6prefix
-ATTRIBUTE	ERX-Qos-Set-Name			130	string
+ATTRIBUTE	IPv6-NdRa-Prefix			129	ipv6prefix
+ATTRIBUTE	Qos-Set-Name				130	string
 
-ATTRIBUTE	ERX-Service-Acct-Interval		140	integer has_tag
+ATTRIBUTE	Service-Acct-Interval			140	integer has_tag
 
-ATTRIBUTE	ERX-DownStream-Calc-Rate		141	integer
-ATTRIBUTE	ERX-UpStream-Calc-Rate			142	integer
-ATTRIBUTE	ERX-Max-Clients-Per-Interface		143	integer
+ATTRIBUTE	DownStream-Calc-Rate			141	integer
+ATTRIBUTE	UpStream-Calc-Rate			142	integer
+ATTRIBUTE	Max-Clients-Per-Interface		143	integer
 
-ATTRIBUTE	ERX-PPP-Monitor-Ingress-Only		144	integer
+ATTRIBUTE	PPP-Monitor-Ingress-Only		144	integer
 
-ATTRIBUTE	ERX-CoS-Scheduler-Pmt-Type		146	string
-ATTRIBUTE	ERX-Backup-Address-Pool			147	string
+ATTRIBUTE	CoS-Scheduler-Pmt-Type			146	string
+ATTRIBUTE	Backup-Address-Pool			147	string
 
-ATTRIBUTE	ERX-ICR-Partition-Id			150	string
-ATTRIBUTE	ERX-IPv6-Acct-Input-Octets		151	integer
-ATTRIBUTE	ERX-IPv6-Acct-Output-Octets		152	integer
-ATTRIBUTE	ERX-IPv6-Acct-Input-Packets		153	integer
-ATTRIBUTE	ERX-IPv6-Acct-Output-Packets		154	integer
-ATTRIBUTE	ERX-IPv6-Acct-Input-Gigawords		155	integer
-ATTRIBUTE	ERX-IPv6-Acct-Output-Gigawords		156	integer
-ATTRIBUTE	ERX-IPv6-NdRa-Pool-Name			157	string
-ATTRIBUTE	ERX-PppoE-Padn				158	string
-ATTRIBUTE	ERX-Dhcp-Option-82			159	octets
-ATTRIBUTE	ERX-Vlan-Map-Id				160	integer
-ATTRIBUTE	ERX-IPv6-Delegated-Pool-Name		161	string
-ATTRIBUTE	ERX-Tx-Connect-Speed			162	integer
-ATTRIBUTE	ERX-Rx-Connect-Speed			163	integer
+ATTRIBUTE	ICR-Partition-Id			150	string
+ATTRIBUTE	IPv6-Acct-Input-Octets			151	integer
+ATTRIBUTE	IPv6-Acct-Output-Octets			152	integer
+ATTRIBUTE	IPv6-Acct-Input-Packets			153	integer
+ATTRIBUTE	IPv6-Acct-Output-Packets		154	integer
+ATTRIBUTE	IPv6-Acct-Input-Gigawords		155	integer
+ATTRIBUTE	IPv6-Acct-Output-Gigawords		156	integer
+ATTRIBUTE	IPv6-NdRa-Pool-Name			157	string
+ATTRIBUTE	PppoE-Padn				158	string
+ATTRIBUTE	Dhcp-Option-82				159	octets
+ATTRIBUTE	Vlan-Map-Id				160	integer
+ATTRIBUTE	IPv6-Delegated-Pool-Name		161	string
+ATTRIBUTE	Tx-Connect-Speed			162	integer
+ATTRIBUTE	Rx-Connect-Speed			163	integer
 
 # ATTRIBUTE 164 - 173 RESERVED
-ATTRIBUTE	ERX-Service-Activate-Type		173	integer
-ATTRIBUTE	ERX-Client-Profile-Name			174	string
-ATTRIBUTE	ERX-Redirect-GW-Address			175	ipaddr
-ATTRIBUTE	ERX-APN-Name				176	string
-ATTRIBUTE	ERX-Cos-Shaping-Rate			177	string
+ATTRIBUTE	Service-Activate-Type			173	integer
+ATTRIBUTE	Client-Profile-Name			174	string
+ATTRIBUTE	Redirect-GW-Address			175	ipaddr
+ATTRIBUTE	APN-Name				176	string
+ATTRIBUTE	Cos-Shaping-Rate			177	string
 
-ATTRIBUTE	ERX-Service-Volume-Gigawords		179	integer
-ATTRIBUTE	ERX-Update-Service			180	string
-ATTRIBUTE	ERX-DHCPv6-Guided-Relay-Server		181	ipv6addr
-ATTRIBUTE	ERX-Acc-Loop-Remote-Id			182	string
-ATTRIBUTE	ERX-Acc-Loop-Encap			183	octets
-ATTRIBUTE	ERX-Inner-Vlan-Map-Id			184	integer
-ATTRIBUTE	ERX-Core-Facing-Interface		185	string
-ATTRIBUTE	ERX-DHCP-First-Relay-IPv4-Address	189	ipaddr
-ATTRIBUTE	ERX-DHCP-First-Relay-IPv6-Address	190	ipv6addr
-ATTRIBUTE	ERX-Input-Interface-Filter		191	string
-ATTRIBUTE	ERX-Output-Interface-Filter		192	string
-ATTRIBUTE	ERX-Pim-Enable				193	integer
-ATTRIBUTE	ERX-Bulk-CoA-Transaction-Id		194	integer
-ATTRIBUTE	ERX-Bulk-CoA-Identifier			195	integer
-ATTRIBUTE	ERX-IPv4-Input-Service-Set		196	string
-ATTRIBUTE	ERX-IPv4-Output-Service-Set		197	string
-ATTRIBUTE	ERX-IPv4-Input-Service-Filter		198	string
-ATTRIBUTE	ERX-IPv4-Output-Service-Filter		199	string
-ATTRIBUTE	ERX-IPv6-Input-Service-Set		200	string
-ATTRIBUTE	ERX-IPv6-Output-Service-Set		201	string
-ATTRIBUTE	ERX-IPv6-Input-Service-Filter		202	string
-ATTRIBUTE	ERX-IPv6-Output-Service-Filter		203	string
-ATTRIBUTE	ERX-Adv-Pcef-Profile-Name		204	string
-ATTRIBUTE	ERX-Adv-Pcef-Rule-Name			205	string
-ATTRIBUTE	ERX-Re-Authentication-Catalyst		206	integer
-ATTRIBUTE	ERX-DHCPv6-Options			207	octets
-ATTRIBUTE	ERX-DHCP-Header				208	octets
-ATTRIBUTE	ERX-DHCPv6-Header			209	octets
-ATTRIBUTE	ERX-Acct-Request-Reason			210	integer
+ATTRIBUTE	Service-Volume-Gigawords		179	integer
+ATTRIBUTE	Update-Service				180	string
+ATTRIBUTE	DHCPv6-Guided-Relay-Server		181	ipv6addr
+ATTRIBUTE	Acc-Loop-Remote-Id			182	string
+ATTRIBUTE	Acc-Loop-Encap				183	octets
+ATTRIBUTE	Inner-Vlan-Map-Id			184	integer
+ATTRIBUTE	Core-Facing-Interface			185	string
+ATTRIBUTE	DHCP-First-Relay-IPv4-Address		189	ipaddr
+ATTRIBUTE	DHCP-First-Relay-IPv6-Address		190	ipv6addr
+ATTRIBUTE	Input-Interface-Filter			191	string
+ATTRIBUTE	Output-Interface-Filter			192	string
+ATTRIBUTE	Pim-Enable				193	integer
+ATTRIBUTE	Bulk-CoA-Transaction-Id			194	integer
+ATTRIBUTE	Bulk-CoA-Identifier			195	integer
+ATTRIBUTE	IPv4-Input-Service-Set			196	string
+ATTRIBUTE	IPv4-Output-Service-Set			197	string
+ATTRIBUTE	IPv4-Input-Service-Filter		198	string
+ATTRIBUTE	IPv4-Output-Service-Filter		199	string
+ATTRIBUTE	IPv6-Input-Service-Set			200	string
+ATTRIBUTE	IPv6-Output-Service-Set			201	string
+ATTRIBUTE	IPv6-Input-Service-Filter		202	string
+ATTRIBUTE	IPv6-Output-Service-Filter		203	string
+ATTRIBUTE	Adv-Pcef-Profile-Name			204	string
+ATTRIBUTE	Adv-Pcef-Rule-Name			205	string
+ATTRIBUTE	Re-Authentication-Catalyst		206	integer
+ATTRIBUTE	DHCPv6-Options				207	octets
+ATTRIBUTE	DHCP-Header				208	octets
+ATTRIBUTE	DHCPv6-Header				209	octets
+ATTRIBUTE	Acct-Request-Reason			210	integer
 
-ATTRIBUTE	ERX-Inner-Tag-Protocol-Id		211	string
-ATTRIBUTE	ERX-Routing-Services			212	integer
-ATTRIBUTE	ERX-Interface-Set-Targeting-Weight	213	integer
-ATTRIBUTE	ERX-Interface-Targeting-Weight		214	integer
-ATTRIBUTE	ERX-Hybrid-Access-DSL-Downstream-Speed	216	integer
-ATTRIBUTE	ERX-Hybrid-Access-LTE-Downstream-Speed	217	integer
+ATTRIBUTE	Inner-Tag-Protocol-Id			211	string
+ATTRIBUTE	Routing-Services			212	integer
+ATTRIBUTE	Interface-Set-Targeting-Weight		213	integer
+ATTRIBUTE	Interface-Targeting-Weight		214	integer
+ATTRIBUTE	Hybrid-Access-DSL-Downstream-Speed	216	integer
+ATTRIBUTE	Hybrid-Access-LTE-Downstream-Speed	217	integer
 
-ATTRIBUTE	ERX-PON-Access-Type			219	integer
-ATTRIBUTE	ERX-ONT-ONU-Average-Data-Rate-Downstream 220	integer
-ATTRIBUTE	ERX-ONT-ONU-Peak-Data-Rate-Downstream	221	integer
-ATTRIBUTE	ERX-ONT-ONU-Maximum-Data-Rate-Upstream	222	integer
-ATTRIBUTE	ERX-ONT-ONU-Assured-Data-Rate-Upstream	223	integer
-ATTRIBUTE	ERX-PON-Tree-Maximum-Data-Rate-Upstream	224	integer
-ATTRIBUTE	ERX-PON-Tree-Maximum-Data-Rate-Downstream 225	integer
+ATTRIBUTE	PON-Access-Type				219	integer
+ATTRIBUTE	ONT-ONU-Average-Data-Rate-Downstream	220	integer
+ATTRIBUTE	ONT-ONU-Peak-Data-Rate-Downstream	221	integer
+ATTRIBUTE	ONT-ONU-Maximum-Data-Rate-Upstream	222	integer
+ATTRIBUTE	ONT-ONU-Assured-Data-Rate-Upstream	223	integer
+ATTRIBUTE	PON-Tree-Maximum-Data-Rate-Upstream	224	integer
+ATTRIBUTE	PON-Tree-Maximum-Data-Rate-Downstream	225	integer
 
-ATTRIBUTE	ERX-Expected-Throughput-Upstream	226	integer
-ATTRIBUTE	ERX-Expected-Throughput-Downstream	227	integer
-ATTRIBUTE	ERX-Attainable-Expected-Throughput-Upstream 228	integer
-ATTRIBUTE	ERX-Attainable-Expected-Throughput-Downstream 229	integer
-ATTRIBUTE	ERX-Gamma-Data-Rate-Upstream		230	integer
-ATTRIBUTE	ERX-Gamma-Data-Rate-Downstream		231	integer
-ATTRIBUTE	ERX-Attainable-Gamma-Data-Rate-Upstream	232	integer
-ATTRIBUTE	ERX-Attainable-Gamma-Data-Rate-Downstream 233	integer
+ATTRIBUTE	Expected-Throughput-Upstream		226	integer
+ATTRIBUTE	Expected-Throughput-Downstream		227	integer
+ATTRIBUTE	Attainable-Expected-Throughput-Upstream	228	integer
+ATTRIBUTE	Attainable-Expected-Throughput-Downstream 229	integer
+ATTRIBUTE	Gamma-Data-Rate-Upstream		230	integer
+ATTRIBUTE	Gamma-Data-Rate-Downstream		231	integer
+ATTRIBUTE	Attainable-Gamma-Data-Rate-Upstream	232	integer
+ATTRIBUTE	Attainable-Gamma-Data-Rate-Downstream	233	integer
 
 #
 #  Values	Attribute		Name			Number
 #
-VALUE	ERX-Ingress-Statistics		disable			0
-VALUE	ERX-Ingress-Statistics		enable			1
+VALUE	Ingress-Statistics		disable			0
+VALUE	Ingress-Statistics		enable			1
 
-VALUE	ERX-Egress-Statistics		disable			0
-VALUE	ERX-Egress-Statistics		enable			1
+VALUE	Egress-Statistics		disable			0
+VALUE	Egress-Statistics		enable			1
 
-VALUE	ERX-Atm-Service-Category	UBR			1
-VALUE	ERX-Atm-Service-Category	UBRPCR			2
-VALUE	ERX-Atm-Service-Category	nrtVBR			3
-VALUE	ERX-Atm-Service-Category	CBR			4
+VALUE	Atm-Service-Category		UBR			1
+VALUE	Atm-Service-Category		UBRPCR			2
+VALUE	Atm-Service-Category		nrtVBR			3
+VALUE	Atm-Service-Category		CBR			4
 
-VALUE	ERX-Cli-Allow-All-VR-Access	disable			0
-VALUE	ERX-Cli-Allow-All-VR-Access	enable			1
+VALUE	Cli-Allow-All-VR-Access		disable			0
+VALUE	Cli-Allow-All-VR-Access		enable			1
 
-VALUE	ERX-Sa-Validate			disable			0
-VALUE	ERX-Sa-Validate			enable			1
+VALUE	Sa-Validate			disable			0
+VALUE	Sa-Validate			enable			1
 
-VALUE	ERX-Igmp-Enable			disable			0
-VALUE	ERX-Igmp-Enable			enable			1
+VALUE	Igmp-Enable			disable			0
+VALUE	Igmp-Enable			enable			1
 
-VALUE	ERX-Qos-Profile-Interface-Type	IP			1
-VALUE	ERX-Qos-Profile-Interface-Type	ATM			2
-VALUE	ERX-Qos-Profile-Interface-Type	HDLC			3
-VALUE	ERX-Qos-Profile-Interface-Type	ETHERNET		4
-VALUE	ERX-Qos-Profile-Interface-Type	SERVER-PORT		5
-VALUE	ERX-Qos-Profile-Interface-Type	ATM-1483		6
-VALUE	ERX-Qos-Profile-Interface-Type	FRAME-RELAY		7
-VALUE	ERX-Qos-Profile-Interface-Type	MPLS-MINOR		8
-VALUE	ERX-Qos-Profile-Interface-Type	CBF			9
-VALUE	ERX-Qos-Profile-Interface-Type	IP-TUNNEL		10
-VALUE	ERX-Qos-Profile-Interface-Type	VLAN-SUB		11
-VALUE	ERX-Qos-Profile-Interface-Type	PPPOE-SUB		12
+VALUE	Qos-Profile-Interface-Type	IP			1
+VALUE	Qos-Profile-Interface-Type	ATM			2
+VALUE	Qos-Profile-Interface-Type	HDLC			3
+VALUE	Qos-Profile-Interface-Type	ETHERNET		4
+VALUE	Qos-Profile-Interface-Type	SERVER-PORT		5
+VALUE	Qos-Profile-Interface-Type	ATM-1483		6
+VALUE	Qos-Profile-Interface-Type	FRAME-RELAY		7
+VALUE	Qos-Profile-Interface-Type	MPLS-MINOR		8
+VALUE	Qos-Profile-Interface-Type	CBF			9
+VALUE	Qos-Profile-Interface-Type	IP-TUNNEL		10
+VALUE	Qos-Profile-Interface-Type	VLAN-SUB		11
+VALUE	Qos-Profile-Interface-Type	PPPOE-SUB		12
 
-VALUE	ERX-Tunnel-Nas-Port-Method	None			0
-VALUE	ERX-Tunnel-Nas-Port-Method	CISCO-CLID		1
+VALUE	Tunnel-Nas-Port-Method		None			0
+VALUE	Tunnel-Nas-Port-Method		CISCO-CLID		1
 
-VALUE	ERX-PPP-Auth-Protocol		None			0
-VALUE	ERX-PPP-Auth-Protocol		PAP			1
-VALUE	ERX-PPP-Auth-Protocol		CHAP			2
-VALUE	ERX-PPP-Auth-Protocol		PAP-CHAP		3
-VALUE	ERX-PPP-Auth-Protocol		CHAP-PAP		4
+VALUE	PPP-Auth-Protocol		None			0
+VALUE	PPP-Auth-Protocol		PAP			1
+VALUE	PPP-Auth-Protocol		CHAP			2
+VALUE	PPP-Auth-Protocol		PAP-CHAP		3
+VALUE	PPP-Auth-Protocol		CHAP-PAP		4
 
-VALUE	ERX-Bearer-Type			None			0
-VALUE	ERX-Bearer-Type			Analog			1
-VALUE	ERX-Bearer-Type			Digital			2
+VALUE	Bearer-Type			None			0
+VALUE	Bearer-Type			Analog			1
+VALUE	Bearer-Type			Digital			2
 
-VALUE	ERX-LI-Action			off			0
-VALUE	ERX-LI-Action			on			1
-VALUE	ERX-LI-Action			noop			2
+VALUE	LI-Action			off			0
+VALUE	LI-Action			on			1
+VALUE	LI-Action			noop			2
 
-VALUE	ERX-DF-Bit			dont-ignore-df-bit	0
-VALUE	ERX-DF-Bit			ignore-df-bit		1
+VALUE	DF-Bit				dont-ignore-df-bit	0
+VALUE	DF-Bit				ignore-df-bit		1
 
-VALUE	ERX-MLD-Version			v1			1
-VALUE	ERX-MLD-Version			v2			2
+VALUE	MLD-Version			v1			1
+VALUE	MLD-Version			v2			2
 
-VALUE	ERX-IGMP-Version		v1			1
-VALUE	ERX-IGMP-Version		v2			2
-VALUE	ERX-IGMP-Version		v3			3
+VALUE	IGMP-Version			v1			1
+VALUE	IGMP-Version			v2			2
+VALUE	IGMP-Version			v3			3
 
-VALUE	ERX-Service-Statistics		disabled		0
-VALUE	ERX-Service-Statistics		time			1
-VALUE	ERX-Service-Statistics		time-volume		2
+VALUE	Service-Statistics		disabled		0
+VALUE	Service-Statistics		time			1
+VALUE	Service-Statistics		time-volume		2
 
-VALUE	ERX-L2TP-Resynch-Method		disable			0
-VALUE	ERX-L2TP-Resynch-Method		failover		1
-VALUE	ERX-L2TP-Resynch-Method		silent-failover		2
-VALUE	ERX-L2TP-Resynch-Method		failover-with-silent-backup 3
+VALUE	L2TP-Resynch-Method		disable			0
+VALUE	L2TP-Resynch-Method		failover		1
+VALUE	L2TP-Resynch-Method		silent-failover		2
+VALUE	L2TP-Resynch-Method		failover-with-silent-backup 3
 
-VALUE	ERX-Tunnel-Tx-Speed-Method	static-layer2		1
-VALUE	ERX-Tunnel-Tx-Speed-Method	dynamic-layer2		2
-VALUE	ERX-Tunnel-Tx-Speed-Method	qos			3
-VALUE	ERX-Tunnel-Tx-Speed-Method	actual			4
+VALUE	Tunnel-Tx-Speed-Method		static-layer2		1
+VALUE	Tunnel-Tx-Speed-Method		dynamic-layer2		2
+VALUE	Tunnel-Tx-Speed-Method		qos			3
+VALUE	Tunnel-Tx-Speed-Method		actual			4
 
-VALUE	ERX-IGMP-Immediate-Leave	disabled		0
-VALUE	ERX-IGMP-Immediate-Leave	enabled			1
+VALUE	IGMP-Immediate-Leave		disabled		0
+VALUE	IGMP-Immediate-Leave		enabled			1
 
-VALUE	ERX-MLD-Immediate-Leave		disabled		0
-VALUE	ERX-MLD-Immediate-Leave		enabled			1
+VALUE	MLD-Immediate-Leave		disabled		0
+VALUE	MLD-Immediate-Leave		enabled			1
 
-VALUE	ERX-IP-Block-Multicast		disabled		0
-VALUE	ERX-IP-Block-Multicast		enabled			1
+VALUE	IP-Block-Multicast		disabled		0
+VALUE	IP-Block-Multicast		enabled			1
 
-VALUE	ERX-IGMP-Explicit-Tracking	disabled		0
-VALUE	ERX-IGMP-Explicit-Tracking	enabled			1
+VALUE	IGMP-Explicit-Tracking		disabled		0
+VALUE	IGMP-Explicit-Tracking		enabled			1
 
-VALUE	ERX-IGMP-No-Tracking-V2-Grps	disabled		0
-VALUE	ERX-IGMP-No-Tracking-V2-Grps	enabled			1
+VALUE	IGMP-No-Tracking-V2-Grps	disabled		0
+VALUE	IGMP-No-Tracking-V2-Grps	enabled			1
 
-VALUE	ERX-MLD-Explicit-Tracking	disabled		0
-VALUE	ERX-MLD-Explicit-Tracking	enabled			1
+VALUE	MLD-Explicit-Tracking		disabled		0
+VALUE	MLD-Explicit-Tracking		enabled			1
 
-VALUE	ERX-MLD-No-Tracking-V1-Grps	disabled		0
-VALUE	ERX-MLD-No-Tracking-V1-Grps	enabled			1
+VALUE	MLD-No-Tracking-V1-Grps		disabled		0
+VALUE	MLD-No-Tracking-V1-Grps		enabled			1
 
-VALUE	ERX-DSL-Line-State		SHOWTIME		1
-VALUE	ERX-DSL-Line-State		IDLE			2
-VALUE	ERX-DSL-Line-State		SILENT			3
+VALUE	DSL-Line-State			SHOWTIME		1
+VALUE	DSL-Line-State			IDLE			2
+VALUE	DSL-Line-State			SILENT			3
 
-VALUE	ERX-DSL-Type			ADSL1			1
-VALUE	ERX-DSL-Type			ADSL2			2
-VALUE	ERX-DSL-Type			ADSL2PLUS		3
-VALUE	ERX-DSL-Type			VDSL1			4
-VALUE	ERX-DSL-Type			VDSL2			5
-VALUE	ERX-DSL-Type			SDSL			6
-VALUE	ERX-DSL-Type			UNKNOWN			7
+VALUE	DSL-Type			ADSL1			1
+VALUE	DSL-Type			ADSL2			2
+VALUE	DSL-Type			ADSL2PLUS		3
+VALUE	DSL-Type			VDSL1			4
+VALUE	DSL-Type			VDSL2			5
+VALUE	DSL-Type			SDSL			6
+VALUE	DSL-Type			UNKNOWN			7
 
-VALUE	ERX-PPP-Monitor-Ingress-Only	disabled		0
-VALUE	ERX-PPP-Monitor-Ingress-Only	enabled			1
+VALUE	PPP-Monitor-Ingress-Only	disabled		0
+VALUE	PPP-Monitor-Ingress-Only	enabled			1
 
-VALUE	ERX-Service-Activate-Type	dynamic			1
-VALUE	ERX-Service-Activate-Type	opscript		1
+VALUE	Service-Activate-Type		dynamic			1
+VALUE	Service-Activate-Type		opscript		1
 
-VALUE	ERX-Pim-Enable			disabled		0
-VALUE	ERX-Pim-Enable			enabled			1
+VALUE	Pim-Enable			disabled		0
+VALUE	Pim-Enable			enabled			1
 
-VALUE	ERX-Re-Authentication-Catalyst	disabled		0
-VALUE	ERX-Re-Authentication-Catalyst	client-renew		1
+VALUE	Re-Authentication-Catalyst	disabled		0
+VALUE	Re-Authentication-Catalyst	client-renew		1
 
-VALUE	ERX-Acct-Request-Reason		Acct-Start-Ack		1
-VALUE	ERX-Acct-Request-Reason		Periodic		2
-VALUE	ERX-Acct-Request-Reason		IP-Active		4
-VALUE	ERX-Acct-Request-Reason		IP-Inactive		8
-VALUE	ERX-Acct-Request-Reason		IPv6-Active		16
-VALUE	ERX-Acct-Request-Reason		IPv6-Inactive		32
-VALUE	ERX-Acct-Request-Reason		Session-Active		64
-VALUE	ERX-Acct-Request-Reason		Session-Inactive	128
-VALUE	ERX-Acct-Request-Reason		Line-Speed-Change	256
-VALUE	ERX-Acct-Request-Reason		Address-Assignment-Change 512
-VALUE	ERX-Acct-Request-Reason		CoA-Complete		1024
+VALUE	Acct-Request-Reason		Acct-Start-Ack		1
+VALUE	Acct-Request-Reason		Periodic		2
+VALUE	Acct-Request-Reason		IP-Active		4
+VALUE	Acct-Request-Reason		IP-Inactive		8
+VALUE	Acct-Request-Reason		IPv6-Active		16
+VALUE	Acct-Request-Reason		IPv6-Inactive		32
+VALUE	Acct-Request-Reason		Session-Active		64
+VALUE	Acct-Request-Reason		Session-Inactive	128
+VALUE	Acct-Request-Reason		Line-Speed-Change	256
+VALUE	Acct-Request-Reason		Address-Assignment-Change 512
+VALUE	Acct-Request-Reason		CoA-Complete		1024
 
-VALUE	ERX-Routing-Services		disabled		0
-VALUE	ERX-Routing-Services		enabled			1
+VALUE	Routing-Services		disabled		0
+VALUE	Routing-Services		enabled			1
 
-VALUE	ERX-PON-Access-Type		Other			0
-VALUE	ERX-PON-Access-Type		GPON			1
-VALUE	ERX-PON-Access-Type		XG-PON1			2
-VALUE	ERX-PON-Access-Type		TWDM-PON		3
-VALUE	ERX-PON-Access-Type		XGS-PON			4
-VALUE	ERX-PON-Access-Type		WDM-PON			5
-VALUE	ERX-PON-Access-Type		UNKNOWN			7
+VALUE	PON-Access-Type			Other			0
+VALUE	PON-Access-Type			GPON			1
+VALUE	PON-Access-Type			XG-PON1			2
+VALUE	PON-Access-Type			TWDM-PON		3
+VALUE	PON-Access-Type			XGS-PON			4
+VALUE	PON-Access-Type			WDM-PON			5
+VALUE	PON-Access-Type			UNKNOWN			7
 
 END-VENDOR	ERX


### PR DESCRIPTION
Let's normalize all dictionaries to not use Vendor name as a prefix.