### PR TITLE
Fix eap tls preload certificate chains for realms

### DIFF
--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -4771,7 +4771,7 @@ static int tls_realms_load(fr_tls_server_conf_t *conf)
 		    S_ISDIR(stat_buf.st_mode)) continue;
 
 		strcpy(buffer2, buffer);
-		p = strchr(buffer2, '.'); /* which must be there... */
+		p = strrchr(buffer2, '.'); /* which must be there... */
 		if (!p) continue;
 
 		/*
@@ -4780,7 +4780,7 @@ static int tls_realms_load(fr_tls_server_conf_t *conf)
 		 *	the chain file.
 		 */
 		strcpy(p, ".key");
-		if (stat(buffer2, &stat_buf) != 0) private_key_file = buffer2;
+		if (stat(buffer2, &stat_buf) == 0) private_key_file = buffer2;
 
 		ctx = tls_init_ctx(conf, 1, buffer, private_key_file);
 		if (!ctx) goto error;


### PR DESCRIPTION
Fix expected incorrect key name when pem file name contains FQDN
Fix trying to load key when it is absent and not loading key when it's present