### PR TITLE
Change 8859 to 8559

### DIFF
--- a/share/dictionary.rfc8559
+++ b/share/dictionary.rfc8559
@@ -2,8 +2,8 @@
 # Copyright (C) 2019 The FreeRADIUS Server project and contributors
 # This work is licensed under CC-BY version 4.0 https://creativecommons.org/licenses/by/4.0
 #
-#        Attributes and values defined in RFC 8859
-#        http://www.ietf.org/rfc/rfc8859
+#        Attributes and values defined in RFC 8559
+#        http://www.ietf.org/rfc/rfc8559
 #
 
 ATTRIBUTE	Operator-NAS-Identifier			241.8	octets

--- a/share/dictionary.rfc8559
+++ b/share/dictionary.rfc8559
@@ -3,7 +3,7 @@
 # This work is licensed under CC-BY version 4.0 https://creativecommons.org/licenses/by/4.0
 #
 #        Attributes and values defined in RFC 8559
-#        http://www.ietf.org/rfc/rfc8559
+#        https://datatracker.ietf.org/doc/html/rfc8559
 #
 
 ATTRIBUTE	Operator-NAS-Identifier			241.8	octets


### PR DESCRIPTION
## Merge Request: Correct RFC Number from 8859 to 8559

### Summary
This merge request corrects the RFC number from 8859 to 8559 in the attribute definition comments. RFC 8559 is the correct reference for the attribute `Operator-NAS-Identifier`.

### Description
The following change has been made in the text header of the attribute definition file:

- Changed RFC number from 8859 to 8559.

### Changes
```diff
# -*- text -*-
# Copyright (C) 2019 The FreeRADIUS Server project and contributors
# This work is licensed under CC-BY version 4.0 https://creativecommons.org/licenses/by/4.0
#
-#        Attributes and values defined in RFC 8859
-#        http://www.ietf.org/rfc/rfc8859
+#        Attributes and values defined in RFC 8559
+#       https://datatracker.ietf.org/doc/html/rfc8559
#

ATTRIBUTE	Operator-NAS-Identifier			241.8	octets
```

### Rationale
RFC 8559 is the correct reference document for the `Operator-NAS-Identifier` attribute. This correction ensures accurate documentation and helps prevent confusion for developers and contributors referencing the attribute definitions.

### Testing
No functional code changes have been made, only comments have been corrected. Therefore, no additional testing is required.

### Review
Please review the changes and approve the merge request if there are no issues.