### PR TITLE
Annotate return_overflow in fr_writev() (CID #1604625)

### DIFF
--- a/src/lib/util/iovec.c
+++ b/src/lib/util/iovec.c
@@ -75,13 +75,6 @@ ssize_t fr_writev(int fd, struct iovec vector[], int iovcnt, fr_time_delta_t tim
 
 		wrote = writev(fd, vector_p, iovcnt);
 		if (wrote > 0) {
-#ifdef __COVERITY__
-			/*
-			 * 	Coverity thinks that total += wrote might underflow,
-			 * 	which causes an issue at the return.
-			 */
-			if (total + wrote < total) return -1;
-#endif
 			total += wrote;
 			while (wrote > 0) {
 				/*
@@ -102,7 +95,10 @@ ssize_t fr_writev(int fd, struct iovec vector[], int iovcnt, fr_time_delta_t tim
 				break;
 			}
 			continue;
-		} else if (wrote == 0) return total;
+		} else if (wrote == 0) {
+			/* coverity[return_overflow] */
+			return total;
+		}
 
 		switch (errno) {
 		/* Write operation would block, use select() to implement a timeout */


### PR DESCRIPTION
In theory, `iovcnt` and the amounts written could total to more than `SSIZE_MAX`, and when Coverity is looking at `fr_writev()` rather than its callers it can't tell. We therefore annotate.