### PR TITLE
Actually fill fr_rand_pool.randrsl

### DIFF
--- a/src/lib/radius.c
+++ b/src/lib/radius.c
@@ -1622,7 +1622,7 @@ int rad_vp2rfc(RADIUS_PACKET const *packet,
 		p = ptr + 2;
 
 		while (vp && !vp->da->vendor && (vp->da->attr == PW_NAS_FILTER_RULE)) {
-			if ((p + zero + vp->vp_length) > end) {				
+			if ((p + zero + vp->vp_length) > end) {
 				break;
 			}
 
@@ -3094,7 +3094,7 @@ static ssize_t data2vp_nas_filter_rule(TALLOC_CTX *ctx,
 		fr_strerror_printf("decode NAS-Filter-Rule: Out of memory");
 		return -1;
 	}
-				
+
 	fr_pair_value_bstrncpy(vp, buffer, q - buffer);
 
 	*pvp = vp;
@@ -3501,7 +3501,7 @@ static ssize_t data2vp_wimax(TALLOC_CTX *ctx,
 	 *	+ continuation, it's a bad attribute.
 	 */
 	if (attrlen < 8) {
-	raw:		
+	raw:
 		/*
 		 *	It's not a Vendor-Specific, it's unknown...
 		 */
@@ -4969,10 +4969,11 @@ void fr_rand_seed(void const *data, size_t size)
 		if (fd >= 0) {
 			size_t total;
 			ssize_t this;
+			char *buf = (char *) fr_rand_pool.randrsl;
 
 			total = 0;
 			while (total < sizeof(fr_rand_pool.randrsl)) {
-				this = read(fd, fr_rand_pool.randrsl,
+				this = read(fd, &buf[total],
 					    sizeof(fr_rand_pool.randrsl) - total);
 				if ((this < 0) && (errno != EINTR)) break;
 				if (this > 0) total += this;


### PR DESCRIPTION
The destination of the read has to change with total or it risks overwiting the leading portion of fr_rand_pool.randrsl and leaving some part of the end unchanged.