### PR TITLE
Annotate false positive overflow_const (CID #1604609)

### DIFF
--- a/src/lib/util/event.c
+++ b/src/lib/util/event.c
@@ -496,8 +496,10 @@ static void event_fd_func_index_build(fr_event_func_map_t *map)
 			 *	with the same function.
 			 */
 			while ((pos = fr_high_bit_pos(fflags))) {
+				/* coverity[overflow_const] */
 				pos -= 1;
 				map->ev_to_func[pos] = entry;
+				/* coverity[overflow_const] */
 				fflags &= ~(1 << pos);
 			}
 		}


### PR DESCRIPTION
Despite the `while` loop condition that passes iff `pos` is nonzero, Coverity thinks that inside the loop `pos` might equal zero so that the decrement would make it 255, making `(1 << pos)` have undefined behavior.