### PR TITLE
configure: Fix type of argument to backtrace_symbols

### DIFF
--- a/configure
+++ b/configure
@@ -14418,7 +14418,7 @@ main (void)
 {
 
       void *sym[1];
-      backtrace_symbols(&sym, sizeof(sym))
+      backtrace_symbols(sym, sizeof(sym))
   ;
   return 0;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -2163,7 +2163,7 @@ if test "x$ac_cv_header_execinfo_h" = "xyes"; then
       #include <execinfo.h>
     ]], [[
       void *sym[1];
-      backtrace_symbols(&sym, sizeof(sym)) ]])],[
+      backtrace_symbols(sym, sizeof(sym)) ]])],[
       AC_MSG_RESULT(yes)
       ac_cv_lib_execinfo_backtrace_symbols="yes"
     ],[


### PR DESCRIPTION
The `backtrace_symbols` function expects a pointer to an array of `void *` values, not a pointer to an array of a single element. Removing the address operator ensures that the right type is used.

This avoids an unconditional failure of this probe with compilers that treat incompatible pointer types as a compilation error.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
