### PR TITLE
Annotate the other missing_lock in connection_check() (CID #1551702)

### DIFF
--- a/src/lib/server/pool.c
+++ b/src/lib/server/pool.c
@@ -774,7 +774,10 @@ static int connection_check(fr_pool_t *pool, request_t *request)
 	if (spare < pool->spare) {
 		/*
 		 *	Don't open too many pending connections.
+		 *	Again, coverity doesn't realize all callers have the lock,
+		 *	so we must annotate here as well.
 		 */
+		/* coverity[missing_lock] */
 		if (pool->state.pending >= pool->pending_window) goto manage_connections;
 
 		/*


### PR DESCRIPTION
As with CID 1551700, Coverity doesn't know that all callers of connection_check() have locked pool->mutex, so we need to annotate the later reference to pool->pending_window.