### PR TITLE
resolved missing previous extern declaration for fr_table_num_sorted_…

### DIFF
--- a/src/modules/rlm_brotli/rlm_brotli.c
+++ b/src/modules/rlm_brotli/rlm_brotli.c
@@ -62,7 +62,7 @@ typedef struct {
 	bool				large_window;		//!< non-standard "large", window size.
 } rlm_brotli_t;
 
-fr_table_num_sorted_t const brotli_mode[] = {
+static fr_table_num_sorted_t const brotli_mode[] = {
 	{ L("font"),		BROTLI_MODE_FONT	},	//!< Probably not useful?
 	{ L("generic"),		BROTLI_MODE_GENERIC	},
 	{ L("text"),		BROTLI_MODE_TEXT	},


### PR DESCRIPTION
Resolved warning: no previous extern declaration for non-static variable 'fr_table_num_sorted_t' by declaring it as static