### PR TITLE
Fix typos in scripts

### DIFF
--- a/scripts/asciidoc/sass/components/_asciidoc.scss
+++ b/scripts/asciidoc/sass/components/_asciidoc.scss
@@ -1295,7 +1295,7 @@ td.hdlist1 {
   }
 }
 
-// reenable once we can style the number too
+// re-enable once we can style the number too
 //.qanda > ol > li > p > em:only-child {
 //  color: darken($primary-color, 5%);
 //}

--- a/scripts/build/fuzzer-fetch-artifacts
+++ b/scripts/build/fuzzer-fetch-artifacts
@@ -35,7 +35,7 @@ Usage:
 
                  This mode will download the specified artifact and extract the
                  reproducers that it contains. (The list of available fuzzer
-                 artifacts is ouput by the preceeding mode.)
+                 artifacts is output by the preceding mode.)
 
   artifact-zip - "path/to/downloaded/artifact/fuzzer-radius-701e5be.zip"
 

--- a/scripts/ci/389ds-setup.sh
+++ b/scripts/ci/389ds-setup.sh
@@ -74,12 +74,12 @@ fi
 #    cat <<EOF > permissions.ldif
 #    dn: dc=example,dc=com
 #    changetype: modify
-#    add: aci
-#    aci: (targetattr="*")(target="ldap:///dc=example,dc=com")(version 3.0; acl "allow whatever"; allow (all)(userdn="ldap:///uid=manager,ou=people,dc=example,dc=com");)
+#    add: acpi
+#    acpi: (targetattr="*")(target="ldap:///dc=example,dc=com")(version 3.0; acl "allow whatever"; allow (all)(userdn="ldap:///uid=manager,ou=people,dc=example,dc=com");)
 #    EOF
 #
 #    ldapmodify -D 'cn=Directory Manager' -w secret123 -H "ldap://threeds:3389/" -x -f permissions.ldif
 #
 #  List ACLs:
-#    ldapsearch -D 'cn=Directory Manager' -w secret123 -H "ldap://threeds:3389/" -x -b 'dc=example,dc=com' '(aci=*)' aci
+#    ldapsearch -D 'cn=Directory Manager' -w secret123 -H "ldap://threeds:3389/" -x -b 'dc=example,dc=com' '(acpi=*)' acpi
 #

--- a/scripts/ci/Jenkinsfile
+++ b/scripts/ci/Jenkinsfile
@@ -17,7 +17,7 @@ def buildClosures(arg) {
         closures[value] = { testEnv_str ->
             def(dir,testEnv) = testEnv_str.split(":")
             stage("$testEnv") {
-                // Docker needs full privileges and capabilites to run the tests
+                // Docker needs full privileges and capabilities to run the tests
                 // This passes the necessary arguments to "docker run"
                 travisImage.inside("--privileged --cap-add=ALL") {
                     checkout([$class: 'GitSCM',\

--- a/scripts/ci/openresty/delay-api.lua
+++ b/scripts/ci/openresty/delay-api.lua
@@ -1,4 +1,4 @@
--- Simple API represending a slow response for testing timeouts
+-- Simple API representing a slow response for testing timeouts
 
 local t0 = os.clock()
 while os.clock() - t0 <= 2 do end

--- a/scripts/ci/package-test.mk
+++ b/scripts/ci/package-test.mk
@@ -6,7 +6,7 @@
 #  installed by the distribution packaging.
 #
 #  We want the run-time environment to be lean, typical of a fresh system
-#  installation so that we catch any missing runtime dependancies, assets
+#  installation so that we catch any missing runtime dependencies, assets
 #  missing from the packages, issues with the dynamic loader, etc.
 #
 #  Therefore we skip the usual build framework so that we do not have so

--- a/scripts/docker/build-centos7/Dockerfile.deps
+++ b/scripts/docker/build-centos7/Dockerfile.deps
@@ -43,7 +43,7 @@ RUN rm /etc/yum.repos.d/CentOS-SCLo-scl.repo
 
 
 #
-#  Documentation build dependecies
+#  Documentation build dependencies
 #
 
 #  - doxygen & JSON.pm
@@ -96,7 +96,7 @@ RUN rpm --import https://packages.networkradius.com/pgp/packages@networkradius.c
 
 
 #
-#  Use LTB's openldap packages intead of the distribution version to avoid linking against NSS
+#  Use LTB's openldap packages instead of the distribution version to avoid linking against NSS
 #
 RUN echo $'[ltb-project]\n\
 name=LTB project packages\n\

--- a/scripts/docker/build-debian10/Dockerfile.deps
+++ b/scripts/docker/build-debian10/Dockerfile.deps
@@ -37,7 +37,7 @@ RUN apt-get update && \
 
 
 #
-#  Documentation build dependecies
+#  Documentation build dependencies
 #
 
 #  - doxygen & JSON.pm

--- a/scripts/docker/build-debian11/Dockerfile.deps
+++ b/scripts/docker/build-debian11/Dockerfile.deps
@@ -37,7 +37,7 @@ RUN apt-get update && \
 
 
 #
-#  Documentation build dependecies
+#  Documentation build dependencies
 #
 
 #  - doxygen & JSON.pm

--- a/scripts/docker/build-debian9/Dockerfile.deps
+++ b/scripts/docker/build-debian9/Dockerfile.deps
@@ -36,7 +36,7 @@ RUN apt-get update && \
 
 
 #
-#  Documentation build dependecies
+#  Documentation build dependencies
 #
 
 #  - doxygen & JSON.pm

--- a/scripts/docker/build-debiansid/Dockerfile.deps
+++ b/scripts/docker/build-debiansid/Dockerfile.deps
@@ -37,7 +37,7 @@ RUN apt-get update && \
 
 
 #
-#  Documentation build dependecies
+#  Documentation build dependencies
 #
 
 #  - doxygen & JSON.pm

--- a/scripts/docker/build-ubuntu18/Dockerfile.deps
+++ b/scripts/docker/build-ubuntu18/Dockerfile.deps
@@ -37,7 +37,7 @@ RUN apt-get update && \
 
 
 #
-#  Documentation build dependecies
+#  Documentation build dependencies
 #
 
 #  - doxygen & JSON.pm

--- a/scripts/docker/build-ubuntu20/Dockerfile.deps
+++ b/scripts/docker/build-ubuntu20/Dockerfile.deps
@@ -37,7 +37,7 @@ RUN apt-get update && \
 
 
 #
-#  Documentation build dependecies
+#  Documentation build dependencies
 #
 
 #  - doxygen & JSON.pm

--- a/scripts/ldap/radiusd2ldif.pl
+++ b/scripts/ldap/radiusd2ldif.pl
@@ -79,7 +79,7 @@ my $debug = $opt_d;
 
 my %passwords;
 # This might or might not be necessary depending if your LDAP server
-# when importing from ldif introduces crypted passwords in the LDAP db
+# when importing from ldif introduces encrypted passwords in the LDAP db
 # (not necessary for Netscape's Directory Server)
 read_passwds ($opt_f) if $opt_f;
 
@@ -198,7 +198,7 @@ $mapping{'framed-ip-route'} = "radiusFramedRoute";
 $mapping{'framed-netmask'} = "radiusFramedIPNetmask";
 $mapping{'user-service'} = "radiusServiceType";
 # Since this might not change they could be placed in the DEFAULT
-# user insted of the LDAP
+# user instead of the LDAP
 #$mapping{'ascend-metric'} = "radiusAscendMetric";
 #$mapping{'ascend-idle-limit'} = "radiusAscendIdleLimit";
 # But this really ought to be there :
@@ -289,7 +289,7 @@ if ( $group ) {
 exit 0;
 
 sub read_passwds {
-# Reads passwords from a file in order to get the crypted
+# Reads passwords from a file in order to get the encrypted
 # version, the file must be of the following format:
 # password	cryptedversion
 	my ($file)=@_;

--- a/scripts/snmp-proxy/README
+++ b/scripts/snmp-proxy/README
@@ -1,5 +1,5 @@
   The files in this directory replace the old FreeRADIUS SNMP
-implementantion with a new one.
+implementation with a new one.
 
 net-radius-freeradius-dictionary.diff
 	Patch to enable the Perl Net::RADIUS module to read the

--- a/scripts/sql/generate_pool_addresses.pl
+++ b/scripts/sql/generate_pool_addresses.pl
@@ -127,7 +127,7 @@
 #
 #      Will create a pool from a sparsely populated IPv4 range for a /16
 #      network (maximum of 65.536 addresses), populating the range with 10,000
-#      addreses. The effective size of the pool can be increased in future by
+#      addresses. The effective size of the pool can be increased in future by
 #      increasing the capacity of the range with:
 #
 #    generate_pool_addresses.pl main_pool 10.66.0.0 10.66.255.255 20000
@@ -300,7 +300,7 @@ sub handle_range {
 
 	if ($range_size < $capacity) {
 		$capacity = "$range_size";
-		warn "WARNING: Insufficent IPs in the range. Will create $capacity entries.";
+		warn "WARNING: Insufficient IPs in the range. Will create $capacity entries.";
 	}
 
 	# Prune the entries to only those within the specified range
@@ -344,7 +344,7 @@ sub handle_range {
 #  the size of the range. It becomes slower as the population of a range nears
 #  the range's limit since it is harder to choose a free address at random.
 #
-#  It is useful for selecting a handful of addresses from an enourmous IPv6 /64
+#  It is useful for selecting a handful of addresses from an enormous IPv6 /64
 #  network for example.
 #
 sub sparse_fill {

--- a/scripts/sql/radsqlrelay
+++ b/scripts/sql/radsqlrelay
@@ -177,7 +177,7 @@ sub process_file($$)
         my ($dbinfo,$query) = @_;
         debug ">";
         until ($dbinfo->{handle}->do($query)) {
-	    # If an error occured and we're disconnected then try to recomnnect
+	    # If an error occurred and we're disconnected then try to recomnnect
 	    # and redo the query, otherwise give up so we don't become stuck.
             print $dbinfo->{handle}->errstr."\n";
             if ($dbinfo->{handle}->ping) {

--- a/scripts/sql/rlm_sqlippool_tool
+++ b/scripts/sql/rlm_sqlippool_tool
@@ -102,7 +102,7 @@
 #  different SQL dialects.
 #
 #  The SQL first creates a temporary table to insert the new pools into,
-#  inserts the addresses, then removes any exisitng entries from the pool
+#  inserts the addresses, then removes any existing entries from the pool
 #  table that do not exist in the new pool.  Finally any new entries that
 #  don't exist in the existing pool table are copied from the temporary
 #  table.
@@ -127,7 +127,7 @@
 #
 #      Will create a pool from a sparsely populated IPv4 range for a /16
 #      network (maximum of 65.536 addresses), populating the range with 10,000
-#      addreses. With SQL output suitable for MySQL.
+#      addresses. With SQL output suitable for MySQL.
 #      The effective size of the pool can be increased in future by increasing
 #      the capacity of the range with:
 #
@@ -540,7 +540,7 @@ sub handle_range {
 
 	if ($range_size < $capacity) {
 		$capacity = "$range_size";
-		warn 'WARNING: Insufficent IPs in the range. Will create '.$capacity.' entries.';
+		warn 'WARNING: Insufficient IPs in the range. Will create '.$capacity.' entries.';
 	}
 
 	#  Prune the entries to only those within the specified range
@@ -583,7 +583,7 @@ sub handle_range {
 #  the size of the range. It becomes slower as the population of a range nears
 #  the range's limit since it is harder to choose a free address at random.
 #
-#  It is useful for selecting a handful of addresses from an enourmous IPv6 /64
+#  It is useful for selecting a handful of addresses from an enormous IPv6 /64
 #  network for example.
 #
 sub sparse_fill {

--- a/scripts/util/archive.sh
+++ b/scripts/util/archive.sh
@@ -166,7 +166,7 @@ for LOGDD in $(ls $LOG_DIR | egrep "$DATE_EXPR"); do
 			DEBUG "Error creating archive for '$LOGFP'"
 			exit 65
 		elif ! rm -rf $LOGDD; then
-			DEBUG "Error removing uncompresed directory"
+			DEBUG "Error removing uncompressed directory"
 			exit 65
 		fi
 	fi

--- a/scripts/util/radeapol_uat.py
+++ b/scripts/util/radeapol_uat.py
@@ -311,7 +311,7 @@ The directory containing the tests may have multiple subdirectories to group the
 	)
 	parser.add_argument("-i",
 						dest = "iter",
-						help = "Number of interations. (default: {})".format(DEFAULT_INTERATIONS),
+						help = "Number of iterations. (default: {})".format(DEFAULT_INTERATIONS),
 						type = int,
 						required = False,
 						default = DEFAULT_INTERATIONS
@@ -368,7 +368,7 @@ The directory containing the tests may have multiple subdirectories to group the
 	print("* Verbose:         {}".format(args.verbose))
 	if args.verbose >= 1:
 		print("* Parallel:        {}".format(args.parallel))
-		print("* Interations:     {}".format(args.iter))
+		print("* Iterations:      {}".format(args.iter))
 		print("* dict_dir:        {}".format(args.dict_dir))
 		print("* eapol_test_bin:  {}".format(args.eapol_test_bin))
 		print("* eapol_test ctrl: {}".format(args.eapol_ctrl))

--- a/scripts/util/radtee
+++ b/scripts/util/radtee
@@ -36,7 +36,7 @@ from __future__ import with_statement
 # - C=x.x.x.x: Ignored packet sniffed from unknown client.
 # - D: Dropped sniffed packet due to processing bottleneck. Consider
 #      increasing THREADS.
-# - I: Invalid/unparseable packet sniffed.
+# - I: Invalid/unparsable packet sniffed.
 # - Mreq: Response was sniffed without sniffing a corresponding request.
 # - Mresp: Request was sniffed without sniffing a corresponding response.
 # - T: Request to test server timed out.


### PR DESCRIPTION
Misspellings found by [codespell](https://github.com/codespell-project/codespell).

I have left out files that appear to have been generated, such as:
	`scripts/boiler.mk`
which has been generated from:
	https://github.com/dmoulding/boilermake