### PR TITLE
hook up Challenge for Post-Auth-Type for inner tunnel processing

### DIFF
--- a/share/dictionary.freeradius.internal
+++ b/share/dictionary.freeradius.internal
@@ -657,7 +657,7 @@ ATTRIBUTE	Radclient-Test-Name			2200	string
 #		Free
 #
 #	Range:	3000-3999
-#		Site-local attributes (see raddb/dictionary.in)
+#		Site-local attributes (see raddb/dictionary)
 #		Do NOT define attributes in this range!
 #
 #	Range:	4000-65535

--- a/src/main/auth.c
+++ b/src/main/auth.c
@@ -850,8 +850,8 @@ int rad_virtual_server(REQUEST *request)
 			break;
 
 		case PW_AUTH_TYPE_REJECT:
-				request->reply->code = PW_CODE_ACCESS_REJECT;
-				break;
+			request->reply->code = PW_CODE_ACCESS_REJECT;
+			break;
 
 		default:
 			break;
@@ -861,6 +861,12 @@ int rad_virtual_server(REQUEST *request)
 	if (request->reply->code == PW_CODE_ACCESS_REJECT) {
 		fr_pair_delete_by_num(&request->config, PW_POST_AUTH_TYPE, 0, TAG_ANY);
 		vp = pair_make_config("Post-Auth-Type", "Reject", T_OP_SET);
+		if (vp) rad_postauth(request);
+	}
+
+	if (request->reply->code == PW_CODE_ACCESS_CHALLENGE) {
+		fr_pair_delete_by_num(&request->config, PW_POST_AUTH_TYPE, 0, TAG_ANY);
+		vp = pair_make_config("Post-Auth-Type", "Challenge", T_OP_SET);
 		if (vp) rad_postauth(request);
 	}
 


### PR DESCRIPTION
For inner-tunnel processing it is not possible to use `Post-Auth-Type Challenge`, for example with `rlm_detail`, as it is completely skipped.

This PR hooks up the doll to allow this.

Works For Me(tm)