### PR TITLE
Placate coverity with excessive buffer_len (CID #1503922, #1503986)

### DIFF
--- a/src/lib/util/pair_legacy_tests.c
+++ b/src/lib/util/pair_legacy_tests.c
@@ -129,7 +129,7 @@ static void test_fr_pair_list_afrom_file(void)
 	fr_pair_t      *vp;
 	fr_pair_list_t list;
 	char const     *buffer = "Test-Uint32-0 = 123\nTest-String-0 = \"Testing123\"\n";
-	FILE           *fp = open_buffer_as_file((uint8_t const *)buffer, strlen(buffer));
+	FILE           *fp = open_buffer_as_file((uint8_t const *)buffer, strlen(buffer) + 1);
 	bool           pfiledone;
 
 	fr_pair_list_init(&list);
@@ -166,7 +166,7 @@ static void test_fr_pair_list_move_op(void)
 	fr_pair_list_t old_list, new_list;
 	bool           pfiledone;
 	char const     *fake_file = "Test-Uint32-0 = 123\nTest-String-0 = \"Testing123\"\n";
-	FILE           *fp = open_buffer_as_file((uint8_t const *)fake_file, strlen(fake_file));
+	FILE           *fp = open_buffer_as_file((uint8_t const *)fake_file, strlen(fake_file) + 1);
 
 	fr_pair_list_init(&old_list);
 	fr_pair_list_init(&new_list);


### PR DESCRIPTION
open_buffer_as_file() is a wrapper aound the fmemopen() function. The example shown on fmemopen()'s man page passes a string as buffer and strlen(<string>) as length, and open_buffer_as_file() calls did the same thing--but coverity gives it an alloc_strlen defect with the comment "allocating insufficient memory for the terminating null of the string".

At least one other project using coverity and calling fmemopen() in conformity with "man fmemopen" also gets this defect and ended up passing strlen(<string>) + 1 to deal with it. Making the analogous change here passes tests and should quiet coverity.