### PR TITLE
cbtls_info() to report "Need to write more data" when called on exit …

### DIFF
--- a/src/main/cb.c
+++ b/src/main/cb.c
@@ -117,6 +117,10 @@ void cbtls_info(SSL const *s, int where, int ret)
 				RDEBUG2("(TLS) %s - %s: Need to read more data: %s", conf->name, role, state);
 				return;
 			}
+			if (SSL_want_write(s)) {
+				RDEBUG2("(TLS) %s - %s: Need to write more data: %s", conf->name, role, state);
+				return;
+			}
 			RERROR("(TLS) %s - %s: Error in %s", conf->name, role, state);
 		}
 	}


### PR DESCRIPTION
…of a handshake function

The current code does seem to miss to cater for the cases when a TLS handshake exits and there is data left that needs either to be extracted from the BIO and/or sent to the other side. Differentiating and logging such cases within cbtls_info() might aid in further debugging any stalled handshakes followed up by timing out requests we experience with the up to date 3.2.x head.