### PR TITLE
Close path opened by fr_mkdir() to avoid fd leak (CID #1636671)

### DIFF
--- a/src/lib/bio/fd_open.c
+++ b/src/lib/bio/fd_open.c
@@ -1239,6 +1239,7 @@ int fr_bio_fd_reopen(fr_bio_t *bio)
 		      }) < 0)) {
 		return -1;
 	}
+	if (cfg->mkdir) close(fd);
 
 	/*
 	 *	Create it if necessary.


### PR DESCRIPTION
In `fr_bio_fd_reopen()`, if `cfg->mkdir` is true, it tries to create a directory and returns -1 if it fails. If it succeeds, the path number of the created directory is stored in `fd`...and the next use of `fd` is assigning the result of `open()` to it, leaving the directory open and accumulating inaccessible open files.