### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/ci-deb.yml
+++ b/.github/workflows/ci-deb.yml
@@ -119,7 +119,7 @@ jobs:
     - name: Update apt repository lists
       run: apt-get update
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: freeradius
 
@@ -141,7 +141,7 @@ jobs:
         mv *.deb debs
 
     - name: Restore eapol_test build directory from cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: hostapd-cache
       with:
         path: ${{ env.HOSTAPD_BUILD_DIR }}
@@ -156,7 +156,7 @@ jobs:
       working-directory: freeradius
 
     - name: Store DEBs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: debs-${{ matrix.env.NAME }}
         path: debs
@@ -204,7 +204,7 @@ jobs:
     steps:
 
     - name: Load DEBs
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: debs-${{ matrix.env.NAME }}
 
@@ -259,7 +259,7 @@ jobs:
         mv eapol_test /usr/local/bin
         chmod +x /usr/local/bin/eapol_test
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: freeradius
 
@@ -274,7 +274,7 @@ jobs:
 
     - name: Upload radius logs on failure
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: radius-logs-${{ matrix.env.NAME }}
         path: |

--- a/.github/workflows/ci-freebsd.yml
+++ b/.github/workflows/ci-freebsd.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
 
     # Checkout, but defer pulling LFS objects until we've restored the cache
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         lfs: false
         path: freeradius
@@ -33,7 +33,7 @@ jobs:
       working-directory: freeradius
 
     - name: Restore LFS cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: lfs-cache
       with:
         path: .git/lfs
@@ -45,14 +45,14 @@ jobs:
       working-directory: freeradius
 
     - name: Restore eapol_test build directory from cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: hostapd-cache
       with:
         path: ${{ env.HOSTAPD_BUILD_DIR }}
         key: hostapd-freebsd-${{ env.HOSTAPD_GIT_TAG }}-v4
 
     - name: Test using a FreeBSD VirtualBox VM
-      uses: cross-platform-actions/action@v0.21.0
+      uses: cross-platform-actions/action@v0.22.0
       with:
         operating_system: freebsd
         version: '13.2'

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
 
     # Checkout, but defer pulling LFS objects until we've restored the cache
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         lfs: false
 
@@ -67,7 +67,7 @@ jobs:
       run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
 
     - name: Restore LFS cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: lfs-cache
       with:
         path: .git/lfs
@@ -78,7 +78,7 @@ jobs:
       run: git lfs pull
 
     - name: Restore eapol_test build directory from cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: hostapd-cache
       with:
         path: ${{ env.HOSTAPD_BUILD_DIR }}
@@ -145,7 +145,7 @@ jobs:
 
     - name: 'Restore OpenSSL 3.0 from the cache'
       if: ${{ matrix.env.LIBS_ALT == 'yes' }}
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: openssl-cache
       with:
         path: /opt/openssl/
@@ -221,7 +221,7 @@ jobs:
         make -j `nproc`
 
     - name: "Clang Static Analyzer: Store assets on failure"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: clang-scan.tgz
         path: build/plist/**/*.html

--- a/.github/workflows/ci-rpm.yml
+++ b/.github/workflows/ci-rpm.yml
@@ -117,7 +117,7 @@ jobs:
       run: |
         yum install -y rpm-build openssl make gcc perl git-core
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: freeradius
 
@@ -142,7 +142,7 @@ jobs:
         mv freeradius/rpmbuild/RPMS/x86_64/*.rpm rpms
 
     - name: Restore eapol_test build directory from cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: hostapd-cache
       with:
         path: ${{ env.HOSTAPD_BUILD_DIR }}
@@ -158,7 +158,7 @@ jobs:
       working-directory: freeradius
 
     - name: Store RPMs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: rpms-${{ matrix.env.NAME }}
         path: rpms
@@ -246,7 +246,7 @@ jobs:
         yum install -y procps-ng
 
     - name: Load RPMs
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: rpms-${{ matrix.env.NAME }}
 
@@ -268,7 +268,7 @@ jobs:
         mv eapol_test /usr/local/bin
         chmod +x /usr/local/bin/eapol_test
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         path: freeradius
 
@@ -283,7 +283,7 @@ jobs:
 
     - name: Upload radius logs on failure
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: radius-logs-${{ matrix.env.NAME }}
         path: |

--- a/.github/workflows/ci-sanitizers.yml
+++ b/.github/workflows/ci-sanitizers.yml
@@ -76,7 +76,7 @@ jobs:
     steps:
 
       # Checkout, but defer pulling LFS objects until we've restored the cache
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: false
 

--- a/.github/workflows/ci-scheduled-fuzzing.yml
+++ b/.github/workflows/ci-scheduled-fuzzing.yml
@@ -86,7 +86,7 @@ jobs:
       run: |
         echo starttimestamp=`date +%s` >> $GITHUB_OUTPUT
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         lfs: false
 
@@ -152,7 +152,7 @@ jobs:
     #  last updated and because we will walk the tree until we find a commit
     #  that builds.
     #
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         lfs: false
         fetch-depth: 500
@@ -176,7 +176,7 @@ jobs:
         echo "corpusage=$CORPUSAGE" >> $GITHUB_OUTPUT
 
     - name: Restore the fuzzer corpus tar file from cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: corpus-cache
       with:
         path: src/tests/fuzzer-corpus/${{ matrix.env.PROTOCOL }}.tar
@@ -244,7 +244,7 @@ jobs:
       if: ${{ !startsWith(github.ref, 'refs/heads/debug-fuzzer-') }}
 
     - name: "Clang libFuzzer: Store assets on failure"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: clang-fuzzer-${{ matrix.env.PROTOCOL }}-${{ steps.pick_commit.outputs.commit_id }}
         path: build/fuzzer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         run: apt-get update && apt-get install -y --no-install-recommends git git-lfs ca-certificates
 
       # Checkout, but defer pulling LFS objects until we've restored the cache
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: false
 
@@ -303,7 +303,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "Merge into upstream"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           lfs: false

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'FreeRADIUS' || github.ref == 'refs/heads/coverity_scan'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Package manager performance improvements
         run: |
@@ -45,7 +45,7 @@ jobs:
           OWNER: ${{ github.repository_owner }}
 
       - name: Cache coverity tool
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-coverity
         with:
           path: coverity_tool.tar.gz

--- a/.github/workflows/docker-refresh.yml
+++ b/.github/workflows/docker-refresh.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           lfs: false
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: true
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -67,7 +67,7 @@ jobs:
       run: tar -czf site.tgz doc/doxygen/html build/docsite
 
     - name: Store output
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: compiled-docs
         path: site.tgz
@@ -102,7 +102,7 @@ jobs:
 
     steps:
     - name: Retrieve output
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: compiled-docs
 
@@ -150,7 +150,7 @@ jobs:
             IdentityFile ~/.ssh/id_rsa-git
 
     - name: Retrieve output
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: compiled-docs
 


### PR DESCRIPTION
This should fix this warning:

> **FreeBSD build**
> 
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/cache@v3, cross-platform-actions/action@v0.21.0. For more information see:
> 	https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.