### PR TITLE
mschapv2: set key length after specifying the cipher

### DIFF
--- a/src/modules/rlm_mschap/rlm_mschap.c
+++ b/src/modules/rlm_mschap/rlm_mschap.c
@@ -1013,14 +1013,14 @@ ntlm_auth_err:
 				return -1;
 			}
 
-			if (!EVP_CIPHER_CTX_set_key_length(ctx, nt_password->vp_length)) {
-				REDEBUG("Failed setting key length");
-				goto error;
-			}
-
 			if (!EVP_EncryptInit_ex(ctx, EVP_rc4(), NULL, nt_password->vp_octets, NULL)) {
 				REDEBUG("Failed setting key value");
 				goto error;;
+			}
+
+			if (!EVP_CIPHER_CTX_set_key_length(ctx, nt_password->vp_length)) {
+				REDEBUG("Failed setting key length");
+				goto error;
 			}
 
 			if (!EVP_EncryptUpdate(ctx, nt_pass_decrypted, &ntlen, new_nt_password, ntlen)) {


### PR DESCRIPTION
We get a sigsegv otherwise:
```
(10) eap_mschapv2:   Auth-Type MS-CHAP {
(10) mschap: Found Cleartext-Password, hashing to create NT-Password
(10) mschap: MS-CHAPv2 password change request received
(10) mschap: Password change payload valid
(10) mschap: Doing MS-CHAPv2 password change locally

Program received signal SIGSEGV, Segmentation fault. 0x00007ffff7b92f18 in EVP_CIPHER_CTX_set_key_length () from /lib/x86_64-linux-gnu/libcrypto.so.3 (gdb) where
    new_nt_password=0x7fffffffb940 "...", nt_password=0x555555ccc290,
    request=0x555555a9fde0, inst=0x5555558bacb0) at src/modules/rlm_mschap/rlm_mschap.c:1016
```