### PR TITLE
Update the base Alpine Linux container image

### DIFF
--- a/scripts/docker/dists/alpine/Dockerfile
+++ b/scripts/docker/dists/alpine/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Rebuild this file with `make docker.alpine.regen`
 #
-ARG from=alpine:3.13
+ARG from=alpine:3.20
 FROM ${from} as build
 
 #

--- a/scripts/docker/m4/Dockerfile.m4
+++ b/scripts/docker/m4/Dockerfile.m4
@@ -18,7 +18,7 @@ define([p_SET], [
 ])
 dnl		D_NAME		PKG_TYPE      OS_NAME	OS_VER	OS_CODENAME	DOCKER_IMAGE
 ifelse(
-	D_NAME, [alpine],	[p_SET([alpine], [alpine], [3.13], [alpine],	[alpine:3.13])],
+	D_NAME, [alpine],	[p_SET([alpine], [alpine], [3.20], [alpine],	[alpine:3.20])],
 	D_NAME, [debian10],	[p_SET([deb], [debian],	[10],	[buster],	[debian:buster])],
 	D_NAME, [debian11],	[p_SET([deb], [debian],	[11],	[bullseye],	[debian:bullseye])],
 	D_NAME, [debian12],	[p_SET([deb], [debian],	[12],	[bookworm],	[debian:bookworm])],


### PR DESCRIPTION
End of support was reached for Alpine Linux 3.13 on November 2022.
Use the latest stable version instead (supported until April 2026).