### PR TITLE
Update ndb schema.sql

### DIFF
--- a/raddb/mods-config/sql/main/ndb/schema.sql
+++ b/raddb/mods-config/sql/main/ndb/schema.sql
@@ -125,9 +125,11 @@ CREATE TABLE radreply (
 -- Table structure for table 'radusergroup'
 --
 CREATE TABLE radusergroup (
+  id int(11) unsigned NOT NULL auto_increment,
   username varchar(64) NOT NULL default '',
   groupname varchar(64) NOT NULL default '',
   priority int(11) NOT NULL default '1',
+  PRIMARY KEY  (id),
   KEY username (username(32))
 ) ENGINE=ndbcluster;
 


### PR DESCRIPTION
Fix `radusergroup` table structure - add missing `id` primary key column

`radusergroup.id` PK column exists in [mysql schema.sql](https://github.com/FreeRADIUS/freeradius-server/blob/master/raddb/mods-config/sql/main/mysql/schema.sql#L127) however is missing from [ndb schema.sql](https://github.com/FreeRADIUS/freeradius-server/blob/master/raddb/mods-config/sql/main/ndb/schema.sql#L127)