### PR TITLE
Added tplink EAP225 radius dictionary

### DIFF
--- a/share/dictionary/radius/dictionary.tplink
+++ b/share/dictionary/radius/dictionary.tplink
@@ -1,0 +1,19 @@
+VENDOR TPLink 11863
+
+ 
+
+BEGIN-VENDOR TPLink
+
+
+ATTRIBUTE TPLink-Recv-limit  1  integer
+ATTRIBUTE TPLink-Xmit-limit  2  integer
+ATTRIBUTE TPLink-Authentication-FindKey  3  Octets
+ATTRIBUTE TPLink-Authentication-FoundKey  4  Octets
+ATTRIBUTE TPLink-User-Command  5  String
+ATTRIBUTE TPLink-Site  6  String
+ATTRIBUTE TPLink-Omada  7  String
+ATTRIBUTE TPLink-Redirect-Url  8  String
+ATTRIBUTE TPLink-Portal-Access-Status  9  integer
+
+
+END-VENDOR TPLink


### PR DESCRIPTION
When imported the attributes can be viewed in the radius logs. Data limits similar to ChilliSpot-Max-Total-Octets and such are not yet supported but the dictionary can be updated with new attributes as TPLink adds in new feature support on their Devices.