### PR TITLE
mute some compiler warnings

### DIFF
--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -542,7 +542,7 @@ static void tls_keylog_cb(UNUSED const SSL *ssl, const char *line)
 
 	len = strlen(line);
 	if ((len + 1) > sizeof(buffer)) {
-		DEBUG("SSLKEYLOGFILE buffer not large enough, max %lu, required %lu", sizeof(buffer), len + 1);
+		DEBUG("SSLKEYLOGFILE buffer not large enough, max %zu, required %zu", sizeof(buffer), len + 1);
 		return;
 	}
 

--- a/src/modules/rlm_otp/otp_mppe.h
+++ b/src/modules/rlm_otp/otp_mppe.h
@@ -34,6 +34,7 @@ RCSIDH(otp_mppe_h, "$Id$")
 #define MPPE_ENC_TYPES_RC4_128    "0x00000004"
 #define MPPE_ENC_TYPES_RC4_40_128 "0x00000006"
 
+#if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER < 0x30000000L)
 /* Translate the above into something easily usable. */
 static char const *otp_mppe_policy[3] = {
   MPPE_ENC_POL_ENCRYPTION_FORBIDDEN,
@@ -44,5 +45,6 @@ static char const *otp_mppe_types[3] = {
   MPPE_ENC_TYPES_RC4_40,
   MPPE_ENC_TYPES_RC4_128,
   MPPE_ENC_TYPES_RC4_40_128 };
+#endif
 
 #endif /* OTP_MPPE_H */

--- a/src/modules/rlm_unpack/rlm_unpack.c
+++ b/src/modules/rlm_unpack/rlm_unpack.c
@@ -360,7 +360,7 @@ static ssize_t substring_xlat(UNUSED void *instance, REQUEST *request,
 	if (start > slen) {
 		*out = '\0';
 		talloc_free(buffer);
-		WARN("Start position %li is after end of string length of %li", start, slen);
+		WARN("Start position %li is after end of string length of %zd", start, slen);
 		return 0;
 	}
 
@@ -371,7 +371,7 @@ static ssize_t substring_xlat(UNUSED void *instance, REQUEST *request,
 	if (len < 0) len = slen - start + len;
 
 	if (len < 0) {
-		WARN("String length of %li too short for substring parameters", slen);
+		WARN("String length of %zd too short for substring parameters", slen);
 		len = 0;
 	}
 


### PR DESCRIPTION
1. Use `%zd` for `ssize_t` and `%zu` for `size_t`. They are not always `long` type on all platforms and compiler complains.
2. `otp_mppe_policy` and `otp_mppe_types` are not used when `OPENSSL_VERSION_NUMBER < 0x30000000`