### PR TITLE
Annotate false positive overflow_sink (CID #1604608)

### DIFF
--- a/src/modules/rlm_mschap/rlm_mschap.c
+++ b/src/modules/rlm_mschap/rlm_mschap.c
@@ -838,6 +838,7 @@ static int write_all(int fd, char const *buf, int len) {
 	int rv, done=0;
 
 	while (done < len) {
+		/* coverity[overflow_sink] */
 		rv = write(fd, buf+done, len-done);
 		if (rv <= 0)
 			break;


### PR DESCRIPTION
Coverity docs say it has a model of `write()`. Ideally it should be able to infer that given the initial value of `done` and the loop invariant, `len - done` will never be negative and thus will be representable as a `size_t`.