### PR TITLE
Comment on trunk test annotations (CID #1469174)

### DIFF
--- a/src/lib/server/trunk_tests.c
+++ b/src/lib/server/trunk_tests.c
@@ -107,6 +107,17 @@ static void test_demux(UNUSED fr_event_list_t *el, UNUSED fr_trunk_connection_t 
 		if (slen <= 0) break;
 
 		if (acutest_verbose_level_ >= 3) printf("%s - Read %p (%zu)\n", __FUNCTION__, preq, (size_t)slen);
+
+		/*
+		 * 	Coverity considers data read from a file to be tainted,
+		 * 	and considers its use to be a defect--but almost all the
+		 * 	rest of the loop validates the pointer to the extent
+		 * 	possible--all of the pointer should be read, its talloc
+		 * 	"dynamic type" had better be right, and it should either
+		 * 	be freed or have a statethe demuxer can handle or ignore.
+		 * 	This isn't like a range check on a numeric value;
+		 * 	Coverity doesn't recognize it as validation.
+		 */
 		TEST_CHECK(slen == sizeof(preq));
 		talloc_get_type_abort(preq, test_proto_request_t);
 


### PR DESCRIPTION
Coverity doesn't recognize the validation of the read treq pointer that text_demux() does, which, aside from signaling complete or cancel complete, is the majority of the loop body.