### PR TITLE
mutexes near returns (CID #1551697, #1551698)

### DIFF
--- a/src/lib/server/exfile.c
+++ b/src/lib/server/exfile.c
@@ -485,6 +485,7 @@ try_lock:
 
 	exfile_trigger_exec(ef, &ef->entries[i], "reserve");
 
+	/* coverity[missing_unlock] */
 	return ef->entries[i].fd;
 }
 

--- a/src/lib/util/atexit.c
+++ b/src/lib/util/atexit.c
@@ -411,7 +411,17 @@ do_threads:
  */
 bool fr_atexit_is_exiting(void)
 {
+#ifdef HAVE_PTHREADS
+	bool save_is_exiting;
+
+	pthread_mutex_lock(&fr_atexit_global_mutex);
+	save_is_exiting = is_exiting;
+	pthread_mutex_unlock(&fr_atexit_global_mutex);
+
+	return save_is_exiting;
+#else
 	return is_exiting;
+#endif
 }
 
 #ifdef HAVE_PTHREADS


### PR DESCRIPTION
1551697 Guard reference to is_exiting if HAVE_PTHREADS defined 
1551698 Annotate leaving exfiles opened for exclusive use locked