### PR TITLE
Reorder fr_command_debug() parameters

### DIFF
--- a/src/bin/unit_test_attribute.c
+++ b/src/bin/unit_test_attribute.c
@@ -1105,7 +1105,7 @@ static void command_print(void)
 	void *walk_ctx = NULL;
 
 	printf("Command hierarchy --------");
-	fr_command_debug(stdout, command_head);
+	fr_command_debug(command_head, stdout);
 
 	printf("Command list --------");
 	while (fr_command_walk(command_head, &walk_ctx, NULL, command_walk) == 1) {

--- a/src/lib/server/command.c
+++ b/src/lib/server/command.c
@@ -1599,7 +1599,7 @@ static void fr_command_debug_internal(FILE *fp, fr_cmd_t *head, int depth)
 	}
 }
 
-void fr_command_debug(FILE *fp, fr_cmd_t *head)
+void fr_command_debug(fr_cmd_t *head, FILE *fp)
 {
 	fr_command_debug_internal(fp, head, 0);
 }

--- a/src/lib/server/command.h
+++ b/src/lib/server/command.h
@@ -79,7 +79,7 @@ int fr_command_walk(fr_cmd_t *head, void **walk_ctx, void *ctx, fr_cmd_walk_t ca
 int fr_command_tab_expand(TALLOC_CTX *ctx, fr_cmd_t *head, fr_cmd_info_t *info, int max_expansions, char const **expansions);
 char const *fr_command_help(fr_cmd_t *head, int argc, char *argv[]);
 int fr_command_run(FILE *fp, FILE *fp_err, fr_cmd_info_t *info, bool read_only);
-void fr_command_debug(FILE *fp, fr_cmd_t *head);
+void fr_command_debug(fr_cmd_t *head, FILE *fp);
 int fr_command_str_to_argv(fr_cmd_t *head, fr_cmd_info_t *info, char const *str);
 int fr_command_clear(int new_argc, fr_cmd_info_t *info) CC_HINT(nonnull);
 


### PR DESCRIPTION
This makes it consistent with fr_{atomic_queue, message_set, queue, ring_buffer, time_tracking, worker}_debug(), to avoid needless special cases when invoking it from lldb.