### PR TITLE
fix: seg-fault when there is an error processing an INCLUDE as part of a module with more than 1 item on the stack (and using BEGIN-PROTOCOL))

### DIFF
--- a/src/lib/util/dict_tokenize.c
+++ b/src/lib/util/dict_tokenize.c
@@ -169,6 +169,7 @@ static int CC_HINT(nonnull)
 dict_dctx_push_or_update(dict_tokenize_ctx_t *dctx, fr_dict_attr_t const *da, dict_nest_t nest)
 {
 	if (dctx->stack[++dctx->stack_depth].nest == nest) {
+		dctx->stack[dctx->stack_depth].filename = dctx->stack[dctx->stack_depth - 1].filename;
 		dctx->stack[dctx->stack_depth].da = da;
 		return 0;
 	}


### PR DESCRIPTION
When using a dictionary that first defines a protocol with "PROTOCOL" the dctx stack da is updated, but not the filename, causing it to be lost as the stack grows, since all future items on the stack inherit the filename. Fixed by also setting the filename when updating the da.