### PR TITLE
Fix typos in src

### DIFF
--- a/src/bin/checkrad.in
+++ b/src/bin/checkrad.in
@@ -1293,7 +1293,7 @@ sub mikrotik_telnet {
   ($login, $password) = naspasswd($terminalserver, 1);
   return 2 if ($password eq "");
 
-  # MikroTik router doesn't tell us to which port the user is connected
+  # MikroTik RouterOS doesn't tell us to which port the user is connected
   # practically this would limit us to a simple only-one user limit for
   # this script to work properly.
   $t = new Net::Telnet (Timeout => 5,

--- a/src/bin/checkrad.in
+++ b/src/bin/checkrad.in
@@ -321,7 +321,7 @@ sub strip_username {
 #	between Acct-Session-ID so can't be used to identify and 802.1X session (we ignore it).
 #
 #	If a session matching the username is found on the port specified, and the 
-#	session is still active then thats good enough...
+#	session is still active then that's good enough...
 #
 #	Author: Arran Cudbard-Bell <arran.cudbard-bell@freeradius.org>
 #
@@ -624,7 +624,7 @@ sub portslave_finger {
 	while(<FD>) {
 		#
 		#	Check for ^Port. If we don't see it we
-		#	wont get confused by non-portslave-finger
+		#	won't get confused by non-portslave-finger
 		#	output too.
 		#
 		if (/^Port/) {
@@ -1188,7 +1188,7 @@ sub bay_finger {		# ARGV: 1=nas_ip, 2=nas_port, 3=login, 4=sessid
 # and tunnel ID's are for a given Virtual-Access interface to construct
 # the following OID: .1.3.6.1.4.1.9.10.24.1.3.2.1.2.2.$tunID.$sessID
 # Then gets the username from that OID.
-# Make sure you set the $realm variable at the begining of the file if
+# Make sure you set the $realm variable at the beginning of the file if
 # needed. The new type for naslist is cisco_l2tp
 
 sub find_l2tp_login
@@ -1256,7 +1256,7 @@ sub mikrotik_snmp {
   # We want  mtxrInterfaceStatsName from MIKROTIK-MIB
   $oid = "1.3.6.1.4.1.14988.1.1.14.1.1.2";
 
-  # Mikrotik doesnt give port IDs correctly to RADIUS :(
+  # Mikrotik doesn't give port IDs correctly to RADIUS :(
   # practically this would limit us to a simple only-one user limit for
   # this script to work properly.
   @output = snmpwalk_prog($ARGV[1], $password, "$oid");
@@ -1293,7 +1293,7 @@ sub mikrotik_telnet {
   ($login, $password) = naspasswd($terminalserver, 1);
   return 2 if ($password eq "");
 
-  # MikroTik routeros doesnt tell us to which port the user is connected
+  # MikroTik router doesn't tell us to which port the user is connected
   # practically this would limit us to a simple only-one user limit for
   # this script to work properly.
   $t = new Net::Telnet (Timeout => 5,
@@ -1320,8 +1320,8 @@ sub mikrotik_telnet {
   $t->waitfor('/\[.*@.*\] > /');
 
   # It is not possible to get the line numbers etc.
-  # Thus we cant support if simultaneous-use is over 1
-  # At least I was using pppoe so it wasnt possible.
+  # Thus we can't support if simultaneous-use is over 1
+  # At least I was using pppoe so it wasn't possible.
   $t->print('ppp active print column name detail');
 
   # Somehow routeros echo'es our commands 2 times. We dont want to mix
@@ -1343,7 +1343,7 @@ sub mikrotik_telnet {
 
   #check for # of $user in output
   #the output includes only one = between name and username so we can
-  #safely use it as a seperator.
+  #safely use it as a separator.
 
 #disabled until mikrotik starts to send newline after each line...
 #  @output = $output;
@@ -1389,7 +1389,7 @@ sub redback_telnet {
 	return 2;
     }
 
-    # Get loggin information
+    # Get login information
     ($root, $password) = naspasswd($terminalserver, 1);
     return 2 if ($password eq "");
 

--- a/src/bin/collectd.c
+++ b/src/bin/collectd.c
@@ -61,7 +61,7 @@ static void _copy_double_to_double(UNUSED rs_t *conf, rs_stats_value_tmpl_t *tmp
 }
 
 
-/** Allocates a stats template which describes a single guage/counter
+/** Allocates a stats template which describes a single gauge/counter
  *
  * This is just intended to simplify allocating a fairly complex memory structure
  * src and dst pointers must be set
@@ -70,7 +70,7 @@ static void _copy_double_to_double(UNUSED rs_t *conf, rs_stats_value_tmpl_t *tmp
  * @param conf Radsniff configuration.
  * @param plugin_instance usually the type of packet (in our case).
  * @param type string, the name of a collection of stats e.g. exchange
- * @param type_instance the name of the counter/guage within the collection e.g. latency.
+ * @param type_instance the name of the counter/gauge within the collection e.g. latency.
  * @param stats structure to derive statistics from.
  * @param values Value templates used to populate lcc_value_list.
  * @return

--- a/src/bin/radclient.h
+++ b/src/bin/radclient.h
@@ -58,7 +58,7 @@ typedef struct {
 	uint64_t rejected;			//!< Requests to which we received a reject
 	uint64_t lost;				//!< Requests to which we received no response
 	uint64_t passed;			//!< Requests which passed a filter
-	uint64_t failed;			//!< Requests which failed a fitler
+	uint64_t failed;			//!< Requests which failed a filter
 } rc_stats_t;
 
 typedef struct {

--- a/src/bin/radiusd.c
+++ b/src/bin/radiusd.c
@@ -674,7 +674,7 @@ int main(int argc, char *argv[])
 	 *	will stay permanently as "activating".
 	 *
 	 *	We detect this condition and warn about it here, using the
-	 *	presence of the NOTIFY_SOCKET envrionmental variable to determine
+	 *	presence of the NOTIFY_SOCKET environmental variable to determine
 	 *	whether we're running under systemd.
 	 */
 	if (getenv("NOTIFY_SOCKET")) INFO("Built without support for systemd watchdog, but running under systemd");
@@ -1080,7 +1080,7 @@ cleanup:
 	/*
 	 *	Ensure all thread local memory is cleaned up
 	 *	before we start cleaning up global resources.
-	 *	This is necessay for single threaded mode
+	 *	This is necessary for single threaded mode
 	 *	to ensure that thread local resources that
 	 *	depend on global resources are freed at the
 	 *	appropriate time.

--- a/src/bin/unit_test_attribute.c
+++ b/src/bin/unit_test_attribute.c
@@ -1153,7 +1153,7 @@ static size_t command_include(command_result_t *result, command_file_ctx_t *cc,
 	RETURN_OK(0);
 }
 
-/** Determine if unresolved atttributes are allowed
+/** Determine if unresolved attributes are allowed
  *
  */
 static size_t command_allow_unresolved(command_result_t *result, command_file_ctx_t *cc,
@@ -3074,7 +3074,7 @@ static fr_table_ptr_sorted_t	commands[] = {
 				}},
 	{ L("max-buffer-size"),   &(command_entry_t){
 					.func = command_max_buffer_size,
-					.usage = "max-buffer-size[ <intger>]",
+					.usage = "max-buffer-size[ <integer>]",
 					.description = "Limit the maximum temporary buffer space available for any command which uses it"
 				}},
 	{ L("migrate "),	&(command_entry_t){

--- a/src/lib/eap_aka_sim/crypto.c
+++ b/src/lib/eap_aka_sim/crypto.c
@@ -127,7 +127,7 @@ int fr_aka_sim_crypto_init_checkcode(TALLOC_CTX *ctx, fr_aka_sim_checkcode_t **c
 		return -1;
 	}
 	if (EVP_DigestInit_ex((*checkcode)->md_ctx, md, NULL) != 1) {
-		fr_tls_strerror_printf("Failed intialising MD ctx");
+		fr_tls_strerror_printf("Failed initialising MD ctx");
 		goto error;
 	}
 
@@ -629,7 +629,7 @@ int fr_aka_sim_crypto_umts_kdf_0(fr_aka_sim_keys_t *keys)
 	Key = CK || IK
 	FC = 0x20
 	P0 = access network identity (3GPP TS 24.302)
-	L0 = length of acceess network identity (2 octets, big endian)
+	L0 = length of access network identity (2 octets, big endian)
 	P1 = SQN xor AK (if AK is not used, AK is treated as 000..0
 	L1 = 0x00 0x06
  @endverbatim

--- a/src/lib/eap_aka_sim/decode.c
+++ b/src/lib/eap_aka_sim/decode.c
@@ -512,7 +512,7 @@ static ssize_t sim_decode_tlv(TALLOC_CTX *ctx, fr_pair_list_t *out,
 /** Create any kind of VP from the attribute contents
  *
  * @param[in] ctx		to allocate new attributes in.
- * @param[in] out		to addd new attributes to.
+ * @param[in] out		to add new attributes to.
  * @param[in] parent		the current attribute we're processing.
  * @param[in] data		to parse. Points to the data field of the attribute.
  * @param[in] attr_len		length of the attribute being parsed.

--- a/src/lib/eap_aka_sim/id.c
+++ b/src/lib/eap_aka_sim/id.c
@@ -642,7 +642,7 @@ int fr_aka_sim_id_3gpp_pseudonym_decrypt(char out[AKA_SIM_IMSI_MAX_LEN + 1],
 
 	/*
 	 *	This should never happen, and probably means that
-	 *	some sort of memory corruption has occured.
+	 *	some sort of memory corruption has occurred.
 	 */
 	if (unlikely(decr_len > (AKA_SIM_IMSI_MAX_LEN + 1))) {
 		fr_strerror_printf("Decrypted data len invalid.  Expected %i bytes, got %zu bytes",

--- a/src/lib/eap_aka_sim/state_machine.c
+++ b/src/lib/eap_aka_sim/state_machine.c
@@ -2799,7 +2799,7 @@ STATE_GUARD(common_challenge)
  * - If the previous section returned a failure rcode, enter the FAILURE-NOTIFICATION state.
  * - ...or call a function to process the contents of the AKA-Identity message, mainly the AT_IDENTITY value.
  * - If the message does not contain AT_IDENTITY, then enter the FAILURE-NOTIFICATION state.
- * - If the user requested another identity, re-enter the AKA-Identity sate.
+ * - If the user requested another identity, re-enter the AKA-Identity state.
  * - ...or continue based on the value of &Identity-Type which was added by #aka_identity,
  *   and possibly modified by the user.
  *   - Fastauth - Enter the REAUTHENTICATION state.
@@ -3066,7 +3066,7 @@ STATE_GUARD(aka_identity)
  * - If the previous section returned a failure rcode, enter the FAILURE-NOTIFICATION state.
  * - ...or call a function to process the contents of the SIM-Start message, mainly the AT_IDENTITY value.
  * - If the message does not contain AT_IDENTITY, then enter the FAILURE-NOTIFICATION state.
- * - If the user requested another identity, re-enter the SIM-START sate.
+ * - If the user requested another identity, re-enter the SIM-START state.
  * - ...or continue based on the value of &Identity-Type which was added by #sim_start,
  *   and possibly modified by the user.
  *   - Fastauth

--- a/src/lib/io/atomic_queue.c
+++ b/src/lib/io/atomic_queue.c
@@ -161,7 +161,7 @@ bool fr_atomic_queue_push(fr_atomic_queue_t *aq, void *data)
 		int64_t seq, diff;
 
 		entry = &aq->entry[ head % aq->size ];
-		seq = aquire(entry->seq);
+		seq = acquire(entry->seq);
 		diff = (seq - head);
 
 		/*
@@ -225,7 +225,7 @@ bool fr_atomic_queue_pop(fr_atomic_queue_t *aq, void **p_data)
 		int64_t diff;
 
 		entry = &aq->entry[ tail % aq->size ];
-		seq = aquire(entry->seq);
+		seq = acquire(entry->seq);
 
 		diff = (seq - (tail + 1));
 

--- a/src/lib/io/atomic_queue.c
+++ b/src/lib/io/atomic_queue.c
@@ -161,7 +161,7 @@ bool fr_atomic_queue_push(fr_atomic_queue_t *aq, void *data)
 		int64_t seq, diff;
 
 		entry = &aq->entry[ head % aq->size ];
-		seq = acquire(entry->seq);
+		seq = aquire(entry->seq);
 		diff = (seq - head);
 
 		/*
@@ -225,7 +225,7 @@ bool fr_atomic_queue_pop(fr_atomic_queue_t *aq, void **p_data)
 		int64_t diff;
 
 		entry = &aq->entry[ tail % aq->size ];
-		seq = acquire(entry->seq);
+		seq = aquire(entry->seq);
 
 		diff = (seq - (tail + 1));
 

--- a/src/lib/io/atomic_queue.h
+++ b/src/lib/io/atomic_queue.h
@@ -44,7 +44,7 @@ RCSIDH(atomic_queue_h, "$Id$")
 #define cas_incr(_store, _var)    atomic_compare_exchange_strong_explicit(&_store, &_var, _var + 1, memory_order_release, memory_order_relaxed)
 #define cas_decr(_store, _var)    atomic_compare_exchange_strong_explicit(&_store, &_var, _var - 1, memory_order_release, memory_order_relaxed)
 #define load(_var)           atomic_load_explicit(&_var, memory_order_relaxed)
-#define aquire(_var)         atomic_load_explicit(&_var, memory_order_acquire)
+#define acquire(_var)         atomic_load_explicit(&_var, memory_order_acquire)
 #define store(_store, _var)  atomic_store_explicit(&_store, _var, memory_order_release)
 
 #ifdef __cplusplus

--- a/src/lib/io/atomic_queue.h
+++ b/src/lib/io/atomic_queue.h
@@ -44,7 +44,7 @@ RCSIDH(atomic_queue_h, "$Id$")
 #define cas_incr(_store, _var)    atomic_compare_exchange_strong_explicit(&_store, &_var, _var + 1, memory_order_release, memory_order_relaxed)
 #define cas_decr(_store, _var)    atomic_compare_exchange_strong_explicit(&_store, &_var, _var - 1, memory_order_release, memory_order_relaxed)
 #define load(_var)           atomic_load_explicit(&_var, memory_order_relaxed)
-#define acquire(_var)         atomic_load_explicit(&_var, memory_order_acquire)
+#define aquire(_var)         atomic_load_explicit(&_var, memory_order_acquire)
 #define store(_store, _var)  atomic_store_explicit(&_store, _var, memory_order_release)
 
 #ifdef __cplusplus

--- a/src/lib/io/control.c
+++ b/src/lib/io/control.c
@@ -313,7 +313,7 @@ int fr_control_message_push(fr_control_t *c, fr_ring_buffer_t *rb, uint32_t id, 
 		(void) fr_control_gc(c, rb);
 		m = fr_control_message_alloc(c, rb, id, data, data_size);
 		if (!m) {
-			fr_strerror_const("Failed allocationg after GC");
+			fr_strerror_const("Failed allocating after GC");
 			return -2;
 		}
 	}

--- a/src/lib/io/master.c
+++ b/src/lib/io/master.c
@@ -671,7 +671,7 @@ static fr_io_connection_t *fr_io_connection_alloc(fr_io_instance_t const *inst,
 
 		/*
 		 *	This is "const", and the user can't
-		 *	touch it.  So we just re-use the same
+		 *	touch it.  So we just reuse the same
 		 *	configuration everywhere.
 		 */
 		connection->child->app_io_instance = inst->app_io_instance;
@@ -3019,7 +3019,7 @@ int fr_master_io_listen(TALLOC_CTX *ctx, fr_io_instance_t *inst, fr_schedule_t *
 
 		/*
 		 *	This is "const", and the user can't
-		 *	touch it.  So we just re-use the same
+		 *	touch it.  So we just reuse the same
 		 *	configuration everywhere.
 		 */
 		child->app_io_instance = inst->app_io_instance;

--- a/src/lib/io/message.c
+++ b/src/lib/io/message.c
@@ -236,7 +236,7 @@ int fr_message_done(fr_message_t *m)
  * @param[in] m the message to be localized
  * @param[in] message_size the size of the message, including the fr_message_t
  * @return
- *	- NULL on allocation errror
+ *	- NULL on allocation error
  *	- a newly localized message
  */
 fr_message_t *fr_message_localize(TALLOC_CTX *ctx, fr_message_t *m, size_t message_size)
@@ -921,7 +921,7 @@ cleanup:
  *  almost immediately fr_message_alloc().  Multiple calls in series
  *  to fr_message_reserve() MUST NOT be done.  The caller could also
  *  just call fr_ring_buffer_alloc(m->rb, size) if they wanted, and
- *  then udpate m->data_size by hand...
+ *  then update m->data_size by hand...
  *
  *  The message is returned
  *

--- a/src/lib/json/jpath.c
+++ b/src/lib/json/jpath.c
@@ -39,7 +39,7 @@ typedef enum {
 	JPATH_SELECTOR_INVALID = 0,
 	JPATH_SELECTOR_ROOT,			//!< Jump to the root of the document.
 	JPATH_SELECTOR_CURRENT,			//!< Continue at the current node in the document.
-	JPATH_SELECTOR_WILDCARD,		//!< Wildcard, operate over all array indicies, or fields
+	JPATH_SELECTOR_WILDCARD,		//!< Wildcard, operate over all array indices, or fields
 	JPATH_SELECTOR_FIELD,			//!< A field, current JSON node must be an object.
 	JPATH_SELECTOR_INDEX,			//!< Array index, current JSON node must be an array.
 	JPATH_SELECTOR_SLICE,			//!< Array slice, current JSON node must be an array.
@@ -539,7 +539,7 @@ static ssize_t jpath_expr_parse(UNUSED jpath_selector_t *selector, UNUSED char c
  * @param inlen length of in.
  * @return
  *	- > 0 on success.
- *	- <= 0 on error (* -1 to get offset error ocurred at).
+ *	- <= 0 on error (* -1 to get offset error occurred at).
  */
 static ssize_t jpath_array_parse(jpath_selector_t *selector, char const *in, size_t inlen)
 {
@@ -808,7 +808,7 @@ static size_t jpath_selector_parse(fr_jpath_node_t *node, char const *in, size_t
  *
  * @return
  *	- > 0 on success.
- *	- <= 0 on error (* -1 to get offset error ocurred at).
+ *	- <= 0 on error (* -1 to get offset error occurred at).
  */
 ssize_t fr_jpath_parse(TALLOC_CTX *ctx, fr_jpath_node_t **head, char const *in, size_t inlen)
 {

--- a/src/lib/json/json.c
+++ b/src/lib/json/json.c
@@ -909,7 +909,7 @@ static json_object *json_smplobj_afrom_pair_list(TALLOC_CTX *ctx, fr_pair_list_t
 
 				/*
 				 *	Existing key will have refcount decremented
-				 *	and will be freed if thise drops to zero.
+				 *	and will be freed if this drops to zero.
 				 */
 				json_object_object_add(obj, fr_sbuff_start(&attr_name), values);
 			}

--- a/src/lib/ldap/base.h
+++ b/src/lib/ldap/base.h
@@ -201,7 +201,7 @@ typedef struct {
 							///< rootDSE.
 	char const		*version_str;		//!< As returned from the vendorVersion attribute in the
 							///< rootDSE.
-	fr_ldap_directory_type_t type;			///< Cannonical server implementation.
+	fr_ldap_directory_type_t type;			///< Canonical server implementation.
 
 	bool			cleartext_password;	//!< Whether the server will return the user's plaintext
 							///< password.
@@ -475,9 +475,9 @@ typedef struct fr_ldap_referral_s {
 	fr_dlist_t		entry;		//!< Entry in list of possible referrals
 	fr_ldap_query_t		*query;		//!< Query this referral relates to
 	LDAPURLDesc		*referral_url;	//!< URL for the referral
-	char			*host_uri;	//!< Host URI used for referral conneciton
+	char			*host_uri;	//!< Host URI used for referral connection
 	char const		*identity;	//!< Bind identity for referral connection
-	char const		*password;	//!< Bind password for referral connecition
+	char const		*password;	//!< Bind password for referral connection
 	fr_ldap_thread_trunk_t	*ttrunk;	//!< Trunk this referral should use
 	request_t		*request;	//!< Request this referral relates to
 } fr_ldap_referral_t;
@@ -577,7 +577,7 @@ struct ldap_filter_s {
 typedef enum {
 	LDAP_PROC_REFERRAL = 2,				//!< LDAP server returned referral URLs.
 	LDAP_PROC_CONTINUE = 1,				//!< Operation is in progress.
-	LDAP_PROC_SUCCESS = 0,				//!< Operation was successfull.
+	LDAP_PROC_SUCCESS = 0,				//!< Operation was successful.
 
 	LDAP_PROC_ERROR	= -1,				//!< Unrecoverable library/server error.
 

--- a/src/lib/ldap/bind.c
+++ b/src/lib/ldap/bind.c
@@ -33,7 +33,7 @@ USES_APPLE_DEPRECATED_API
  * @param[in] el	the event occurred in.
  * @param[in] fd	the event occurred on.
  * @param[in] flags	from kevent.
- * @param[in] fd_errno	The error that ocurred.
+ * @param[in] fd_errno	The error that occurred.
  * @param[in] uctx	Connection config and handle.
  */
 static void _ldap_bind_io_error(UNUSED fr_event_list_t *el, UNUSED int fd,

--- a/src/lib/ldap/connection.c
+++ b/src/lib/ldap/connection.c
@@ -265,7 +265,7 @@ fr_ldap_connection_t *fr_ldap_connection_alloc(TALLOC_CTX *ctx)
 	/*
 	 *	Ensure the fd is invalid to start with, preventing
 	 *	attempts to remove fd events if the server is shut down
-	 *	before the LDAP conneciton is established
+	 *	before the LDAP connection is established
 	 */
 	c->fd = -1;
 
@@ -482,7 +482,7 @@ static void ldap_request_cancel(UNUSED fr_connection_t *conn, void *preq, UNUSED
  *
  * Inform the remote LDAP server that we no longer want responses to specific queries.
  *
- * @param[in] el	For timer mangement.
+ * @param[in] el	For timer management.
  * @param[in] tconn	The trunk connection handle
  * @param[in] conn	The specific connection queries will be cancelled on
  * @param[in] uctx	Context provided to fr_trunk_alloc
@@ -624,7 +624,7 @@ static void ldap_trunk_connection_notify(fr_trunk_connection_t *tconn, fr_connec
  *
  * @param[in] tconn		Trunk handle.
  * @param[in] el		Event list which will be used for I/O and timer events.
- * @param[in] conn_conf		Configuration of the connnection.
+ * @param[in] conn_conf		Configuration of the connection.
  * @param[in] log_prefix	What to prefix log messages with.
  * @param[in] uctx		User context passed to fr_trunk_alloc.
  */

--- a/src/lib/ldap/control.c
+++ b/src/lib/ldap/control.c
@@ -34,7 +34,7 @@ USES_APPLE_DEPRECATED_API
 /** Merge connection and call specific client and server controls
  *
  * LDAP_OPT_CLIENT_CONTROLS and LDAP_OPT_SERVER_CONTROLS are useless
- * because they're overriden in their entirety if any call specific
+ * because they're overridden in their entirety if any call specific
  * controls are specified.
  *
  * @param[out] serverctrls_out	Where to write serverctrls.

--- a/src/lib/ldap/edir.c
+++ b/src/lib/ldap/edir.c
@@ -45,7 +45,7 @@ USES_APPLE_DEPRECATED_API
 #define NMAS_E_ACCESS_NOT_ALLOWED	(NMAS_E_BASE-59)	/* -1659 0xFFFFF985 */
 #define NMAS_E_INVALID_SPM_REQUEST	(NMAS_E_BASE-97)	/* -1697 0xFFFFF95F */
 
-/* OID of LDAP extenstion calls to read Universal Password */
+/* OID of LDAP extension calls to read Universal Password */
 #define NMASLDAP_GET_PASSWORD_REQUEST     "2.16.840.1.113719.1.39.42.100.13"
 #define NMASLDAP_GET_PASSWORD_RESPONSE    "2.16.840.1.113719.1.39.42.100.14"
 

--- a/src/lib/ldap/filter.c
+++ b/src/lib/ldap/filter.c
@@ -477,7 +477,7 @@ static bool ldap_filter_node_eval(ldap_filter_t *node, fr_ldap_connection_t *con
 
 				/*
 				 *	Walk the value (v) and test (t), comparing until
-				 *	there is a mis-match or the end of one is reached.
+				 *	there is a mismatch or the end of one is reached.
 				 */
 				while ((v <= v_end) && (t <= t_end)) {
 					/*

--- a/src/lib/ldap/sasl.c
+++ b/src/lib/ldap/sasl.c
@@ -36,7 +36,7 @@ static void _ldap_sasl_bind_io_write(fr_event_list_t *el, int fd, UNUSED int fla
  * @param[in] el	the event occurred in.
  * @param[in] fd	the event occurred on.
  * @param[in] flags	from kevent.
- * @param[in] fd_errno	The error that ocurred.
+ * @param[in] fd_errno	The error that occurred.
  * @param[in] uctx	Connection config and handle.
  */
 static void _ldap_sasl_bind_io_error(UNUSED fr_event_list_t *el, UNUSED int fd,

--- a/src/lib/ldap/start_tls.c
+++ b/src/lib/ldap/start_tls.c
@@ -44,7 +44,7 @@ typedef struct {
  * @param[in] el	the event occurred in.
  * @param[in] fd	the event occurred on.
  * @param[in] flags	from kevent.
- * @param[in] fd_errno	The error that ocurred.
+ * @param[in] fd_errno	The error that occurred.
  * @param[in] uctx	Connection config and handle.
  */
 static void _ldap_start_tls_io_error(UNUSED fr_event_list_t *el, UNUSED int fd, UNUSED int flags,

--- a/src/lib/redis/base.h
+++ b/src/lib/redis/base.h
@@ -85,7 +85,7 @@ extern size_t redis_rcodes_len;
  * be returned to the redis cluster code.
  */
 typedef enum {
-	REDIS_RCODE_SUCCESS = 0,		//!< Operation was successfull.
+	REDIS_RCODE_SUCCESS = 0,		//!< Operation was successful.
 	REDIS_RCODE_ERROR = -1,			//!< Unrecoverable library/server error.
 	REDIS_RCODE_TRY_AGAIN = -2,		//!< Try the operation again.
 	REDIS_RCODE_RECONNECT = -3,		//!< Transitory error, caller should retry the operation

--- a/src/lib/redis/cluster.c
+++ b/src/lib/redis/cluster.c
@@ -111,7 +111,7 @@
  *
  *   #cluster_map_get and #cluster_map_apply, perform the operations described
  *   above. The get function, issues the 'cluster slots' command and performs validation, the
- *   apply function processes and applys the map.
+ *   apply function processes and applies the map.
  *
  *   Failing to apply a map is not a fatal error at runtime, and is only fatal on startup if
  *   pool.start > 0.
@@ -217,7 +217,7 @@ struct fr_redis_cluster_node_s {
 	fr_socket_t		pending_addr;		//!< New node address to be applied when the pool
 							//!< is reconnected.
 
-	fr_redis_cluster_t	*cluster;		//!< Commmon configuration (database number,
+	fr_redis_cluster_t	*cluster;		//!< Common configuration (database number,
 							//!< password, etc..).
 	fr_pool_t		*pool;			//!< Pool associated with this node.
 	CONF_SECTION		*pool_cs;		//!< Pool configuration section associated with node.
@@ -1829,7 +1829,7 @@ finish:
  * - May perform a temporary redirect on receiving a #REDIS_RCODE_ASK status.
  * - May reserve a new connection on receiving a #REDIS_RCODE_RECONNECT status.
  *
- * If a remap is in progress, has ocurred within the last second, has recently failed,
+ * If a remap is in progress, has occurred within the last second, has recently failed,
  * or fails, the '-MOVE' will be treated as a temporary redirect (-ASK).
  *
  * This allows the server to be more responsive during remaps, as unless the worker has been
@@ -2335,7 +2335,7 @@ fr_redis_cluster_t *fr_redis_cluster_alloc(TALLOC_CTX *ctx,
 
 		tls_conf = fr_tls_conf_parse_client(tls_cs);
 		if (!tls_conf) {
-			ERROR("%s - Failed to parse TLS configuation", cluster->log_prefix);
+			ERROR("%s - Failed to parse TLS configuration", cluster->log_prefix);
 			talloc_free(cluster);
 			return NULL;
 		}

--- a/src/lib/redis/io.c
+++ b/src/lib/redis/io.c
@@ -74,7 +74,7 @@ static void _redis_io_service_readable(UNUSED fr_event_list_t *el, int fd, UNUSE
 	fr_connection_t const	*conn = talloc_get_type_abort_const(uctx, fr_connection_t);
 	fr_redis_handle_t	*h = conn->h;
 
-	DEBUG4("redis handle %p - FD %i now readble", h, fd);
+	DEBUG4("redis handle %p - FD %i now readable", h, fd);
 
 	redisAsyncHandleRead(h->ac);
 }

--- a/src/lib/redis/redis.c
+++ b/src/lib/redis/redis.c
@@ -274,7 +274,7 @@ int fr_redis_reply_to_value_box(TALLOC_CTX *ctx, fr_value_box_t *out, redisReply
 		FALL_THROUGH;
 
 #if HIREDIS_MAJOR >= 1
-	case REDIS_REPLY_BIGNUM:	/* FIXME - Could try and conver to integer ? */
+	case REDIS_REPLY_BIGNUM:	/* FIXME - Could try and convert to integer ? */
 #endif
 	case REDIS_REPLY_STRING:
 	case REDIS_REPLY_STATUS:

--- a/src/lib/server/cf_file.c
+++ b/src/lib/server/cf_file.c
@@ -973,7 +973,7 @@ static int process_include(cf_stack_t *stack, CONF_SECTION *parent, char const *
 				return 0;
 			}
 
-			ERROR("%s[%d]: Failed expanding '%s' - No matchin files", frame->filename, frame->lineno,
+			ERROR("%s[%d]: Failed expanding '%s' - No matching files", frame->filename, frame->lineno,
 			      value);
 			return -1;
 		}
@@ -2614,7 +2614,7 @@ added_pair:
 	/*
 	 *	Skip semicolon if we see it after a
 	 *	CONF_PAIR.  Also allow comma for
-	 *	backwards compatablity with secret
+	 *	backwards compatibility with secret
 	 *	things in v3.
 	 */
 	if ((*ptr == ';') || (*ptr == ',')) {

--- a/src/lib/server/cf_parse.c
+++ b/src/lib/server/cf_parse.c
@@ -17,7 +17,7 @@
 /**
  * $Id$
  * @file cf_parse.c
- * @brief Covert internal format configuration values into native C types.
+ * @brief Convert internal format configuration values into native C types.
  *
  * @copyright 2017 Arran Cudbard-Bell (a.cudbardb@freeradius.org)
  * @copyright 2000,2006 The FreeRADIUS server project

--- a/src/lib/server/cf_parse.h
+++ b/src/lib/server/cf_parse.h
@@ -235,7 +235,7 @@ _Generic(&(_ct), \
  * @param[in] _name		of the CONF_PAIR to search for.
  * @param[in] _type		to parse the CONF_PAIR as.
  * @param[in] _flags		controlling parsing behaviour.
- * @param[in] _struct		contaning the field to write the result to.
+ * @param[in] _struct		containing the field to write the result to.
  * @param[in] _field		to write the result to.
  */
 #  define FR_CONF_OFFSET_TYPE_FLAGS(_name, _type, _flags, _struct, _field) \
@@ -250,7 +250,7 @@ _Generic(&(_ct), \
  *
  * @param[in] _name		of the CONF_PAIR to search for.
  * @param[in] _flags		controlling parsing behaviour.
- * @param[in] _struct		contaning the field to write the result to.
+ * @param[in] _struct		containing the field to write the result to.
  * @param[in] _field		to write the result to.
  */
 #  define FR_CONF_OFFSET_FLAGS(_name, _flags, _struct, _field)  \
@@ -262,7 +262,7 @@ _Generic(&(_ct), \
 /** conf_parser_t which parses a single CONF_PAIR, writing the result to a field in a struct
  *
  * @param[in] _name		of the CONF_PAIR to search for.
- * @param[in] _struct		contaning the field to write the result to.
+ * @param[in] _struct		containing the field to write the result to.
  * @param[in] _field		to write the result to.
  */
 #  define FR_CONF_OFFSET(_name, _struct, _field)  \
@@ -276,7 +276,7 @@ _Generic(&(_ct), \
  * @param[in] _name		of the CONF_PAIR to search for.
  * @param[in] _type		to parse the CONF_PAIR as.
  * @param[in] _flags		controlling parsing behaviour.
- * @param[in] _struct		contaning the field to write the result to.
+ * @param[in] _struct		containing the field to write the result to.
  * @param[in] _field		to write the result to.
  */
 #  define FR_CONF_OFFSET_IS_SET(_name, _type, _flags, _struct, _field) \
@@ -397,7 +397,7 @@ _Generic(&(_ct), \
  */
 DIAG_OFF(attributes)
 typedef enum CC_HINT(flag_enum) {
-	CONF_FLAG_HIDDEN		= 0,				//!< Used by scripts to ommit items from the
+	CONF_FLAG_HIDDEN		= 0,				//!< Used by scripts to omit items from the
 									///< generated documentation.
 	CONF_FLAG_SUBSECTION		= (1 << 1),			//!< Instead of putting the information into a
 									///< configuration structure, the configuration

--- a/src/lib/server/cf_util.c
+++ b/src/lib/server/cf_util.c
@@ -549,7 +549,7 @@ CONF_ITEM *_cf_parent(CONF_ITEM const *ci)
  *
  * @param[in] ci	to return the location of.
  * @return
- *	- -1 if the #CONF_ITEM was created programatically.
+ *	- -1 if the #CONF_ITEM was created programmatically.
  *	- >= 0 where in the config file the line was parsed from.
  */
 int _cf_lineno(CONF_ITEM const *ci)
@@ -563,7 +563,7 @@ int _cf_lineno(CONF_ITEM const *ci)
  *
  * @param[in] ci	to return the location of.
  * @return
- *	- NULL if the #CONF_ITEM was created programatically.
+ *	- NULL if the #CONF_ITEM was created programmatically.
  *	- The path of the config file the #CONF_ITEM was located in.
  */
 char const *_cf_filename(CONF_ITEM const *ci)

--- a/src/lib/server/client.c
+++ b/src/lib/server/client.c
@@ -147,7 +147,7 @@ fr_client_list_t *client_list_init(CONF_SECTION *cs)
 #ifdef WITH_TRIE
 /*
  *	@todo - either support client definitions where "proto = *",
- *	or udpate this code to allow for that.  i.e. we create yet
+ *	or update this code to allow for that.  i.e. we create yet
  *	another set of v4/v6 tries, for "proto = *" clients.  And then
  *	do lookups there, too.  Or, just unify the udp/tcp tries, and
  *	instead do post-processing?  Though those two clients can have
@@ -762,7 +762,7 @@ fr_client_t *client_afrom_cs(TALLOC_CTX *ctx, CONF_SECTION *cs, CONF_SECTION *se
 					       &FR_DBUFF_TMP(bin, bin_len),
 					       &FR_SBUFF_IN(value + 2, hex_len), false);
 			if (converted < (bin_len - 1)) {
-				cf_log_err(cs, "Invalide hex string in shared secret");
+				cf_log_err(cs, "Invalid hex string in shared secret");
 				goto error;
 			}
 

--- a/src/lib/server/command.c
+++ b/src/lib/server/command.c
@@ -77,7 +77,7 @@ static int split(char **input, char **output, bool syntax_string);
 
 /*
  *	Hacks for simplicity.  These data types aren't allowed as
- *	parameters, so we can re-use them for something else.
+ *	parameters, so we can reuse them for something else.
  */
 
 // our fixed string.  Any data type LESS than this must be a real data type

--- a/src/lib/server/connection.c
+++ b/src/lib/server/connection.c
@@ -616,7 +616,7 @@ uint64_t fr_connection_get_num_timed_out(fr_connection_t const *conn)
 
 /** The requisite period of time has passed, try and re-open the connection
  *
- * @param[in] el	the time event ocurred on.
+ * @param[in] el	the time event occurred on.
  * @param[in] now	The current time.
  * @param[in] uctx	The #fr_connection_t the fd is associated with.
  */
@@ -685,7 +685,7 @@ static void connection_state_enter_closed(fr_connection_t *conn)
  *
  * Connection wasn't opened within the configured period of time
  *
- * @param[in] el	the time event ocurred on.
+ * @param[in] el	the time event occurred on.
  * @param[in] now	The current time.
  * @param[in] uctx	The #fr_connection_t the fd is associated with.
  */

--- a/src/lib/server/connection.h
+++ b/src/lib/server/connection.h
@@ -124,7 +124,7 @@ typedef fr_connection_state_t (*fr_connection_init_t)(void **h_out, fr_connectio
  * @param[in] h		Handle that was successfully opened.
  * @param[in] uctx	User context.
  * @return
- *	- #FR_CONNECTION_STATE_CONNECTED	if the handle is useable.
+ *	- #FR_CONNECTION_STATE_CONNECTED	if the handle is usable.
  *	- #FR_CONNECTION_STATE_FAILED		if the handle is unusable.
  */
 typedef fr_connection_state_t (*fr_connection_open_t)(fr_event_list_t *el, void *h, void *uctx);

--- a/src/lib/server/exec.c
+++ b/src/lib/server/exec.c
@@ -603,7 +603,7 @@ int fr_exec_fork_wait(pid_t *pid_p,
  * @param[in] request		currently being processed, may be NULL.
  * @param[in] args		to call as a fr_value_box_list_t.  Program will
  *      			be the first box and arguments in the subsequent boxes.
- * @param[in] env_pairs		list of pairs to be presented as evironment variables
+ * @param[in] env_pairs		list of pairs to be presented as environment variables
  *				to the child.
  * @param[in] env_escape	Wrap string values in double quotes, and apply doublequote
  *				escaping to all environmental variable values.
@@ -948,7 +948,7 @@ static void exec_stdout_read(UNUSED fr_event_list_t *el, int fd, int flags, void
  * @param[in] request		currently being processed, may be NULL.
  * @param[in] args		to call as a fr_value_box_list_t.  Program will
  *      			be the first box and arguments in the subsequent boxes.
- * @param[in] env_pairs		list of pairs to be presented as evironment variables
+ * @param[in] env_pairs		list of pairs to be presented as environment variables
  *				to the child.
  * @param[in] env_escape	Wrap string values in double quotes, and apply doublequote
  *				escaping to all environmental variable values.

--- a/src/lib/server/exec_legacy.c
+++ b/src/lib/server/exec_legacy.c
@@ -215,7 +215,7 @@ static NEVER_RETURNS void exec_child_legacy(request_t *request, char **argv, cha
  * @param[in] cmd		Command to execute. This is parsed into argv[]
  *				parts, then each individual argv part is
  *				xlat'ed.
- * @param[in] request		Current reuqest
+ * @param[in] request		Current request
  * @param[in] exec_wait		set to true to read from or write to child.
  * @param[in] input_pairs	list of value pairs - these will be put into
  *				the environment variables of the child.

--- a/src/lib/server/global_lib.c
+++ b/src/lib/server/global_lib.c
@@ -92,7 +92,7 @@ static int lib_init_call(global_lib_inst_t *lib)
  *
  * @param to_init	Array of autoinit structures detailing libraries to initialise
  * @return
- *	- 0 on succcess
+ *	- 0 on success
  *	- -1 on failure
  */
 static int lib_auto_instantiate(global_lib_autoinst_t * const *to_init)

--- a/src/lib/server/log.c
+++ b/src/lib/server/log.c
@@ -620,7 +620,7 @@ void log_request(fr_log_type_t type, fr_log_lvl_t lvl, request_t *request,
  *
  * This could all be done in a macro, but it turns out some implementations of the
  * variadic macros do not work at all well if the va_list being written to is further
- * up the stack (which is required as you still need a function to convert the elipses
+ * up the stack (which is required as you still need a function to convert the ellipsis
  * into a va_list).
  *
  * So, we use this small wrapper function instead, which will hopefully guarantee

--- a/src/lib/server/main_config.c
+++ b/src/lib/server/main_config.c
@@ -1346,7 +1346,7 @@ do {\
 	/*
 	 *	Reset the colourisation state.  The configuration
 	 *	files can disable colourisation if the terminal
-	 *	supports it.  The configation files *cannot* enable
+	 *	supports it.  The configuration files *cannot* enable
 	 *	colourisation if the terminal window doesn't support
 	 *	it.
 	 */

--- a/src/lib/server/main_config.h
+++ b/src/lib/server/main_config.h
@@ -101,7 +101,7 @@ struct main_config_s {
 
 #ifdef HAVE_SETUID
 	uid_t		server_uid;			//!< UID we're running as.
-	gid_t		server_gid;			//!< GID we're runing as.
+	gid_t		server_gid;			//!< GID we're running as.
 	uid_t		uid;				//!< UID we should run as.
 	bool		uid_is_set;
 	gid_t		gid;				//!< GID we should run as.

--- a/src/lib/server/module.c
+++ b/src/lib/server/module.c
@@ -583,7 +583,7 @@ static int _module_thread_inst_list_free(void *tilp)
  * The majority of modules will have a single set of thread-specific instance data.
  *
  * An exception is dynamic modules, which may have multiple sets of thread-specific instance data tied to
- * a sepcific dynamic use of that module.
+ * a specific dynamic use of that module.
  *
  * @param[in] ctx	Talloc ctx to bind thread specific data to.
  * @param[out] out	Where to write the allocated #module_thread_instance_t.
@@ -616,7 +616,7 @@ static int module_thread_instantiate(TALLOC_CTX *ctx, module_thread_instance_t *
 		rmi = module_root(mi);
 
 		/*
-		 *	Fixup the type name, incase something calls
+		 *	Fixup the type name, in case something calls
 		 *	talloc_get_type_abort() on it...
 		 */
 		if (!mi->module->thread_inst_type) {
@@ -751,7 +751,7 @@ int module_instantiate(module_instance_t *instance)
  * Allows the module to initialise connection pools, and complete any registrations that depend on
  * attributes created during the bootstrap phase.
  *
- * @param[in] ml containing modules ot instantiate.
+ * @param[in] ml containing modules to instantiate.
  * @return
  *	- 0 on success.
  *	- -1 on failure.

--- a/src/lib/server/module_ctx.h
+++ b/src/lib/server/module_ctx.h
@@ -41,7 +41,7 @@ extern "C" {
 typedef struct {
 	dl_module_inst_t const		*inst;		//!< Dynamic loader API handle for the module.
 	void				*thread;	//!< Thread specific instance data.
-	void				*env_data;	//!< Per call enviornment data.
+	void				*env_data;	//!< Per call environment data.
 	void				*rctx;		//!< Resume ctx that a module previously set.
 } module_ctx_t;
 

--- a/src/lib/server/module_rlm.c
+++ b/src/lib/server/module_rlm.c
@@ -347,7 +347,7 @@ fr_pool_t *module_rlm_connection_pool_init(CONF_SECTION *module,
 	/*
 	 *	We're reusing pool data add it to our local config
 	 *	section. This allows other modules to transitively
-	 *	re-use a pool through this module.
+	 *	reuse a pool through this module.
 	 */
 	if (mycs != cs) {
 		DEBUG4("%s: Copying pool reference %p from config item \"%s.pool\" to config item \"%s.pool\"",
@@ -534,7 +534,7 @@ module_instance_t *module_rlm_by_name_and_method(module_method_t *method, call_e
 		 *	module as "foo" in the configuration.  If the
 		 *	module exports a "recv bar" method, and the
 		 *	virtual server has a "recv bar" processing
-		 *	section, then they shoul match.
+		 *	section, then they should match.
 		 *
 		 *	Unfortunately, this process is O(N*M).
 		 *	Luckily, we only do it if all else fails, so
@@ -966,7 +966,7 @@ int modules_rlm_instantiate(void)
  * @param[in] root of the server configuration.
  * @return
  *	- 0 if all modules were bootstrapped successfully.
- *	- -1 if a module/virtual module failed to boostrap.
+ *	- -1 if a module/virtual module failed to bootstrap.
  */
 int modules_rlm_bootstrap(CONF_SECTION *root)
 {

--- a/src/lib/server/password.c
+++ b/src/lib/server/password.c
@@ -43,7 +43,7 @@ RCSID("$Id$")
 
 typedef enum {
 	PASSWORD_CLEARTEXT = 0,			//!< Variable length.
-	PASSWORD_HASH,				//!< Fixed lenth.
+	PASSWORD_HASH,				//!< Fixed length.
 	PASSWORD_HASH_SALTED,			//!< Fixed length hash, variable length salt.
 	PASSWORD_HASH_VARIABLE			//!< Variable length everything.
 } password_type_t;
@@ -242,7 +242,7 @@ static fr_pair_t *password_process_sha3(TALLOC_CTX *ctx, request_t *request, fr_
 #endif
 static fr_pair_t *password_process_header(TALLOC_CTX *ctx, request_t *request, fr_pair_t *known_good);
 
-/** Metdata for various password attributes
+/** Metadata for various password attributes
  *
  */
 static password_info_t password_info[] = {
@@ -936,7 +936,7 @@ static fr_pair_t *password_normalise_and_recheck(TALLOC_CTX *ctx, request_t *req
 /** Find a "known good" password in the control list of a request
  *
  * Searches for a "known good" password attribute, and applies any processing
- * and normification operations to it, returning a new mormalised fr_pair_t.
+ * and normification operations to it, returning a new normalised fr_pair_t.
  *
  * The ctx passed in should be freed when the caller is done with the returned
  * fr_pair_t, or alternatively, a persistent ctx may be used and the value

--- a/src/lib/server/process.h
+++ b/src/lib/server/process.h
@@ -25,7 +25,7 @@
  *
  * The following macros must be defined before this header is included:
  *
- * - PROCESS_INST			the type fo structure that holds instance data for the process module.
+ * - PROCESS_INST			the type of structure that holds instance data for the process module.
  * - PROCESS_PACKET_TYPE		an enum, or generic type (uint32) that can hold
  *					all valid packet types.
  * - PROCESS_PACKET_CODE_VALID		the name of a macro or function which accepts one argument

--- a/src/lib/server/request.h
+++ b/src/lib/server/request.h
@@ -185,7 +185,7 @@ struct request_s {
 						//!< and responses.
 	fr_dict_t const		*dict;		//!< Dictionary of the protocol that this request belongs to.
 
-	fr_pair_t		*pair_root;	//!< Root atribute which contains the
+	fr_pair_t		*pair_root;	//!< Root attribute which contains the
 						///< other list attributes as children.
 
 	/** Pair lists associated with the request

--- a/src/lib/server/request_data.c
+++ b/src/lib/server/request_data.c
@@ -39,7 +39,7 @@ struct request_data_s {
 	void		*opaque;		//!< Opaque data.
 	bool		free_on_replace;	//!< Whether to talloc_free(opaque) when the request data is removed.
 	bool		free_on_parent;		//!< Whether to talloc_free(opaque) when the request is freed
-	bool		persist;		//!< Whether this data should be transfered to a session_entry_t
+	bool		persist;		//!< Whether this data should be transferred to a session_entry_t
 						//!< after we're done processing this request.
 
 #ifndef NDEBUG

--- a/src/lib/server/state.c
+++ b/src/lib/server/state.c
@@ -151,7 +151,7 @@ struct fr_state_tree_s {
 	fr_rb_tree_t		*tree;				//!< rbtree used to lookup state value.
 	fr_dlist_head_t		to_expire;			//!< Linked list of entries to free.
 
-	fr_time_delta_t		timeout;			//!< How long to wait before cleaning up state entires.
+	fr_time_delta_t		timeout;			//!< How long to wait before cleaning up state entries.
 
 	bool			thread_safe;			//!< Whether we lock the tree whilst modifying it.
 	pthread_mutex_t		mutex;				//!< Synchronisation mutex.
@@ -549,7 +549,7 @@ static fr_state_entry_t *state_entry_create(fr_state_tree_t *state, request_t *r
 	}
 
 	/*
-	 *	Link it to the end of the list, which is implicitely
+	 *	Link it to the end of the list, which is implicitly
 	 *	ordered by cleanup time.
 	 */
 	fr_dlist_insert_tail(&state->to_expire, entry);
@@ -702,7 +702,7 @@ int fr_state_to_request(fr_state_tree_t *state, request_t *request)
 	 *
 	 *	If the request is freed, it's freed immediately.
 	 *
-	 *	Otherwise, if there's another round, we re-use
+	 *	Otherwise, if there's another round, we reuse
 	 *	the state entry and insert it back into the
 	 *	tree.
 	 */

--- a/src/lib/server/tmpl_dcursor_tests.c
+++ b/src/lib/server/tmpl_dcursor_tests.c
@@ -99,7 +99,7 @@ static request_t *request_fake_alloc(void)
  *	due to the ability to add multiple instances of each attribute for the
  *	pair list performance tests.
  *
- * 	So, when entering strings to build tmpls, ensure the top level attriubutes
+ * 	So, when entering strings to build tmpls, ensure the top level attributes
  *	all end -0.
  *
  *	The same applies to immediate children of group attributes since they will
@@ -268,7 +268,7 @@ static void test_level_1_one_all(void)
 }
 
 /*
- *	One instance of attribute at the top level - search for non-existant
+ *	One instance of attribute at the top level - search for non-existent
  */
 static void test_level_1_one_missing(void)
 {

--- a/src/lib/server/tmpl_eval.c
+++ b/src/lib/server/tmpl_eval.c
@@ -248,7 +248,7 @@ fr_type_t tmpl_expanded_type(tmpl_t const *vpt)
  *
  * Depending what arguments are passed, either copies the value to buff, or writes a pointer
  * to a string buffer to out. This allows the most efficient access to the value resolved by
- * the #tmpl_t, avoiding unecessary string copies.
+ * the #tmpl_t, avoiding unnecessary string copies.
  *
  * @note This function is used where raw string values are needed, which may mean the string
  *	returned may be binary data or contain unprintable chars. #fr_snprint or #fr_asprint

--- a/src/lib/server/tmpl_tokenize.c
+++ b/src/lib/server/tmpl_tokenize.c
@@ -1952,7 +1952,7 @@ do_suffix:
 			 *	If the ref is outside of the internal namespace, then we use it.
 			 *
 			 *	If the ref is inside of the internal namespace (e.g. "request"), then we do
-			 *	somthing else.
+			 *	something else.
 			 *
 			 *	If we were given a root dictionary on input, use that.  We have to follow this
 			 *	dictionary because this function calls itself recursively, WITHOUT updating
@@ -3820,7 +3820,7 @@ static inline CC_HINT(always_inline) int tmpl_attr_resolve(tmpl_t *vpt, tmpl_res
 	if (!dict_def || tr_rules->force_dict_def) dict_def = tr_rules->dict_def;
 
 	/*
-	 *	First component is special becase we may need
+	 *	First component is special because we may need
 	 *	to search for it in multiple dictionaries.
 	 *
 	 *	This emulates what's done in the initial
@@ -4237,7 +4237,7 @@ static void attr_to_raw(tmpl_t *vpt, tmpl_attr_t *ref)
 	TMPL_ATTR_VERIFY(vpt);
 }
 
-/** Covert the leaf attribute of a tmpl to a unknown/raw type
+/** Convert the leaf attribute of a tmpl to a unknown/raw type
  *
  */
 void tmpl_attr_to_raw(tmpl_t *vpt)
@@ -4551,7 +4551,7 @@ fr_slen_t tmpl_attr_print(fr_sbuff_t *out, tmpl_t const *vpt, tmpl_attr_prefix_t
 			 *	For refs we skip the attribute pointed to be the ref
 			 *	and just print its children.
 			 *
-			 * 	In addtion skip printing "request." in most cases.
+			 * 	In addition skip printing "request." in most cases.
 			 */
 			if ((stack.da[depth] == request_attr_request) && tmpl_attr_list_next(tmpl_attr(vpt), ar) &&
 			    (ar->filter.type == TMPL_ATTR_FILTER_TYPE_NONE)) continue;
@@ -4644,7 +4644,7 @@ fr_slen_t tmpl_attr_print(fr_sbuff_t *out, tmpl_t const *vpt, tmpl_attr_prefix_t
 /** Print a #tmpl_t to a string
  *
  * This function should primarily be used for regenerating vpt->name when the contents
- * of the #tmpl_t is changed programatically, or when the #tmpl_t is being serialized
+ * of the #tmpl_t is changed programmatically, or when the #tmpl_t is being serialized
  * in some non-standard way, i.e. as a value for a field in a database.
  *
  * This function is the direct counterpart to #tmpl_afrom_substr.
@@ -4815,7 +4815,7 @@ do { \
 
 /** Verify the attribute reference in a tmpl_t make sense
  *
- * @note If the attribute refernece is is invalid, causes the server to exit.
+ * @note If the attribute reference is is invalid, causes the server to exit.
  *
  * @param file obtained with __FILE__.
  * @param line obtained with __LINE__.
@@ -5407,7 +5407,7 @@ ssize_t tmpl_preparse(char const **out, size_t *outlen, char const *in, size_t i
 		 *	simple parse that isn't wrong.  We therefore
 		 *	accept most anything that's vaguely well
 		 *	formed, and rely on the next stage to do a
-		 *	more rigourous check.
+		 *	more rigorous check.
 		 */
 	skip_string:
 		*out = p;

--- a/src/lib/server/trunk.c
+++ b/src/lib/server/trunk.c
@@ -840,7 +840,7 @@ int fr_trunk_del_watch(fr_trunk_t *trunk, fr_trunk_state_t state, fr_trunk_watch
  * @param[in] oneshot	Should this watcher only be run once.
  * @param[in] uctx	Context to pass to function.
  * @return
- *	- NULL if an invlaid state is passed.
+ *	- NULL if an invalid state is passed.
  *	- A new watch entry handle on success.
  */
 fr_trunk_watch_entry_t *fr_trunk_add_watch(fr_trunk_t *trunk, fr_trunk_state_t state,
@@ -1919,7 +1919,7 @@ done:
 /** Move requests off of a connection and requeue elsewhere
  *
  * @note We don't re-queue on draining or draining to free, as requests should have already been
- *	 moved off of te connection.  It's also dangerous as the trunk management code main
+ *	 moved off of the connection.  It's also dangerous as the trunk management code main
  *	 clean up a connection in this state when it's run on re-queue, and then the caller
  *	 may try and access a now freed connection.
  *
@@ -4429,7 +4429,7 @@ static uint64_t trunk_requests_per_connection(uint16_t *conn_count_out, uint32_t
 	 *	In the case of TRUNK_CONN_DRAINING_TO_FREE the trunk
 	 *	management code should spawn a new connection to takes its place.
 	 *
-	 *	Connections placed in the DRAINING_TO_FREE sate are being
+	 *	Connections placed in the DRAINING_TO_FREE state are being
 	 *	closed preemptively to deal with bugs on the server we're
 	 *	talking to, or misconfigured firewalls which are trashing
 	 *	TCP/UDP connection states.

--- a/src/lib/server/trunk.h
+++ b/src/lib/server/trunk.h
@@ -254,7 +254,7 @@ typedef struct {
 	size_t			req_pool_size;		//!< The size of the talloc pool allocated with the treq.
 
 	bool			always_writable;	//!< Set to true if our ability to write requests to
-							///< a connection handle is not dependant on the state
+							///< a connection handle is not dependent on the state
 							///< of the underlying connection, i.e. if the library
 							///< used to implement the connection can always receive
 							///< and buffer new requests irrespective of the state
@@ -558,7 +558,7 @@ typedef void (*fr_trunk_request_cancel_mux_t)(fr_event_list_t *el,
  *
  * If the treq (trunk request) is in the FR_TRUNK_REQUEST_STATE_PARTIAL or
  * FR_TRUNK_REQUEST_STATE_SENT states, this callback will be called prior
- * to moving the treq to a new connection, requeueing the tre or freeing
+ * to moving the treq to a new connection, requeueing the treq or freeing
  * the treq.
  *
  * The treq, and any associated resources, should be

--- a/src/lib/tls/bio.c
+++ b/src/lib/tls/bio.c
@@ -350,7 +350,7 @@ BIO *fr_tls_bio_dbuff_thread_local(TALLOC_CTX *ctx, size_t init, size_t max)
 		return bd->bio;
 	}
 
-	fr_assert_msg(!tls_bio_talloc_agg->dbuff_out.buff, "BIO not finialised");
+	fr_assert_msg(!tls_bio_talloc_agg->dbuff_out.buff, "BIO not finalised");
 	MEM(fr_dbuff_init_talloc(ctx, &bd->dbuff_out, &bd->tctx, init, max));	/* Where we read from */
 	bd->dbuff_in = FR_DBUFF_BIND_END_ABS(&bd->dbuff_out);			/* Where we write to */
 

--- a/src/lib/tls/cache.c
+++ b/src/lib/tls/cache.c
@@ -933,7 +933,7 @@ again:
 		{
 			SESSION_ID(sess_id, tls_cache->load.sess);
 
-			RDEBUG3("Session ID %pV - Session ownership transfered to libssl", &sess_id);
+			RDEBUG3("Session ID %pV - Session ownership transferred to libssl", &sess_id);
 			*copy = 0;
 			tls_cache->load.sess = NULL;
 		}
@@ -1412,7 +1412,7 @@ int fr_tls_cache_ctx_init(SSL_CTX *ctx, fr_tls_cache_conf_t const *cache_conf)
 
 		/*
 		 *	If keys is NULL, then OpenSSL returns the expected
-		 *	key length, which may be different across diferent
+		 *	key length, which may be different across different
 		 *	flavours/versions of OpenSSL.
 		 *
 		 *	We could calculate this in conf.c, but, if in future

--- a/src/lib/tls/ctx.c
+++ b/src/lib/tls/ctx.c
@@ -476,7 +476,7 @@ int tls_ctx_version_set(
 	 *	TLS1_3_VERSION is available in OpenSSL 1.1.1.
 	 *
 	 *	TLS1_4_VERSION does not exist yet.  But we allow it
-	 *	only if it is explictly permitted by the
+	 *	only if it is explicitly permitted by the
 	 *	administrator.
 	 */
 	if (conf->tls_max_version > (float) 0.0) {
@@ -937,7 +937,7 @@ post_ca:
 #endif
 
 	/*
-	 *	Set eliptical curve crypto configuration.
+	 *	Set elliptical curve crypto configuration.
 	 */
 #ifndef OPENSSL_NO_ECDH
 	if (ctx_ecdh_curve_set(ctx, conf->ecdh_curve, conf->disable_single_dh_use) < 0) goto error;

--- a/src/lib/tls/pairs.c
+++ b/src/lib/tls/pairs.c
@@ -249,7 +249,7 @@ skip_alt:
 
 	/*
 	 *	Grab the X509 extensions, and create attributes out of them.
-	 *	For laziness, we re-use the OpenSSL names
+	 *	For laziness, we reuse the OpenSSL names
 	 */
 	if (sk_X509_EXTENSION_num(ext_list) > 0) {
 		int			i;

--- a/src/lib/tls/session.c
+++ b/src/lib/tls/session.c
@@ -1088,7 +1088,7 @@ finish:
  */
 int fr_tls_session_alert(UNUSED request_t *request, fr_tls_session_t *session, uint8_t level, uint8_t description)
 {
-	if (session->alerts_sent > 3) return -1;		/* Some kind of sate machine brokenness */
+	if (session->alerts_sent > 3) return -1;		/* Some kind of state machine brokenness */
 
 	/*
 	 *	Ignore less severe alerts
@@ -1286,7 +1286,7 @@ static unlang_action_t tls_session_async_handshake_done_round(UNUSED rlm_rcode_t
  *
  * @param[in] request	being cancelled.
  * @param[in] action	we're being signalled with.
- * @param[in] uctx	the SSL * to cancell.
+ * @param[in] uctx	the SSL * to cancel.
  */
 static void tls_session_async_handshake_signal(UNUSED request_t *request, UNUSED fr_signal_t action, void *uctx)
 {

--- a/src/lib/unlang/call_env.c
+++ b/src/lib/unlang/call_env.c
@@ -632,7 +632,7 @@ void call_env_parsed_set_multi_index(call_env_parsed_t *parsed, size_t count, si
 
 /** Remove a call_env_parsed_t from the list of parsed call envs
  *
- * @note Indended to be used by subsection callbacks to remove a call_env_parsed_t
+ * @note Intended to be used by subsection callbacks to remove a call_env_parsed_t
  *	from the list of parsed call envs (typically on error).
  *
  * @param[in] parsed		to remove parsed data from.

--- a/src/lib/unlang/compile.c
+++ b/src/lib/unlang/compile.c
@@ -938,7 +938,7 @@ static unlang_t *compile_map(unlang_t *parent, unlang_compile_t *unlang_ctx, CON
 	 *
 	 *	Ensure that the module has a "map" entry in its module
 	 *	header?  Or ensure that the map is registered in the
-	 *	"boostrap" phase, so that it's always available here.
+	 *	"bootstrap" phase, so that it's always available here.
 	 */
 	if (!pass2_fixup_map_rhs(g, unlang_ctx->rules)) goto error;
 
@@ -1907,7 +1907,7 @@ static bool compile_retry_section(unlang_actions_t *actions, CONF_ITEM *ci)
 		value = cf_pair_value(cp);
 
 		if (!value) {
-			cf_log_err(csi, "Retry configuration must specifiy a value");
+			cf_log_err(csi, "Retry configuration must specify a value");
 			return false;
 		}
 
@@ -2076,7 +2076,7 @@ static unlang_t *compile_empty(unlang_t *parent, unlang_compile_t *unlang_ctx, C
 
 	/*
 	 *	If we're compiling an empty section, then the
-	 *	*intepreter* type is GROUP, even if the *debug names*
+	 *	*interpreter* type is GROUP, even if the *debug names*
 	 *	are something else.
 	 */
 	g = group_allocate(parent, cs, ext);

--- a/src/lib/unlang/edit.c
+++ b/src/lib/unlang/edit.c
@@ -1189,7 +1189,7 @@ static int expanded_lhs_value(request_t *request, unlang_frame_state_edit_t *sta
 	fr_assert(current->parent);
 
 	if (!box) {
-		RWDEBUG("Failed exapnding result");
+		RWDEBUG("Failed expanding result");
 		return -1;
 	}
 
@@ -1354,7 +1354,7 @@ static int check_lhs(request_t *request, unlang_frame_state_edit_t *state, edit_
 		/*
 		 *	For "+=", if there's no existing attribute, create one, and rewrite the operator we
 		 *	apply to ":=".  Which also means moving the operator be in edit_map_t, and then updating the
-		 *	"apply" funtions above to use that for the operations, but map->op for printing.
+		 *	"apply" functions above to use that for the operations, but map->op for printing.
 		 *
 		 *	This allows "foo += 4" to set "foo := 4" when the attribute doesn't exist.  It also allows us
 		 *	to do list appending to an empty list.  But likely only for strings, octets, and numbers.

--- a/src/lib/unlang/interpret.c
+++ b/src/lib/unlang/interpret.c
@@ -293,7 +293,7 @@ static void instruction_timeout_handler(UNUSED fr_event_list_t *el, UNUSED fr_ti
 /** Update the current result after each instruction, and after popping each stack frame
  *
  * @param[in] request		The current request.
- * @param[in] frame		The curren stack frame.
+ * @param[in] frame		The current stack frame.
  * @param[in,out] result	The current section result.
  * @param[in,out] priority	The current section priority.
  * @return
@@ -500,7 +500,7 @@ finalize:
 /** Evaluates all the unlang nodes in a section
  *
  * @param[in] request		The current request.
- * @param[in] frame		The curren stack frame.
+ * @param[in] frame		The current stack frame.
  * @param[in,out] result	The current section result.
  * @param[in,out] priority	The current section priority.
  * @return
@@ -1314,7 +1314,7 @@ bool unlang_request_is_cancelled(request_t const *request)
  *
  * @param[in] request		The current request.
  * @return
- *	- true if the request is resumable (i.e. has yeilded)
+ *	- true if the request is resumable (i.e. has yielded)
  *	- false if the request is not resumable (i.e. has not yielded)
  */
 bool unlang_interpret_is_resumable(request_t *request)

--- a/src/lib/unlang/interpret.h
+++ b/src/lib/unlang/interpret.h
@@ -63,23 +63,23 @@ typedef void (*unlang_request_stop_t)(request_t *request, void *uctx);
 
 /** Signal the owner of the interpreter that a request has yielded
  *
- * This is called whenever a request has given control back to the interpeter.
+ * This is called whenever a request has given control back to the interpreter.
  */
 typedef void (*unlang_request_yield_t)(request_t *request, void *uctx);
 
-/** Signal the owner of the interpeter that a request is ready to be resumed
+/** Signal the owner of the interpreter that a request is ready to be resumed
  *
  * This is called any time a yielded request has resumed.
  */
 typedef void (*unlang_request_resume_t)(request_t *request, void *uctx);
 
-/** Signal the owner of the interpeter that a request is now runnable
+/** Signal the owner of the interpreter that a request is now runnable
  *
  * This is called any time a yielded request has been marked runnable.
  */
 typedef void (*unlang_request_runnable_t)(request_t *request, void *uctx);
 
-/** Signal the owner of the interpeter that a request is now runnable
+/** Signal the owner of the interpreter that a request is now runnable
  *
  * This is called any time a yielded request has been marked runnable.
  */

--- a/src/lib/unlang/map.c
+++ b/src/lib/unlang/map.c
@@ -174,7 +174,7 @@ static unlang_action_t list_mod_create(rlm_rcode_t *p_result, request_t *request
 
 		case UNLANG_UPDATE_MAP_EXPANDED_LHS:
 			/*
-			 *	map_to_list_mod() already concatentates the LHS, so we don't need to do it here.
+			 *	map_to_list_mod() already concatenates the LHS, so we don't need to do it here.
 			 */
 			if (!map->rhs) goto next;
 

--- a/src/lib/unlang/module.c
+++ b/src/lib/unlang/module.c
@@ -432,7 +432,7 @@ int unlang_module_set_resume(request_t *request, module_method_t resume)
  * the resumption frame and execute the xlat interpreter.
  *
  * When the xlat interpreter finishes, and pops the xlat frame, the unlang interpreter
- * will then call the module resumption frame, allowing the module to continue exectuion.
+ * will then call the module resumption frame, allowing the module to continue execution.
  *
  * @param[in] ctx		To allocate talloc value boxes and values in.
  * @param[out] p_success	Whether xlat evaluation was successful.
@@ -478,7 +478,7 @@ unlang_action_t unlang_module_yield_to_xlat(TALLOC_CTX *ctx, bool *p_success, fr
  * the resumption frame and execute the tmpl expansion.
  *
  * When the tmpl interpreter finishes, and pops the tmpl frame, the unlang interpreter
- * will then call the module resumption frame, allowing the module to continue exectuion.
+ * will then call the module resumption frame, allowing the module to continue execution.
  *
  * @param[in] ctx		To allocate talloc value boxes and values in.
  * @param[out] out		Where to write the result of the expansion.

--- a/src/lib/unlang/try_priv.h
+++ b/src/lib/unlang/try_priv.h
@@ -19,7 +19,7 @@
  * $Id$
  *
  * @file unlang/try_priv.h
- * @brief Declarations for unlang trys
+ * @brief Declarations for unlang tries
  *
  * @copyright 2023 Network RADIUS SAS (legal@networkradius.com)
  */

--- a/src/lib/unlang/try_priv.h
+++ b/src/lib/unlang/try_priv.h
@@ -19,7 +19,7 @@
  * $Id$
  *
  * @file unlang/try_priv.h
- * @brief Declarations for unlang tries
+ * @brief Declaration for unlang try
  *
  * @copyright 2023 Network RADIUS SAS (legal@networkradius.com)
  */

--- a/src/lib/unlang/xlat.h
+++ b/src/lib/unlang/xlat.h
@@ -348,7 +348,7 @@ typedef int (*xlat_thread_detach_t)(xlat_thread_inst_ctx_t const *xctx);
  *
  *
  * @param[in] XLAT_ARGS_N	the name of the macro to expand.
- *				Created by concating ``XLAT_ARGS_ + <number of variadic arguments>``.
+ *				Created by concatenating ``XLAT_ARGS_ + <number of variadic arguments>``.
  * @param[in] _list		The input list of value boxes.
  * @param[in] ...		The variadic arguments themselves.
  */

--- a/src/lib/unlang/xlat_builtin.c
+++ b/src/lib/unlang/xlat_builtin.c
@@ -1107,7 +1107,7 @@ static xlat_action_t xlat_func_log_debug(UNUSED TALLOC_CTX *ctx, UNUSED fr_dcurs
  *
  * Example:
 @verbatim
-%log.err("Big errror here")
+%log.err("Big error here")
 @endverbatim
  *
  * @ingroup xlat_functions

--- a/src/lib/unlang/xlat_eval.c
+++ b/src/lib/unlang/xlat_eval.c
@@ -18,7 +18,7 @@
  * $Id$
  *
  * @file xlat_eval.c
- * @brief String expansion ("translation").  Evaluation of pre-parsed xlat epxansions.
+ * @brief String expansion ("translation").  Evaluation of pre-parsed xlat expansions.
  *
  * @copyright 2018-2021 Arran Cudbard-Bell (a.cudbardb@freeradius.org)
  * @copyright 2000,2006 The FreeRADIUS server project

--- a/src/lib/unlang/xlat_expr.c
+++ b/src/lib/unlang/xlat_expr.c
@@ -1046,7 +1046,7 @@ static int xlat_expr_logical_purify(xlat_exp_t *node, void *instance, request_t 
 		}
 
 		/*
-		 *	Start searching from the next entry, OR start seaching from where we left off before.
+		 *	Start searching from the next entry, OR start searching from where we left off before.
 		 */
 		if (j < 0) j = i + 1;
 
@@ -2355,7 +2355,7 @@ static fr_slen_t tokenize_field(xlat_exp_head_t *head, xlat_exp_t **out, fr_sbuf
 
 		/*
 		 *	We've parsed one "thing", so we stop.  The
-		 *	next thing shoud be an operator, not another
+		 *	next thing should be an operator, not another
 		 *	value.
 		 */
 		*out_c = '\0';

--- a/src/lib/unlang/xlat_func.c
+++ b/src/lib/unlang/xlat_func.c
@@ -184,7 +184,7 @@ xlat_t *xlat_func_find_module(module_inst_ctx_t const *mctx, char const *name)
 
 /** Register an xlat function for a module
  *
- * @param[in] ctx		Used to automate deregistration of the xlat fnction.
+ * @param[in] ctx		Used to automate deregistration of the xlat function.
  * @param[in] mctx		Instantiation context from the module.
  *				Will be duplicated and passed to future xlat calls.
  * @param[in] name		of the xlat.
@@ -279,7 +279,7 @@ xlat_t *xlat_func_register_module(TALLOC_CTX *ctx, module_inst_ctx_t const *mctx
 
 /** Register an xlat function
  *
- * @param[in] ctx		Used to automate deregistration of the xlat fnction.
+ * @param[in] ctx		Used to automate deregistration of the xlat function.
  * @param[in] name		of the xlat.
  * @param[in] func		to register.
  * @param[in] return_type	what type of output the xlat function will produce.
@@ -314,7 +314,7 @@ static inline int xlat_arg_parser_validate(xlat_t *x, xlat_arg_parser_t const *a
 	if (arg->variadic) {
 		if (!fr_cond_assert_msg(last, "%s - variadic can only be set on the last argument", x->name)) return -1;
 		if (!fr_cond_assert_msg(!arg->required, "%s - required can't be set on a variadic argument. "
-					"Set required in the preceeding entry", x->name)) return -1;
+					"Set required in the preceding entry", x->name)) return -1;
 	}
 
 	if (arg->always_escape) {

--- a/src/lib/unlang/xlat_priv.h
+++ b/src/lib/unlang/xlat_priv.h
@@ -154,7 +154,7 @@ struct xlat_exp_s {
 
 #ifndef NDEBUG
 	char const * _CONST	file;		//!< File where the xlat was allocated.
-	int			line;		//!< Line where the xlat was alocated.
+	int			line;		//!< Line where the xlat was allocated.
 #endif
 
 	union {
@@ -187,7 +187,7 @@ struct xlat_exp_head_s {
 
 #ifndef NDEBUG
 	char const * _CONST	file;		//!< File where the xlat was allocated.
-	int			line;		//!< Line where the xlat was alocated.
+	int			line;		//!< Line where the xlat was allocated.
 #endif
 };
 

--- a/src/lib/unlang/xlat_purify.c
+++ b/src/lib/unlang/xlat_purify.c
@@ -386,7 +386,7 @@ static int binary_peephole_optimize(TALLOC_CTX *ctx, xlat_exp_t **out, xlat_exp_
 	/*
 	 *	value op attribute
 	 *
-	 *	We just swap LHS and RHS without caring about the operator, because wee don't use the
+	 *	We just swap LHS and RHS without caring about the operator, because we don't use the
 	 *	operator, and the caller has no idea that we swapped the pointers..
 	 */
 	if ((rhs->type == XLAT_TMPL) && tmpl_is_attr(rhs->vpt) &&

--- a/src/lib/unlang/xlat_redundant.c
+++ b/src/lib/unlang/xlat_redundant.c
@@ -322,7 +322,7 @@ static int xlat_redundant_instantiate(xlat_inst_ctx_t const *xctx)
 		 */
 		head->flags = node->flags;
 		if (xlat_finalize(head, NULL) < 0) {
-			PERROR("Failed boostrapping function \"%s\"",
+			PERROR("Failed bootstrapping function \"%s\"",
 			       xrf->func->name);
 			goto error;
 		}

--- a/src/lib/util/dbuff.h
+++ b/src/lib/util/dbuff.h
@@ -349,7 +349,7 @@ void _fr_dbuff_init(fr_dbuff_t *out, uint8_t const *start, uint8_t const *end, b
  * @param[out] _out		Pointer to buffer to parse
  * @param[in] _start		Start of the buffer to parse.
  * @param[in] _len_or_end	Either an end pointer or the length
- *				of the buffer we're deconding.
+ *				of the buffer we're decoding.
  */
 #define fr_dbuff_init(_out, _start, _len_or_end) \
 _fr_dbuff_init(_out, \
@@ -566,7 +566,7 @@ do { \
 /** @name Extension requests
  *
  * These functions/macros may be used to request that the underlying buffer is
- * either extended to accomodate more data, or that data is shifted out of the
+ * either extended to accommodate more data, or that data is shifted out of the
  * buffer, and that the buffer is refilled.
  *
  * @{
@@ -1767,7 +1767,7 @@ FR_DBUFF_OUT_DEF(int64)
 /** Copy data from a dbuff or marker to a fixed sized C type
  *
  * @param[out] _out			Where to write the data.  If out is an integer type
- *					a byteswap will be performed if native endianess
+ *					a byteswap will be performed if native endianness
  *      				is not big endian.
  * @param[in] _dbuff_or_marker		to copy data from. Will be advanced by the number
  *					of bytes consumed, i.e. if out is a uin16_t *,

--- a/src/lib/util/dict.h
+++ b/src/lib/util/dict.h
@@ -274,7 +274,7 @@ typedef enum {
 	FR_DICT_ATTR_NOTFOUND		= -1,			//!< Attribute couldn't be found.
 	FR_DICT_ATTR_PROTOCOL_NOTFOUND	= -2,			//!< Protocol couldn't be found.
 	FR_DICT_ATTR_PARSE_ERROR	= -3,			//!< Attribute string couldn't be parsed
-	FR_DICT_ATTR_INTERNAL_ERROR	= -4,			//!< Internal error ocurred.
+	FR_DICT_ATTR_INTERNAL_ERROR	= -4,			//!< Internal error occurred.
 	FR_DICT_ATTR_OOM		= -5,			//!< Memory allocation error.
 	FR_DICT_ATTR_NOT_DESCENDENT	= -6,			//!< Attribute is not a descendent of the parent
 								///< attribute.
@@ -347,7 +347,7 @@ extern bool const	fr_dict_enum_allowed_chars[UINT8_MAX + 1];
 #include <freeradius-devel/util/dict_ext.h>
 /** @} */
 
-/** @name Programatically create dictionary attributes and values
+/** @name Programmatically create dictionary attributes and values
  *
  * @{
  */

--- a/src/lib/util/dict_test.c
+++ b/src/lib/util/dict_test.c
@@ -14,7 +14,7 @@
  *   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-/** Common functions for test files which need to programatically create test dictionaries
+/** Common functions for test files which need to programmatically create test dictionaries
  *
  * @file src/lib/util/dict_test.c
  *

--- a/src/lib/util/dict_tokenize.c
+++ b/src/lib/util/dict_tokenize.c
@@ -2791,7 +2791,7 @@ static int dict_from_file(fr_dict_t *dict,
 
 /** (Re-)Initialize the special internal dictionary
  *
- * This dictionary has additional programatically generated attributes added to it,
+ * This dictionary has additional programmatically generated attributes added to it,
  * and is checked in addition to the protocol specific dictionaries.
  *
  * @note The dictionary pointer returned in out must have its reference counter

--- a/src/lib/util/dict_util.c
+++ b/src/lib/util/dict_util.c
@@ -1932,7 +1932,7 @@ fr_slen_t fr_dict_oid_component(fr_dict_attr_err_t *err,
  * @note Will leave the sbuff pointing at the component the error occurred at
  *	 so that the caller can attempt to process the component in another way.
  *	 An err pointer should be provided in order to determine if an error
- *	 ocurred.
+ *	 occurred.
  *
  * @param[out] err		The parsing error that occurred.
  * @param[out] out		The deepest attribute we resolved.
@@ -2250,7 +2250,7 @@ bool fr_dict_compatible(fr_dict_t const *dict1, fr_dict_t const *dict2)
  * @param[in] da	The vendor attribute.
  * @return
  *	- The vendor.
- *	- NULL if no vendor with that number was regitered for this protocol.
+ *	- NULL if no vendor with that number was registered for this protocol.
  */
 fr_dict_vendor_t const *fr_dict_vendor_by_da(fr_dict_attr_t const *da)
 {
@@ -2272,7 +2272,7 @@ fr_dict_vendor_t const *fr_dict_vendor_by_da(fr_dict_attr_t const *da)
  * @param[in] name		to search for.
  * @return
  *	- The vendor.
- *	- NULL if no vendor with that name was regitered for this protocol.
+ *	- NULL if no vendor with that name was registered for this protocol.
  */
 fr_dict_vendor_t const *fr_dict_vendor_by_name(fr_dict_t const *dict, char const *name)
 {
@@ -2295,7 +2295,7 @@ fr_dict_vendor_t const *fr_dict_vendor_by_name(fr_dict_t const *dict, char const
  * @param[in] vendor_pen	to search for.
  * @return
  *	- The vendor.
- *	- NULL if no vendor with that number was regitered for this protocol.
+ *	- NULL if no vendor with that number was registered for this protocol.
  */
 fr_dict_vendor_t const *fr_dict_vendor_by_num(fr_dict_t const *dict, uint32_t vendor_pen)
 {
@@ -2574,7 +2574,7 @@ fr_slen_t dict_attr_search_qualified(fr_dict_attr_err_t *err, fr_dict_attr_t con
  * This function will search through all loaded dictionaries, or a subset of
  * loaded dictionaries, for a matching attribute in the top level namespace.
  *
- * This attribute may be qualified with `<protcol>.` to selection an attribute
+ * This attribute may be qualified with `<protocol>.` to selection an attribute
  * in a specific case.
  *
  * @note If calling this function from the server any list or request qualifiers
@@ -2638,7 +2638,7 @@ fr_slen_t fr_dict_attr_search_by_name_substr(fr_dict_attr_err_t *err, fr_dict_at
  * @note If calling this function from the server any list or request qualifiers
  *  should be stripped first.
  *
- * @note err should be checked to determine if a parse error ocurred.
+ * @note err should be checked to determine if a parse error occurred.
  *
  * @param[out] err		Why parsing failed. May be NULL.
  *				@see fr_dict_attr_err_t
@@ -2667,7 +2667,7 @@ fr_slen_t fr_dict_attr_search_by_qualified_oid_substr(fr_dict_attr_err_t *err, f
  * @note If calling this function from the server any list or request qualifiers
  *  should be stripped first.
  *
- * @note err should be checked to determine if a parse error ocurred.
+ * @note err should be checked to determine if a parse error occurred.
  *
  * @param[out] err		Why parsing failed. May be NULL.
  *				@see fr_dict_attr_err_t
@@ -2781,7 +2781,7 @@ fr_slen_t fr_dict_attr_by_name_substr(fr_dict_attr_err_t *err, fr_dict_attr_t co
 	}
 
 	/*
-	 *	Do a second pass, ensuring that the name has at least one alpha-numeric character.
+	 *	Do a second pass, ensuring that the name has at least one alphanumeric character.
 	 */
 	for (p = buffer; p < (buffer + len); p++) {
 		if (sbuff_char_alpha_num[(uint8_t) *p]) break;
@@ -3741,7 +3741,7 @@ int _fr_dict_autofree(fr_dict_autoload_t const *to_free, char const *dependent)
  *
  * This should only be used when dictionaries are being dynamically loaded during
  * compilation.  It should not be used to load dictionaries at runtime, or if
- * modules need to load dicitonaries (use static fr_dict_autoload_t defs).
+ * modules need to load dictionaries (use static fr_dict_autoload_t defs).
 
  */
 struct fr_dict_autoload_talloc_s {
@@ -3763,11 +3763,11 @@ static int _fr_dict_autoload_talloc_free(fr_dict_autoload_talloc_t const *to_fre
  * Mainly useful for resolving "forward" references from unlang immediately.
  *
  * @note If the talloc chunk is freed it does not mean the dictionary will
- *	 be immediately freeed.  It will be freed when all other references
+ *	 be immediately freed.  It will be freed when all other references
  *	 to the dictionary are gone.
  *
- * @parma[in] ctx	to bind the dictionary lifetime to.
- * @parma[in] proto	to load.
+ * @param[in] ctx	to bind the dictionary lifetime to.
+ * @param[in] proto	to load.
  * @param[in] dependent to register this reference to.  Will be dupd.
  */
 fr_dict_autoload_talloc_t *_fr_dict_autoload_talloc(TALLOC_CTX *ctx, fr_dict_t const **out, char const *proto, char const *dependent)

--- a/src/lib/util/dns.c
+++ b/src/lib/util/dns.c
@@ -288,7 +288,7 @@ static bool dns_label_compress(uint8_t const *packet, uint8_t const *start, uint
 	 *	Note that by design, next > end.  We don't care about
 	 *	the size of the buffer we put "label" into.  We only
 	 *	care that all bytes of "label" are valid, and we don't
-	 *	access memroy after "label".
+	 *	access memory after "label".
 	 */
 
 	/*
@@ -978,7 +978,7 @@ ssize_t fr_dns_label_uncompressed_length(uint8_t const *packet, uint8_t const *b
 			 *	... an entire domain name or a list of
 			 *	labels at the end of a domain name is
 			 *	replaced with a pointer to a prior
-			 *	occurance of the same name.
+			 *	occurrence of the same name.
 			 *	...
 			 *
 			 *	Note the key word PRIOR.  If we

--- a/src/lib/util/edit.c
+++ b/src/lib/util/edit.c
@@ -673,7 +673,7 @@ int fr_edit_list_replace_pair(fr_edit_list_t *el, fr_pair_list_t *list, fr_pair_
 	/*
 	 *	We call edit_record() twice, which involves two
 	 *	complete passes over the edit list.  That's fine,
-	 *	either the edit list is small, OR we will eventially
+	 *	either the edit list is small, OR we will eventually
 	 *	put the VPs to be edited into an RB tree.
 	 */
 	if (edit_record(el, FR_EDIT_INSERT, vp, list, to_replace) < 0) return -1;
@@ -835,7 +835,7 @@ fr_edit_list_t *fr_edit_list_alloc(TALLOC_CTX *ctx, int hint, fr_edit_list_t *pa
 /** Commit an edit list.
  *
  *  If there are nested transactions, then this transaction is
- *  committed only when the parent transaction has been commited.
+ *  committed only when the parent transaction has been committed.
  *
  */
 void fr_edit_list_commit(fr_edit_list_t *el)

--- a/src/lib/util/event.c
+++ b/src/lib/util/event.c
@@ -666,7 +666,7 @@ static void fr_event_fd_noop(UNUSED fr_event_list_t *el, UNUSED int fd, UNUSED i
  * @param[in] prev		Previous set of functions mapped to filters.
  * @return
  *	- >= 0 the number of changes written to out.
- *	- < 0 an error ocurred.
+ *	- < 0 an error occurred.
  */
 static ssize_t fr_event_build_evset(
 #ifndef WITH_EVENT_DEBUG
@@ -1219,7 +1219,7 @@ int _fr_event_filter_insert(NDEBUG_LOCATION_ARGS
  * @param[in] error	function to call when an error occurs on the fd.
  * @param[in] uctx	to pass to handler.
  * @return
- *	- 0 on succes.
+ *	- 0 on success.
  *	- -1 on failure.
  */
 int _fr_event_fd_insert(NDEBUG_LOCATION_ARGS
@@ -1467,7 +1467,7 @@ int _fr_event_timer_at(NDEBUG_LOCATION_ARGS
 	}
 
 	/*
-	 *	If there is an event, re-use it instead of freeing it
+	 *	If there is an event, reuse it instead of freeing it
 	 *	and allocating a new one.  This is to reduce memory
 	 *	churn for repeat events.
 	 */
@@ -1872,7 +1872,7 @@ int _fr_event_pid_wait(NDEBUG_LOCATION_ARGS
 		/*
 		 *	Failed adding waiter for process, but process has not completed...
 		 *
-		 *	This weird, but seems to happen on macOS ocassionally.
+		 *	This weird, but seems to happen on macOS occasionally.
 		 *
 		 *	Add an event to run early exit...
 		 *

--- a/src/lib/util/file.c
+++ b/src/lib/util/file.c
@@ -107,7 +107,7 @@ static ssize_t _fr_mkdir(int *fd_out, char *start, char *path, mode_t mode, fr_m
 	 *	exist.  Look for the LAST path name.  Try
 	 *	to create that.  If there's an error, we leave
 	 *	the path path as the one at which the
-	 *	error occured.
+	 *	error occurred.
 	 */
 	p = strrchr(path, FR_DIR_SEP);
 	if (!p || (p == path)) return start - path;	/* last path component and we've previously failed */

--- a/src/lib/util/hw.c
+++ b/src/lib/util/hw.c
@@ -96,7 +96,7 @@ uint32_t fr_hw_num_cores_active(void)
 	/*
 	 *	Catch Linux weirdness.
 	 *
-	 *	You'd think this'd be enough to quiet clang scan,
+	 *	You'd think this would be enough to quiet clang scan,
 	 *	but it's not.
 	 */
 	if (unlikely((tsibs == 0) || (lcores == 0) || (lcores > tsibs))) {

--- a/src/lib/util/inet.c
+++ b/src/lib/util/inet.c
@@ -227,7 +227,7 @@ void fr_ipaddr_mask(fr_ipaddr_t *addr, uint8_t prefix)
  * found and a record for AF_INET6 exists that record will be returned.
  *
  * If fallback is specified and af is AF_INET6, and a record with AF_INET4 exists
- * that record will be returned inseted.
+ * that record will be returned inserted.
  *
  * @param[out] out Where to write result.
  * @param[in] af To search for in preference.

--- a/src/lib/util/iovec.c
+++ b/src/lib/util/iovec.c
@@ -54,7 +54,7 @@ fr_slen_t fr_concatv(fr_dbuff_t *out, struct iovec vector[], int iovcnt)
  *
  * @note Should only be used on nonblocking file descriptors.
  * @note Socket should likely be closed on timeout.
- * @note iovec may be modified in such a way that it's not re-usable.
+ * @note iovec may be modified in such a way that it's not reusable.
  * @note Leaves errno set to the last error that occurred.
  *
  * @param fd to write to.

--- a/src/lib/util/machine.c
+++ b/src/lib/util/machine.c
@@ -290,7 +290,7 @@ static int state_post(fr_machine_t *m, int state)
  *
  * @param m	The state machine
  * @return
- *	- 0 for "no transition has occured"
+ *	- 0 for "no transition has occurred"
  *	- >0 for "we are in a new state".
  *	-<0 for "error, you should tear down the state machine".
  *
@@ -609,7 +609,7 @@ void fr_machine_resume(fr_machine_t *m)
  * @param m	The state machine
  * @param signal the signal to send to the state machne
  * @return
- *	- 0 for "no transition has occured"
+ *	- 0 for "no transition has occurred"
  *	- >0 for "we are in a new state".
  *	-<0 for "error, you should tear down the state machine".
  *

--- a/src/lib/util/pair.c
+++ b/src/lib/util/pair.c
@@ -350,7 +350,7 @@ int fr_pair_reinit_from_da(fr_pair_list_t *list, fr_pair_t *vp, fr_dict_attr_t c
  * If attr and vendor match a dictionary entry then a VP with that #fr_dict_attr_t
  * will be returned.
  *
- * If attr or vendor are uknown will call dict_attruknown to create a dynamic
+ * If attr or vendor are unknown will call dict_attruknown to create a dynamic
  * #fr_dict_attr_t of #FR_TYPE_OCTETS.
  *
  * Which type of #fr_dict_attr_t the #fr_pair_t was created with can be determined by
@@ -634,7 +634,7 @@ static void *fr_pair_iter_next_by_da(fr_dlist_head_t *list, void *current, void 
 
 /** Iterate over pairs which are decedents of the specified da
  *
- * @param[in] list	to itterate over.
+ * @param[in] list	to iterate over.
  * @param[in] current	The fr_pair_t cursor->current.  Will be advanced and checked to
  *			see if it matches the specified fr_dict_attr_t.
  * @param[in] uctx	The fr_dict_attr_t to search for.

--- a/src/lib/util/pair_inline.c
+++ b/src/lib/util/pair_inline.c
@@ -157,7 +157,7 @@ _INLINE size_t fr_pair_list_num_elements(fr_pair_list_t const *list)
  *
  * @param[in] list to get the head from
  *
- * @return the pointer to the dlist wihin the pair list.
+ * @return the pointer to the dlist within the pair list.
  */
 _INLINE fr_dlist_head_t *fr_pair_list_to_dlist(fr_pair_list_t const *list)
 {

--- a/src/lib/util/pair_legacy.c
+++ b/src/lib/util/pair_legacy.c
@@ -699,7 +699,7 @@ void fr_pair_list_move_op(fr_pair_list_t *to, fr_pair_list_t *from, fr_token_t o
 			if (!found) goto do_add;
 
 			/*
-			 *	Delete *all* matching attribues.
+			 *	Delete *all* matching attributes.
 			 */
 			fr_pair_delete_by_da(to, found->da);
 			goto do_add;

--- a/src/lib/util/pair_list_perf_test.c
+++ b/src/lib/util/pair_list_perf_test.c
@@ -220,7 +220,7 @@ static void pair_list_init(TALLOC_CTX *ctx, fr_pair_t ***out, fr_dict_t const *d
 		if ((i == 0) && (perc > 0) && (reps > 0)) {
 			fr_pair_t	*new_vp;
 			/*
-			 *  Copy the required number of attributes from the first itteration
+			 *  Copy the required number of attributes from the first iteration
 			 *  to use for duplicating attributes to required percentage.
 			 *  Duplicates are at the beginning of the source list
 			 */
@@ -237,13 +237,13 @@ static void pair_list_init(TALLOC_CTX *ctx, fr_pair_t ***out, fr_dict_t const *d
 
 		if (i == 0) {
 			/*
-			 *  On the first itteration, just move the test pairs to the final list
+			 *  On the first iteration, just move the test pairs to the final list
 			 */
 			fr_pair_list_append(&full_list, &list);
 		} else {
 			/*
-			 *  With subsequent itterations, replicate the duplicates from the first
-			 *  itteration to maintain the percentage of attribute repeats
+			 *  With subsequent iterations, replicate the duplicates from the first
+			 *  iteration to maintain the percentage of attribute repeats
 			 */
 			vp = fr_pair_list_head(&dups);
 			fr_pair_sublist_copy(ctx, &full_list, &dups, vp, 0);

--- a/src/lib/util/pair_tests.c
+++ b/src/lib/util/pair_tests.c
@@ -243,7 +243,7 @@ static void test_fr_pair_raw_from_pair(void)
 	TEST_CASE("Validating PAIR_VERIFY()");
 	PAIR_VERIFY(vp);
 
-	TEST_CASE("Converting regular 'vp' as unkown");
+	TEST_CASE("Converting regular 'vp' as unknown");
 	TEST_CHECK(fr_pair_raw_from_pair(vp, &value, 1) == 0);
 
 	TEST_CASE("Checking if a real 'raw' vp");

--- a/src/lib/util/proto.c
+++ b/src/lib/util/proto.c
@@ -89,7 +89,7 @@ void fr_proto_da_stack_print(char const *file, int line, char const *func, fr_da
 
 /** Implements the default iterator to encode pairs belonging to a specific dictionary that are not internal
  *
- * @param[in] list	to itterate over.
+ * @param[in] list	to iterate over.
  * @param[in] current	The fr_pair_t cursor->current.  Will be advanced and checked to
  *			see if it matches the specified fr_dict_t.
  * @param[in] uctx	The fr_dict_t to search for.

--- a/src/lib/util/rb.h
+++ b/src/lib/util/rb.h
@@ -119,7 +119,7 @@ struct fr_rb_tree_s {
 
 /** Initialises a red black tree
  *
- * This variant initates an #fr_rb_node_t on the heap.  This allows the data structure
+ * This variant initiates an #fr_rb_node_t on the heap.  This allows the data structure
  * to be inserted into multiple trees.
  *
  * @param[out] _tree		to initialise.
@@ -139,7 +139,7 @@ struct fr_rb_tree_s {
 /** Initialises a red black that verifies elements are of a specific talloc type
  *
  * This variant stores #fr_rb_node_t data inline with the data structure to avoid
- * initating #fr_rb_node_t on the heap.
+ * initiating #fr_rb_node_t on the heap.
  *
  * It is suitable for use where the data structure will only be inserted into a
  * fixed set of trees.
@@ -162,7 +162,7 @@ struct fr_rb_tree_s {
 /** Initialises a red black tree
  *
  * This variant stores #fr_rb_node_t data inline with the data structure to avoid
- * initating #fr_rb_node_t on the heap.
+ * initiating #fr_rb_node_t on the heap.
  *
  * It is suitable for use where the data structure will only be inserted into a
  * fixed set of trees.

--- a/src/lib/util/sbuff.c
+++ b/src/lib/util/sbuff.c
@@ -1124,7 +1124,7 @@ fr_slen_t fr_sbuff_out_bool(bool *out, fr_sbuff_t *in)
 	return -1;
 }
 
-/** Used to define a number parsing functions for singed integers
+/** Used to define a number parsing functions for signed integers
  *
  * @param[in] _name	Function suffix.
  * @param[in] _type	Output type.
@@ -1192,7 +1192,7 @@ SBUFF_PARSE_INT_DEF(int32, int32_t, INT32_MIN, INT32_MAX, 11, 0)
 SBUFF_PARSE_INT_DEF(int64, int64_t, INT64_MIN, INT64_MAX, 20, 0)
 SBUFF_PARSE_INT_DEF(ssize, ssize_t, SSIZE_MIN, SSIZE_MAX, 20, 0)
 
-/** Used to define a number parsing functions for singed integers
+/** Used to define a number parsing functions for signed integers
  *
  * @param[in] _name	Function suffix.
  * @param[in] _type	Output type.
@@ -1785,7 +1785,7 @@ size_t fr_sbuff_adv_past_allowed(fr_sbuff_t *sbuff, size_t len, bool
 			*	normally stop at the "-".  However, we will still stop at "Framed-=User", as
 			*	"-=" may be a terminal sequence.
 			*
-			*	There is no perfect solution here, other than to fix the input grammer so that
+			*	There is no perfect solution here, other than to fix the input grammar so that
 			*	it has no ambiguity.  Since we can't do that, we choose to err on the side of
 			*	allowing the existing grammar, where it makes sense
 			*/
@@ -2041,7 +2041,7 @@ char *fr_sbuff_adv_to_strcase(fr_sbuff_t *sbuff, size_t len, char const *needle,
  * @param[in] sbuff	to search for char in.
  * @param[in] c		char to search for.
  * @return
- *	- true and avance if the next character matches.
+ *	- true and advance if the next character matches.
  *	- false and don't advance if the next character doesn't match.
  */
 bool fr_sbuff_next_if_char(fr_sbuff_t *sbuff, char c)
@@ -2062,7 +2062,7 @@ bool fr_sbuff_next_if_char(fr_sbuff_t *sbuff, char c)
  * @param[in] sbuff	to search for char in.
  * @param[in] c		char to search for.
  * @return
- *	- true and avance unless the character matches.
+ *	- true and advance unless the character matches.
  *	- false and don't advance if the next character matches.
  */
 bool fr_sbuff_next_unless_char(fr_sbuff_t *sbuff, char c)

--- a/src/lib/util/sbuff.h
+++ b/src/lib/util/sbuff.h
@@ -578,7 +578,7 @@ size_t	fr_sbuff_shift(fr_sbuff_t *sbuff, size_t shift);
 
 size_t	fr_sbuff_extend_file(fr_sbuff_t *sbuff, size_t extension);
 
-size_t	fr_sbuff_extend_talloc(fr_sbuff_t *sbuff, size_t extenison);
+size_t	fr_sbuff_extend_talloc(fr_sbuff_t *sbuff, size_t extension);
 
 int	fr_sbuff_trim_talloc(fr_sbuff_t *sbuff, size_t len);
 

--- a/src/lib/util/sbuff_tests.c
+++ b/src/lib/util/sbuff_tests.c
@@ -528,7 +528,7 @@ static void test_unescape_until(void)
 	/*
 	 *	Escapes and substitution
 	 */
-	TEST_CASE("Escape with substition to same char");
+	TEST_CASE("Escape with substitution to same char");
 	fr_sbuff_init_in(&sbuff, in_escapes, sizeof(in_escapes) - 1);
 	slen = fr_sbuff_out_unescape_until(&FR_SBUFF_OUT(escape_out, sizeof(escape_out)), &sbuff, SIZE_MAX,
 					   &FR_SBUFF_TERM("g"), &pipe_rules);
@@ -536,7 +536,7 @@ static void test_unescape_until(void)
 	TEST_CHECK_STRCMP(escape_out, "i am a |t|est string");
 	TEST_CHECK_STRCMP(sbuff.p, "");
 
-	TEST_CASE("Escape with substition to different char");
+	TEST_CASE("Escape with substitution to different char");
 	fr_sbuff_init_in(&sbuff, in_escapes, sizeof(in_escapes) - 1);
 	slen = fr_sbuff_out_unescape_until(&FR_SBUFF_OUT(escape_out, sizeof(escape_out)), &sbuff, SIZE_MAX,
 					   &FR_SBUFF_TERM("g"), &pipe_rules_sub);
@@ -1324,7 +1324,7 @@ static void test_adv_to_utf8(void)
 	p = fr_sbuff_adv_to_chr_utf8(&sbuff, SIZE_MAX, "🍆 ");
 	TEST_CHECK(p == NULL);
 
-	TEST_CASE("Check for token at the end of the string within len contraints");
+	TEST_CASE("Check for token at the end of the string within len constraints");
 	fr_sbuff_init_in(&sbuff, in, sizeof(in) - 1);
 	p = fr_sbuff_adv_to_chr_utf8(&sbuff, (sizeof("🥺🥺🥺🥺🍪😀") - 1), "😀");
 	TEST_CHECK(p == sbuff.start + (sizeof("🥺🥺🥺🥺🍪") - 1));

--- a/src/lib/util/sem.c
+++ b/src/lib/util/sem.c
@@ -399,7 +399,7 @@ static bool sem_check_gid(char const *file, int proj_id,
 
 /** Returns a semid for the semaphore associated with the file
  *
- * @param[in] file		to get or create sempahore from.
+ * @param[in] file		to get or create semaphore from.
  * @param[in] proj_id		if 0 will default to '0xf4ee4a31'.
  * @param[in] uid		that should own the semaphore.
  * @param[in] gid		that should own the semaphore.

--- a/src/lib/util/slab.h
+++ b/src/lib/util/slab.h
@@ -15,7 +15,7 @@
  *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-/** Resouce pool management using slabs of memory
+/** Resource pool management using slabs of memory
  *
  * @file src/lib/util/slab.h
  *

--- a/src/lib/util/slab_tests.c
+++ b/src/lib/util/slab_tests.c
@@ -208,7 +208,7 @@ static void test_reuse_reset(void)
 
 	/*
 	 *	Releasing the first element should reset the destructor
-	 *	so releasing this re-use of it will not update the result
+	 *	so releasing this reuse of it will not update the result
 	 *	of the initial release.
 	 */
 	if (test_elements[4]) test_elements[4]->name = talloc_strdup(test_elements[4], "Different length string");
@@ -259,7 +259,7 @@ static void test_reuse_noreset(void)
 	if (test_elements[0] && test_elements[2]) TEST_CHECK(test_elements[2]->name == test_elements[0]->name);
 
 	/*
-	 *	Replace the element's string so that the callback on relase has
+	 *	Replace the element's string so that the callback on release has
 	 *	a different string to work on.
 	 */
 	if (test_elements[2]) talloc_free(test_elements[2]->name);

--- a/src/lib/util/snprintf.c
+++ b/src/lib/util/snprintf.c
@@ -39,7 +39,7 @@
  *	 1.0:
  *		*	supporting must ANSI syntaxic_sugars
  *	 0.0:
- *		*	suppot %s %c %d
+ *		*	support %s %c %d
  *
  * THANKS(for the patches and ideas):
  *		 Miles Bader
@@ -160,7 +160,7 @@ double * ip;
 /*
  * return an ascii representation of the integral part of the number
  * and set fract to be an ascii representation of the fraction part
- * the container for the fraction and the integral part or staticly
+ * the container for the fraction and the integral part or statically
  * declare with fix size
  */
 PRIVATE char *
@@ -339,7 +339,7 @@ char *tmp;
 		i = (i < p->precision ? i : p->precision);
 	p->width -= i;
 	PAD_RIGHT(p);
-	while (i-- > 0) { /* put the sting */
+	while (i-- > 0) { /* put the string */
 		PUT_CHAR(*tmp, p);
 		tmp++;
 	}

--- a/src/lib/util/time.c
+++ b/src/lib/util/time.c
@@ -505,7 +505,7 @@ fr_slen_t fr_time_delta_to_str(fr_sbuff_t *out, fr_time_delta_t delta, fr_time_r
 
 	/*
 	 *	If there's nothing after the decimal point,
-	 *	trunctate the decimal point.  i.e. Don't print
+	 *	truncate the decimal point.  i.e. Don't print
 	 *	"5."
 	 */
 	if (*q == '.') {

--- a/src/lib/util/time.h
+++ b/src/lib/util/time.h
@@ -521,7 +521,7 @@ static inline int64_t fr_unix_time_to_day(fr_unix_time_t delta)
 	return (fr_unix_time_unwrap(delta) / NSEC) / 386400;
 }
 
-/** Covert a time_t into out internal fr_unix_time_t
+/** Convert a time_t into out internal fr_unix_time_t
  *
  * Our internal unix time representation is unsigned and in nanoseconds which
  * is different from time_t which is signed and has seconds resolution.

--- a/src/lib/util/trie.c
+++ b/src/lib/util/trie.c
@@ -558,7 +558,7 @@ static fr_trie_node_t *trie_node_alloc(TALLOC_CTX *ctx, int bits)
 /** Free a fr_trie_t
  *
  *  We can't use talloc_free(), because we can't talloc_parent the
- *  nodes frome each other, as talloc_steal() is O(N).  So, we just
+ *  nodes from each other, as talloc_steal() is O(N).  So, we just
  *  recurse manually.
  */
 static void trie_free(fr_trie_t *trie)
@@ -824,7 +824,7 @@ static CC_HINT(nonnull(2)) fr_trie_node_t *trie_node_split(TALLOC_CTX *ctx, fr_t
 
 	/*
 	 *	Note that we do NOT free "node".  The caller still
-	 *	needs it for some activies.
+	 *	needs it for some activities.
 	 */
 	return split;
 }

--- a/src/lib/util/value.c
+++ b/src/lib/util/value.c
@@ -29,7 +29,7 @@
  *
  * - NETWORK format is the format we send/receive on the wire.  It is not a perfect representation
  *   of data packing for all protocols, so you will likely need to overload conversion for some types.
- *   - fr_value_box_to_network is used to covert INTERNAL format data to generic NETWORK format data.
+ *   - fr_value_box_to_network is used to convert INTERNAL format data to generic NETWORK format data.
  *     For uint32s, IP addresses etc... This means BIG ENDIAN uint8 ordering.
  *   - fr_value_box_from_network is used to convert packet buffer fragments in NETWORK format to
  *     INTERNAL format.
@@ -503,7 +503,7 @@ fr_sbuff_parse_rules_t const value_parse_rules_backtick_unquoted = {
  * data from external data sources like SQL databases and REST APIs.
  *
  * They do not include terminals to stop parsing as it assumes the values
- * are discreet, and not wrapped in quotes.
+ * are discrete, and not wrapped in quotes.
  */
 fr_sbuff_parse_rules_t const *value_parse_rules_unquoted[T_TOKEN_LAST] = {
 	[T_BARE_WORD]			= &value_parse_rules_bareword_unquoted,
@@ -1337,7 +1337,7 @@ size_t fr_value_box_network_length(fr_value_box_t const *value)
  *
  * #FR_TYPE_SIZE is not encodable, as it is system specific.
  *
- * This function will not encode stuctural types (TLVs, VSAs etc...).  These are usually
+ * This function will not encode structural types (TLVs, VSAs etc...).  These are usually
  * specific to the protocol anyway.
  *
  *  All of the dictionary rules are respected.  string/octets can have
@@ -3471,7 +3471,7 @@ int fr_value_box_cast_in_place(TALLOC_CTX *ctx, fr_value_box_t *vb,
 {
 	fr_value_box_t tmp;
 	/*
-	 *	Store list poiters to restore later - fr_value_box_cast clears them
+	 *	Store list pointers to restore later - fr_value_box_cast clears them
 	 */
 	fr_value_box_entry_t entry = vb->entry;
 
@@ -4560,7 +4560,7 @@ void fr_value_box_increment(fr_value_box_t *vb)
  * @param[in] tainted		Whether the value came from a trusted source.
  * @return
  *	- >= 0 on success (number of bytes parsed).
- *	- < 0 on error (where the parse error ocurred).
+ *	- < 0 on error (where the parse error occurred).
  */
 static inline CC_HINT(always_inline)
 fr_slen_t fr_value_box_from_numeric_substr(fr_value_box_t *dst, fr_type_t dst_type,
@@ -5519,7 +5519,7 @@ ssize_t fr_value_box_list_concat_as_string(bool *tainted, bool *secret, fr_sbuff
 
 	/*
 	 *	Free the boxes last so if there's
-	 *	an issue concating them, everything
+	 *	an issue concatenating them, everything
 	 *	is still in a known state.
 	 */
 	fr_value_box_list_foreach_safe(list, vb) {
@@ -5621,7 +5621,7 @@ ssize_t fr_value_box_list_concat_as_octets(bool *tainted, bool *secret, fr_dbuff
 
 	/*
 	 *	Free the boxes last so if there's
-	 *	an issue concating them, everything
+	 *	an issue concatenating them, everything
 	 *	is still in a known state.
 	 */
 	fr_value_box_list_foreach_safe(list, vb) {

--- a/src/lib/util/value.h
+++ b/src/lib/util/value.h
@@ -153,7 +153,7 @@ typedef union {
  *
  * fr_type_t should be an enumeration of the values in this union.
  *
- * Don't change the order of the fields below without checing that the output of radsize doesn't change.
+ * Don't change the order of the fields below without checking that the output of radsize doesn't change.
  */
 struct value_box_s {
 	/** Type and flags should appear together for packing efficiency
@@ -571,7 +571,7 @@ void _fr_value_box_init(NDEBUG_LOCATION_ARGS fr_value_box_t *vb, fr_type_t type,
 
 /** Initialise an empty/null box that will be filled later
  *
- * @param[in] _vb	to initalise.
+ * @param[in] _vb	to initialise.
  */
 #define fr_value_box_init_null(_vb) _fr_value_box_init(NDEBUG_LOCATION_EXP _vb, FR_TYPE_NULL, NULL, false)
 
@@ -910,7 +910,7 @@ DEF_UNBOXING_FUNC(double, float64, FR_TYPE_FLOAT64)
 
 DEF_UNBOXING_FUNC(fr_unix_time_t, date, FR_TYPE_DATE)
 
-/** Unbox simple types peforming type checks
+/** Unbox simple types performing type checks
  *
  * @param[out] _var	to write to.
  * @param[in] _box	to unbox.

--- a/src/listen/bfd/session.h
+++ b/src/listen/bfd/session.h
@@ -26,7 +26,7 @@
 #include "proto_bfd.h"
 
 typedef struct {
-	fr_client_t			client;			//!< might as well re-use this, others need it
+	fr_client_t			client;			//!< might as well reuse this, others need it
 
 	uint16_t			port;			//!< peer port where packets are sent to
 

--- a/src/listen/cron/proto_cron.c
+++ b/src/listen/cron/proto_cron.c
@@ -189,7 +189,7 @@ static ssize_t mod_encode(UNUSED void const *instance, request_t *request, uint8
  *
  * @param[in] instance	Ctx data for this application.
  * @param[in] sc	to add our file descriptor to.
- * @param[in] conf	Listen section parsed to give us isntance.
+ * @param[in] conf	Listen section parsed to give us instance.
  * @return
  *	- 0 on success.
  *	- -1 on failure.

--- a/src/listen/detail/proto_detail.c
+++ b/src/listen/detail/proto_detail.c
@@ -267,7 +267,7 @@ static int mod_decode(void const *instance, request_t *request, uint8_t *const d
 		MPRINT("LINE   :%s", p);
 
 		/*
-		 *	Skip this for backwards compatability.
+		 *	Skip this for backwards compatibility.
 		 */
 		if (strncasecmp((char const *) p, "Request-Authenticator", 21) == 0) goto next;
 
@@ -401,7 +401,7 @@ static int mod_priority_set(void const *instance, UNUSED uint8_t const *buffer, 
  *
  * @param[in] instance	Ctx data for this application.
  * @param[in] sc	to add our file descriptor to.
- * @param[in] conf	Listen section parsed to give us isntance.
+ * @param[in] conf	Listen section parsed to give us instance.
  * @return
  *	- 0 on success.
  *	- -1 on failure.

--- a/src/listen/detail/proto_detail_file.c
+++ b/src/listen/detail/proto_detail_file.c
@@ -466,7 +466,7 @@ static void mod_vnode_delete(fr_event_list_t *el, int fd, UNUSED int fflags, voi
 /** Start processing a new work file
  *
  * @param[in] thread			the thread instance.
- * @param[in] triggered_by_delete	true if this was trigged by a vnode_delete.
+ * @param[in] triggered_by_delete	true if this was triggered by a vnode_delete.
  *					When a new file is moved over a workfile
  *					vnode delete can serve as an indication
  *					that new data is available.

--- a/src/listen/dhcpv4/proto_dhcpv4.c
+++ b/src/listen/dhcpv4/proto_dhcpv4.c
@@ -370,7 +370,7 @@ static int mod_priority_set(void const *instance, uint8_t const *buffer, size_t 
  *
  * @param[in] instance	Ctx data for this application.
  * @param[in] sc	to add our file descriptor to.
- * @param[in] conf	Listen section parsed to give us isntance.
+ * @param[in] conf	Listen section parsed to give us instance.
  * @return
  *	- 0 on success.
  *	- -1 on failure.

--- a/src/listen/dhcpv6/proto_dhcpv6.c
+++ b/src/listen/dhcpv6/proto_dhcpv6.c
@@ -369,7 +369,7 @@ static int mod_priority_set(void const *instance, uint8_t const *buffer, UNUSED 
  *
  * @param[in] instance	Ctx data for this application.
  * @param[in] sc	to add our file descriptor to.
- * @param[in] conf	Listen section parsed to give us isntance.
+ * @param[in] conf	Listen section parsed to give us instance.
  * @return
  *	- 0 on success.
  *	- -1 on failure.

--- a/src/listen/dns/proto_dns.c
+++ b/src/listen/dns/proto_dns.c
@@ -318,7 +318,7 @@ static int mod_priority_set(void const *instance, uint8_t const *buffer, size_t 
  *
  * @param[in] instance	Ctx data for this application.
  * @param[in] sc	to add our file descriptor to.
- * @param[in] conf	Listen section parsed to give us isntance.
+ * @param[in] conf	Listen section parsed to give us instance.
  * @return
  *	- 0 on success.
  *	- -1 on failure.

--- a/src/listen/ldap_sync/persistent_search.h
+++ b/src/listen/ldap_sync/persistent_search.h
@@ -19,7 +19,7 @@
  * $Id$
  *
  * @file persistent_search.h
- * @brief Callback routines for direcories implementing persistent search
+ * @brief Callback routines for directories implementing persistent search
  *
  * @copyright 2022 Network RADIUS SAS (legal@networkradius.com)
  */

--- a/src/listen/ldap_sync/proto_ldap_sync.c
+++ b/src/listen/ldap_sync/proto_ldap_sync.c
@@ -301,13 +301,13 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 	 */
 	if (inst->app_io->common.instantiate &&
 	    (inst->app_io->common.instantiate(MODULE_INST_CTX(inst->io_submodule)) < 0)) {
-		cf_log_err(conf, "Instantation failed for \"%s\"", inst->app_io->common.name);
+		cf_log_err(conf, "Instantiation failed for \"%s\"", inst->app_io->common.name);
 		return -1;
 	}
 
 	/*
 	 *	These configuration items are not printed by default,
-	 *	because normal people shouln't be touching them.
+	 *	because normal people shouldn't be touching them.
 	 */
 	if (!inst->max_packet_size) inst->max_packet_size = inst->app_io->default_message_size;
 	if (!inst->num_messages) inst->num_messages = 2;

--- a/src/listen/ldap_sync/proto_ldap_sync_ldap.c
+++ b/src/listen/ldap_sync/proto_ldap_sync_ldap.c
@@ -272,7 +272,7 @@ finish:
 	(void) fr_event_timer_in(sync, el, &sync->cookie_ev, sync->inst->cookie_interval, ldap_sync_cookie_event, sync);
 }
 
-/** Enque a new cookie store packet
+/** Enqueue a new cookie store packet
  *
  * Create a new internal packet containing the cookie we received from the LDAP server.
  * This allows the administrator to store the cookie and provide it on a future call to
@@ -599,7 +599,7 @@ static int proto_ldap_child_mod_close(fr_listen_t *li)
  *
  *   - Sync Info Message with syncInfoValue of syncIdSet can reference
  *     multiple directory entries.
- *   - Various sync related messages can inculde a new cookie in
+ *   - Various sync related messages can include a new cookie in
  *     addition to their other data.
  */
 static ssize_t proto_ldap_child_mod_read(fr_listen_t *li, UNUSED void **packet_ctx, UNUSED fr_time_t *recv_time_p, UNUSED uint8_t *buffer,

--- a/src/listen/ldap_sync/rfc4533.h
+++ b/src/listen/ldap_sync/rfc4533.h
@@ -19,7 +19,7 @@
  * $Id$
  *
  * @file rfc4533.h
- * @brief Callback routines for direcories implementing RFC 4533
+ * @brief Callback routines for directories implementing RFC 4533
  *
  * @copyright 2022 Network RADIUS SAS (legal@networkradius.com)
  */

--- a/src/listen/load/proto_load.c
+++ b/src/listen/load/proto_load.c
@@ -189,7 +189,7 @@ static ssize_t mod_encode(UNUSED void const *instance, request_t *request, uint8
  *
  * @param[in] instance	Ctx data for this application.
  * @param[in] sc	to add our file descriptor to.
- * @param[in] conf	Listen section parsed to give us isntance.
+ * @param[in] conf	Listen section parsed to give us instance.
  * @return
  *	- 0 on success.
  *	- -1 on failure.

--- a/src/listen/radius/proto_radius_tcp.c
+++ b/src/listen/radius/proto_radius_tcp.c
@@ -370,7 +370,7 @@ static int mod_track_compare(void const *instance, UNUSED void *thread_instance,
 	if (ret != 0) return ret;
 
 	/*
-	 *	Then ordered by code, which is usally the same.
+	 *	Then ordered by code, which is usually the same.
 	 */
 	return (a[0] < b[0]) - (a[0] > b[0]);
 }

--- a/src/listen/vmps/proto_vmps.c
+++ b/src/listen/vmps/proto_vmps.c
@@ -338,7 +338,7 @@ static int mod_priority_set(void const *instance, uint8_t const *buffer, UNUSED 
  *
  * @param[in] instance	Ctx data for this application.
  * @param[in] sc	to add our file descriptor to.
- * @param[in] conf	Listen section parsed to give us isntance.
+ * @param[in] conf	Listen section parsed to give us instance.
  * @return
  *	- 0 on success.
  *	- -1 on failure.

--- a/src/listen/vmps/proto_vmps_udp.c
+++ b/src/listen/vmps/proto_vmps_udp.c
@@ -383,7 +383,7 @@ static int mod_track_compare(UNUSED void const *instance, UNUSED void *thread_in
 	if (ret != 0) return ret;
 
 	/*
-	 *	Then ordered by opcode, which is usally the same.
+	 *	Then ordered by opcode, which is usually the same.
 	 */
 	return (a->opcode < b->opcode) - (a->opcode > b->opcode);
 }

--- a/src/modules/rlm_cache/rlm_cache.h
+++ b/src/modules/rlm_cache/rlm_cache.h
@@ -173,7 +173,7 @@ typedef cache_status_t	(*cache_entry_expire_t)(rlm_cache_config_t const *config,
 						request_t *request, void *handle,
 						fr_value_box_t const *key);
 
-/** Update the ttl of an entry in the cace
+/** Update the ttl of an entry in the cache
  *
  * @note This callback optional. If it's not specified the cache code will expire and
  *	 recreate the entry with a new TTL.

--- a/src/modules/rlm_cipher/rlm_cipher.c
+++ b/src/modules/rlm_cipher/rlm_cipher.c
@@ -239,7 +239,7 @@ static const conf_parser_t module_config[] = {
 	CONF_PARSER_TERMINATOR
 };
 
-/** Calls EVP_get_digestbyname() to covert the digest type
+/** Calls EVP_get_digestbyname() to convert the digest type
  *
  * @param[in] ctx	to allocate data in.
  * @param[out] out	EVP_MD representing the OpenSSL digest type.

--- a/src/modules/rlm_couchbase/couchbase.c
+++ b/src/modules/rlm_couchbase/couchbase.c
@@ -254,7 +254,7 @@ lcb_error_t couchbase_init_connection(lcb_t *instance, const char *host, const c
 lcb_error_t couchbase_server_stats(lcb_t instance, const void *cookie)
 {
 	lcb_error_t error;                         /* couchbase command return */
-	lcb_server_stats_cmd_t cmd;                /* server stats command stuct */
+	lcb_server_stats_cmd_t cmd;                /* server stats command struct */
 	const lcb_server_stats_cmd_t *commands[1]; /* server stats commands array */
 
 	/* init commands */
@@ -288,7 +288,7 @@ lcb_error_t couchbase_server_stats(lcb_t instance, const void *cookie)
 lcb_error_t couchbase_set_key(lcb_t instance, const char *key, const char *document, int expire)
 {
 	lcb_error_t error;                  /* couchbase command return */
-	lcb_store_cmd_t cmd;                /* store command stuct */
+	lcb_store_cmd_t cmd;                /* store command struct */
 	const lcb_store_cmd_t *commands[1]; /* store commands array */
 
 	/* init commands */

--- a/src/modules/rlm_couchbase/mod.c
+++ b/src/modules/rlm_couchbase/mod.c
@@ -17,7 +17,7 @@
 /**
  * $Id$
  *
- * @brief Utillity functions used in the module.
+ * @brief Utility functions used in the module.
  * @file mod.c
  *
  * @author Aaron Hurt (ahurt@anbcs.com)
@@ -195,7 +195,7 @@ void *mod_conn_create(TALLOC_CTX *ctx, void *instance, fr_time_delta_t timeout)
 
 /** Check the health of a connection handle
  *
- * Attempt to determing the state of the Couchbase connection by requesting
+ * Attempt to determine the state of the Couchbase connection by requesting
  * a cluster statistics report.  Mark the connection as failed if the request
  * returns anything other than success.
  *
@@ -238,7 +238,7 @@ int mod_build_attribute_element_map(CONF_SECTION *conf, rlm_couchbase_t *inst)
 {
 	CONF_SECTION *cs;                   /* module config list */
 	CONF_ITEM *ci;                      /* config item */
-	CONF_PAIR *cp;                      /* conig pair */
+	CONF_PAIR *cp;                      /* config pair */
 	const char *attribute, *element;    /* attribute and element names */
 
 	/* find update list */
@@ -854,7 +854,7 @@ int mod_load_client_documents(rlm_couchbase_t *inst, CONF_SECTION *tmpl, CONF_SE
 				cf_section_alloc(NULL, NULL, "client", vkey);
 
 		if (client_map_section(client, map, _get_client_value, cookie->jobj) < 0) {
-			/* free config setion */
+			/* free config section */
 			talloc_free(client);
 			/* set return */
 			retval = -1;
@@ -868,7 +868,7 @@ int mod_load_client_documents(rlm_couchbase_t *inst, CONF_SECTION *tmpl, CONF_SE
 		c = client_afrom_cs(NULL, client, false, 0);
 		if (!c) {
 			ERROR("failed to allocate client");
-			/* free config setion */
+			/* free config section */
 			talloc_free(client);
 			/* set return */
 			retval = -1;

--- a/src/modules/rlm_couchbase/rlm_couchbase.c
+++ b/src/modules/rlm_couchbase/rlm_couchbase.c
@@ -87,7 +87,7 @@ fr_dict_attr_autoload_t rlm_couchbase_dict_attr[] = {
 
 /** Handle authorization requests using Couchbase document data
  *
- * Attempt to fetch the document assocaited with the requested user by
+ * Attempt to fetch the document associated with the requested user by
  * using the deterministic key defined in the configuration.  When a valid
  * document is found it will be parsed and the containing value pairs will be
  * injected into the request.
@@ -434,7 +434,7 @@ static int mod_detach(module_detach_ctx_t const *mctx)
 
 /** Initialize the rlm_couchbase module
  *
- * Intialize the module and create the initial Couchbase connection pool.
+ * Initialize the module and create the initial Couchbase connection pool.
  *
  * @param  mctx     The module instance.
  * @return

--- a/src/modules/rlm_csv/rlm_csv.c
+++ b/src/modules/rlm_csv/rlm_csv.c
@@ -691,7 +691,7 @@ static int mod_bootstrap(module_inst_ctx_t const *mctx)
 		 *	map to which entries.
 		 *
 		 *	Some fields are unused, so there isn't a 1-1
-		 *	mapping betweeen CSV file fields, and fields
+		 *	mapping between CSV file fields, and fields
 		 *	in the map.
 		 */
 		if (last_field && (*p == ',') && (strcmp(p + 1, inst->index_field_name) == 0)) {

--- a/src/modules/rlm_eap/types/rlm_eap_fast/eap_fast.c
+++ b/src/modules/rlm_eap/types/rlm_eap_fast/eap_fast.c
@@ -788,7 +788,7 @@ static fr_radius_packet_code_t eap_fast_crypto_binding(request_t *request, UNUSE
 
 	fr_hmac_sha1(binding->compound_mac, (uint8_t *)binding, sizeof(*binding), t->cmk, EAP_FAST_CMK_LEN);
 	if (memcmp(binding->compound_mac, cmac, sizeof(cmac))) {
-		RDEBUG2("Crypto-Binding TLV mis-match");
+		RDEBUG2("Crypto-Binding TLV mismatch");
 		RHEXDUMP3((uint8_t const *) binding->compound_mac,
                 sizeof(binding->compound_mac), "Calculated Compound MAC");
 		return FR_RADIUS_CODE_ACCESS_REJECT;

--- a/src/modules/rlm_eap/types/rlm_eap_peap/rlm_eap_peap.c
+++ b/src/modules/rlm_eap/types/rlm_eap_peap/rlm_eap_peap.c
@@ -163,7 +163,7 @@ static unlang_action_t mod_handshake_resume(rlm_rcode_t *p_result, module_ctx_t 
 	case EAP_TLS_RECORD_RECV_COMPLETE:
                 /*
                  *     TLSv1.3 makes application data immediately
-                 *     avaliable when the handshake is finished.
+                 *     available when the handshake is finished.
                  */
 		if (SSL_is_init_finished(tls_session->ssl) && (peap->status == PEAP_STATUS_INVALID)) {
 			peap->status = PEAP_STATUS_TUNNEL_ESTABLISHED;

--- a/src/modules/rlm_eap/types/rlm_eap_pwd/eap_pwd.c
+++ b/src/modules/rlm_eap/types/rlm_eap_pwd/eap_pwd.c
@@ -464,7 +464,7 @@ int compute_password_element (request_t *request, pwd_session_t *session, uint16
 	}
 
 	/*
-	* now we can savely construct PWE
+	* now we can safely construct PWE
 	*/
 	BN_bin2bn(xbuf, primebytelen, x_candidate);
 	do_equation(session->group, y_sqrd, x_candidate, bnctx);

--- a/src/modules/rlm_eap/types/rlm_eap_tls/rlm_eap_tls.c
+++ b/src/modules/rlm_eap/types/rlm_eap_tls/rlm_eap_tls.c
@@ -145,7 +145,7 @@ static unlang_action_t mod_handshake_resume(rlm_rcode_t *p_result, module_ctx_t 
 	 *	Anything else: fail.
 	 *
 	 *	Also, remove the session from the cache so that
-	 *	the client can't re-use it.
+	 *	the client can't reuse it.
 	 */
 	default:
 		fr_tls_cache_deny(request, tls_session);

--- a/src/modules/rlm_idn/rlm_idn.c
+++ b/src/modules/rlm_idn/rlm_idn.c
@@ -71,7 +71,7 @@ static const conf_parser_t mod_config[] = {
 	 *	...and if we want raw punycode or to tweak Bootstring parameters,
 	 *	we can do similar things.  All defaults should result in IDNA
 	 *	ToASCII with the use_std3_ascii_rules flag set, allow_unassigned unset,
-	 *	because that is the forseeable use case.
+	 *	because that is the foreseeable use case.
 	 *
 	 *	Note that doing anything much different will require choosing the
 	 *	appropriate libidn API functions, as we currently call the IDNA

--- a/src/modules/rlm_imap/rlm_imap.c
+++ b/src/modules/rlm_imap/rlm_imap.c
@@ -58,7 +58,7 @@ typedef struct {
 	char const			*uri;		//!< URI of imap server
 	fr_time_delta_t 		timeout;	//!< Timeout for connection and server response
 	fr_curl_tls_t			tls;
-	fr_curl_conn_config_t		conn_config;	//!< Re-usable CURL handle config
+	fr_curl_conn_config_t		conn_config;	//!< Reusable CURL handle config
 } rlm_imap_t;
 
 FR_SLAB_TYPES(imap, fr_curl_io_request_t)
@@ -146,7 +146,7 @@ static unlang_action_t CC_HINT(nonnull) mod_authenticate_resume(rlm_rcode_t *p_r
  *		timeout information
  *		and TLS information
  *
- *	Then it queues the request and yeilds until a response is given
+ *	Then it queues the request and yields until a response is given
  *	When it responds, mod_authenticate_resume is called.
  */
 static unlang_action_t CC_HINT(nonnull(1,2)) mod_authenticate(rlm_rcode_t *p_result, module_ctx_t const *mctx, request_t *request)

--- a/src/modules/rlm_isc_dhcp/rlm_isc_dhcp.c
+++ b/src/modules/rlm_isc_dhcp/rlm_isc_dhcp.c
@@ -1560,7 +1560,7 @@ static int parse_subnet(rlm_isc_dhcp_tokenizer_t *state, rlm_isc_dhcp_info_t *in
 		rlm_isc_dhcp_info_t *old;
 
 		/*
-		 *	Duplicate or overlapping "subnet" entries aren't allowd.
+		 *	Duplicate or overlapping "subnet" entries aren't allowed.
 		 */
 		old = fr_trie_lookup_by_key(parent->subnets, &(info->argv[0]->vb_ipv4addr), bits);
 		if (old) {

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -1326,7 +1326,7 @@ static unlang_action_t mod_authenticate_resume(rlm_rcode_t *p_result, UNUSED int
 #ifdef WITH_SASL
 		ldap_auth_call_env_t *call_env = auth_ctx->call_env;
 
-		RDEBUG2("Login attept using identity \"%pV\"", &call_env->user_sasl_authname);
+		RDEBUG2("Login attempt using identity \"%pV\"", &call_env->user_sasl_authname);
 
 		return fr_ldap_sasl_bind_auth_async(request, auth_ctx->thread, call_env->user_sasl_mech.vb_strvalue,
 						 call_env->user_sasl_authname.vb_strvalue,
@@ -1394,7 +1394,7 @@ static unlang_action_t CC_HINT(nonnull) mod_authenticate(rlm_rcode_t *p_result, 
 	};
 
 	/*
-	 *	Check for a cahed copy of the DN
+	 *	Check for a cached copy of the DN
 	 */
 	auth_ctx->dn = rlm_find_user_dn_cached(request);
 
@@ -1425,15 +1425,15 @@ static unlang_action_t mod_authorize_start(UNUSED rlm_rcode_t *p_result, UNUSED 
 
 /** Resume function called after each potential yield in LDAP authorization
  *
- * Some operations may or may not yeild.  E.g. if group membership is
+ * Some operations may or may not yield.  E.g. if group membership is
  * read from an attribute returned with the user object and is already
- * in the correct form, that will not yeild.
+ * in the correct form, that will not yield.
  * Hence, each state may fall through to the next.
  *
  * @param p_result	Result of current authorization.
  * @param priority	Unused.
  * @param request	Current request.
- * @param uctx		Current authrorization context.
+ * @param uctx		Current authorization context.
  * @return One of the RLM_MODULE_* values.
  */
 static unlang_action_t mod_authorize_resume(rlm_rcode_t *p_result, UNUSED int *priority, request_t *request, void *uctx)
@@ -1531,7 +1531,7 @@ static unlang_action_t mod_authorize_resume(rlm_rcode_t *p_result, UNUSED int *p
 			autz_ctx->dn = rlm_find_user_dn_cached(request);
 
 			/*
-			 *	Retrive universal password
+			 *	Retrieve universal password
 			 */
 			REPEAT_MOD_AUTHORIZE_RESUME;
 			autz_ctx->status = LDAP_AUTZ_EDIR_BIND;
@@ -1848,7 +1848,7 @@ static unlang_action_t user_modify_resume(rlm_rcode_t *p_result, UNUSED int *pri
 
 /** Modify user's object in LDAP
  *
- * Process a modifcation map to update a user object in the LDAP directory.
+ * Process a modification map to update a user object in the LDAP directory.
  *
  * @param[out] p_result		the result of the modification.
  * @param[in] inst		rlm_ldap instance.

--- a/src/modules/rlm_linelog/rlm_linelog.c
+++ b/src/modules/rlm_linelog/rlm_linelog.c
@@ -902,7 +902,7 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 
 	case LINELOG_DST_UNIX:
 #ifndef HAVE_SYS_UN_H
-		cf_log_err(conf, "Unix sockets are not supported on this sytem");
+		cf_log_err(conf, "Unix sockets are not supported on this system");
 		return -1;
 #else
 		inst->pool = module_rlm_connection_pool_init(cf_section_find(conf, "unix", NULL),

--- a/src/modules/rlm_logtee/rlm_logtee.c
+++ b/src/modules/rlm_logtee/rlm_logtee.c
@@ -500,7 +500,7 @@ static void logtee_it(fr_log_type_t type, fr_log_lvl_t lvl, request_t *request,
 
 finish:
 	/*
-	 *	Don't free, we re-use the fr_pair_ts for the next message
+	 *	Don't free, we reuse the fr_pair_ts for the next message
 	 */
 	vp = fr_dcursor_remove(&cursor);
 	if (!fr_cond_assert(vp == t->lvl)) fr_dcursor_append(&cursor, vp);
@@ -630,7 +630,7 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 
 	case LOGTEE_DST_UNIX:
 #ifndef HAVE_SYS_UN_H
-		cf_log_err(conf, "Unix sockets are not supported on this sytem");
+		cf_log_err(conf, "Unix sockets are not supported on this system");
 		return -1;
 #endif
 

--- a/src/modules/rlm_ocsp/ocsp.c
+++ b/src/modules/rlm_ocsp/ocsp.c
@@ -61,7 +61,7 @@ typedef enum {
 
 DIAG_OFF(DIAG_UNKNOWN_PRAGMAS)
 DIAG_OFF(used-but-marked-unused)	/* fix spurious warnings for sk macros */
-/** Extract components of OCSP responser URL from a certificate
+/** Extract components of OCSP responder URL from a certificate
  *
  * @param[in] cert to extract URL from.
  * @param[out] host_out Portion of the URL (must be freed with free()).

--- a/src/modules/rlm_perl/rlm_perl.c
+++ b/src/modules/rlm_perl/rlm_perl.c
@@ -175,7 +175,7 @@ static void rlm_perl_close_handles(void **handles)
 
 /*
  *	This is wrapper for fr_log
- *	Now users can call radiusd::log(level,msg) wich is the same
+ *	Now users can call radiusd::log(level,msg) which is the same
  *	as calling fr_log from C code.
  */
 static XS(XS_radiusd_log)
@@ -200,7 +200,7 @@ static XS(XS_radiusd_log)
 }
 
 /*
- *	This is a wraper for xlat_aeval
+ *	This is a wrapper for xlat_aeval
  *	Now users are able to get data that is accessible only via xlat
  *	e.g. %client(...)
  *	Call syntax is radiusd::xlat(string), string will be handled the
@@ -990,7 +990,7 @@ static int mod_thread_detach(module_thread_inst_ctx_t const *mctx)
  *	that must be referenced in later calls, store a handle to it
  *	in *instance otherwise put a null pointer there.
  *
- *	Setup a hashes wich we will use later
+ *	Setup a hashes which we will use later
  *	parse a module and give it a chance to live
  *
  */
@@ -1028,7 +1028,7 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 	 *	Allocate a new perl interpreter to do the parsing
 	 */
 	if ((inst->perl = perl_alloc()) == NULL) {
-		ERROR("No memory for allocating new perl interpretor!");
+		ERROR("No memory for allocating new perl interpreter!");
 		return -1;
 	}
 	perl_construct(inst->perl);	/* ...and initialise it */

--- a/src/modules/rlm_radius/rlm_radius.c
+++ b/src/modules/rlm_radius/rlm_radius.c
@@ -250,7 +250,7 @@ static int status_check_type_parse(UNUSED TALLOC_CTX *ctx, void *out, UNUSED voi
 	code = type_enum->value->vb_uint32;
 
 	/*
-	 *	Cheat, and re-use the "type" array for allowed packet
+	 *	Cheat, and reuse the "type" array for allowed packet
 	 *	types.
 	 */
 	if (!code ||

--- a/src/modules/rlm_radius/rlm_radius_udp.c
+++ b/src/modules/rlm_radius/rlm_radius_udp.c
@@ -312,7 +312,7 @@ static void udp_request_reset(udp_request_t *u)
 	u->can_retransmit = false;
 }
 
-/** Reset a status_check packet, ready to re-use
+/** Reset a status_check packet, ready to reuse
  *
  */
 static void status_check_reset(udp_handle_t *h, udp_request_t *u)
@@ -1794,7 +1794,7 @@ static void request_mux(fr_event_list_t *el,
 		 *	packet, then u->rr MUST already have been
 		 *	deleted in the request_cancel() function
 		 *	or request_release_conn() function when
-		 *	the REQUEUE signal was recevied.
+		 *	the REQUEUE signal was received.
 		 */
 		if (!u->packet || !u->can_retransmit) {
 			fr_assert(!u->rr);

--- a/src/modules/rlm_radius/test_plan.adoc
+++ b/src/modules/rlm_radius/test_plan.adoc
@@ -142,7 +142,7 @@ incoming RADIUS packets.
 
 Platforms:: MacOS, Linux, FreeBSD
 
-Rationale:: As there are no ACKs required this tests mesures the rate at which rlm_radius + transport can send
+Rationale:: As there are no ACKs required this tests measures the rate at which rlm_radius + transport can send
 packets. On Linux and FreeBSD we'd expect an exceptionally high packet rate in this mode as we coalesce multiple
 outbound packets and send them using single system call
 (`sendmmsg` for datagrams, and aggregated buffers + `write` for streams).
@@ -380,10 +380,10 @@ You will need to use different subrequest types to produce the different packet 
 ** Verify No Message-Authenticator attribute is present
 * Send a <<CoA-Request>>
 ** Verify packet is well formed.
-** Verify Message-Authenticator attribue is present.
+** Verify Message-Authenticator attribute is present.
 * Send a <<Disconnect-Request>>
 ** Verify packet is well formed.
-** Verify Message-Authenticator attribue is present.
+** Verify Message-Authenticator attribute is present.
 
 === 3.2. Outbound packet buffer overrun
 

--- a/src/modules/rlm_radutmp/rlm_radutmp.c
+++ b/src/modules/rlm_radutmp/rlm_radutmp.c
@@ -151,7 +151,7 @@ static unlang_action_t radutmp_zap(rlm_rcode_t *p_result, request_t *request, ch
 			RETURN_MODULE_FAIL;
 		}
 	}
-	close(fd);	/* and implicitely release the locks */
+	close(fd);	/* and implicitly release the locks */
 
 	RETURN_MODULE_OK;
 }
@@ -550,7 +550,7 @@ static unlang_action_t CC_HINT(nonnull) mod_accounting(rlm_rcode_t *p_result, mo
 	talloc_free(filename);
 
 	if (fd > -1) {
-		close(fd);	/* and implicitely release the locks */
+		close(fd);	/* and implicitly release the locks */
 	}
 
 	RETURN_MODULE_RCODE(rcode);

--- a/src/modules/rlm_redis_ippool/rlm_redis_ippool.c
+++ b/src/modules/rlm_redis_ippool/rlm_redis_ippool.c
@@ -530,7 +530,7 @@ static void ippool_action_print(request_t *request, ippool_action_t action,
 
 	/*
 	 *	Ordering is important, needs to be LIFO
-	 *	for proper talloc pool re-use.
+	 *	for proper talloc pool reuse.
 	 */
 	talloc_free(device_str);
 	talloc_free(gateway_str);

--- a/src/modules/rlm_rest/rlm_rest.c
+++ b/src/modules/rlm_rest/rlm_rest.c
@@ -467,7 +467,7 @@ static xlat_action_t rest_xlat(UNUSED TALLOC_CTX *ctx, UNUSED fr_dcursor_t *out,
 	if (!randle) return XLAT_ACTION_FAIL;
 
 	/*
-	 *	Walk the incomming boxes, assessing where each is in the URI,
+	 *	Walk the incoming boxes, assessing where each is in the URI,
 	 *	escaping tainted ones where needed.  Following each space in the
 	 *	input a new VB group is started.
 	 */

--- a/src/modules/rlm_sigtran/event.c
+++ b/src/modules/rlm_sigtran/event.c
@@ -176,7 +176,7 @@ static int sigtran_m3ua_route_from_conf(UNUSED TALLOC_CTX *ctx,
  *
  * @note The final version needs to be much more complex.  We can only have one
  *	event loop per instance of rlm_sigtran, so we need to record link references
- *	and re-use existing SCTP/MTP3 connections where appropriate.
+ *	and reuse existing SCTP/MTP3 connections where appropriate.
  *
  * @param[in] ctx	to allocate connection data in.
  * @param[out] out	where to write the new sigtran connection.

--- a/src/modules/rlm_sigtran/libosmo-m3ua/bss_patch.c
+++ b/src/modules/rlm_sigtran/libosmo-m3ua/bss_patch.c
@@ -392,7 +392,7 @@ void bss_rewrite_header_for_msc(int rc, struct msgb *target, struct msgb *inpt, 
 	}
 }
 
-/* it is asssumed that the SCCP stack checked the size */
+/* it is assumed that the SCCP stack checked the size */
 static int patch_address(uint32_t offset, int pc, struct msgb *msg)
 {
 	struct sccp_called_party_address *party;

--- a/src/modules/rlm_sigtran/libosmo-m3ua/counter.c
+++ b/src/modules/rlm_sigtran/libosmo-m3ua/counter.c
@@ -37,7 +37,7 @@ static const struct rate_ctr_desc mtp_lset_cfg_description[] = {
 static const struct rate_ctr_desc mtp_link_cfg_description[] = {
 	[MTP_LNK_IN]		= { "total.in",       "Messages in        "},
 	[MTP_LNK_OUT]		= { "total.out",      "Messages out       "},
-	[MTP_LNK_ERROR]		= { "total.error",    "Errors occured     "},
+	[MTP_LNK_ERROR]		= { "total.error",    "Errors occurred    "},
 	[MTP_LNK_DRP]		= { "total.dropped",  "Messages dropped   "},
 	[MTP_LNK_SLTM_TOUT]	= { "sltm.timeouts",  "SLTM timeouts      "},
 };

--- a/src/modules/rlm_sigtran/libosmo-m3ua/debug.c
+++ b/src/modules/rlm_sigtran/libosmo-m3ua/debug.c
@@ -26,7 +26,7 @@
 static const struct log_info_cat default_categories[] = {
 	[DINP] = {
 		.name = "DINP",
-		.description = "A-bis Intput Subsystem",
+		.description = "A-bis Input Subsystem",
 		.enabled = 1, .loglevel = LOGL_NOTICE,
 	},
 	[DSCCP] = {

--- a/src/modules/rlm_sigtran/libosmo-m3ua/include/msc_connection.h
+++ b/src/modules/rlm_sigtran/libosmo-m3ua/include/msc_connection.h
@@ -65,7 +65,7 @@ struct msc_connection {
 	struct osmo_timer_list ping_timeout;
 	struct osmo_timer_list pong_timeout;
 
-	/* mgcp messgaes */
+	/* mgcp messages */
 	struct mgcp_callagent mgcp_agent;
 
 	/* application pointer */

--- a/src/modules/rlm_sigtran/libosmo-m3ua/include/sctp_m3ua.h
+++ b/src/modules/rlm_sigtran/libosmo-m3ua/include/sctp_m3ua.h
@@ -1,5 +1,5 @@
 /*
- * Represet M3UA client (and later server) links
+ * Represent M3UA client (and later server) links
  */
 #pragma once
 

--- a/src/modules/rlm_sigtran/libosmo-m3ua/include/ss7_application.h
+++ b/src/modules/rlm_sigtran/libosmo-m3ua/include/ss7_application.h
@@ -84,7 +84,7 @@ struct ss7_application {
 
 	/* various hacks/quirks to deal with broken equipment */
 	/*
-	 * Some equipments do not look into the codec list but only the
+	 * Some equipment do not look into the codec list but only the
 	 * size of it.
 	 */
 	unsigned fixed_ass_cmpl_reply : 1;

--- a/src/modules/rlm_sigtran/libosmo-m3ua/ipaccess.c
+++ b/src/modules/rlm_sigtran/libosmo-m3ua/ipaccess.c
@@ -117,7 +117,7 @@ struct msgb *ipaccess_read_msg(struct osmo_fd *bfd, int *error)
 
 	msgb_put(msg, ret);
 
-	/* then read te length as specified in header */
+	/* then read the length as specified in header */
 	msg->l2h = msg->data + sizeof(*hh);
 	len = ntohs(hh->len);
 	ret = recv(bfd->fd, msg->l2h, len, 0);

--- a/src/modules/rlm_sigtran/libosmo-m3ua/link_udp.c
+++ b/src/modules/rlm_sigtran/libosmo-m3ua/link_udp.c
@@ -132,7 +132,7 @@ static int udp_read_cb(struct osmo_fd *fd)
 		mtp_link_failure(link);
 		goto exit;
 	} else if (hdr->data_type > UDP_DATA_MSU_PRIO_3) {
-		LOGP(DINP, LOGL_ERROR, "Link failue on %d/%s of %d/%s.\n",
+		LOGP(DINP, LOGL_ERROR, "Link failure on %d/%s of %d/%s.\n",
 		     link->nr, link->name, link->set->nr, link->set->name);
 		mtp_link_failure(link);
 		goto exit;

--- a/src/modules/rlm_sigtran/libosmo-m3ua/links.c
+++ b/src/modules/rlm_sigtran/libosmo-m3ua/links.c
@@ -52,7 +52,7 @@ void mtp_link_down(struct mtp_link *link)
 	link->was_up = 0;
 	one_up = is_one_up(link->set);
 
-	/* our linkset is now unsuable */
+	/* our linkset is now unusable */
 	if (was_up && !one_up)
 		mtp_linkset_down(link->set);
 	link->clear_queue(link);

--- a/src/modules/rlm_sigtran/libosmo-m3ua/mtp_layer3.c
+++ b/src/modules/rlm_sigtran/libosmo-m3ua/mtp_layer3.c
@@ -174,7 +174,7 @@ static struct msgb *mtp_sccp_alloc_scmg(struct mtp_link_set *set,
 	/* this appears to be round robin or such.. */
 	hdr->addr = MTP_ADDR(sls % 16, set->dpc, set->sccp_opc);
 
-	/* generate the UDT message... libsccp does not offer formating yet */
+	/* generate the UDT message... libsccp does not offer formatting yet */
 	udt = (struct sccp_data_unitdata *) msgb_put(out, sizeof(*udt));
 	udt->type = SCCP_MSG_TYPE_UDT;
 	udt->proto_class = SCCP_PROTOCOL_CLASS_0;

--- a/src/modules/rlm_sigtran/libosmo-m3ua/sccp_state.c
+++ b/src/modules/rlm_sigtran/libosmo-m3ua/sccp_state.c
@@ -142,7 +142,7 @@ static void handle_local_sccp(struct mtp_link_set *set, struct msgb *inpt, struc
 		struct sccp_connection_request *cr;
 		struct msgb *msg;
 
-		LOGP(DINP, LOGL_NOTICE, "Handling CR localy.\n");
+		LOGP(DINP, LOGL_NOTICE, "Handling CR locally.\n");
 		cr = (struct sccp_connection_request *) inpt->l2h;
 		msg = create_sccp_refuse(&cr->source_local_reference);
 		if (msg) {

--- a/src/modules/rlm_sigtran/libosmo-m3ua/ss7_application.c
+++ b/src/modules/rlm_sigtran/libosmo-m3ua/ss7_application.c
@@ -182,7 +182,7 @@ static int ss7_app_setup_stp(struct ss7_application *app,
 		return -1;
 	}
 
-	/* veryify the MTP Linkset */
+	/* verify the MTP Linkset */
 	src = mtp_link_set_num(app->bsc, src_num);
 	if (!src) {
 		LOGP(DINP, LOGL_ERROR,
@@ -199,11 +199,11 @@ static int ss7_app_setup_stp(struct ss7_application *app,
 		return -3;
 	}
 
-	/* veryify the MTP Linkset */
+	/* verify the MTP Linkset */
 	dst = mtp_link_set_num(app->bsc, dst_num);
 	if (!dst) {
 		LOGP(DINP, LOGL_ERROR,
-		     "SS7 %d/%s destionation linkset not found with nr: %d.\n",
+		     "SS7 %d/%s destination linkset not found with nr: %d.\n",
 		     app->nr, app->name, dst_num);
 		return -2;
 	}
@@ -257,7 +257,7 @@ static int ss7_app_setup_relay(struct ss7_application *app, int type,
 		return -1;
 	}
 
-	/* veryify the MTP Linkset */
+	/* verify the MTP Linkset */
 	mtp = mtp_link_set_num(app->bsc, src_num);
 	if (!mtp) {
 		LOGP(DINP, LOGL_ERROR,

--- a/src/modules/rlm_smtp/rlm_smtp.c
+++ b/src/modules/rlm_smtp/rlm_smtp.c
@@ -103,7 +103,7 @@ typedef struct {
 	header_list_t		header_list;		//!< List of SMTP headers to add to emails.
 	bool 			set_date;
 
-	fr_curl_conn_config_t	conn_config;		//!< Re-usable CURL handle config
+	fr_curl_conn_config_t	conn_config;		//!< Reusable CURL handle config
 } rlm_smtp_t;
 
 /*
@@ -771,7 +771,7 @@ static unlang_action_t smtp_io_module_resume(rlm_rcode_t *p_result, module_ctx_t
  *		Email header and body
  *		File attachments
  *
- *	Then it queues the request and yeilds until a response is given
+ *	Then it queues the request and yields until a response is given
  *	When it responds, smtp_io_module_resume is called.
  */
 static unlang_action_t CC_HINT(nonnull) mod_mail(rlm_rcode_t *p_result, module_ctx_t const *mctx, request_t *request)

--- a/src/modules/rlm_sql/drivers/rlm_sql_cassandra/rlm_sql_cassandra.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_cassandra/rlm_sql_cassandra.c
@@ -687,7 +687,7 @@ static sql_rcode_t sql_finish_query(rlm_sql_handle_t *handle, rlm_sql_config_t c
 
 	/*
 	 *	Clear our local log buffer, and free any messages which weren't
-	 *	reconfiged (so we don't leak memory).
+	 *	reconfigured (so we don't leak memory).
 	 */
 	talloc_free_children(conn->log_ctx);
 	memset(&conn->last_error, 0, sizeof(conn->last_error));

--- a/src/modules/rlm_sql/drivers/rlm_sql_db2/rlm_sql_db2.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_db2/rlm_sql_db2.c
@@ -77,7 +77,7 @@ static sql_rcode_t sql_socket_init(rlm_sql_handle_t *handle, rlm_sql_config_t co
 
 	/* Set the connection timeout */
 #if 0
-	/* Not suported ? */
+	/* Not supported ? */
 	SQLSetConnectAttr(conn->dbc_handle, SQL_ATTR_LOGIN_TIMEOUT, &timeout_ms, SQL_IS_UINTEGER);
 #endif
 

--- a/src/modules/rlm_sql/drivers/rlm_sql_firebird/rlm_sql_firebird.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_firebird/rlm_sql_firebird.c
@@ -102,7 +102,7 @@ static sql_rcode_t sql_query(rlm_sql_handle_t *handle, UNUSED rlm_sql_config_t c
 
 	try_again:
 	/*
-	 *	Try again query when deadlock, beacuse in any case it
+	 *	Try again query when deadlock, because in any case it
 	 *	will be retried.
 	 */
 	if (fb_sql_query(conn, query)) {

--- a/src/modules/rlm_sql/drivers/rlm_sql_sqlite/rlm_sql_sqlite.c
+++ b/src/modules/rlm_sql/drivers/rlm_sql_sqlite/rlm_sql_sqlite.c
@@ -164,7 +164,7 @@ static sql_rcode_t sql_check_error(sqlite3 *db, int status)
  *
  * @param db handle to extract error from (may be NULL).
  * @param status to check (if unused, set to SQLITE_OK).
- * @param fmt to preprend.
+ * @param fmt to prepend.
  * @param ... arguments to fmt.
  */
 static void sql_print_error(sqlite3 *db, int status, char const *fmt, ...)
@@ -546,7 +546,7 @@ static sql_rcode_t sql_fetch_row(rlm_sql_row_t *out, rlm_sql_handle_t *handle, r
 	TALLOC_FREE(handle->row);
 
 	/*
-	 *	Executes the SQLite query and interates over the results
+	 *	Executes the SQLite query and iterates over the results
 	 */
 	status = sqlite3_step(conn->statement);
 

--- a/src/modules/rlm_sqlippool/rlm_sqlippool.c
+++ b/src/modules/rlm_sqlippool/rlm_sqlippool.c
@@ -810,7 +810,7 @@ static unlang_action_t CC_HINT(nonnull) mod_mark(rlm_rcode_t *p_result, module_c
 }
 
 /*
- *	Check Accounting packets for their accoutning status
+ *	Check Accounting packets for their accounting status
  *	Call the relevant module based on the status
  */
 static unlang_action_t CC_HINT(nonnull) mod_accounting(rlm_rcode_t *p_result, module_ctx_t const *mctx, request_t *request)

--- a/src/modules/rlm_totp/totp.c
+++ b/src/modules/rlm_totp/totp.c
@@ -98,7 +98,7 @@ int fr_totp_cmp(fr_totp_t const *cfg, request_t *request, time_t now, uint8_t co
 	 *	First try to authenticate against the current OTP, then step
 	 *	back in increments of BACK_STEP_SECS, up to BACK_STEPS times,
 	 *	to authenticate properly in cases of long transit delay, as
-	 *	described in RFC 6238, secion 5.2.
+	 *	described in RFC 6238, section 5.2.
 	 */
 
 	for (i = 0, then = now; i <= cfg->lookback_steps; i++, then -= cfg->lookback_steps) {

--- a/src/modules/rlm_unbound/rlm_unbound.5
+++ b/src/modules/rlm_unbound/rlm_unbound.5
@@ -52,7 +52,7 @@ Performs a PTR lookup for the owner.
 Performs an MX lookup for the owner, returning just the first result.
 .PP
 .SH CAVEATS
-Logging from rlm_unbound can be problematic, especialy if more than one
+Logging from rlm_unbound can be problematic, especially if more than one
 instantiation of the module is used.  This is due to the need for additional
 features in the underlying libunbound which hopefully will be enhanced over
 time.

--- a/src/modules/rlm_unbound/rlm_unbound.c
+++ b/src/modules/rlm_unbound/rlm_unbound.c
@@ -462,7 +462,7 @@ static int mod_thread_instantiate(module_thread_inst_ctx_t const *mctx)
 	/*
 	 *	The unbound context needs to be "finalised" to fix its settings.
 	 *	The API does not expose a method to do this, rather it happens on first
-	 *	use.  A quick workround is to delete data which won't be present
+	 *	use.  A quick workaround is to delete data which won't be present
 	 */
 	ub_ctx_data_remove(t->ev_b->ub, "notar33lsite.foo123.nottld A 127.0.0.1");
 

--- a/src/protocols/dhcpv4/raw.c
+++ b/src/protocols/dhcpv4/raw.c
@@ -53,7 +53,7 @@
  * @param[in] ifindex		of the interface we're binding to.
  * @return
  *	- >= 0 a file descriptor to read/write packets on.
- *	- <0 an error ocurred.
+ *	- <0 an error occurred.
  */
 int fr_dhcpv4_raw_socket_open(struct sockaddr_ll *link_layer, int ifindex)
 {
@@ -206,7 +206,7 @@ fr_radius_packet_t *fr_dhcpv4_raw_packet_recv(int sockfd, struct sockaddr_ll *li
 	sock_len = sizeof(struct sockaddr_ll);
 	data_len = recvfrom(sockfd, raw_packet, MAX_PACKET_SIZE, 0, (struct sockaddr *)link_layer, &sock_len);
 
-	data_offset = ETH_HDR_SIZE + IP_HDR_SIZE + UDP_HDR_SIZE; /* DHCP data datas after Ethernet, IP, UDP */
+	data_offset = ETH_HDR_SIZE + IP_HDR_SIZE + UDP_HDR_SIZE; /* DHCP data after Ethernet, IP, UDP */
 
 	if (data_len <= data_offset) DISCARD_RP("Payload (%d) smaller than required for layers 2+3+4", (int)data_len);
 

--- a/src/protocols/ethernet/ethernet.h
+++ b/src/protocols/ethernet/ethernet.h
@@ -47,7 +47,7 @@
  */
 #define VLAN_VID_UNPACK(_vlan)		((htons((_vlan)->tag_control) & 0x0fff))
 
-/** Pack the PCP (Priority Code Point) DEI (Drop Eligable Indicator) and VID (VLAN ID)
+/** Pack the PCP (Priority Code Point) DEI (Drop Eligible Indicator) and VID (VLAN ID)
  *
  * Packs the PCP, DEI and VID into the TCI (Tag control information). Output will be a 16bit integer
  * in network byte order.

--- a/src/protocols/internal/decode.c
+++ b/src/protocols/internal/decode.c
@@ -369,7 +369,7 @@ ssize_t fr_internal_decode_pair_dbuff(TALLOC_CTX *ctx, fr_pair_list_t *out, fr_d
  * @param out		list to append pairs to
  * @param parent	attribute within which which to decode
  * @param dbuff		to parse
- * @param decode_ctx	to pass to decoder funtion
+ * @param decode_ctx	to pass to decoder function
  * @return
  *	- bytes of dbuff consumed
  *	- < 0 on error

--- a/src/protocols/radius/abinary.c
+++ b/src/protocols/radius/abinary.c
@@ -218,7 +218,7 @@ typedef struct {
  *	value:		A value to compare against the masked bits at
  *			offset in a users packet.
  *
- *	compNeq:	Defines type of comarison (Equal or Notequal)
+ *	compNeq:	Defines type of comparison (Equal or Notequal)
  *			default is Equal.
  *
  *	fill:		Round things out to a dword boundary

--- a/src/protocols/radius/base.c
+++ b/src/protocols/radius/base.c
@@ -456,7 +456,7 @@ bool fr_radius_ok(uint8_t const *packet, size_t *packet_len_p,
 
 	/*
 	 *	Code of 0 is not understood.
-	 *	Code of 16 or greate is not understood.
+	 *	Code of 16 or greater is not understood.
 	 */
 	if ((packet[0] == 0) ||
 	    (packet[0] >= FR_RADIUS_CODE_MAX)) {
@@ -662,7 +662,7 @@ bool fr_radius_ok(uint8_t const *packet, size_t *packet_len_p,
 	 *	Message-Authenticator attributes.
 	 */
 	if (require_ma && !seen_ma) {
-		FR_DEBUG_STRERROR_PRINTF("we equire Message-Authenticator attribute, but it is not in the packet");
+		FR_DEBUG_STRERROR_PRINTF("we require Message-Authenticator attribute, but it is not in the packet");
 		failure = DECODE_FAIL_MA_MISSING;
 		goto finish;
 	}

--- a/src/protocols/radius/decode.c
+++ b/src/protocols/radius/decode.c
@@ -1423,7 +1423,7 @@ create_attrs:
 
 	/*
 	 *	When the unknown attributes were created by
-	 *	decode_vsa_internal, the hierachy between that unknown
+	 *	decode_vsa_internal, the hierarchy between that unknown
 	 *	attribute and first known attribute was cloned
 	 *	meaning we can now free the unknown vendor.
 	 */
@@ -1895,7 +1895,7 @@ ssize_t fr_radius_decode_pair_value(TALLOC_CTX *ctx, fr_pair_list_t *out,
 	case FR_TYPE_OCTETS:
 		/*
 		 *	This attribute SHOULD have fixed size, but it
-		 *	doesn't.  Therefor it's malformed.
+		 *	doesn't.  Therefore it's malformed.
 		 */
 		if (parent->flags.length && (data_len != parent->flags.length)) goto raw;
 		FALL_THROUGH;
@@ -1962,7 +1962,7 @@ ssize_t fr_radius_decode_pair(TALLOC_CTX *ctx, fr_pair_list_t *out,
 
 	/*
 	 *	If we don't have a tag root already, then record where
-	 *	we're putting the top level attributes and add tha tags
+	 *	we're putting the top level attributes and add the tags
 	 *	there.
 	 */
 	if (!packet_ctx->tag_root) {

--- a/src/protocols/radius/encode.c
+++ b/src/protocols/radius/encode.c
@@ -1048,7 +1048,7 @@ static ssize_t encode_vendor_attr(fr_dbuff_t *dbuff,
 
 	case 1:
 		/*
-		 *	Lenght fields are set to zero, because they
+		 *	Length fields are set to zero, because they
 		 *	will get over-ridden later.
 		 */
 		fr_dbuff_marker(&vsa_length_field, &work_dbuff);

--- a/src/protocols/radius/list.c
+++ b/src/protocols/radius/list.c
@@ -428,7 +428,7 @@ bool fr_packet_list_id_alloc(fr_packet_list_t *pl, int proto,
 	}
 
 	/*
-	 *	FIXME: Go to an LRU system.  This prevents ID re-use
+	 *	FIXME: Go to an LRU system.  This prevents ID reuse
 	 *	for as long as possible.  The main problem with that
 	 *	approach is that it requires us to populate the
 	 *	LRU/FIFO when we add a new socket, or a new destination,

--- a/src/protocols/tacacs/decode.c
+++ b/src/protocols/tacacs/decode.c
@@ -517,7 +517,7 @@ ssize_t fr_tacacs_decode(TALLOC_CTX *ctx, fr_pair_list_t *out, fr_dict_attr_t co
 	/*
 	 *	3.6. Encryption
 	 *
-	 *	If there's a secret, we alway decrypt the packets.
+	 *	If there's a secret, we always decrypt the packets.
 	 */
 	if (secret && packet_is_encrypted(pkt)) {
 		size_t length;

--- a/src/tests/daemon/all.mk
+++ b/src/tests/daemon/all.mk
@@ -54,7 +54,7 @@ $(BUILD_DIR)/tests/tmux.key:
 	${Q}echo $(TMUX_KEY) > $@
 
 #
-#  Stupid 'make' doesn' know how to create directories.
+#  Stupid 'make' doesn't know how to create directories.
 #
 .PHONY: $(BUILD_DIR)/tests/daemon/
 $(BUILD_DIR)/tests/daemon/:

--- a/src/tests/keywords/if-regex-match
+++ b/src/tests/keywords/if-regex-match
@@ -51,7 +51,7 @@ else {
 	test_fail
 }
 
-# Checking full capture group overun
+# Checking full capture group overrun
 if ('a_b_c_d_e_f_g_h_i_j_k_l_m_n_o_p_q_r_s_t_u_v_w_x_y_z_A_B_C_D_E_F_G' =~ /^(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)_(.)$/) {
 	if (!("%{0}%{1}%{2}%{3}%{4}%{5}%{6}%{7}%{8}%{9}%{10}%{11}%{12}%{13}%{14}%{15}%{16}%{17}%{18}%{19}%{20}%{21}%{22}%{23}%{24}%{25}%{26}%{27}%{28}%{29}%{30}%{31}%{32}" == 'a_b_c_d_e_f_g_h_i_j_k_l_m_n_o_p_q_r_s_t_u_v_w_x_y_z_A_B_C_D_E_F_GabcdefghijklmnopqrstuvwxyzABCDEF')) {
 		test_fail

--- a/src/tests/keywords/parallel
+++ b/src/tests/keywords/parallel
@@ -26,7 +26,7 @@ if (!(%{control.Tmp-Integer-0[#]} == 4)) {
 }
 
 #
-#  We can't check order, as there's offically no guarantee on the
+#  We can't check order, as there's officially no guarantee on the
 #  order in which child sections will be evaluated.
 #
 

--- a/src/tests/keywords/update-prepend
+++ b/src/tests/keywords/update-prepend
@@ -27,7 +27,7 @@ update request {
 	&Tmp-String-0 ^= 'boink'
 }
 
-# The prepended value should be first followd by the other two
+# The prepended value should be first followed by the other two
 if (!((&Tmp-String-0[0] == 'boink')) || (!(&Tmp-String-0[1] == 'foo')) || (!(%{Tmp-String-0[2]} == 'baz'))) {
 	test_fail
 }
@@ -65,7 +65,7 @@ update control {
 #	&control.Tmp-String-0 ^= &Tmp-String-0
 #}
 
-# (Temporary method to acheive the same - as per issue noted above)
+# (Temporary method to achieve the same - as per issue noted above)
 update {
 	&control ^= &request
 }

--- a/src/tests/ldap_sync/all.mk
+++ b/src/tests/ldap_sync/all.mk
@@ -28,7 +28,7 @@ SUBMAKEFILES := $(FILES)
 $(TEST): test.ldap_sync.dir $(patsubst %/all.mk,test.ldap_sync/%,$(FILES))
 
 #
-#  Ensure diretory for "touch" files exists
+#  Ensure directory for "touch" files exists
 #
 test.ldap_sync.dir:
 	${Q}mkdir -p $(BUILD_DIR)/tests/test.ldap_sync

--- a/src/tests/modules/json/eval.unlang
+++ b/src/tests/modules/json/eval.unlang
@@ -398,7 +398,7 @@ if !(&Tmp-uint64-0 == 9223372036854775807) {
 
 &request -= &Tmp-uint64-0[*]
 
-# 36. Multiple array indicies
+# 36. Multiple array indices
 map json &Tmp-String-0 {
 	&Tmp-Signed-0 += '$[3][0,1]'
 }

--- a/src/tests/modules/json/parser.unlang
+++ b/src/tests/modules/json/parser.unlang
@@ -167,7 +167,7 @@ if (%json_jpath_validate("$[0][1]") != '7:$[0][1]') {
 	test_fail
 }
 
-# 33. Expect success - Nested array with multiple indicies
+# 33. Expect success - Nested array with multiple indices
 if (%json_jpath_validate("$[0][1,2]") != '9:$[0][1,2]') {
 	test_fail
 }

--- a/src/tests/modules/ldap/auth_ssl.unlang
+++ b/src/tests/modules/ldap/auth_ssl.unlang
@@ -1,5 +1,5 @@
 #
-#  Run the "ldapssl" module - an instance of ldap using an ssl conneciton
+#  Run the "ldapssl" module - an instance of ldap using an ssl connection
 #  PRE: acct
 #
 ldapssl

--- a/src/tests/modules/ldap/auth_starttls.unlang
+++ b/src/tests/modules/ldap/auth_starttls.unlang
@@ -1,5 +1,5 @@
 #
-#  Run the "ldapssl" module - an instance of ldap using an ssl conneciton
+#  Run the "ldapssl" module - an instance of ldap using an ssl connection
 #  PRE: auth_ssl
 #
 

--- a/src/tests/modules/perl/test.pl
+++ b/src/tests/modules/perl/test.pl
@@ -67,7 +67,7 @@ sub authenticate {
 	if ($RAD_REQUEST{'User-Name'} =~ /^baduser/i) {
 		# Reject user and tell him why
 		$RAD_REPLY{'Reply-Message'} = "Denied access by rlm_perl function";
-		# For testing return NOTFOUND - returning REJECT immediatly rejects the packet so fails the test
+		# For testing return NOTFOUND - returning REJECT immediately rejects the packet so fails the test
 		return RLM_MODULE_NOTFOUND;
 	} else {
 		# Accept user and set some attribute

--- a/src/tests/modules/perl/xlat.pl
+++ b/src/tests/modules/perl/xlat.pl
@@ -51,7 +51,7 @@ sub xlatscalar2array {
 	return split(/ /, $_[0]);
 }
 
-# Take an arbitary number of scalars and retun an array of array refs
+# Take an arbitrary number of scalars and return an array of array refs
 sub xlatscalar2arrayref {
 	my @array;
 	for (my $i = 0; $i <= $#_; $i++) {

--- a/src/tests/modules/perl/xlat.unlang
+++ b/src/tests/modules/perl/xlat.unlang
@@ -4,7 +4,7 @@
 #  TODO
 #  A number of these tests return multiple values - either arrays, or hashes.
 #  Currently xlats have all returned values concatenated into a single value box -
-#  once multiple retuned boxes are handled to produce multiple attributes the tests
+#  once multiple returned boxes are handled to produce multiple attributes the tests
 #  will need amending.
 
 &Tmp-String-0 := "hello,goodbye,welcome,farewell"

--- a/src/tests/modules/rest/rest_xlat.unlang
+++ b/src/tests/modules/rest/rest_xlat.unlang
@@ -18,14 +18,14 @@ if (!(&control.Tmp-String-1 == "Sample text response\n")) {
 	test_fail
 }
 
-# Take host from incomming packet
+# Take host from incoming packet
 &control.Tmp-String-1 := "%(rest:http://%{Login-IP-Host}:%{Tmp-Integer-0}/test.txt)"
 
 if (!(&REST-HTTP-Status-Code == 200) || !(&control.Tmp-String-1 == "Sample text response\n")) {
 	test_fail
 }
 
-# Port is not allowed from incomming packet
+# Port is not allowed from incoming packet
 &control.Tmp-String-1 := "%(rest:http://%{Tmp-String-0}:%{NAS-Port}/test.txt)"
 
 if (!(&Module-Failure-Message == "Failed escaping URI: Tainted value not allowed for port") || !(&control.Tmp-String-1 == "")) {

--- a/src/tests/process/radius/proxy_state
+++ b/src/tests/process/radius/proxy_state
@@ -11,7 +11,7 @@ subrequest RADIUS.Access-Request {
 		test_fail
 	}
 
-	# We shouldnt magically acquire new proxy state values
+	# We shouldn't magically acquire new proxy state values
 	if (&reply.Proxy-State) {
 		test_fail
 	}

--- a/src/tests/salt-test-server/salt/ldap.sls
+++ b/src/tests/salt-test-server/salt/ldap.sls
@@ -1,7 +1,7 @@
 {% if grains['os'] == 'Ubuntu' %}
 
 # In Ubuntu 14.10, openldap comes with a broken AppArmor profile (can't connect through socket)
-# Disable AppArmor alltogether
+# Disable AppArmor altogether
 /etc/init.d/apparmor teardown:
    cmd.run
 

--- a/src/tests/salt-test-server/salt/postgres/schema.sql
+++ b/src/tests/salt-test-server/salt/postgres/schema.sql
@@ -63,7 +63,7 @@ CREATE INDEX radacct_start_user_idx ON radacct (AcctStartTime, UserName);
 -- There was WAAAY too many indexes previously. This combo index
 -- should take care of the most common searches.
 -- I have commented out all the old indexes, but left them in case
--- someone wants them. I don't recomend anywone use them all at once
+-- someone wants them. I don't recommend anywone use them all at once
 -- as they will slow down your DB too much.
 --  - pnixon 2003-07-13
 --

--- a/src/tests/tacacs/all.mk
+++ b/src/tests/tacacs/all.mk
@@ -1,7 +1,7 @@
 TACACS_BUILD_DIR  := $(BUILD_DIR)/tests/tacacs
 
 #
-#	We need the 'tacacs_plus' Python3 module to excute TACACS+ tests
+#	We need the 'tacacs_plus' Python3 module to execute TACACS+ tests
 #	i.e: Needed by ./scripts/tacacs/tacacs_client
 #
 $(TACACS_BUILD_DIR)/depends.mk:

--- a/src/tests/unit/condition/filter.txt
+++ b/src/tests/unit/condition/filter.txt
@@ -33,7 +33,7 @@ match ERROR offset 12: Invalid array index '-1' (should be between 0-1000)
 #
 #  And we do not (yet) allow for filters on leaf attributes.  See
 #
-#  @todo - feature - allowe expressions in tmpl_attr_parse_filter(()
+#  @todo - feature - allow expressions in tmpl_attr_parse_filter(()
 #
 condition &User-Name[&User-Name == 'bar'] == "foo"
 match ERROR offset 12: Invalid filter - cannot use filter on leaf attributes

--- a/src/tests/util/radius1_test.c
+++ b/src/tests/util/radius1_test.c
@@ -360,7 +360,7 @@ static void master_process(TALLOC_CTX *ctx)
 				MPRINT1("Master ignoring packet (data length %zd)\n", data_size);
 
 			discard:
-				fr_message_done(&cd->m); /* yeah, re-use it for the next packet... */
+				fr_message_done(&cd->m); /* yeah, reuse it for the next packet... */
 				continue;
 			}
 

--- a/src/tests/util/ring_buffer_test.c
+++ b/src/tests/util/ring_buffer_test.c
@@ -127,7 +127,7 @@ static NEVER_RETURNS void usage(void)
 	fprintf(stderr, "usage: ring_buffer_test [OPTS]\n");
 	fprintf(stderr, "  -x                     Debugging mode.\n");
 	fprintf(stderr, "  -s <string>            Set random seed to <string>.\n");
-	fprintf(stderr, "  -l <length>            Set the interation number to <length>.\n");
+	fprintf(stderr, "  -l <length>            Set the iteration number to <length>.\n");
 
 	fr_exit_now(EXIT_SUCCESS);
 }


### PR DESCRIPTION
Misspellings found by [codespell](https://github.com/codespell-project/codespell).

I have tried not to modify vendored/generated files that are clearly maintained elsewhere. Needs double-checking though.