### PR TITLE
Fix typos in documentation

### DIFF
--- a/doc/antora/modules/raddb/pages/mods-available/files.adoc
+++ b/doc/antora/modules/raddb/pages/mods-available/files.adoc
@@ -6,7 +6,7 @@
 
 The `users` file as located in `raddb/mods-config/files/authorize`. (Livingston-style format).
 
-See the xref:raddb:mods-config/files/users.adoc[users] file documention for information
+See the xref:raddb:mods-config/files/users.adoc[users] file documentation for information
 on the format of the input file, and how it operates.
 
 

--- a/doc/antora/modules/reference/nav.adoc
+++ b/doc/antora/modules/reference/nav.adoc
@@ -82,7 +82,7 @@
 **** xref:xlat/pairs.adoc[Print attributes]
 **** xref:xlat/rpad.adoc[Right pad]
 **** xref:xlat/randstr.adoc[Random strings]
-**** xref:xlat/tolower.adoc[Conver to lowercase]
+**** xref:xlat/tolower.adoc[Convert to lowercase]
 **** xref:xlat/toupper.adoc[Convert to uppercase]
 *** xref:xlat/builtin.adoc[Built-in Expansions]
 *** xref:xlat/character.adoc[Single Letter Expansions]

--- a/doc/antora/modules/reference/pages/dictionary/vendor.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/vendor.adoc
@@ -15,7 +15,7 @@ These codes are assigned by the Internet Assigned Numbers Authority
 
 <name>:: The name of the vendor.
 
-<numver>:: The number associated with the vendor.
+<number>:: The number associated with the vendor.
 
 <option>:: The protocol-specific option associated with the vendor definition.
 +

--- a/doc/antora/modules/reference/pages/unlang/caller.adoc
+++ b/doc/antora/modules/reference/pages/unlang/caller.adoc
@@ -26,7 +26,7 @@ subrequest.  It is largely equivalent to something like:
 
 [source,unlang]
 ----
-if (parant && parent dictionary is RADIUS) {
+if (parent && parent dictionary is RADIUS) {
     ... statements ...
 }
 ----

--- a/doc/antora/modules/reference/pages/unlang/edit.adoc
+++ b/doc/antora/modules/reference/pages/unlang/edit.adoc
@@ -30,7 +30,7 @@ Unlike version 3, attribute editing can result in a `fail` return
 code.  That is, edits either return `noop` on success, or `fail` on failure.
 
 In most cases, an edit failure will result in the processing section
-exiting, and returning `fail`.  This behavior can be overriden with a xref:unlang/transaction.adoc[transaction], or a xref:unlang/try.adoc[try] / xref:unlang/catch.adoc[catch] block.
+exiting, and returning `fail`.  This behavior can be overridden with a xref:unlang/transaction.adoc[transaction], or a xref:unlang/try.adoc[try] / xref:unlang/catch.adoc[catch] block.
 
 An edit statement has the following standard syntax:
 

--- a/doc/antora/modules/reference/pages/xlat/randstr.adoc
+++ b/doc/antora/modules/reference/pages/xlat/randstr.adoc
@@ -8,7 +8,7 @@ Build strings of random chars, useful for generating tokens and passcodes
 Format similar to the Perl module `String::Random`.
 
 Format characters may include the following, and may be
-preceeded by an integer repetition count:
+preceded by an integer repetition count:
 
 .Character Classes
 [options="header"]


### PR DESCRIPTION
Misspellings found by [codespell](https://github.com/codespell-project/codespell).