### PR TITLE
Tweak mod_read() range check on packet code (CID #1419883?)

### DIFF
--- a/src/listen/radius/proto_radius_tcp.c
+++ b/src/listen/radius/proto_radius_tcp.c
@@ -134,7 +134,7 @@ static ssize_t mod_read(fr_listen_t *li, UNUSED void **packet_ctx, fr_time_t *re
 	/*
 	 *	We MUST always start with a known RADIUS packet.
 	 */
-	if ((buffer[0] == 0) || (buffer[0] > FR_RADIUS_CODE_MAX)) {
+	if ((buffer[0] == 0) || (buffer[0] >= FR_RADIUS_CODE_MAX)) {
 		DEBUG("proto_radius_tcp got invalid packet code %d", buffer[0]);
 		thread->stats.total_unknown_types++;
 		return -1;


### PR DESCRIPTION
buffer[0] is used as index into fr_radius_packet_names[], so allowing FR_PACKET_CODE_MAX will fall off the end. This may placate coverity, but I believe it is needed in any case.