### PR TITLE
support tcp packets in radsniff

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1020,6 +1020,7 @@ AC_CHECK_HEADERS( \
   net/if_dl.h \
   netdb.h \
   netinet/in.h \
+  netinet/tcp.h \
   netpacket/packet.h \
   prot.h \
   pwd.h \

--- a/src/bin/radsniff.h
+++ b/src/bin/radsniff.h
@@ -28,6 +28,7 @@
 RCSIDH(radsniff_h, "$Id$")
 
 #include <sys/types.h>
+#include <netinet/tcp.h>
 
 #include <freeradius-devel/util/pcap.h>
 #include <freeradius-devel/util/event.h>


### PR DESCRIPTION
Radius over TCP generally appears in complete packets with the PSH flag set, and generally one radius packet per TCP PSH packet.  This code is to enable the reading of TCP packets for this one common case.  Tested for IP4.

The handling of `#include <netinet/tcp.h>` might not be correct - sorry.

Testing with pcap file:

    DIR=. ; PROGRAM=radsniff ; $DIR/build/make/jlibtool --mode=execute $FR_DEBUGGER $DIR/build/bin/local/$PROGRAM -d $DIR/raddb -D $DIR/share/dictionary -x -f  'tcp and port 1812 or 1813' -I tcp.pcap