### PR TITLE
fr_socket_client_tcp() needs literal nonblock value to use it as an a…

### DIFF
--- a/src/main/listen.c
+++ b/src/main/listen.c
@@ -3593,7 +3593,7 @@ rad_listen_t *proxy_new_listener(TALLOC_CTX *ctx, home_server_t *home, uint16_t 
 		this->fd = fr_socket_client_tcp(&home->src_ipaddr,
 						&home->ipaddr, home->port,
 #ifdef WITH_TLS
-						!this->nonblock
+						this->nonblock
 #else
 						false
 #endif


### PR DESCRIPTION
…sync parameter

fd is currently missing O_NONBLOCK property that should be set via nested fr_socket_client_tcp() ->  fr_nonblock() -> fcntl() calls.

this will fix the issue #5342 

https://github.com/FreeRADIUS/freeradius-server/pull/5342