### PR TITLE
Revise a couple of uses of FR_TYPE_STRUCTURAL

### DIFF
--- a/src/lib/util/types.h
+++ b/src/lib/util/types.h
@@ -217,6 +217,19 @@ typedef enum {
 	_mid(FR_TYPE_TLV) \
 	_end(FR_TYPE_VENDOR)
 
+/** Hack for truthiness check
+ *
+ * - VSAs
+ * - Structs
+ * - TLVs
+ * - Vendors
+ */
+#define FR_TYPE_STRUCTURAL_EXCEPT_GROUP_DEF(_beg, _mid, _end) \
+	_beg(FR_TYPE_VSA) \
+	_mid(FR_TYPE_STRUCT) \
+	_mid(FR_TYPE_TLV) \
+	_end(FR_TYPE_VENDOR)
+
 /** Match all non value types in case statements
  *
  * - Groups
@@ -279,6 +292,7 @@ typedef enum {
 #define FR_TYPE_QUOTED				FR_TYPE_QUOTED_DEF(CASE_BEG, CASE_MID, CASE_END)
 
 #define FR_TYPE_STRUCTURAL_EXCEPT_VSA		FR_TYPE_STRUCTURAL_EXCEPT_VSA_DEF(CASE_BEG, CASE_MID, CASE_END)
+#define FR_TYPE_STRUCTURAL_EXCEPT_GROUP		FR_TYPE_STRUCTURAL_EXCEPT_GROUP_DEF(CASE_BEG, CASE_MID, CASE_END)
 #define FR_TYPE_STRUCTURAL			FR_TYPE_STRUCTURAL_DEF(CASE_BEG, CASE_MID, CASE_END)
 #define FR_TYPE_LEAF				FR_TYPE_LEAF_DEF(CASE_BEG, CASE_MID, CASE_END)
 #define FR_TYPE_NON_LEAF			FR_TYPE_NON_LEAF_DEF(CASE_BEG, CASE_MID, CASE_END)

--- a/src/lib/util/value.c
+++ b/src/lib/util/value.c
@@ -6063,11 +6063,11 @@ bool fr_value_box_is_truthy(fr_value_box_t const *in)
 
 	switch (in->type) {
 	case FR_TYPE_NULL:
+	case FR_TYPE_STRUCTURAL_EXCEPT_GROUP:
 		return false;
 
-	case FR_TYPE_STRUCTURAL:
-		if (in->type == FR_TYPE_GROUP) return (fr_value_box_list_num_elements(&in->vb_group) > 0);
-		return false;
+	case FR_TYPE_GROUP:
+		return (fr_value_box_list_num_elements(&in->vb_group) > 0);
 
 	case FR_TYPE_BOOL:
 		return in->vb_bool;


### PR DESCRIPTION
FR_TYPE_STRUCTURAL has a name of the same form as the values of fr_type_t, but is carefully #defined so it can appear in a switch statement looking like a single value but underneath expanding to multiple cases, making some of its uses counterintuitive.