### PR TITLE
V3.2.x Add handling for Subject Alternative Name (SAN) URIs

### DIFF
--- a/share/dictionary.freeradius.internal
+++ b/share/dictionary.freeradius.internal
@@ -578,6 +578,8 @@ ATTRIBUTE	TLS-Client-Cert-X509v3-Basic-Constraints 1930	string
 ATTRIBUTE	TLS-Client-Cert-Subject-Alt-Name-Dns	1931	string
 ATTRIBUTE	TLS-Client-Cert-Subject-Alt-Name-Upn	1932	string
 ATTRIBUTE	TLS-PSK-Identity			1933	string
+ATTRIBUTE	TLS-Cert-Subject-Alt-Name-Uri	1934	string
+ATTRIBUTE	TLS-Client-Cert-Subject-Alt-Name-Uri	1935	string
 ATTRIBUTE	TLS-Client-Cert-X509v3-Extended-Key-Usage-OID 1936	string
 ATTRIBUTE	TLS-Client-Cert-Valid-Since		1937	string
 ATTRIBUTE	TLS-Cache-Method			1938	integer

--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -3191,7 +3191,7 @@ int cbtls_verify(int ok, X509_STORE_CTX *ctx)
 #ifdef GEN_URI
 				case GEN_URI:
 					vp = fr_pair_make(talloc_ctx, certs, cert_attr_names[FR_TLS_SAN_URI][lookup],
-									(char const *) ASN1_STRING_get0_data(name->d.uniformResourceIdentifier), T_OP_SET);
+						      (char const *) ASN1_STRING_get0_data(name->d.uniformResourceIdentifier), T_OP_SET);
 					rdebug_pair(L_DBG_LVL_2, request, vp, NULL);
 					break;
 #endif /* GEN_URI */

--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -2930,22 +2930,22 @@ ocsp_end:
  */
 static char const *cert_attr_names[10][2] = {
 	{ "TLS-Client-Cert-Serial",			"TLS-Cert-Serial" },
-	{ "TLS-Client-Cert-Expiration",		"TLS-Cert-Expiration" },
-	{ "TLS-Client-Cert-Subject",		"TLS-Cert-Subject" },
+	{ "TLS-Client-Cert-Expiration",			"TLS-Cert-Expiration" },
+	{ "TLS-Client-Cert-Subject",			"TLS-Cert-Subject" },
 	{ "TLS-Client-Cert-Issuer",			"TLS-Cert-Issuer" },
-	{ "TLS-Client-Cert-Common-Name",	"TLS-Cert-Common-Name" },
+	{ "TLS-Client-Cert-Common-Name",		"TLS-Cert-Common-Name" },
 	{ "TLS-Client-Cert-Subject-Alt-Name-Email",	"TLS-Cert-Subject-Alt-Name-Email" },
 	{ "TLS-Client-Cert-Subject-Alt-Name-Dns",	"TLS-Cert-Subject-Alt-Name-Dns" },
 	{ "TLS-Client-Cert-Subject-Alt-Name-Upn",	"TLS-Cert-Subject-Alt-Name-Upn" },
 	{ "TLS-Client-Cert-Subject-Alt-Name-Uri",	"TLS-Cert-Subject-Alt-Name-Uri" },
-	{ "TLS-Client-Cert-Valid-Since",			"TLS-Cert-Valid-Since" }
+	{ "TLS-Client-Cert-Valid-Since",		"TLS-Cert-Valid-Since" }
 };
 
 #define FR_TLS_SERIAL		(0)
 #define FR_TLS_EXPIRATION	(1)
 #define FR_TLS_SUBJECT		(2)
 #define FR_TLS_ISSUER		(3)
-#define FR_TLS_CN			(4)
+#define FR_TLS_CN		(4)
 #define FR_TLS_SAN_EMAIL	(5)
 #define FR_TLS_SAN_DNS		(6)
 #define FR_TLS_SAN_UPN		(7)

--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -2928,27 +2928,29 @@ ocsp_end:
 /*
  *	For creating certificate attributes.
  */
-static char const *cert_attr_names[9][2] = {
+static char const *cert_attr_names[10][2] = {
 	{ "TLS-Client-Cert-Serial",			"TLS-Cert-Serial" },
-	{ "TLS-Client-Cert-Expiration",			"TLS-Cert-Expiration" },
-	{ "TLS-Client-Cert-Subject",			"TLS-Cert-Subject" },
+	{ "TLS-Client-Cert-Expiration",		"TLS-Cert-Expiration" },
+	{ "TLS-Client-Cert-Subject",		"TLS-Cert-Subject" },
 	{ "TLS-Client-Cert-Issuer",			"TLS-Cert-Issuer" },
-	{ "TLS-Client-Cert-Common-Name",		"TLS-Cert-Common-Name" },
+	{ "TLS-Client-Cert-Common-Name",	"TLS-Cert-Common-Name" },
 	{ "TLS-Client-Cert-Subject-Alt-Name-Email",	"TLS-Cert-Subject-Alt-Name-Email" },
 	{ "TLS-Client-Cert-Subject-Alt-Name-Dns",	"TLS-Cert-Subject-Alt-Name-Dns" },
 	{ "TLS-Client-Cert-Subject-Alt-Name-Upn",	"TLS-Cert-Subject-Alt-Name-Upn" },
-	{ "TLS-Client-Cert-Valid-Since",		"TLS-Cert-Valid-Since" }
+	{ "TLS-Client-Cert-Subject-Alt-Name-Uri",	"TLS-Cert-Subject-Alt-Name-Uri" },
+	{ "TLS-Client-Cert-Valid-Since",			"TLS-Cert-Valid-Since" }
 };
 
 #define FR_TLS_SERIAL		(0)
 #define FR_TLS_EXPIRATION	(1)
 #define FR_TLS_SUBJECT		(2)
 #define FR_TLS_ISSUER		(3)
-#define FR_TLS_CN		(4)
-#define FR_TLS_SAN_EMAIL       	(5)
-#define FR_TLS_SAN_DNS          (6)
-#define FR_TLS_SAN_UPN          (7)
-#define FR_TLS_VALID_SINCE	(8)
+#define FR_TLS_CN			(4)
+#define FR_TLS_SAN_EMAIL	(5)
+#define FR_TLS_SAN_DNS		(6)
+#define FR_TLS_SAN_UPN		(7)
+#define FR_TLS_SAN_URI		(8)
+#define FR_TLS_VALID_SINCE	(9)
 
 /*
  *	Before trusting a certificate, you must make sure that the
@@ -3186,6 +3188,13 @@ int cbtls_verify(int ok, X509_STORE_CTX *ctx)
 					}
 					break;
 #endif	/* GEN_OTHERNAME */
+#ifdef GEN_URI
+				case GEN_URI:
+					vp = fr_pair_make(talloc_ctx, certs, cert_attr_names[FR_TLS_SAN_URI][lookup],
+									(char const *) ASN1_STRING_get0_data(name->d.uniformResourceIdentifier), T_OP_SET);
+					rdebug_pair(L_DBG_LVL_2, request, vp, NULL);
+					break;
+#endif /* GEN_URI */
 				default:
 					/* XXX TODO handle other SAN types */
 					break;


### PR DESCRIPTION
Add handling for Subject Alternative Name (SAN) URIs.

These URIs can be leveraged by network access control systems to make authentication and authorization decisions based on external device management services, such as Intune, where device certs may include the "IntuneDeviceId://guid" SAN URI.

Once this is included, we can look at calling the Intune Graph API to query device compliance status & group membership etc.

