### PR TITLE
Annotate missing unlock in connection_spawn() (CID #1414434)

### DIFF
--- a/src/lib/server/pool.c
+++ b/src/lib/server/pool.c
@@ -529,6 +529,7 @@ static fr_pool_connection_t *connection_spawn(fr_pool_t *pool, request_t *reques
 	pthread_cond_broadcast(&pool->done_spawn);
 	if (unlock) pthread_mutex_unlock(&pool->mutex);
 
+	/* coverity[missing_unlock] */
 	return this;
 }
 


### PR DESCRIPTION
Coverity insists on unlocking mutexes in the same function invocation the lock occurs in, but there are times when you want exclusive use of a resource and thus lock it on allocation and free on release, hence the annotation.