### PR TITLE
Annotate return when exfile_open() fails (CID #1206498, #1206499)

### DIFF
--- a/src/modules/rlm_detail/rlm_detail.c
+++ b/src/modules/rlm_detail/rlm_detail.c
@@ -418,7 +418,9 @@ static unlang_action_t CC_HINT(nonnull) detail_do(rlm_rcode_t *p_result, module_
 	outfd = exfile_open(inst->ef, buffer, inst->perm, NULL);
 	if (outfd < 0) {
 		RPERROR("Couldn't open file %s", buffer);
-		RETURN_MODULE_FAIL;
+		*p_result = RLM_MODULE_FAIL;
+		/* coverity[missing_unlock] */
+		return UNLANG_ACTION_CALCULATE_RESULT;
 	}
 
 	if (inst->group_is_set) {

--- a/src/modules/rlm_sql/sql.c
+++ b/src/modules/rlm_sql/sql.c
@@ -609,6 +609,7 @@ void rlm_sql_query_log(rlm_sql_t const *inst, request_t *request, sql_acct_secti
 		ERROR("Couldn't open logfile '%s': %s", expanded, fr_syserror(errno));
 
 		talloc_free(expanded);
+		/* coverity[missing_unlock] */
 		return;
 	}
 


### PR DESCRIPTION
Unfortunately, this is in the callers of exfile_open(), not exfile_open() itself. Coverity doesn't notice that the mutex is unlocked in exfile_open() if it fails, and we haven't been able to model it, hence the annotations.