### PR TITLE
Only add positive r values to total (CID #16046001)

### DIFF
--- a/src/listen/control/conduit.c
+++ b/src/listen/control/conduit.c
@@ -38,7 +38,7 @@ static ssize_t lo_read(int fd, void *out, size_t outlen)
 	ssize_t r;
 	uint8_t *p = out;
 
-	for (total = 0; total < outlen; total += r) {
+	for (total = 0; total < outlen; ) {
 		r = read(fd, p + total, outlen - total);
 
 		if (r == 0) return total;
@@ -60,6 +60,7 @@ static ssize_t lo_read(int fd, void *out, size_t outlen)
 
 			return -1;
 		}
+		total += r;
 	}
 
 	return total;


### PR DESCRIPTION
With the addition of r to total in the for loop header, the continue for EINTR causes a negative value of r to be added to total. That's the only thing that looks like it could cause an overflow and taint total.