### PR TITLE
Placate coverity CID #1542424, #152423, #152422)

### DIFF
--- a/src/lib/eap/chbind.c
+++ b/src/lib/eap/chbind.c
@@ -187,7 +187,7 @@ fr_radius_packet_code_t chbind_process(request_t *request, CHBIND_REQ *chbind)
 	/* Set-up the fake request */
 	fake = request_alloc_internal(request, &(request_init_args_t){ .parent = request });
 	MEM(fr_pair_prepend_by_da(fake->request_ctx, &vp, &fake->request_pairs, attr_freeradius_proxied_to) >= 0);
-	fr_pair_value_from_str(vp, "127.0.0.1", sizeof("127.0.0.1") - 1, NULL, false);
+	(void) fr_pair_value_from_str(vp, "127.0.0.1", sizeof("127.0.0.1") - 1, NULL, false);
 
 	/* Add the username to the fake request */
 	if (chbind->username) {

--- a/src/modules/rlm_eap/types/rlm_eap_fast/eap_fast.c
+++ b/src/modules/rlm_eap/types/rlm_eap_fast/eap_fast.c
@@ -602,7 +602,7 @@ static fr_radius_packet_code_t eap_fast_eap_payload(request_t *request, eap_sess
 	 *	Tell the request that it's a fake one.
 	 */
 	MEM(fr_pair_prepend_by_da(fake->request_ctx, &vp, &fake->request_pairs, attr_freeradius_proxied_to) >= 0);
-	fr_pair_value_from_str(vp, "127.0.0.1", sizeof("127.0.0.1") - 1, NULL, false);
+	(void)fr_pair_value_from_str(vp, "127.0.0.1", sizeof("127.0.0.1") - 1, NULL, false);
 
 	/*
 	 *	If there's no User-Name in the stored data, look for

--- a/src/modules/rlm_eap/types/rlm_eap_peap/peap.c
+++ b/src/modules/rlm_eap/types/rlm_eap_peap/peap.c
@@ -608,7 +608,7 @@ static int CC_HINT(nonnull) setup_fake_request(request_t *request, request_t *fa
 	 *	Tell the request that it's a fake one.
 	 */
 	MEM(fr_pair_prepend_by_da(fake->request_ctx, &vp, &fake->request_pairs, attr_freeradius_proxied_to) >= 0);
-	fr_pair_value_from_str(vp, "127.0.0.1", sizeof("127.0.0.1") - 1, NULL, false);
+	(void) fr_pair_value_from_str(vp, "127.0.0.1", sizeof("127.0.0.1") - 1, NULL, false);
 
 	if (t->username) {
 		vp = fr_pair_copy(fake->request_ctx, t->username);


### PR DESCRIPTION
Currently, three functions mark requests as fake. That involves calling fr_pair_value_from_str() with the string being "127.0.0.1". Coverity notices that fr_pair_value_from_str() returns a value that isn't checked, though one would think it would always work.

 * setup_fake_request() nominally returns an int, but it always returns zero, and no caller actuallly checks its return value.
 * The other functions, chbind_process() and eap_fast_eap_payload(), return fr_radius_packet_code_t, and it's not clear which fr_radius_packet_code_t makes sense in this case.

So... we cast the fr_pair_value_from_str() calls to void.