### PR TITLE
Update mods-available/rest to use urlquote instead of url.quote

### DIFF
--- a/raddb/mods-available/rest
+++ b/raddb/mods-available/rest
@@ -228,7 +228,7 @@ rest {
 	#                     may be specified with `body`. Will be expanded.
 	#                     Values from expansion will not be escaped, this should be
 	#		      done using the appropriate `xlat` method e.g.
-	#		      `%url.quote(<attr>)`
+	#		      `%urlquote(<attr>)`
 	#  | `auth`         | HTTP auth method to use, one of 'none', 'srp', 'basic',			| yes
 	#                     'digest', 'digest-ie', 'gss-negotiate', 'ntlm',
 	#                     'ntlm-winbind', 'any', 'safe'. defaults to _'none'_.


### PR DESCRIPTION
The function registered is urlquote, url.quote seems to no longer be a supported reference
