### PR TITLE
wire in a timestamp for Client-Lost so rlm_detail does not use the epoch

### DIFF
--- a/src/main/state.c
+++ b/src/main/state.c
@@ -271,6 +271,11 @@ static REQUEST *fr_state_cleanup_request(state_entry_t *entry)
 	request->handle = rad_postauth;
 
 	/*
+	 *	xlat (and thus rlm_detail) needs something to work with
+	 */
+	gettimeofday(&request->packet->timestamp, NULL);
+
+	/*
 	 *	Move session-state VPS over, after first freeing the
 	 *	separately-parented state_ctx that was allocated along with the
 	 *	fake request.


### PR DESCRIPTION
This PR resolves during `Post-Auth-Type Client-Lost` the fake request passed to `rlm_detail` does not have `request->packet->timestamp` populated so we end up jumping back to the epoch:
```
(5) Using Post-Auth-Type Client-Lost
(5) # Executing group from file /etc/freeradius/sites-enabled/default
(5)   Post-Auth-Type Client-Lost {
(5) [snipped]
(5) detail_kitchensink: EXPAND .../detail/kitchensink/%Y/%m/%d/%H/%G
(5) detail_kitchensink:    --> .../detail/kitchensink/1970/01/01/00/00
(5) detail_kitchensink: .../detail/kitchensink/%Y/%m/%d/%H/%G expands to .../detail/kitchensink/1970/01/01/00/00 <---------
(5) detail_kitchensink: EXPAND ts0=%l.%M ts=%c.%C reqid=%I reqno=%n
(5) detail_kitchensink:    --> ts0=0.000000 ts=1719580464.298668 reqid=-1 reqno=5
(5)       [detail_kitchensink] = ok
```

On a related note, I notice that cleanup on an idle server does not take place till another packet is received. Is this intention? Should another wakeup be installed to clean this up in a timely fashion and get this event captured in the logging downstream?