### PR TITLE
add define for Solaris.

### DIFF
--- a/src/main/listen.c
+++ b/src/main/listen.c
@@ -55,7 +55,7 @@ RCSID("$Id$")
 #ifdef WITH_TLS
 #include <netinet/tcp.h>
 
-#  if defined(__APPLE__) || defined(__FreeBSD__) || defined(__illumos__)
+#  if defined(__APPLE__) || defined(__FreeBSD__) || defined(__illumos__) || defined(__sun__)
 #    if !defined(SOL_TCP) && defined(IPPROTO_TCP)
 #      define SOL_TCP IPPROTO_TCP
 #    endif


### PR DESCRIPTION
Solaris, like illumos and FreeBSD does not define SOL_TCP