### PR TITLE
Fix typos in man

### DIFF
--- a/man/man5/radiusd.conf.5
+++ b/man/man5/radiusd.conf.5
@@ -134,7 +134,7 @@ Variables are referenced by ${variable_name}, as in the following examples.
 
 If the variable exists in a section or subsection, it can be
 referenced as ${section.subsection.variable}.  Forward references are
-not allowed.  Relative references are allowed, by pre-pending the name
+not allowed.  Relative references are allowed, by prepending the name
 with one or more period.
 
 .DS

--- a/man/man5/unlang.5
+++ b/man/man5/unlang.5
@@ -858,7 +858,7 @@ Serialize attributes as a string
 e.g. "%(pairs:request.[*])" == 'User-Name = "foo"User-Password = "bar"...'
 
 .IP %(concat:<attr> <sep>)
-Concatenate the value of multiple attrubute values with an optional separator
+Concatenate the value of multiple attribute values with an optional separator
 
 e.g. "%(concat:%{request.[*]} ', ')" == "foo, bar, ..."
 

--- a/man/man8/rlm_sqlippool_tool.8
+++ b/man/man8/rlm_sqlippool_tool.8
@@ -50,7 +50,7 @@ fields are left to be populated with their database defaults.
 .SH OPTIONS
 
 .IP \-c\ \fIcapacity\fP
-Number of IP addreses to populate the pool with.  Defaults to 65536,
+Number of IP addresses to populate the pool with.  Defaults to 65536,
 or the maximum number that can be provisioned between the start and
 end of the range.
 .IP \-d\ \fIdialect\fP
@@ -64,7 +64,7 @@ is specified, then \fBrlm_sqlippool_tool\fP will parse the configuration
 and attempt to talk directly to the database server specified in
 the FreeRADIUS configuration.
 .IP \-i\ \fIinstance\fP
-Used in conjuction with -f.  Specifies the name of the sql module
+Used in conjunction with -f.  Specifies the name of the sql module
 instance to parse in the FreeRADIUS configuration.  Defaults to \fIsql\fP.
 .IP \-p\ \fIpool_name\fP
 The pool name to populate.
@@ -74,7 +74,7 @@ are allowed.
 .IP \-t\ \fItable_name\fP
 Name of the table in the database to populate.
 .IP \-x\ \fIexisting_ips_file\fP
-A file containing exsiting IP addresses in the pool.  Use of this allows
+A file containing existing IP addresses in the pool.  Use of this allows
 for more controlled growth of a sparesly populated pool.
 .IP \-y\ \fIpool_defs_yaml_file\fP
 A YAML formatted file containing specifications for a number of pools.


### PR DESCRIPTION
Misspellings found by [codespell](https://github.com/codespell-project/codespell).