### PR TITLE
Ask for the right mutex (CID #1551705)

### DIFF
--- a/src/modules/rlm_stats/rlm_stats.c
+++ b/src/modules/rlm_stats/rlm_stats.c
@@ -130,7 +130,7 @@ static void coalesce(uint64_t final_stats[FR_RADIUS_CODE_MAX], rlm_stats_thread_
 	 *	Loop over all of the other thread instances, locking
 	 *	them, and adding their statistics in.
 	 */
-	pthread_mutex_lock(&t->mutex);
+	pthread_mutex_lock(&t->inst->mutex);
 	for (other = fr_dlist_head(&t->inst->list);
 	     other != NULL;
 	     other = fr_dlist_next(&t->inst->list, other)) {
@@ -154,7 +154,7 @@ static void coalesce(uint64_t final_stats[FR_RADIUS_CODE_MAX], rlm_stats_thread_
 
 		pthread_mutex_unlock(&other->mutex);
 	}
-	pthread_mutex_unlock(&t->mutex);
+	pthread_mutex_unlock(&t->inst->mutex);
 }
 
 


### PR DESCRIPTION
Coverity message: "Accessing t->inst->list without holding lock rlm_stats_t.mutex." rlm_stats_t, not rlm_stats_thread_t, so the mutex to lock is t->inst->mutex, not t->mutex.