### PR TITLE
Don't directly use buffer set in sbuff (CID #1634622)

### DIFF
--- a/src/bin/dhcpclient.c
+++ b/src/bin/dhcpclient.c
@@ -511,10 +511,13 @@ static void dhcp_packet_debug(fr_packet_t *packet, fr_pair_list_t *list, bool re
 	for (vp = fr_pair_list_head(list);
 	     vp;
 	     vp = fr_pair_list_next(list, vp)) {
+		fr_sbuff_t out;
+
 		PAIR_VERIFY(vp);
 
-		(void) fr_pair_print(&FR_SBUFF_OUT(buffer, sizeof(buffer)), NULL, vp);
-		printf("\t%s\n", buffer);
+		out = FR_SBUFF_OUT(buffer, sizeof(buffer));
+		(void) fr_pair_print(&out, NULL, vp);
+		printf("\t%s\n", fr_sbuff_start(&out));
 	}
 }
 


### PR DESCRIPTION
Another case of an uninitialized local buffer used in an sbuff but referenced by name to print out. Coverity complains about it, not recognizing the the sbuff operation puts a value there. Referencing the start of the sbuff gets the same effect without complaint.