### PR TITLE
Actually fill fr_rand_pool.randrsl

### DIFF
--- a/src/lib/util/rand.c
+++ b/src/lib/util/rand.c
@@ -44,10 +44,11 @@ void fr_rand_init(void)
 	if (fd >= 0) {
 		size_t total;
 		ssize_t this;
+		char *buf = (char *) fr_rand_pool.randrsl;
 
 		total = 0;
 		while (total < sizeof(fr_rand_pool.randrsl)) {
-			this = read(fd, fr_rand_pool.randrsl,
+			this = read(fd, &buf[total],
 				    sizeof(fr_rand_pool.randrsl) - total);
 			if ((this < 0) && (errno != EINTR)) break;
 			if (this > 0) total += this;


### PR DESCRIPTION
In `fr_rand_init()`, where `/dev/urandom` is available, the code as written would always read into the beginning of `fr_rand_pool.randrsl`, so that only the first max(read return value) bytes would be filled.

(Not associated with CID #1604611, but found while looking into it.)