### PR TITLE
Add tls configuration parameter allow_missing_crl

### DIFF
--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -369,6 +369,10 @@ eap {
 		#
 	#	allow_expired_crl = no
 
+		# Accept a missing Certificate Revocation List
+		#
+	#	allow_missing_crl = no
+
 		#  If check_cert_issuer is set, the value will
 		#  be checked against the DN of the issuer in
 		#  the client certificate.  If the values do not

--- a/src/include/tls-h
+++ b/src/include/tls-h
@@ -390,6 +390,7 @@ struct fr_tls_server_conf_t {
 	bool		check_crl;
 	bool		check_all_crl;
 	bool		allow_expired_crl;
+	bool		allow_missing_crl;
 	uint32_t	ca_path_reload_interval;
 	uint32_t	ca_path_last_reload;
 	X509_STORE	*old_x509_store;

--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -1681,6 +1681,7 @@ static CONF_PARSER tls_server_config[] = {
 #endif
 	{ "ca_path_reload_interval", FR_CONF_OFFSET(PW_TYPE_INTEGER, fr_tls_server_conf_t, ca_path_reload_interval), "0" },
 	{ "allow_expired_crl", FR_CONF_OFFSET(PW_TYPE_BOOLEAN, fr_tls_server_conf_t, allow_expired_crl), NULL },
+	{ "allow_missing_crl", FR_CONF_OFFSET(PW_TYPE_BOOLEAN, fr_tls_server_conf_t, allow_missing_crl), NULL },
 	{ "check_cert_cn", FR_CONF_OFFSET(PW_TYPE_STRING, fr_tls_server_conf_t, check_cert_cn), NULL },
 	{ "cipher_list", FR_CONF_OFFSET(PW_TYPE_STRING, fr_tls_server_conf_t, cipher_list), NULL },
 	{ "cipher_server_preference", FR_CONF_OFFSET(PW_TYPE_BOOLEAN, fr_tls_server_conf_t, cipher_server_preference), NULL },
@@ -3202,6 +3203,16 @@ int cbtls_verify(int ok, X509_STORE_CTX *ctx)
 	if (!my_ok &&
 	    (conf->allow_expired_crl) &&
 	    (err == X509_V_ERR_CRL_HAS_EXPIRED)) {
+		my_ok = 1;
+		X509_STORE_CTX_set_error( ctx, 0 );
+	}
+
+	/*
+	 *	If the CRL is missing, that might still be OK
+	 */
+	if (!my_ok &&
+	    (conf->allow_missing_crl) &&
+	    (err == X509_V_ERR_UNABLE_TO_GET_CRL)) {
 		my_ok = 1;
 		X509_STORE_CTX_set_error( ctx, 0 );
 	}


### PR DESCRIPTION
This will allow a connection to continue even with a missing CRL.