### PR TITLE
fix confusing message in rlm_sql when user mangles query

### DIFF
--- a/src/modules/rlm_sql/rlm_sql.c
+++ b/src/modules/rlm_sql/rlm_sql.c
@@ -1706,7 +1706,7 @@ static rlm_rcode_t mod_checksimul(void *instance, REQUEST * request)
 
 		num_rows = (inst->module->sql_num_fields)(handle, inst->config);
 		if (num_rows < 8) {
-			RDEBUG("Too few rows returned.  Please do not edit 'simul_verify_query'");
+			WARN("SELECT returned too few fields.  Please do not edit 'simul_verify_query'");
 			rcode = RLM_MODULE_FAIL;
 
 			goto finish;


### PR DESCRIPTION
830c3dece7c missed fixing this too, but also changed from RDEBUG to WARN to match the `client_query` warning