### PR TITLE
Annotate false positive overflow_const (CID #1604617)

### DIFF
--- a/src/lib/util/dbuff.h
+++ b/src/lib/util/dbuff.h
@@ -1590,6 +1590,7 @@ static inline ssize_t _fr_dbuff_in_uint64v(uint8_t **pos_p, fr_dbuff_t *dbuff, u
 	ret = ROUND_UP_DIV((size_t)fr_high_bit_pos(num | 0x08), 8);
 	fr_nbo_from_uint64(swapped, num);
 
+	/* coverity[overflow_const] */
 	return _fr_dbuff_in_memcpy(pos_p, dbuff, (swapped + (sizeof(uint64_t) - ret)), ret);
 }
 


### PR DESCRIPTION
Given what `ret` is assigned, its value is necessarily between 1 and 8 inclusive, rather than 2305843009213693952 which Coverity thinks it is, so that `sizeof(uint64_t) - ret` will not underflow as Coverity thinks it will.