### PR TITLE
Fix typos in assorted build files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -431,7 +431,7 @@ dnl   sed -e 's%src/modules/.*/% (sub)- %; s%.*/%- %' |\
 dnl   awk '{print "                            "$0}']))
 
 AC_ARG_ENABLE(strict-dependencies,
-[  --enable-strict-dependencies  fail configure on lack of module dependancy.])
+[  --enable-strict-dependencies  fail configure on lack of module dependency.])
 
 AC_ARG_ENABLE(werror,
 [  --enable-werror         causes the build to fail if any warnings are generated.],
@@ -1970,7 +1970,7 @@ if test "x$developer" = "xyes"; then
   fi
 
   dnl #
-  dnl #  Can't use mutliple -fsanitize flags, so we need to combine
+  dnl #  Can't use multiple -fsanitize flags, so we need to combine
   dnl #  the values into one.
   dnl #
   fsanitizeflags=
@@ -2653,7 +2653,7 @@ case "$target" in
     dnl #  and LLDB throws an EXC_BAD_INSTRUCTION exception.
     dnl #
     dnl #  OpenSSL installs a SIGILL handler to catch the signal but this
-    dnl #  is also overriden by lldb.
+    dnl #  is also overridden by lldb.
     dnl #
     dnl #  To allow us to debug on macOS + LLDB + ARM we need to ignore
     dnl #  this exception and ignore SIGILL.

--- a/debian/freeradius.default
+++ b/debian/freeradius.default
@@ -1,4 +1,4 @@
-# Options passed to the FreeRADIUS deamon.
+# Options passed to the FreeRADIUS daemon.
 #
 FREERADIUS_OPTIONS=""
 

--- a/redhat/freeradius.spec
+++ b/redhat/freeradius.spec
@@ -33,7 +33,7 @@
 # Enable asserts and additional debugging
 %bcond_with developer
 
-# Enable various clang/gcc debugging tool sypport
+# Enable various clang/gcc debugging tool support
 %bcond_with address_sanitizer
 %bcond_with leak_sanitizer
 %bcond_with thread_sanitizer

--- a/redhat/openssl/freeradius-openssl.spec
+++ b/redhat/openssl/freeradius-openssl.spec
@@ -123,7 +123,7 @@ sslarch=linux-ppc64
 # ia64, x86_64, ppc are OK by default
 # Configure the build tree.  Override OpenSSL defaults with known-good defaults
 # usable on all platforms.  The Configure script already knows to use -fPIC and
-# RPM_OPT_FLAGS, so we can skip specifiying them here.
+# RPM_OPT_FLAGS, so we can skip specifying them here.
 ./Configure \
 	--prefix=%{_prefix} --openssldir=%{_sysconfdir}/pki/tls ${sslflags} \
 	zlib enable-camellia enable-seed enable-rfc3779 \

--- a/version.sh
+++ b/version.sh
@@ -105,7 +105,7 @@ version_component()
 		)
 	;;
 
-	# - If $RELEASE is set, that takes precendence
+	# - If $RELEASE is set, that takes precedence
 	# - Otherwise if a RELEASE file is present, then release = 1.
 	# - If we're in a git repo
 	#    - If there's a release_* tag matching the current commit,


### PR DESCRIPTION
Misspellings found by [codespell](https://github.com/codespell-project/codespell).

I have left out generated files such as:
```
	configure
	debian/rules
```
I hope I haven't kept any generated file in this pull request.