### PR TITLE
use strlcpy()i rather than strcpy() (CIDs #1618878-#161880)

### DIFF
--- a/src/bin/unit_test_attribute.c
+++ b/src/bin/unit_test_attribute.c
@@ -1379,7 +1379,7 @@ static size_t command_radmin_add(command_result_t *result, command_file_ctx_t *c
 
 	table = talloc_zero(cc->tmp_ctx, fr_cmd_table_t);
 
-	strcpy(buffer, in);
+	strlcpy(buffer, in, sizeof(buffer));
 
 	p = strchr(buffer, ':');
 	if (!p) {
@@ -1755,7 +1755,7 @@ size_t command_encode_dns_label(command_result_t *result, command_file_ctx_t *cc
 	uint8_t		*enc_p;
 	char		buffer[8192];
 
-	strcpy(buffer, in);
+	strlcpy(buffer, in, sizeof(buffer));
 
 	p = buffer;
 	next = strchr(p, ',');
@@ -2024,7 +2024,7 @@ static size_t command_encode_raw(command_result_t *result, command_file_ctx_t *c
 	size_t	len;
 	char	buffer[8192];
 
-	strcpy(buffer, in);
+	strlcpy(buffer, in, sizeof(buffer));
 
 	len = encode_rfc(buffer, cc->buffer_start, cc->buffer_end - cc->buffer_start);
 	if (len <= 0) RETURN_PARSE_ERROR(0);


### PR DESCRIPTION
`command_encode_dns_label()`, `command_radmin_add()`, and `command_encode_raw()` all `strcpy()` the incoming string `in` to a local fixed-size buffer `buffer`. The callers all pass a pointer to a buffer no bigger than the local buffer, but Coverity apparently cannot tell that. (It looks like all calls to hem are made through an array of structures--perhaps that's why.) To pacify Coverity, we switch from `strcpy()` to `strlcpy()`, which takes an extra parameter to let us guarantee it won't overrun `buffer.`