### PR TITLE
Annotate fr_nbo_to_uint{16,24}() at function level

### DIFF
--- a/src/lib/util/nbo.h
+++ b/src/lib/util/nbo.h
@@ -133,6 +133,7 @@ static inline size_t fr_nbo_from_uint64v(uint8_t out[static sizeof(uint64_t)], u
  * @param[in] data	To convert to a 16bit unsigned integer of native endianness.
  * @return a 16 bit unsigned integer of native endianness.
  */
+/* coverity[-taint_source : arg-0] */
 static inline uint16_t fr_nbo_to_uint16(uint8_t const data[static sizeof(uint16_t)])
 {
 	return (((uint16_t)data[0]) << 8) | data[1];
@@ -143,6 +144,7 @@ static inline uint16_t fr_nbo_to_uint16(uint8_t const data[static sizeof(uint16_
  * @param[in] data	To convert to a 24bit unsigned integer of native endianness.
  * @return a 24 bit unsigned integer of native endianness.
  */
+/* coverity[-taint_source : arg-0] */
 static inline uint32_t fr_nbo_to_uint24(uint8_t const data[static 3])
 {
 	return (((uint32_t)data[0]) << 16) | (((uint32_t)data[1]) << 8) | data[2];

--- a/src/listen/radius/proto_radius_tcp.c
+++ b/src/listen/radius/proto_radius_tcp.c
@@ -192,7 +192,6 @@ static ssize_t mod_read(fr_listen_t *li, UNUSED void **packet_ctx, fr_time_t *re
 	/*
 	 *	Print out what we received.
 	 */
-	/* coverity[tainted_data] */
 	DEBUG2("proto_radius_tcp - Received %s ID %d length %d %s",
 	       fr_radius_packet_names[buffer[0]], buffer[1],
 	       (int) packet_len, thread->name);

--- a/src/modules/rlm_tacacs/rlm_tacacs_tcp.c
+++ b/src/modules/rlm_tacacs/rlm_tacacs_tcp.c
@@ -1144,7 +1144,6 @@ static void request_demux(UNUSED fr_event_list_t *el, fr_trunk_connection_t *tco
 		 *	TACACS+ doesn't care about packet codes.  All packet of the codes share the same ID
 		 *	space.
 		 */
-		/* coverity[tainted_data] */
 		treq = h->tracking[h->recv.read[1]];
 		if (!treq) {
 			WARN("%s - Ignoring reply with ID %i that arrived too late",

--- a/src/protocols/dhcpv4/decode.c
+++ b/src/protocols/dhcpv4/decode.c
@@ -410,7 +410,6 @@ next:
 		fr_pair_append(out, vp);
 	}
 
-	/* coverity[tainted_data] */
 	len = fr_pair_tlvs_from_network(vp, &vp->vp_group, vendor, p, option_len, decode_ctx, decode_option, verify_tlvs, false);
 	if (len <= 0) return len;
 

--- a/src/protocols/radius/packet.c
+++ b/src/protocols/radius/packet.c
@@ -190,7 +190,6 @@ int fr_radius_packet_decode(TALLOC_CTX *ctx, fr_pair_list_t *out,
 		 *	This may return many VPs
 		 */
 		fr_assert(ptr != NULL);
-		/* coverity[tainted_data] */
 		my_len = fr_radius_decode_pair(ctx, &tmp_list, ptr, packet_length, &packet_ctx);
 		if (my_len < 0) {
 		fail:

--- a/src/protocols/tacacs/base.c
+++ b/src/protocols/tacacs/base.c
@@ -496,7 +496,6 @@ void _fr_tacacs_packet_log_hex(fr_log_t const *log, fr_tacacs_packet_t const *pa
 			print_ascii(log, file, line, "      rem_addr       ", p, hdr[6], end);
 			p += hdr[6];
 
-			/* coverity[tainted_data] */
 			print_hex(log, file, line, "      data           ", p, hdr[7], end); /* common auth flows */
 
 		} else if (packet_is_authen_continue(packet)) {


### PR DESCRIPTION
CIDs: #1419883, #1520415, #1503954, #14516665, #1519002

This should keep coverity from tainting the pointer to data being converted to host order.