### PR TITLE
Avoid fr_nbo_to_uint16() to get EAP packet length in eap_identity() (CID #1243443)

### DIFF
--- a/src/lib/eap/session.c
+++ b/src/lib/eap/session.c
@@ -235,7 +235,7 @@ static char *eap_identity(request_t *request, eap_session_t *eap_session, eap_pa
 	    (eap_packet->code != FR_EAP_CODE_RESPONSE) ||
 	    (eap_packet->data[0] != FR_EAP_METHOD_IDENTITY)) return NULL;
 
-	len = fr_nbo_to_uint16(eap_packet->length);
+	len = talloc_array_length((uint8_t *) eap_packet);
 
 	/*
 	 *  Note: The minimum length here is 5.


### PR DESCRIPTION
Moved to talloc_array_length() instead, which worked much better after I looked at the source and saw it's a macro that uses the type of the argument, so it requires casting to pointer to the type it was allocated with.