### PR TITLE
Attempt Coverity-only overflow check in xlat_print() (CID #1604615)

### DIFF
--- a/src/lib/unlang/xlat_tokenize.c
+++ b/src/lib/unlang/xlat_tokenize.c
@@ -1222,7 +1222,12 @@ ssize_t xlat_print(fr_sbuff_t *out, xlat_exp_head_t const *head, fr_sbuff_escape
 
 	xlat_exp_foreach(head, node) {
 		slen = xlat_print_node(out, head, node, e_rules, 0);
-		if (slen < 0) return slen - (fr_sbuff_used_total(out) - at_in);
+		if (slen < 0) {
+#ifdef __COVERITY__
+			if ((ssize_t) (slen - (fr_sbuff_used_total(out) - at_in)) >= 0) return -1;
+#endif
+			return slen - (fr_sbuff_used_total(out) - at_in);
+		}
 	}
 
 	return fr_sbuff_used_total(out) - at_in;


### PR DESCRIPTION
The error return subtracts a `size_t` from an `ssize_t`, which C does in `size_t`, and then casts the result to `ssize_t` for return, which in theory raises the possibility of overflow. We add a Coverity-only check that tries to catch it. If Coverity doesn't recognize it, we'll have to fall back to annotation.