### PR TITLE
Replace radsecret with a Bash variant

### DIFF
--- a/src/main/radsecret
+++ b/src/main/radsecret
@@ -1,7 +1,3 @@
-#!/usr/bin/env perl
-#
-#  A tool which generates strong shared secrets.
-#
-use Convert::Base32;
-use Crypt::URandom();
-print join('-', unpack("(A4)*", lc encode_base32(Crypt::URandom::urandom(12)))), "\n";
+#!/bin/bash
+data=$(dd if=/dev/urandom bs=1 count=13 2>/dev/null| base32 | tr 'A-Z' 'a-z')
+echo ${data:0:4}-${data:4:4}-${data:8:4}-${data:12:4}-${data:16:4}


### PR DESCRIPTION
This avoids adding two extra perl dependencies just because of this script, and trigger a component mismatch in Ubuntu (where a package in main [freeradius] cannot depend on packages from universe [these two new perl modules]).

Use 13 bytes instead of 12, due to
https://bugs.launchpad.net/ubuntu/+source/freeradius/+bug/2073269/comments/6

Fixes Ubuntu bug [LP: #2073269](https://bugs.launchpad.net/ubuntu/+source/freeradius/+bug/2073269/comments/6)
Fixes Debian bug [#1076458](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1076458)