### PR TITLE
Fixup Doxygen comments

### DIFF
--- a/src/modules/rlm_winbind/rlm_winbind.c
+++ b/src/modules/rlm_winbind/rlm_winbind.c
@@ -77,9 +77,9 @@ fr_dict_attr_autoload_t rlm_winbind_dict_attr[] = {
 
 /** Group comparison for Winbind-Group
  *
- * @param instance	Instance of this module
+ * @param inst		Instance of this module
  * @param request	The current request
- * @param check		Value pair containing group to be searched
+ * @param name		Group name to be searched
  *
  * @return
  *	- 0 user is in group


### PR DESCRIPTION
It fixes the below warnings:

```
src/modules/rlm_winbind/rlm_winbind.c:80:11: warning: parameter 'instance' not found in the function declaration [-Wdocumentation]
 * @param instance      Instance of this module
          ^~~~~~~~
src/modules/rlm_winbind/rlm_winbind.c:82:11: warning: parameter 'check' not found in the function declaration [-Wdocumentation]
 * @param check         Value pair containing group to be searched
```