### PR TITLE
Annotate bogus overflow complaint (CID 1604606)

### DIFF
--- a/src/lib/util/calc.c
+++ b/src/lib/util/calc.c
@@ -1330,6 +1330,7 @@ static int calc_ipv4_prefix(UNUSED TALLOC_CTX *ctx, fr_value_box_t *dst, fr_valu
 				if (mask == b->vb_uint32) break;
 
 				prefix--;
+				/* coverity[overflow_const] */
 				mask <<= 1;
 			}
 			fr_assert(prefix > 0);


### PR DESCRIPTION
Coverity complains about "mask <<= 1", but mask has an unsigned type, so that's perfectly valid and its behavior defined.