### PR TITLE
Annotate false positive overflow_const issues (CID #1604607, #1604626)

### DIFF
--- a/src/lib/util/hash.c
+++ b/src/lib/util/hash.c
@@ -861,6 +861,7 @@ uint32_t fr_hash_string(char const *p)
 	uint32_t      hash = FNV_MAGIC_INIT;
 
 	while (*p) {
+		/* coverity[overflow_const] */
 		hash *= FNV_MAGIC_PRIME;
 		hash ^= (uint32_t) (*p++);
 	}
@@ -876,6 +877,7 @@ uint32_t fr_hash_case_string(char const *p)
 	uint32_t      hash = FNV_MAGIC_INIT;
 
 	while (*p) {
+		/* coverity[overflow_const] */
 		hash *= FNV_MAGIC_PRIME;
 		hash ^= (uint32_t) (tolower((uint8_t) *p++));
 	}


### PR DESCRIPTION
Coverity sees the initialization of `hash` and the multiplication by `FNV_MAGIC_PRIME` and points out that the product is too large for a `uint32_t`, but because the multiplication is done in an unsigned type, that is defined behavior and the intended behavior for the hash functions.