### PR TITLE
Declare the local fflags consistently with the fflags field.

### DIFF
--- a/src/lib/util/event.c
+++ b/src/lib/util/event.c
@@ -489,7 +489,7 @@ static void event_fd_func_index_build(fr_event_func_map_t *map)
 		if (unlikely(!map->ev_to_func)) abort();
 
 		for (entry = map->func_to_ev; entry->name; entry++) {
-			int fflags = entry->fflags;
+			typeof_field(fr_event_func_map_entry_t, fflags) fflags = entry->fflags;
 
 			/*
 			 *	Multiple notes can be associated


### PR DESCRIPTION
In the `FR_EVENT_FUNC_IDX_FFFLAGS` case in `event_fd_func_index()`, the first loop directly passes `entry->fflags`, which has type `uint32_t`, to `fr_high_bit_pos()`. but the loop that iterates over the bits of `fflags` uses a local of type `int`. `fr_high_bit_pos()` takes a parameter of type `uint64_t`.

C rules for widening from signed types to unsigned types differs from that for widening from unsigned types to unsigned types. The former will effectively sign extend the signed value, but the latter zero extends. I suspect that there's no current `fflags` value with the most significant bit set, so it makes no difference now, but

1. Should it happen, you'll definitely fall off the end of `map->ev_to_func`.
2. Why go out of one's way to give the local a different type, risking just this sort of issue and making whoever reads the code wonder about it.

This won't affect CID #1604609; it turned up while I was looking at it.