### PR TITLE
Make IN_RANGE_INTEGER_*() nontrivial iff it can actually fail (CID #1…

### DIFF
--- a/src/modules/rlm_lua/lua.c
+++ b/src/modules/rlm_lua/lua.c
@@ -56,6 +56,7 @@ static int fr_lua_marshall(request_t *request, lua_State *L, fr_pair_t const *vp
 {
 	if (!vp) return -1;
 
+#if PTRDIFF_MAX < INT64_MAX
 #define IN_RANGE_INTEGER_SIGNED(_x) \
 	do { \
 		if ((((int64_t)(_x)) < PTRDIFF_MIN) || (((int64_t)(_x)) > PTRDIFF_MAX)) { \
@@ -73,6 +74,15 @@ static int fr_lua_marshall(request_t *request, lua_State *L, fr_pair_t const *vp
 			return -1; \
 		} \
 	} while (0)
+#else
+#define IN_RANGE_INTEGER_SIGNED(_x) \
+        do { \
+        } while (0)
+
+#define IN_RANGE_INTEGER_UNSIGNED(_x) \
+        do { \
+        } while (0)
+#endif
 
 #define IN_RANGE_FLOAT_SIGNED(_x) \
 	do { \


### PR DESCRIPTION
…445201)

The range check can only fail if PTRDIFF_MAX < INT64_MAX. Since that's not the case for the Coverity run, you get a defect of the result_independent_of_operands flavor, just like the range checks for fr_sbuff_out_[u]int64() used to.

The floating point version, I believe, will notice +/-infinity and denormalized numbers, so Coverity wouldn't complain about it.