### PR TITLE
Fix ldap user config example

### DIFF
--- a/doc/antora/modules/howto/pages/modules/ldap/base_configuration/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/base_configuration/index.adoc
@@ -45,8 +45,8 @@ ldap {
 		# example - base_dn = "ou=people,${..base_dn}"
 		base_dn = "<path_from_base_dn_to_user_obj_dn>,${..base_dn}"  <5>
 
-		# example = "(&(uid=%{&Stripped-User-Name || &User-Name)(objectClass=posixAccount))"
-		filter = "(&(<user_uid_attribute>=%{&Stripped-User-Name || &User-Name)(<user_filter>))"  <6>
+		# example = "(&(uid=%{%{Stripped-User-Name}:-%{User-Name}})(objectClass=posixAccount))"
+		filter = "(&(<user_uid_attribute>=%{%{Stripped-User-Name}:-%{User-Name}})(<user_filter>))"  <6>
 	}
 }
 ----


### PR DESCRIPTION
Creating a test server using the docker image I found that the syntax of example in LDAP documentation is wrong.
The proposed example gives me the following error:
```bash
server_1  | (0) ldap: ERROR: (&(uid=%{&Stripped-User-Name || &User-Name)(objectclass=inetOrgPerson))
server_1  | (0) ldap: ERROR:         ^ No matching closing brace
server_1  | (0) ldap: ERROR: Unable to create filter
server_1  | rlm_ldap (ldap): Released connection (0)
```

Just adding a final `}` after *User-Name* also failed for me.
```bash
server_1  | (0) ldap: ERROR: (&(uid=%{&Stripped-User-Name || &User-Name})(objectclass=inetOrgPerson))
server_1  | (0) ldap: ERROR:         ^ No matching closing brace
server_1  | (0) ldap: ERROR: Unable to create filter
```
Finally, I tested the code provided in this PR and it worked.
The code is from [this tutorial](https://warlord0blog.wordpress.com/2020/07/07/freeradius-and-docker/)