### PR TITLE
Update listen.c for illumos and Solaris in v3.0.x

### DIFF
--- a/src/main/listen.c
+++ b/src/main/listen.c
@@ -55,7 +55,7 @@ RCSID("$Id$")
 #ifdef WITH_TLS
 #include <netinet/tcp.h>
 
-#  if defined(__APPLE__) || defined(__FreeBSD__)
+#  if defined(__APPLE__) || defined(__FreeBSD__) || defined(__illumos__) || defined(__sun__)
 #    if !defined(SOL_TCP) && defined(IPPROTO_TCP)
 #      define SOL_TCP IPPROTO_TCP
 #    endif


### PR DESCRIPTION
add define for illumos and Solaris.

The same as Fixes #5135 #5313 in v3.2.x