### PR TITLE
Do size calculation in appropriate type (CID #1604603)

### DIFF
--- a/src/lib/util/lst.c
+++ b/src/lib/util/lst.c
@@ -418,8 +418,8 @@ static bool lst_expand(fr_lst_t *lst)
 
 	n = talloc_realloc(lst, lst->p, void *, n_capacity);
 	if (unlikely(!n)) {
-		fr_strerror_printf("Failed expanding lst to %u elements (%u bytes)",
-				   n_capacity, n_capacity * (unsigned int)sizeof(void *));
+		fr_strerror_printf("Failed expanding lst to %u elements (%zu bytes)",
+				   n_capacity, n_capacity * sizeof(void *));
 		return false;
 	}
 


### PR DESCRIPTION
In the error message in lst_expand(), the calculation of the size has to be done in size_t. The cast of sizeof(void *) to uint32_t causes it to be done in uint32_t, but that has the possibility of overflow; note that n_capacity may be set to UINT_MAX, which would guarantee it. The format conversion is changed to match.