### PR TITLE
Use size_t where needed (CID #1604623)

### DIFF
--- a/src/lib/util/lst.c
+++ b/src/lib/util/lst.c
@@ -180,8 +180,8 @@ static bool stack_expand(fr_lst_t *lst, pivot_stack_t *s)
 
 	n = talloc_realloc(lst, s->data, fr_lst_index_t, n_size);
 	if (unlikely(!n)) {
-		fr_strerror_printf("Failed expanding lst stack to %u elements (%u bytes)",
-				   n_size, n_size * (unsigned int)sizeof(fr_lst_index_t));
+		fr_strerror_printf("Failed expanding lst stack to %u elements (%zu bytes)",
+				   n_size, n_size * sizeof(fr_lst_index_t));
 		return false;
 	}
 


### PR DESCRIPTION
Coverity correctly noted that the calculation of the number of bytes in an error message can overflow unsigned int, so we use size_t instead (with matching format change)