### PR TITLE
Fix typos in raddb

### DIFF
--- a/raddb/dictionary
+++ b/raddb/dictionary
@@ -39,7 +39,7 @@
 #
 #  v4 also supports a `dictionary { ... }` subsection in a virtual
 #  server.  If the attributes are used only in one virtual server,
-#  they shuld be defined there.
+#  they should be defined there.
 #
 
 #
@@ -85,7 +85,7 @@
 #  ## v3 Compatible names.
 #
 #  All of the attributes have been renamed from v3.  This change was
-#  necessary in order to support new funtionality in v4.  The
+#  necessary in order to support new functionality in v4.  The
 #  unfortunate side effect of this change is that all of the names in
 #  SQL, LDAP, and the "files" module are incompatible with v4.
 #
@@ -131,7 +131,7 @@
 #  Yes, we recognize that this process is a bit of work.  However, we
 #  wish to encourage everyone using v4 to upgrade to using the new v4
 #  features.  Our experience shows that if we automatically enable
-#  "compatibility functions", then those compatiblity functions will
+#  "compatibility functions", then those compatibility functions will
 #  be used for a decade.  So we need to find a balance between
 #  upgrades and ongoing support.  Easy upgrades will mean complex
 #  ongoing support.  Complex upgrades make ongoing support easier, but

--- a/raddb/mods-available/files
+++ b/raddb/mods-available/files
@@ -9,7 +9,7 @@
 #
 #  The `users` file as located in `raddb/mods-config/files/authorize`. (Livingston-style format).
 #
-#  See the doc/antora/modules/raddb/pages/mods-config/files/users.adoc file documention for information
+#  See the doc/antora/modules/raddb/pages/mods-config/files/users.adoc file documentation for information
 #  on the format of the input file, and how it operates.
 #
 

--- a/raddb/mods-config/perl/example.pl
+++ b/raddb/mods-config/perl/example.pl
@@ -36,15 +36,15 @@ use Data::Dumper;
 # Bring the global hashes into the package scope
 our (%RAD_REQUEST, %RAD_REPLY, %RAD_CONFIG, %RAD_STATE);
 
-# This is hash wich hold original request from radius
+# This hash holds the original request from radius
 #my %RAD_REQUEST;
 # In this hash you add values that will be returned to NAS.
 #my %RAD_REPLY;
-#This is for config items (was %RAD_CHECK in earlier versions)
+# This hash contains config items (was %RAD_CHECK in earlier versions)
 #my %RAD_CONFIG;
-# This is the session-sate
+# This is the session state
 #my %RAD_STATE;
-# This is configuration items from "config" perl module configuration section
+# This hash contains config items from "config" perl module configuration section
 #my %RAD_PERLCONF;
 
 # Multi-value attributes are mapped to perl arrayrefs.

--- a/raddb/mods-config/sql/driver/cassandra
+++ b/raddb/mods-config/sql/driver/cassandra
@@ -89,7 +89,7 @@ cassandra {
 		# Number of hosts used at each remote dc (default 0).
 #		hosts_per_remote_dc = 0
 
-		# Allow remote hosts to be used in no local dc hosts are avaiable and the
+		# Allow remote hosts to be used if no local dc hosts are available and the
 		# consistency level is 'local_one' or 'local_quorum' (default no).
 #		allow_remote_dcs_for_local_cl = no
 	}

--- a/raddb/mods-config/sql/driver/mysql
+++ b/raddb/mods-config/sql/driver/mysql
@@ -18,6 +18,6 @@ mysql {
 #
 	# If yes, (or auto and libmysqlclient reports warnings are
 	# available), will retrieve and log additional warnings from
-	# the server if an error has occured. Defaults to 'auto'
+	# the server if an error has occurred. Defaults to 'auto'
 	warnings = auto
 }

--- a/raddb/mods-config/sql/ippool/mssql/procedure.sql
+++ b/raddb/mods-config/sql/ippool/mssql/procedure.sql
@@ -39,7 +39,7 @@ AS
 
 		-- MS SQL lacks a "SELECT FOR UPDATE" statement, and its table
 		-- hints do not provide a direct means to implement the row-level
-		-- read lock needed to guarentee that concurrent queries do not
+		-- read lock needed to guarantee that concurrent queries do not
 		-- select the same Framed-IP-Address for allocation to distinct
 		-- users.
 		--

--- a/raddb/mods-config/sql/ippool/mssql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mssql/queries.conf
@@ -202,7 +202,7 @@ update_free = "\
 #  This query must update a row when a lease is successfully requested -
 #  queries that update no rows will result in a "notfound" response to
 #  the module which by default will give a NAK reply (for DHCPv4).
-#  In this example incrementing "counter" is used to acheive this.
+#  In this example incrementing "counter" is used to achieve this.
 #
 update_update = "\
 	UPDATE ${ippool_table} \

--- a/raddb/mods-config/sql/ippool/mysql/queries.conf
+++ b/raddb/mods-config/sql/ippool/mysql/queries.conf
@@ -164,7 +164,7 @@ update_free = "\
 #  This query must update a row when a lease is successfully requested -
 #  queries that update no rows will result in a "notfound" response to
 #  the module which by default will give a NAK reply.  In this example
-#  incrementing "counter" is used to acheive this.
+#  incrementing "counter" is used to achieve this.
 #
 update_update = "\
 	UPDATE ${ippool_table} \

--- a/raddb/mods-config/sql/ippool/oracle/queries.conf
+++ b/raddb/mods-config/sql/ippool/oracle/queries.conf
@@ -121,7 +121,7 @@ pool_check = "\
 #  This query must update a row when a lease is successfully requested -
 #  queries that update no rows will result in a "notfound" response to
 #  the module which by default will give a NAK reply.  In this example
-#  incrementing "counter" is used to acheive this.
+#  incrementing "counter" is used to achieve this.
 #
 update_begin = "commit"
 update_update = "\

--- a/raddb/mods-config/sql/ippool/postgresql/queries.conf
+++ b/raddb/mods-config/sql/ippool/postgresql/queries.conf
@@ -183,7 +183,7 @@ update_free = "\
 #  This query must update a row when a lease is successfully requested -
 #  queries that update no rows will result in a "notfound" response to
 #  the module which by default will give a NAK reply.  In this example
-#  incrementing "counter" is used to acheive this.
+#  incrementing "counter" is used to achieve this.
 #
 update_update = "\
 	UPDATE ${ippool_table} \

--- a/raddb/mods-config/sql/ippool/sqlite/queries.conf
+++ b/raddb/mods-config/sql/ippool/sqlite/queries.conf
@@ -32,7 +32,7 @@ alloc_commit = "COMMIT"
 #
 
 #
-#  Is there an exsiting address for this client
+#  Is there an existing address for this client
 #
 alloc_existing = "SELECT address \
 	FROM ${ippool_table} \
@@ -133,7 +133,7 @@ update_free = "\
 #  This query must update a row when a lease is successfully requested -
 #  queries that update no rows will result in a "notfound" response to
 #  the module which by default will give a NAK reply.  In this example
-#  incrementing "counter" is used to acheive this.
+#  incrementing "counter" is used to achieve this.
 #
 update_update = "\
 	UPDATE ${ippool_table} \

--- a/raddb/mods-config/sql/main/mysql/process-radacct.sql
+++ b/raddb/mods-config/sql/main/mysql/process-radacct.sql
@@ -173,7 +173,7 @@ DELIMITER ;
 --  this strategy leaves them open and records the NAS reload time in the
 --  nasreload table.
 --
---  Where applicable, the onus is on the administator to:
+--  Where applicable, the onus is on the administrator to:
 --
 --    * Consider the nas reload times when deriving a list of
 --      active/inactive sessions, and when determining the duration of sessions

--- a/raddb/mods-config/sql/main/postgresql/extras/cisco_h323_db_schema.sql
+++ b/raddb/mods-config/sql/main/postgresql/extras/cisco_h323_db_schema.sql
@@ -115,7 +115,7 @@ CREATE TABLE StopTelephony (
 	processed		BOOLEAN DEFAULT false
 );
 
--- You can have more than one record that is identical except for CiscoNASPort if you have a dial peer hungroup
+-- You can have more than one record that is identical except for CiscoNASPort if you have a dial peer huntgroup
 -- configured for multiple PRIs.
 create UNIQUE index stoptelephonycombo on stoptelephony (AcctTime, nasipaddress, CallID, CiscoNASPort);
 
@@ -180,7 +180,7 @@ CREATE TRUSTED LANGUAGE "plpgsql" HANDLER "plpgsql_call_handler";
 -- We therefore do not bother to strip asterisks (*) from timestamps, as you NEED ntp setup
 -- unless you don't care about billing at all!
 --
---  * Example useage:
+--  * Example usage:
 --      insert into mytable values (strip_dot('.16:46:02.356 EET Wed Dec 11 2002'));
 --
 CREATE OR REPLACE FUNCTION strip_dot (VARCHAR) RETURNS TIMESTAMPTZ AS '

--- a/raddb/mods-config/sql/main/postgresql/extras/update_radacct_group.sql
+++ b/raddb/mods-config/sql/main/postgresql/extras/update_radacct_group.sql
@@ -3,7 +3,7 @@
 --
 -- OPTIONAL Postgresql trigger for FreeRADIUS
 --
--- This trigger updates fills in the groupname field (which doesnt come in Accounting packets)
+-- This trigger updates fills in the groupname field (which doesn't come in Accounting packets)
 -- by querying the radusergroup table.
 -- This makes it easier to do group summary reports, however note that it does add some extra
 -- database load to 50% of your SQL accounting queries. If you dont care about group summary

--- a/raddb/mods-config/sql/main/postgresql/process-radacct.sql
+++ b/raddb/mods-config/sql/main/postgresql/process-radacct.sql
@@ -159,7 +159,7 @@ $$;
 --  this strategy leaves them open and records the NAS reload time in the
 --  nasreload table.
 --
---  Where applicable, the onus is on the administator to:
+--  Where applicable, the onus is on the administrator to:
 --
 --    * Consider the nas reload times when deriving a list of
 --      active/inactive sessions, and when determining the duration of sessions

--- a/raddb/mods-config/sql/main/sqlite/process-radacct-schema.sql
+++ b/raddb/mods-config/sql/main/sqlite/process-radacct-schema.sql
@@ -63,7 +63,7 @@ CREATE INDEX idx_data_usage_by_period_period_end ON data_usage_by_period(period_
 --  this strategy leaves them open and records the NAS reload time in the
 --  nasreload table.
 --
---  Where applicable, the onus is on the administator to:
+--  Where applicable, the onus is on the administrator to:
 --
 --    * Consider the nas reload times when deriving a list of
 --      active/inactive sessions, and when determining the duration of sessions

--- a/raddb/policy.d/accounting
+++ b/raddb/policy.d/accounting
@@ -42,7 +42,7 @@ acct_unique {
 	#  Acct-Unique-Session-Id, but this may cause problems
 	#  with NAS that carry Class values across between
 	#  multiple linked sessions.  So we rehash class with
-	#  Acct-Session-ID to provide a truely unique session
+	#  Acct-Session-ID to provide a truly unique session
 	#  identifier.
 	#
 	#  Using a Class/Session-ID combination is more robust

--- a/raddb/policy.d/time
+++ b/raddb/policy.d/time
@@ -6,7 +6,7 @@ expiration {
 		time_delta timeout
 
 		#
-		#  %l is "when the server received the reuest"
+		#  %l is "when the server received the request"
 		#
 		if (&control.Expiration < %l) {
 			disallow

--- a/raddb/radiusd.conf.in
+++ b/raddb/radiusd.conf.in
@@ -368,7 +368,7 @@ log debug {
 #
 ENV {
 	#
-	#  Set environment varable `FOO` to value '/bar/baz'.
+	#  Set environment variable `FOO` to value '/bar/baz'.
 	#
 	#  NOTE: Note that you MUST use '='.  You CANNOT use '+=' to append
 	#  values.


### PR DESCRIPTION
Misspellings found by [codespell](https://github.com/codespell-project/codespell).

See #5249.