### PR TITLE
radclient: fix debug to not show source port in hex but as integer

### DIFF
--- a/src/lib/packet.c
+++ b/src/lib/packet.c
@@ -1090,7 +1090,7 @@ void fr_packet_header_print(FILE *fp, RADIUS_PACKET *packet, bool received)
 	 *	This really belongs in a utility library
 	 */
 	if (is_radius_code(packet->code)) {
-		fprintf(fp, "%s %s Id %i from %s%s%s:%x to %s%s%s:%u length %zu\n",
+		fprintf(fp, "%s %s Id %i from %s%s%s:%u to %s%s%s:%u length %zu\n",
 		        received ? "Received" : "Sent",
 		        fr_packet_codes[packet->code],
 		        packet->id,
@@ -1108,7 +1108,7 @@ void fr_packet_header_print(FILE *fp, RADIUS_PACKET *packet, bool received)
 		        packet->dst_port,
 		        packet->data_len);
 	} else {
-		fprintf(fp, "%s code %u Id %i from %s%s%s:%u to %s%s%s:%i length %zu\n",
+		fprintf(fp, "%s code %u Id %i from %s%s%s:%u to %s%s%s:%u length %zu\n",
 		        received ? "Received" : "Sent",
 		        packet->code,
 		        packet->id,


### PR DESCRIPTION
Noticed when running `radtest` I was seeing hex used to represent the source port.

No idea if this was intention (appeared during some RADIUSv1.1 work), as the destination port is shown as an integer, but this commit makes the source port an integer.