### PR TITLE
Add support for OpenLDAP and 389ds PBKDF2 passwords

### DIFF
--- a/share/dictionary/freeradius/dictionary.freeradius.internal.password
+++ b/share/dictionary/freeradius/dictionary.freeradius.internal.password
@@ -64,6 +64,8 @@ ATTRIBUTE	SSHA3-256				28	octets
 ATTRIBUTE	SSHA3-384				29	octets
 ATTRIBUTE	SSHA3-512				30	octets
 
+ATTRIBUTE	PBKDF2-389DS				31	octets
+
 END-TLV		Password
 
 #  TOTP passwords and secrets

--- a/src/tests/modules/pap/pbkdf2_389ds_sha1.attrs
+++ b/src/tests/modules/pap/pbkdf2_389ds_sha1.attrs
@@ -1,0 +1,11 @@
+#
+#  Input packet
+#
+Packet-Type = Access-Request
+User-Name = 'pbkdf2_389ds_sha1'
+User-Password = 'password'
+
+#
+#  Expected answer
+#
+Packet-Type == Access-Accept

--- a/src/tests/modules/pap/pbkdf2_389ds_sha1.unlang
+++ b/src/tests/modules/pap/pbkdf2_389ds_sha1.unlang
@@ -1,0 +1,17 @@
+if ("${feature.tls}" == no) {
+	test_pass
+	return
+}
+
+if (&User-Name == 'pbkdf2_389ds_sha1') {
+	&control.Password.With-Header := '{PBKDF2-SHA1}10000$kX7ZFznyliHoBZ+7ZIIAI1yH+V9yZg6j$35n7xsdaw763OdDgKGSMsJUWz8s='
+
+	pap.authorize
+	pap.authenticate
+
+	if (ok) {
+		test_pass
+	} else {
+		test_fail
+	}
+}

--- a/src/tests/modules/pap/pbkdf2_389ds_sha256.attrs
+++ b/src/tests/modules/pap/pbkdf2_389ds_sha256.attrs
@@ -1,0 +1,11 @@
+#
+#  Input packet
+#
+Packet-Type = Access-Request
+User-Name = 'pbkdf2_389ds_sha256'
+User-Password = 'password'
+
+#
+#  Expected answer
+#
+Packet-Type == Access-Accept

--- a/src/tests/modules/pap/pbkdf2_389ds_sha256.unlang
+++ b/src/tests/modules/pap/pbkdf2_389ds_sha256.unlang
@@ -1,0 +1,17 @@
+if ("${feature.tls}" == no) {
+	test_pass
+	return
+}
+
+if (&User-Name == 'pbkdf2_389ds_sha256') {
+	&control.Password.With-Header := '{PBKDF2-SHA256}10000$kX7ZFznyliHoBZ+7ZIIAI1yH+V9yZg6j$kH2xGFdC+rS5+tjPnTXj/pGK0eFXTez2QqF2QZhunBM='
+
+	pap.authorize
+	pap.authenticate
+
+	if (ok) {
+		test_pass
+	} else {
+		test_fail
+	}
+}

--- a/src/tests/modules/pap/pbkdf2_389ds_sha512.attrs
+++ b/src/tests/modules/pap/pbkdf2_389ds_sha512.attrs
@@ -1,0 +1,11 @@
+#
+#  Input packet
+#
+Packet-Type = Access-Request
+User-Name = 'pbkdf2_389ds_sha512'
+User-Password = 'password'
+
+#
+#  Expected answer
+#
+Packet-Type == Access-Accept

--- a/src/tests/modules/pap/pbkdf2_389ds_sha512.unlang
+++ b/src/tests/modules/pap/pbkdf2_389ds_sha512.unlang
@@ -1,0 +1,17 @@
+if ("${feature.tls}" == no) {
+	test_pass
+	return
+}
+
+if (&User-Name == 'pbkdf2_389ds_sha512') {
+	&control.Password.With-Header := '{PBKDF2-SHA512}10000$kX7ZFznyliHoBZ+7ZIIAI1yH+V9yZg6j$kyzz433C/pdvdkzPTjwi8wr6cHNTFD0dCKuUkKVMmSgilGBDQjNxfDQwZzFBiPgChQJTFAm8oThm65xrLGFnAg=='
+
+	pap.authorize
+	pap.authenticate
+
+	if (ok) {
+		test_pass
+	} else {
+		test_fail
+	}
+}


### PR DESCRIPTION
This commit enables the PAP module to recognize and handle OpenLDAP and 389ds style PBKDF2 passwords.
A new password type was added that leaves the password header intact when passing it to the authentication module, because it contains the hash function used. Currently, password_process_header strips that out, as none of the other supported hash formats need it.