### PR TITLE
Annotate return_overflow in `mod_write()` (CID #1604620)

### DIFF
--- a/src/listen/tacacs/proto_tacacs_tcp.c
+++ b/src/listen/tacacs/proto_tacacs_tcp.c
@@ -315,6 +315,7 @@ static ssize_t mod_write(fr_listen_t *li, UNUSED void *packet_ctx, UNUSED fr_tim
 	 *	Return the packet we wrote, plus any bytes previously
 	 *	left over from previous packets.
 	 */
+	/* coverity[return_overflow] */
 	return data_size + written;
 }
 


### PR DESCRIPTION
This is arguably another example of trying to return a value not representable in the function return type. It's highly unlikely that anyone will pass a buffer of more than `SSIZE_MAX` bytes, but Coverity apparently doesn't consider that.

CIDs #1604605 and #1604616 explicitly do return error values not representable as int, but a ridiculously large buffer allocation will fail long before anyone calls `mod_write()`, so we annotate.