### PR TITLE
Annotate yet another "hash *= FNV_MAGIC_PRIME" (CID#1604612)

### DIFF
--- a/src/lib/util/dict_util.c
+++ b/src/lib/util/dict_util.c
@@ -111,6 +111,7 @@ static uint32_t dict_hash_name(char const *name, size_t len)
 		int c = *(unsigned char const *)p;
 		if (isalpha(c)) c = tolower(c);
 
+		/* coverity[overflow_const] */
 		hash *= FNV_MAGIC_PRIME;
 		hash ^= (uint32_t)(c & 0xff);
 		p++;


### PR DESCRIPTION
Like 1604607 and 1604626, this is an FNV hash, and Coverity complains about the multiplication by FNV_MAGIC_PRIME.