### PR TITLE
Sending EAP Success once both the inner tunnel authentication success

### DIFF
--- a/src/modules/rlm_eap/types/rlm_eap_teap/eap_teap.h
+++ b/src/modules/rlm_eap/types/rlm_eap_teap/eap_teap.h
@@ -253,6 +253,8 @@ typedef struct teap_tunnel_t {
 	}			pac;
 
 	bool			result_final;
+	bool            result_intermed;
+	bool            send_eap_success;
 
 #ifdef WITH_PROXY
 	bool		proxy_tunneled_request_as_eap;	//!< Proxy tunneled session as EAP, or as de-capsulated


### PR DESCRIPTION
-  Introduced two new states in `teap_tunnel_t` to send the EAP Success after both cert check is completed

 