### PR TITLE
cassandra start query is missing two escape characters

### DIFF
--- a/raddb/mods-config/sql/main/cassandra/queries.conf
+++ b/raddb/mods-config/sql/main/cassandra/queries.conf
@@ -175,7 +175,7 @@ accounting {
 				framedipv6prefix, \
 				framedinterfaceid, \
 				delegatedipv6prefix, \
-				class
+				class \
 			) VALUES ( \
 				'%{Acct-Unique-Session-Id}', \
 				'%{Acct-Session-Id}', \
@@ -200,7 +200,7 @@ accounting {
 				'%{Framed-IPv6-Prefix}', \
 				'%{Framed-Interface-Id}', \
 				'%{Delegated-IPv6-Prefix}', \
-				'%{Class}'
+				'%{Class}' \
 			);"
 	}
 


### PR DESCRIPTION
When using the current cassandra start query, freeradius fails to start with an unterminated string error. These escape characters resolve that issue.