### PR TITLE
Fix typos in documentation

### DIFF
--- a/doc/all.mk
+++ b/doc/all.mk
@@ -186,7 +186,7 @@ install.doxygen: $(R)$(docdir)/doxygen/html/index.html
 
 
 #
-#  Add the doxygen files to the install targt
+#  Add the doxygen files to the install target
 #
 install.doc: install.doxygen
 

--- a/doc/antora/main-site.yml.in
+++ b/doc/antora/main-site.yml.in
@@ -1,6 +1,6 @@
 #
 #  Used by the GitHub Actions "Documentation" job to build
-#  the FreeRADIUS web site docuementation on each push. To
+#  the FreeRADIUS web site documentation on each push. To
 #  generate the site locally use 'make docsite' in the top
 #  level directory, not this file.
 #

--- a/doc/antora/modules/ROOT/pages/index.adoc
+++ b/doc/antora/modules/ROOT/pages/index.adoc
@@ -44,7 +44,7 @@ desired outcome. At a high level, the subject areas describe:
 * xref:developers:index.adoc[Developer documentation].
 
 This organization means that for example, the `ldap` module will have
-documention located in multiple places. We feel that organizing the
+documentation located in multiple places. We feel that organizing the
 documentation by desired _goal_ is better than the alternatives.
 
 Within each section, the documentation is split into small pages, which

--- a/doc/antora/modules/concepts/pages/modules/ldap/authentication.adoc
+++ b/doc/antora/modules/concepts/pages/modules/ldap/authentication.adoc
@@ -68,7 +68,7 @@ Bind as user::
 The user supplies a `User-Password` (plaintext or EAP-TTLS/PAP)
 +
 FreeRADIUS uses that password to "bind as the user" to LDAP, using the
-supplied `User-Name` and `User-Password.  If the bind is successfull,
+supplied `User-Name` and `User-Password.  If the bind is successful,
 the user is authenticated.  Otherwise, authentication fails.
 
 CHAP::
@@ -145,7 +145,7 @@ then the "bind as user" _will not work_.  There is no amount of
 
 The second caveat is that the `CHAP` authentication type works _only_
 when a "clear text" password is stored in the LDAP database.  The
-`CHAP` calclulations are designed around having access to the "clear
+`CHAP` calculations are designed around having access to the "clear
 text" password.  It is impossible to use any "encrypted" or "hashed"
 passwords with `CHAP`.
 

--- a/doc/antora/modules/developers/pages/coding-methods.adoc
+++ b/doc/antora/modules/developers/pages/coding-methods.adoc
@@ -26,7 +26,7 @@ Variables and functions should have names. Calling them `x`, `xx`,
 and `xxx` makes your life hell. Even `foo` and `i` are
 problematic.
 
-Avoid smurfs. Don’t re-use struct names in field names, i. e.
+Avoid smurfs. Don’t reuse struct names in field names, i. e.
 
 [source,c]
 ----

--- a/doc/antora/modules/developers/pages/sbuff-ng.adoc
+++ b/doc/antora/modules/developers/pages/sbuff-ng.adoc
@@ -8,7 +8,7 @@
 - Shifting data out of sbuffs is expensive because we need to update every nested sbuff, and every marker associated with them.
 - Passing terminals and unescape callbacks into functions leads to massive complexity, and needing to allocate memory to allocate merged tables of token sequences.
 - Last matched token isn't stored anywhere, so the caller of a parsing function needs to check the current position of an sbuff against its tokens.
-- Returning negative offsets to indicate error positions dosn't work when there are transform functions in the sbuff chain.
+- Returning negative offsets to indicate error positions doesn't work when there are transform functions in the sbuff chain.
 
 ## Fixes
 ### Marker release
@@ -30,7 +30,7 @@ typedef struct {
 In almost every instance a "legacy" C function that's operating on a standard C buffer takes a `buffer` and a `length`.
 
 Direct access into the sbuff should be restricted, and a macro should be provided that provides both the length of the
-data and a pointer into the sbuff as consective function arguments.  This prevents assignments to C pointers as this will
+data and a pointer into the sbuff as consecutive function arguments.  This prevents assignments to C pointers as this will
 result in a syntax error.
 
 [source,c]
@@ -169,12 +169,12 @@ as they will never need to be updated during shifts.  marker's offsets remain re
 
 If `sbuff->offset < sbuff->start`, this event would trigger a backtrack.
 
-### Pasing terminal sequences and escape rules into functions is awful
+### Parsing terminal sequences and escape rules into functions is awful
 
 Text transformation must be transparent to the parsing function, anything else will not function correctly, or will add
 horendous complexity.
 
-A trasnformation sbuff takes data from its parent, transforms it, and places it in and output buffer.  The transform sbuff's
+A transformation sbuff takes data from its parent, transforms it, and places it in and output buffer.  The transform sbuff's
 offsets are valid for its output buffer only.
 
 A terminal sbuff takes requests for more data and scans the stream coming from its parent sbuff for terminal sequences.

--- a/doc/antora/modules/howto/pages/index.adoc
+++ b/doc/antora/modules/howto/pages/index.adoc
@@ -2,7 +2,7 @@
 
 The documents in this section describe how to perform various common tasks with
 FreeRADIUS. They also provide worked examples on using the various modules in
-common deployment scenarions.
+common deployment scenarios.
 
 If you have a topic you'd like to see included in the list of howtos, contact
 the developers on the

--- a/doc/antora/modules/howto/pages/modules/eap/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/eap/index.adoc
@@ -56,7 +56,7 @@ events happen in addition to the above EAP events.
 . The RADIUS server sends the key for this session (Session key) to the
 AP.
 . The AP encrypts its Broadcast key with the Session key
-. The AP sends the encypted key to the supplicant
+. The AP sends the encrypted key to the supplicant
 . The supplicant decrypts the Broadcast key with the Session key and the
 session continues using the Broadcast and Session keys until the session
 ends.
@@ -320,7 +320,7 @@ the server can have only one default `EAP-Type`, as above.
 
 Once `EAP-Identity` response is received by the server, based on the
 `default_eap_type`, the server will send a new request (`MD5-Challenge`
-request incase of md5, `TLS-START` request incase of tls) to the
+request in case of md5, `TLS-START` request in case of tls) to the
 supplicant. If the supplicant is `rfc2284` compliant and does not support
 the `EAP-Type` sent by the server then it sends `EAP-Acknowledge` with the
 supported `EAP-Type`. If this `EAP-Type` is supported by the server then it
@@ -361,7 +361,7 @@ int detach(void **type_arg);
 required resources.
 
 `initiate()` function begins the conversation when EAP-Identity
-response is received. Incase of EAP-MD5, `initiate()` function sends
+response is received. In case of EAP-MD5, `initiate()` function sends
 the challenge.
 
 `authenticate()` function uses specific EAP-Type authentication

--- a/doc/antora/modules/howto/pages/modules/ldap/authentication.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/authentication.adoc
@@ -16,7 +16,7 @@ EOF
 
 ==== Access-Accept
 
-If this works you should see `radclient` report `Access-Accept` almostly immediately without delay:
+If this works you should see `radclient` report `Access-Accept` almost immediately without delay:
 
 [source,log]
 ----
@@ -136,7 +136,7 @@ Here FreeRADIUS describes it:
 
 This occurs as the LDAP credentials used by FreeRADIUS to connect to the LDAP server is *unable* to extract a the `userPassword` attribute; as could been seen from the example `ldapsearch` command provided earlier.
 
-You have two options avaliable to you here (`Ctrl-C` the running FreeRADIUS server, make the change and restart):
+You have two options available to you here (`Ctrl-C` the running FreeRADIUS server, make the change and restart):
 
  . change the permissions of the LDAP credentials used so that FreeRADIUS can read the LDAP `userPassword` attribute
  ** this is the recommended option
@@ -203,6 +203,6 @@ Here FreeRADIUS is describes it:
  ** it finds no suitable password RADIUS attributes to use
  ** as it makes no changes, the module returns `noop`
  . the authenticate section runs and hands off to `ldap` as `&control.Auth-Type = ldap` was set earlier
- ** attemps to LDAP bind as `uid=john,ou=people,dc=example,dc=com`
+ ** attempts to LDAP bind as `uid=john,ou=people,dc=example,dc=com`
  ** successful so `ok` is returned
  . we return `Access-Accept` as `ok` was returned to unlang

--- a/doc/antora/modules/howto/pages/modules/ldap/bootstrap_openldap/packages.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/bootstrap_openldap/packages.adoc
@@ -53,7 +53,7 @@ After installing OpenLDAP, `slapd` (the main OpenLDAP daemon) needs to be
 switched to using OLC (on-line configuration).
 
 OLC provides an LDAP based interface for dynamically changing OpenLDAP's
-configuration at runtime. OLC also allows more programatic manipulation of
+configuration at runtime. OLC also allows more programmatic manipulation of
 OpenLDAP's configuration, which is the primary reason for using it in this
 example.
 
@@ -73,7 +73,7 @@ include         ${OPENLDAP_PATH}/etc/openldap/schema/core.schema
 pidfile         ${OPENLDAP_PATH}/var/run/slapd.pid
 argsfile        ${OPENLDAP_PATH}/var/run/slapd.args
 
-# Provide a defintion for the OLC database
+# Provide a definition for the OLC database
 database config
 # Allow access to the root user only
 access to * by dn.exact="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth" manage

--- a/doc/antora/modules/howto/pages/modules/ldap/ldapsearch/connection_parameters.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/ldapsearch/connection_parameters.adoc
@@ -120,7 +120,7 @@ ldap_bind: Confidentiality required (13)
 If you're not sure which encryption method is used (LDAPS or StartTLS) try
 each of them in turn.
 
-In order to configure either encryption method you will need to have acces
+In order to configure either encryption method you will need to have access
 to the certificate chain for the certificate the LDAP server presents.
 
 See the section below on retrieving certificate chains if you don't have

--- a/doc/antora/modules/howto/pages/modules/pam/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/pam/index.adoc
@@ -55,7 +55,7 @@ required /lib/security/pam_unix_session.so
 ```
 
 If you don’t want to run your freeradius server in debug mode as root
-(ie, run as an unpriviledged user) you will need to run freeradius with
+(ie, run as an unprivileged user) you will need to run freeradius with
 a group membership that is able to read the /etc/shadow file - otherwise
 pam will be unable to read the /etc/shadow file and will fail. I suggest
 a group called `shadow' or the like.

--- a/doc/antora/modules/howto/pages/modules/passwd/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/passwd/index.adoc
@@ -35,7 +35,7 @@ Q: How can I say passwd to add attribute even if it’s value is empty?
 
 A: set `ignore_empty` to `no` in module configuration.
 
-== Acknowlegements
+== Acknowledgements
 
 * ZARAZA, mailto:3APA3A@security.nnov.ru[3APA3A@security.nnov.ru]
 * Michael Chernyakhovsky mailto:mike@mgn.ru[mike@mgn.ru]

--- a/doc/antora/modules/howto/pages/modules/python/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/python/index.adoc
@@ -46,7 +46,7 @@ python {
 * `func_detach` is passed no parameters, returns module return value.
 * If functions returns None (plain `return' no return), default to
 RLM_OK
-* Python instantation function can return -1 to signal failure and abort
+* Python instantiation function can return -1 to signal failure and abort
 startup.
 
 Available to module:

--- a/doc/antora/modules/howto/pages/modules/rest/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/rest/index.adoc
@@ -11,7 +11,7 @@ module to communicate with a REST service.
 == xref:modules/rest/fixed_data.adoc[Calling REST endpoints with fixed data formats]
 
 The REST module was developed to allow business logic to be separated out into a
-separate discreet service.  This reduces the role of FreeRADIUS to a translation
+separate discrete service.  This reduces the role of FreeRADIUS to a translation
 daemon, receiving packets from the network and presenting them in JSON or POST
 format for consumption by the API, then parsing a JSON or POST response, and
 translating that back into a network packet.

--- a/doc/antora/modules/howto/pages/modules/sql/data-usage-reporting.adoc
+++ b/doc/antora/modules/howto/pages/modules/sql/data-usage-reporting.adoc
@@ -64,7 +64,7 @@ users.
 FreeRADIUS is distributed with a schema extension which introduces a
 `data_usage_by_period` table containing data usage keyed by time-period and
 user, and provides the means of running an update process to correctly populate
-this table, either by calling a stored procedure or running a seperate script:
+this table, either by calling a stored procedure or running a separate script:
 
  [raddb]/mods-config/sql/main/[database]/process-radacct.sql
 

--- a/doc/antora/modules/howto/pages/modules/sql/odbc.adoc
+++ b/doc/antora/modules/howto/pages/modules/sql/odbc.adoc
@@ -11,7 +11,7 @@ reason to use ODBC.
 ODBC is a library specification for accessing multiple data sources using a
 common API. FreeRADIUS uses the unixODBC implementation of ODBC and the data
 source is normally hosted by a database server. The ODBC implementation is
-seperate from FreeRADIUS with a discrete configuration that must be configured
+separate from FreeRADIUS with a discrete configuration that must be configured
 and tested first.
 
 Since FreeRADIUS is not interfacing directly with the backend database the

--- a/doc/antora/modules/howto/pages/modules/sqlcounter/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/sqlcounter/index.adoc
@@ -88,7 +88,7 @@ $INCLUDE $\{confdir}/sqlcounter.conf
 …some other entries here…
 
 [3] Make sure to have the sqlcounter names under authorize section like
-the followings:
+the following:
 
 ```
 recv Access-Request {
@@ -156,6 +156,6 @@ radcheck VALUES (’`,’test0003',`Max-Monthly-Session',`10800',`:=');
 ```
 
 NOTE: The `Max-All-Session`, `Max-Daily-Session` and `Max-Monthly-Session` are
-definied in `sqlcounter.conf`
+defined in `sqlcounter.conf`
 
 WARNING: Accounting must be done via sql or this will not work.

--- a/doc/antora/modules/howto/pages/modules/sqlippool/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/sqlippool/index.adoc
@@ -98,7 +98,7 @@ device, on subsequent allocation requests.  With some database backends
 `alloc_existing` and `alloc_find` queries, reducing round trips
 to the database and improving performance.
 
-. The module returns `updated` to indicate that it was successfull in
+. The module returns `updated` to indicate that it was successful in
 allocating an IP address.
 
 . After some additional processing (modules, `unlang`, etc.),
@@ -118,7 +118,7 @@ updated based on the configured `lease_duration`. This update extends
 the initial lease to the configured `lease_duration` in case the event
 that the Accounting Start request was delayed.
 
-. The module returns `updated` to indicate that it was successfull in
+. The module returns `updated` to indicate that it was successful in
 updating the state of the IP address.
 
 . After some additional processing (modules, `unlang`, etc.),
@@ -136,7 +136,7 @@ uses the configured `pool_key` and NAS identifier in order to identify
 which entry in the `radippool` table to update.  The `expiry_time` is
 updated based on the configured `lease_duration`.
 
-. The module returns `updated` to indicate that it was successfull in
+. The module returns `updated` to indicate that it was successful in
 updating the state of the IP address.
 
 . After some additional processing (modules, `unlang`, etc.),
@@ -157,7 +157,7 @@ or device was associated with that address.  The result is that on
 subsequent allocations, it is possible to re-allocate the same IP
 address to the same user or device.
 
-. The module returns `updated` to indicate that it was successfull in
+. The module returns `updated` to indicate that it was successful in
 updating the state of the IP address.
 
 . After some additional processing (modules, `unlang`, etc.),
@@ -174,10 +174,10 @@ FreeRADIUS.  After some processing (modules. `unlang`, etc.), the
 uses the `NAS-IP-Address` in order to identify all leases in the
 `radippool` table which belong to the NAS in question.  The leases are
 cleared, and the IP addresses are immediately released for further
-allocation.  This proces effectively returns all IP address occupied
+allocation.  This process effectively returns all IP address occupied
 by the dropped sessions back into the pool.
 
-. The module returns `updated` to indicate that it was successfull in
+. The module returns `updated` to indicate that it was successful in
 updating the state of the IP addresses.
 
 . After some additional processing (modules, `unlang`, etc.),
@@ -217,7 +217,7 @@ http://lists.freeradius.org/mailman/listinfo/freeradius-users[freeradius-users]
 mailing list.  Please also read the
 https://wiki.freeradius.org/list-help[list help] instructions, for
 what information we need in order to help you.  This information is
-typically an explantion of what you are trying to achieve, what
+typically an explanation of what you are trying to achieve, what
 exactly isn't working and provide the full debugging output for a
 relevant test run.
 
@@ -1103,7 +1103,7 @@ identifying devices. In some cases a circuit-specific identifier such as
 CAUTION: However, a circuit-specific identifier is unsuitable if there are
 multiple hosts on the circuit with which you issue individual addresses (for
 example when using PPPoE passthrough to provide unique sessions to firewalls
-behind a seperate CPE modem.) In this case the "device" must be thought of not
+behind a separate CPE modem.) In this case the "device" must be thought of not
 as the circuit but the individual hosts behind it.
 
 The `Calling-Station-Id` attribute may contain host specific information (such

--- a/doc/antora/modules/howto/pages/tuning/tuning_guide.adoc
+++ b/doc/antora/modules/howto/pages/tuning/tuning_guide.adoc
@@ -1,4 +1,4 @@
-= Tunning Guide
+= Tuning Guide
 
 == Main Server
 

--- a/doc/antora/modules/installation/pages/source.adoc
+++ b/doc/antora/modules/installation/pages/source.adoc
@@ -27,7 +27,7 @@ The FreeRADIUS source may be obtained from a number of locations:
 * download from
   https://github.com/FreeRADIUS/freeradius-server/[GitHub].
 
-The file wil be name something like: `freeradius-server-4.0.0.tar.gz`.
+The file will be named something like: `freeradius-server-4.0.0.tar.gz`.
 Later version will be `4.0.1`, or `4.1.0`, etc. PGP signatures are
 also provided for official releases from the FTP site; these are
 named e.g. `freeradius-server-4.0.0.tar.gz.sig`.
@@ -99,7 +99,7 @@ The installation process will not over-write your existing configuration
 files. It will, however, warn you about the files it did not install.
 These will require manual integration with the existing files.
 
-It is generally not possible to re-use configurations between different
+It is generally not possible to reuse configurations between different
 major versions of the server. (For example - version 2 to version 3, or
 version 3 to version 4.
 
@@ -186,7 +186,7 @@ broke the configuration.
 It is also considered a best practice to maintain a staging or
 development environment. This allows you to test and integrate your
 changes without impacting your active production environment. You should
-make the appropirate investment in order to properly support a critical
+make the appropriate investment in order to properly support a critical
 resource such as your authentication servers.
 
 Configuring and running the server MAY be complicated. Many modules have

--- a/doc/antora/modules/installation/pages/upgrade.adoc
+++ b/doc/antora/modules/installation/pages/upgrade.adoc
@@ -53,7 +53,7 @@ Much of the information in this section is also in the
 `raddb/dictionary` file
 
 All of the attributes have been renamed from v3.  This change was
-necessary in order to support new funtionality in v4.  The
+necessary in order to support new functionality in v4.  The
 unfortunate side effect of this change is that all of the names in
 SQL, LDAP, and the `files` module are incompatible with v4.
 
@@ -94,14 +94,14 @@ definition in the v3 dictionaries.
 
 You will need to add a `$INCLUDE` line for each vendor-specific
 dictionary which is used by your local system.  The default v4
-dictionaries do not enable all of v3 compatibilty names.  The reason
+dictionaries do not enable all of v3 compatibility names.  The reason
 is simple: the alias names _mostly_ work, in most situations.  But
 there are situations where the aliases do not behave correctly.
 
 We recognize that this process is a bit of work.  However, we wish to
 encourage everyone using v4 to upgrade to using the new v4 features.
 Our experience shows that if we automatically enable "compatibility
-features", then those compatiblity features will be used for a decade,
+features", then those compatibility features will be used for a decade,
 and no one will upgrade to use the new features.  So we need to find a
 balance between upgrades and ongoing support.  Easy upgrades will mean
 complex ongoing support.  Complex upgrades make ongoing support
@@ -756,7 +756,7 @@ The following modules exhibit changed behaviour.
 into the current request. It defaults to `no`. The primary use case,
 is if you’re using xlat expansions in the cache module itself to
 retrieve information for caching, and need the result of those
-expensions to be available immediately.
+expansions to be available immediately.
 
 Two new control attributes `&control.Cache-Allow-Merge` and
 `&control.Cache-Allow-Insert` have been added. These control whether
@@ -853,7 +853,7 @@ will no longer work.  Instead, use
 if (%ldap.memberof(foo)) { ...
 ```
 
-The cacheing of group membership into attributes in the `control` list is
+The caching of group membership into attributes in the `control` list is
 still available, so
 
 ```

--- a/doc/antora/modules/raddb/pages/dictionary.adoc
+++ b/doc/antora/modules/raddb/pages/dictionary.adoc
@@ -35,7 +35,7 @@ here, nothing bad will happen.
 
 v4 also supports a `dictionary { ... }` subsection in a virtual
 server.  If the attributes are used only in one virtual server,
-they shuld be defined there.
+they should be defined there.
 
 
 
@@ -78,7 +78,7 @@ required, or add your own.
 ## v3 Compatible names.
 
 All of the attributes have been renamed from v3.  This change was
-necessary in order to support new funtionality in v4.  The
+necessary in order to support new functionality in v4.  The
 unfortunate side effect of this change is that all of the names in
 SQL, LDAP, and the "files" module are incompatible with v4.
 
@@ -117,14 +117,14 @@ The v3 names are in `${dictdir}/radius/alias/VENDOR.txt` where
 _VENDOR_ is the name of the vendor, which is taken from the `VENDOR`
 definition in the v3 dictionaries.
 
-You will need to add a `$INCLUD`E line for each vendor-specific
+You will need to add a `$INCLUDE` line for each vendor-specific
 dictionary which is used by your local system.  The default v4
 dictionaries do not enable all of v3 compatibility names.
 
 Yes, we recognize that this process is a bit of work.  However, we
 wish to encourage everyone using v4 to upgrade to using the new v4
 features.  Our experience shows that if we automatically enable
-"compatibility functions", then those compatiblity functions will
+"compatibility functions", then those compatibility functions will
 be used for a decade.  So we need to find a balance between
 upgrades and ongoing support.  Easy upgrades will mean complex
 ongoing support.  Complex upgrades make ongoing support easier, but

--- a/doc/antora/modules/raddb/pages/format.adoc
+++ b/doc/antora/modules/raddb/pages/format.adoc
@@ -112,7 +112,7 @@ that the double quoted strings can expand variable references. Please
 see the <<Variable References>> section for more information.
 
 The contents of a double-quoted can be interpreted as a string, a
-number, or an IP address, depending on the configuration varible.
+number, or an IP address, depending on the configuration variable.
 
 .Double-Quoted Strings
 ====
@@ -143,7 +143,7 @@ be otherwise difficult to represent.
 == Configuration Sections
 
 A _configuration section_ is allows named variables to be collected
-togther in a logical group.  Configuration sections can also contain
+together in a logical group.  Configuration sections can also contain
 other configuration sections, to any depth of nesting.
 
 A configuration section begins with a section name, followed on the
@@ -160,7 +160,7 @@ same line by an open bracket `{`.  A section ends with a close bracket
 <name>:: The name of this configuration section.  The set of allowed
 names depends on the context.
 
-<instance>:: An optional secton name.
+<instance>:: An optional section name.
 
 [ statements ]:: Zero or more statements, including comments, variable
 assignments, and other sections.

--- a/doc/antora/modules/raddb/pages/mods-available/date.adoc
+++ b/doc/antora/modules/raddb/pages/mods-available/date.adoc
@@ -89,7 +89,7 @@ to be escaped itself, as in `%date(+%%A)`
 In some cases, it is useful for the module to parse dates instead
 of printing them.  In this mode, the format string is ignored.
 Instead, the input arguments are parsed, and the output is an
-integer containg the requested value.
+integer containing the requested value.
 
 The following expansions return integer numbers:
 

--- a/doc/antora/modules/raddb/pages/mods-available/exec.adoc
+++ b/doc/antora/modules/raddb/pages/mods-available/exec.adoc
@@ -27,7 +27,7 @@ The value of the attribute will be replaced with the output of the
 program which is executed.
 
 The attributes from the list referenced in the `input_pairs`
-configuraton item will be placed into environment variables of the executed
+configuration item will be placed into environment variables of the executed
 program.
 
 Alternatively, by setting the `program` item of the module configuration,

--- a/doc/antora/modules/raddb/pages/mods-available/json.adoc
+++ b/doc/antora/modules/raddb/pages/mods-available/json.adoc
@@ -202,7 +202,7 @@ the module was defined as `json jdoc {...}`, then the xlat name will be
 
 The xlat should be passed a list of attributes to encode. Each attribute
 (after template expansion) will be added to a list of attributes to include
-in the JSON document. If any of the attributes given are preceeded with a `!`
+in the JSON document. If any of the attributes given are preceded with a `!`
 then they are removed from the list. Once all attributes have been processed,
 the JSON document will be created using this list.
 

--- a/doc/antora/modules/raddb/pages/mods-available/ldap.adoc
+++ b/doc/antora/modules/raddb/pages/mods-available/ldap.adoc
@@ -649,7 +649,7 @@ to the LDAP server.
 
 This connection pool is used for LDAP queries run as the administrative user.
 
-All LDAP operations are perfomed asynchronously, meaning that many queries
+All LDAP operations are performed asynchronously, meaning that many queries
 can be active on a single connection simultaneously.
 
 
@@ -691,7 +691,7 @@ lifetime:: The lifetime (in seconds) of the connection.
 
 open_delay:: Open delay (in seconds).
 
-How long must we be above the target utilisation for connections to be openned.
+How long must we be above the target utilisation for connections to be opened.
 
 
 close_delay:: Close delay (in seconds).

--- a/doc/antora/modules/raddb/pages/mods-available/sql.adoc
+++ b/doc/antora/modules/raddb/pages/mods-available/sql.adoc
@@ -171,7 +171,7 @@ connection is used.
 
 [NOTE]
 ====
-If you want to have multiple SQL modules re-use the same connection pool, use `pool = name`
+If you want to have multiple SQL modules reuse the same connection pool, use `pool = name`
 instead of a `pool` section.
 
 e.g:

--- a/doc/antora/modules/raddb/pages/mods-available/unpack.adoc
+++ b/doc/antora/modules/raddb/pages/mods-available/unpack.adoc
@@ -25,8 +25,8 @@ The arguments are three fields:
 
 data::
 
-Either `octets` or `string` type data, litteral or expanded attributes.
-If `string` type data contains a representaion of hex data, e.g. 0xabcdef
+Either `octets` or `string` type data, literal or expanded attributes.
+If `string` type data contains a representation of hex data, e.g. 0xabcdef
 that is first converted to `octets`.
 
 offset::

--- a/doc/antora/modules/raddb/pages/radiusd.conf.adoc
+++ b/doc/antora/modules/raddb/pages/radiusd.conf.adoc
@@ -291,7 +291,7 @@ You should instead just use a normal configuration variable for
 that.
 
 
-Set environment varable `FOO` to value '/bar/baz'.
+Set environment variable `FOO` to value '/bar/baz'.
 
 NOTE: Note that you MUST use '='.  You CANNOT use '+=' to append
 values.

--- a/doc/antora/modules/raddb/pages/sites-available/dhcpv6.adoc
+++ b/doc/antora/modules/raddb/pages/sites-available/dhcpv6.adoc
@@ -206,7 +206,7 @@ internal state of the server.
 
 It's recommended to only enable this config item
 for debugging, or in conjunction with
-move_failure_message_to_parent where the upsteam
+move_failure_message_to_parent where the upstream
 relay is trusted and secure.
 
 

--- a/doc/antora/modules/raddb/pages/sites-available/index.adoc
+++ b/doc/antora/modules/raddb/pages/sites-available/index.adoc
@@ -325,7 +325,7 @@ it without paying attention to the sockets or clients you want to add
 later, and without adding a second virtual server. Once it works, then
 add the second virtual server.
 
-If you want to re-use the previously defined sockets with the second
+If you want to reuse the previously defined sockets with the second
 virtual server, then you will need one or more global "client"
 sections. Those clients will contain a "virtual_server = …" entry that
 will direct requests from those clients to the appropriate virtual

--- a/doc/antora/modules/raddb/pages/sites-available/ldap_sync.adoc
+++ b/doc/antora/modules/raddb/pages/sites-available/ldap_sync.adoc
@@ -30,10 +30,10 @@ However, when an object is deleted from the directory, the entry which is
 received only contains the DN, or, if the deletion is reported as part of
 the initial refresh phase it may only be the UUID.
 
-Active Direcory
+Active Directory
 ---------------
 Active Directory will only provide updates from the time the query started;
-there is no mechanism to catch up on changes which occured while the
+there is no mechanism to catch up on changes which occurred while the
 client was not connected.  In addition it is not possible to apply a
 filter to the query so that only a subset of objects are considered.
 
@@ -177,7 +177,7 @@ Search scope, may be 'base', 'one', 'sub' or 'children'
 
 Specify a map of LDAP attributes to FreeRADIUS dictionary attributes.
 
-The result of this map determines how attriubtes from the LDAP
+The result of this map determines how attributes from the LDAP
 query are presented in the requests processed by the various
 "recv" sections below.
 
@@ -186,7 +186,7 @@ This is a very limited form of map:
  - the right hand side is LDAP attributes which will be
    included in the query.
  - only = and += are valid operators with = setting a
-   single instance of the attriubte and += setting as
+   single instance of the attribute and += setting as
    many as the LDAP query returns.
 
 Protocol specific attributes must be qualified e.g. &Proto.radius.User-Name
@@ -217,7 +217,7 @@ specified in this configuration.  The key limitation is
 The only extensible match filters supported are the Active
 Directory bitwise AND and OR.
 
-A suitable filter, to only receive notificaitons regarding
+A suitable filter, to only receive notifications regarding
 normal user accounts could be:
 
   (userAccountControl:1.2.840.113556.1.4.803:=512)

--- a/doc/antora/modules/raddb/pages/sites-available/resource-check.adoc
+++ b/doc/antora/modules/raddb/pages/sites-available/resource-check.adoc
@@ -85,7 +85,7 @@ authentication and accounting.
 
 
 
-Within this virual server we provide only an Autz-Type Status-Server section
+Within this virtual server we provide only an Autz-Type Status-Server section
 whose task is to perform the resource checks and sets the status of the
 "control module"
 

--- a/doc/antora/modules/reference/pages/dictionary/alias.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/alias.adoc
@@ -42,7 +42,7 @@ file.
 == v3 Compatible names
 
 All of the attributes have been renamed from v3.  This change was
-necessary in order to support new funtionality in v4.  The unfortunate
+necessary in order to support new functionality in v4.  The unfortunate
 side effect of this change is that all of the names which are
 currently in SQL, LDAP, and the "files" module for use with v3, are
 incompatible with v4.
@@ -56,7 +56,7 @@ old ones were not.
 The "old" names were all in flat lists, so that `User-Name` appeared
 next to `Cisco-AVPAir`.  This organization was simple enough to work
 for 20 years, but its time has come.  The new names are hierarchical,
-and are contained in "parent" attributes.  This arrangment does not
+and are contained in "parent" attributes.  This arrangement does not
 ysyakky change the length of most attribute names.
 
 For v4, the `Cisco-AVPair` attribute is called `AVPair`, and it lives
@@ -85,12 +85,12 @@ definition in the v3 dictionaries.
 
 You will need to add a `$INCLUDE` line for each vendor-specific
 dictionary which is used by your local system.  The default v4
-dictionaries do not enable all of v3 compatibilty names.
+dictionaries do not enable all of v3 compatibility names.
 
 Yes, we recognize that this process is a bit of work.  However, we
 wish to encourage everyone using v4 to upgrade to using the new v4
 features.  Our experience shows that if we automatically enable
-"compatibility functions", then those compatiblity functions will
+"compatibility functions", then those compatibility functions will
 be used for a decade.  So we need to find a balance between
 upgrades and ongoing support.  Easy upgrades will mean complex
 ongoing support.  Complex upgrades make ongoing support easier, but

--- a/doc/antora/modules/reference/pages/dictionary/attribute.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/attribute.adoc
@@ -71,7 +71,7 @@ ATTRIBUTE baz 3 ipv4addr
 
 == Enum
 
-In some cases, attributes need to re-use the same set of `VALUE` statements.
+In some cases, attributes need to reuse the same set of `VALUE` statements.
 The `enum=...` flag allows an attribute to copy enumerated vl
 
 The `enum` flag can only be used for "leaf" data types.  i.e. ones

--- a/doc/antora/modules/reference/pages/man/radsniff.adoc
+++ b/doc/antora/modules/reference/pages/man/radsniff.adoc
@@ -109,7 +109,7 @@ The following options are for statistics gathering.
   The instance name passed to the collectd plugin.
 
 *-O server*::
-  Write output statics to the named collectd server.
+  Write output statistics to the named collectd server.
 
 *-T timeout*::
   The timeout in milliseconds before the request is considered

--- a/doc/antora/modules/reference/pages/policy/index.adoc
+++ b/doc/antora/modules/reference/pages/policy/index.adoc
@@ -88,7 +88,7 @@ changing one thing will break something else.
 +
 Saving a copy of the configuration means that you can always revert
 the your changes to a "known working" version.  It doesn't matter how
-the files are saved.  You cna use a revision control system like
+the files are saved.  You can use a revision control system like
 `git`, or `tar` files, or even just copying the files to a different
 directory (named for the current time/date).
 +

--- a/doc/antora/modules/reference/pages/type/cast.adoc
+++ b/doc/antora/modules/reference/pages/type/cast.adoc
@@ -1,7 +1,7 @@
 = Casts
 
 Values can be *cast* from one data type to another.  However, this
-cast only changes the _type_ of the data, it does not change the datas
+cast only changes the _type_ of the data, it does not change the data's
 _value_.  That is, a cast allows you to convert an `octets` data type
 to a `string`, but the resulting `string` may still contain
 non-printable characters.
@@ -22,7 +22,7 @@ if (%sql("SELECT ipaddress FROM table WHERE user=%{User-Name}") == 192.0.2.1) }
 Since there is no attribute reference on either side of the `==`
 operator, the interpreter has no way of knowing that the string
 `192.0.2.1` is an IP address.  In most cases, the interpreter will
-guess correctly.  Howerver, there is no way of _always_ parsing
+guess correctly.  However, there is no way of _always_ parsing
 strings in order to automatically determine which data type to use.
 Any such automatic parsing works most of the time, but it does have
 error cases where the parsing may be incorrect.
@@ -125,7 +125,7 @@ of how double-quoted strings are used.
 === Lists
 
 When a cast is applied to a list, the cast is applied _individually to
-each entry in the list_.  This behavior is most noticable when calling
+each entry in the list_.  This behavior is most noticeable when calling
 a function, or looping over a set of attributes.
 
 The following example will first create two `Reply-Message` attributes

--- a/doc/antora/modules/reference/pages/type/index.adoc
+++ b/doc/antora/modules/reference/pages/type/index.adoc
@@ -68,7 +68,7 @@ comparisons, for all attributes and data types.
 
 Values can be xref:type/cast.adoc[cast] from one data type to another.
 However, this cast only changes the _type_ of the data, it does not
-change the datas _value_.  That is, a cast allows you to convert an
+change the data's _value_.  That is, a cast allows you to convert an
 `octets` data type to a `string`, but the resulting `string` may still
 contain non-printable characters.
 

--- a/doc/antora/modules/reference/pages/unlang/actions.adoc
+++ b/doc/antora/modules/reference/pages/unlang/actions.adoc
@@ -41,7 +41,7 @@ a number greater than or equal to 0, or a named action.
 |=====
 | Action 	| Description
 | break		| "break" out of the parent block and stop processing it.
-| default	| Use the defaut priority for this rcode.
+| default	| Use the default priority for this rcode.
 | reject	| return a `reject` rcode.
 | retry		| re-run the section, as given by the the `retry` subsection.
 | return	| return out of the parent block and stop processing it.

--- a/doc/antora/modules/reference/pages/unlang/call.adoc
+++ b/doc/antora/modules/reference/pages/unlang/call.adoc
@@ -12,7 +12,7 @@ The `call` statement will run the current request through another
 virtual server.  Once that virtual server is complete, the request
 will continue being processed in the original virtual server.
 
-<server>::  The virtual server which wil process the request.
+<server>::  The virtual server which will process the request.
 +
 The called virtual server must have the same `namespace` value as the
 calling virtual server.

--- a/doc/antora/modules/reference/pages/unlang/edit.adoc
+++ b/doc/antora/modules/reference/pages/unlang/edit.adoc
@@ -119,12 +119,12 @@ the list operations are simple, and well defined.
 |=====
 | Operator | Description
 | =        | Set the list to the contents of the _<rhs>_, if the _<list>_ does not exist.  If the list already exists, nothing is done.  If the list does not exist, it is created, and the contents set to the value of the _<rhs>_
-| :=       | Override the list to the contents with the _<rhs>_.  If the list already exists, its value is over-written.  If the list does not exist, it is created, and the contents set to thex value of the _<rhs>_
+| :=       | Override the list to the contents with the _<rhs>_.  If the list already exists, its value is over-written.  If the list does not exist, it is created, and the contents set to the value of the _<rhs>_
 | +=       | Perform list append operation.  The contents of the _<rhs>_ are appended to the _<list>_.  The resulting list is _<list><rhs>_.
 | ^=       | Perform a list prepend operation.  The contents of the _<rhs>_ are prepended to the _<list>_.  The resulting list is _<rhs><list>_.
 | -=       | Remove attributes from the _<list>_ which match the _<rhs>_ attribute or list.
 | \|=       | Perform a list union.  The resulting list has all of the contents of the original _<list>_, and the _<rhs>_ list.
-| &=       | Perform a list intersection.  The resulting list has only the attributes which are in both the origianl _<list>_, and the _<rhs>_ list.
+| &=       | Perform a list intersection.  The resulting list has only the attributes which are in both the original _<list>_, and the _<rhs>_ list.
 | >=       | Perform a priority merge of two lists. The resulting list has all of the contents of the original _<list>_, and of all _<rhs>_ list attributes which are not already in _<list>_.
 | \<=       | Perform a priority merge of two lists. The resulting list has all of the contents of the original _<rhs>_, and of all _<list>_ list attributes which are not in _<rhs>_ are left alone..
 |=====
@@ -185,7 +185,7 @@ This operation can best be understood as a two-step process:
 
 1. Create a temporary "in-place" list from the _<rhs>_ of the edit
 operation.  This "in-place" list is not associated with any previous
-list, but instead exists on its own, independt of anything else.  As
+list, but instead exists on its own, independent of anything else.  As
 such, there is no need to use operators for the _<rhs>_ list.
 Instead, the attributes for this list are created in order, exactly as they are
 given.
@@ -286,7 +286,7 @@ hacks.
 
 For now, regular expression operators are not supported.
 
-=== List to List Operatons
+=== List to List Operations
 
 Lists can also be copied using the operators.
 
@@ -310,7 +310,7 @@ copies all of the `request` list contents to the `reply` list.
 === Parsing strings as lists
 
 It is also possible to have strings on the _<rhs>_ of a list
-assignment.  This funtionality is most useful for putting attribute
+assignment.  This functionality is most useful for putting attribute
 lists into a database, and then reading them back when a request is
 processed.
 
@@ -411,7 +411,7 @@ The operators also apply to variable-sized values.
 |=====
 | Operator | Description
 | =        | Set the attribute to the contents of the _<rhs>_, if the _<attribute>_ does not exist.  If the attribute already exists, nothing is done.  If the attribute does not exist, it is created, and the contents set to the value of the _<rhs>_
-| :=       | Override the attribute with the contents with the _<rhs>_.  If the attribute already exists, its value is over-written.  If the attribute does not exist, it is created, and the contents set to thex value of the _<rhs>_
+| :=       | Override the attribute with the contents with the _<rhs>_.  If the attribute already exists, its value is over-written.  If the attribute does not exist, it is created, and the contents set to the value of the _<rhs>_
 | +=       | Perform string append.  The contents of the _<rhs>_ are appended to the _<attribute>_.
 | -=       | Inverse of string append. The contents of the _<rhs>_ are deleted from from the _<attribute>_, if the `_<rhs>_` is a suffix of _<attribute>_ 
 | ^=       | For `string`, performs a "prepend" operation.  The contents of the _<rhs>_ are prepended to the _<attribute>_.  This is the opposite of `+=`.

--- a/doc/antora/modules/reference/pages/unlang/index.adoc
+++ b/doc/antora/modules/reference/pages/unlang/index.adoc
@@ -78,7 +78,7 @@ xref:unlang/local.adoc[Local variables] can be defined, so that the
 local `dictionary` file no longer needs to be modified.
 
 Most request packets will result in reply packets that contain
-additional information for the requestor.  Attribute editing allows
+additional information for the requester.  Attribute editing allows
 policies to add attributes to requests, replies, or to other places.
 
 .Example

--- a/doc/antora/modules/reference/pages/unlang/parallel.adoc
+++ b/doc/antora/modules/reference/pages/unlang/parallel.adoc
@@ -18,7 +18,7 @@ The `parallel` section is most useful for running modules which call
 external systems and wait for a reply.  When modules are run in
 series, the first module must run to completion, and only then can the
 second and subsequent modules be executed.  With parallel, the first
-module is run, and then as soon as that module yeilds in order to wait
+module is run, and then as soon as that module yields in order to wait
 for an event, the second module can immediately run.
 
 Each child subsection is executed using a

--- a/doc/antora/modules/reference/pages/xlat/builtin.adoc
+++ b/doc/antora/modules/reference/pages/xlat/builtin.adoc
@@ -220,7 +220,7 @@ If no argument is passed, it returns the current time.  Otherwise if the argumen
 This expansion should be used in preference to the xref:xlat/character.adoc[single letter expansions] `%l`.  That expansion returns integer seconds, and is not suitable for millisecond or microsecond resolution.
 ====
 
-Due to limitations in the underlying time funtions (both system and
+Due to limitations in the underlying time functions (both system and
 FreeRADIUS), previous versions of FreeRADIUS did not always handle
 dates correctly.  When print dates, the time zone information would
 sometimes not be printed, or the time zone would sometimes be ignored

--- a/doc/antora/modules/reference/pages/xlat/character.adoc
+++ b/doc/antora/modules/reference/pages/xlat/character.adoc
@@ -21,7 +21,7 @@ decimal number.
 Note that creating a "fractional" time from an expansion like `%c.%C`
 should only be used when creating strings, such as for logging.  If
 you need to calculate time differences, the time values should be left
-as type `date`, and then you can substract two dates to get a
+as type `date`, and then you can subtract two dates to get a
 `time_delta`.  That `time_delta` can then be printed in an appropriate
 precision and scale.
 

--- a/doc/antora/modules/reference/pages/xlat/file.adoc
+++ b/doc/antora/modules/reference/pages/xlat/file.adoc
@@ -14,7 +14,7 @@ This function returns an escaped or "safe" version of the input string.
 
 In some cases, as when using `%exec(...)`, it is impossible to determine which arguments are filenames, and which are simple strings.  This function allows the server to safely pass in a filename to external programs.
 
-The returned filename is guaranteed to be safe to use.  Any portion of the filename which is taken from a "safe" source (i.e. configuration files, etc. controlled by an administator) is used as-is.  Any portion of the filename which is taken from an "unsafe" source (i.e. network apckets) is escaped.  The result is that characters like `/` in unsafe inputs cannot be used to perform directory traversal attacks.
+The returned filename is guaranteed to be safe to use.  Any portion of the filename which is taken from a "safe" source (i.e. configuration files, etc. controlled by an administrator) is used as-is.  Any portion of the filename which is taken from an "unsafe" source (i.e. network apckets) is escaped.  The result is that characters like `/` in unsafe inputs cannot be used to perform directory traversal attacks.
 
 .Safely pass a filename to `%exec(...)`
 ====

--- a/doc/antora/modules/reference/pages/xlat/interpreter.adoc
+++ b/doc/antora/modules/reference/pages/xlat/interpreter.adoc
@@ -26,7 +26,7 @@ recv Access-Request {
 }
 ----
 
-.Output (_extra informations only for that condition_)
+.Output (_extra information only for that condition_)
 
 ```
 ...
@@ -81,7 +81,7 @@ recv Access-Request {
 == State
 
 The state of the interpreter can be queried via the
-`%interpeter(<name>)` expansion.  The individual expansions are
+`%interpreter(<name>)` expansion.  The individual expansions are
 documented below.
 
 Each expansion given here can be prefixed with one or more dot (`.`)
@@ -92,34 +92,34 @@ no parent, the expansion returns the string `<underflow>`.
 For example `'filename'` is the name of the current file being
 executed, while `'..filename'` is the filename of the parent request.
 
-== %interpeter('filename')
+== %interpreter('filename')
 
 Which filename is currently being executed.
 
-== %interpeter('line')
+== %interpreter('line')
 
 The line number in the current file being executed.
 
-== %interpeter('processing_stage')
+== %interpreter('processing_stage')
 
 Which section of a virtual server is processing the request.
 
 
-== %interpeter('module')
+== %interpreter('module')
 
 The current module being executed.  If the expansions is done in an
 `unlang` statement and outside of any module, it returns the name of
 the previous module which was executed.
 
-== %interpeter('processing_stage')
+== %interpreter('processing_stage')
 
 Which section of a virtual server is processing the request.
 
-== %interpeter('rcode')
+== %interpreter('rcode')
 
 The current interpreter return code, e.g. `handle`, or `ok`, etc.
 
-== %interpeter('server')
+== %interpreter('server')
 
 The name of the virtual server which is running the request.
 

--- a/doc/antora/modules/reference/pages/xlat/log.adoc
+++ b/doc/antora/modules/reference/pages/xlat/log.adoc
@@ -39,7 +39,7 @@ Logs a message at a INFO level.  This function returns nothing.
 
 The INFO messages are always logged.
 
-== %log.watn(_string_)
+== %log.warn(_string_)
 
 Logs a message at a WARN level.  This function returns nothing.
 

--- a/doc/antora/modules/tutorials/pages/dynamic-translation.adoc
+++ b/doc/antora/modules/tutorials/pages/dynamic-translation.adoc
@@ -103,7 +103,7 @@ multiplied by the value of the "UID" of the RADIUS server.
 
 == Further considerations
 
-Run-time variables allow inter-module calling. The administator may perform LDAP
+Run-time variables allow inter-module calling. The administrator may perform LDAP
 queries and SQL queries to use database information in other modules.
 
 Unfortunately, the format of the string is module-dependent. This limitation

--- a/doc/antora/modules/tutorials/pages/simultaneous_use.adoc
+++ b/doc/antora/modules/tutorials/pages/simultaneous_use.adoc
@@ -45,7 +45,7 @@ authentication attempt fails.
 
 After running the `bob-acct-stop.sh` script, you should run the
 `bob-login-two.sh` script again, to verify that the other login attempt
-is now permitted to succed.
+is now permitted to succeed.
 
 == Questions
 

--- a/doc/antora/modules/tutorials/pages/unlang_return_codes.adoc
+++ b/doc/antora/modules/tutorials/pages/unlang_return_codes.adoc
@@ -51,7 +51,7 @@ executing the `files` module to provide an alternative source of credentials.
 [TIP]
 ====
 You may need to modify the return code priorities of the
-xref:raddb:mods-available/sometimes.adoc[somtimes] module.
+xref:raddb:mods-available/sometimes.adoc[sometimes] module.
 ====
 
 If the policies are correct you will see that FreeRADIUS returns an

--- a/doc/css/toc_focus.js
+++ b/doc/css/toc_focus.js
@@ -1,5 +1,5 @@
 $(function () {
-    // Add a new container for the tocify toc into the existing toc so we can re-use its
+    // Add a new container for the tocify toc into the existing toc so we can reuse its
     // styling
     $("#toc").append("<div id='generated-toc'></div>");
     $("#generated-toc").tocify({

--- a/doc/doxygen/extra/toc.c
+++ b/doc/doxygen/extra/toc.c
@@ -11,7 +11,7 @@
 FreeRADIUS is a high-performance modular RADIUS server, supporting PAP, CHAP,
 EAP (including EAP-TLS, EAP-TTLS, EAP-PEAP with EAP-MSCHAP) and a very flexible
 configuration model, including conditional request processing, querying of
-LDAP and SQL databases, exection of external scripts and more.
+LDAP and SQL databases, execution of external scripts and more.
 
 FreeRADIUS uses a thread pool to serve requests. Each request is processed
 synchronously, and processing passes through a series of stages, and a list

--- a/doc/schemas/ldap/edir/freeradius-clients.ldif
+++ b/doc/schemas/ldap/edir/freeradius-clients.ldif
@@ -5,7 +5,7 @@
 #
 # 1.3.6.1.4.1.11344.4.1.1 is the toplevel OID for this work
 #	          .1 = objectclasses
-#	          .2 = attributs
+#	          .2 = attributes
 dn: cn=schema
 changetype: modify
 add: attributetypes

--- a/scripts/health/radhttpcheck/README.md
+++ b/scripts/health/radhttpcheck/README.md
@@ -95,7 +95,7 @@ codes are used to indicate errors.
 | code          | meaning           | comment                                                  |
 |---------------|-------------------|----------------------------------------------------------|
 | `200`         | Success           | We received a valid response from the RADIUS server.     |
-| `500`         | Script failure    | An internal error ocurred in the healthcheck script.     |
+| `500`         | Script failure    | An internal error occurred in the healthcheck script.     |
 | `502`         | Invalid response  | Either the response packet was malformed or failed validation (bad shared secret), or `require_ack` was enabled, and the response contained a NAK response like `Access-Reject`. |
 | `504`         | Timeout           | No response received from the RADIUS server.             |
 


### PR DESCRIPTION
Misspellings found by [codespell](https://github.com/codespell-project/codespell).