### PR TITLE
Attempt to placate Coverity in rs_packet_process() (CID #1587345)

### DIFF
--- a/src/bin/radsniff.c
+++ b/src/bin/radsniff.c
@@ -1856,7 +1856,7 @@ static void rs_packet_process(uint64_t count, rs_event_t *event, struct pcap_pkt
 		 *	It also justifies allocating FR_RADIUS_CODE_MAXinstances of rs_latency_t.
 		 */
 		rs_stats_update_latency(&stats->exchange[packet->code], &latency);
-		rs_stats_update_latency(&stats->exchange[original->expect->code], &latency);
+		if (original->expect) rs_stats_update_latency(&stats->exchange[original->expect->code], &latency);
 
 		/*
 		 *	We're filtering on response, now print out the full data from the request


### PR DESCRIPTION
Coverity infers from the check of original->expect in the call to fr_radius_decode_simple() that original->expect can be NULL, and hence the later call to rs_stats_update_latency() call that dereferences original->expect may fail. It may be that if original and original->linked are non-NULL, one can infer original->expect is non-NULL. Coverity can't; hence the added check on that call to rs_stats_update_latency().