### PR TITLE
Fix EAP preproxy

### DIFF
--- a/src/modules/rlm_eap/rlm_eap.c
+++ b/src/modules/rlm_eap/rlm_eap.c
@@ -591,7 +591,8 @@ static rlm_rcode_t CC_HINT(nonnull) mod_authorize(void *instance, REQUEST *reque
 static rlm_rcode_t CC_HINT(nonnull) mod_pre_proxy(UNUSED void *instance, REQUEST *request)
 {
 	VALUE_PAIR	*vp;
-	size_t		length, eap_length;
+	vp_cursor_t	cursor;
+	size_t		length, eap_length = 0;
 
 	vp = fr_pair_find_by_num(request->packet->vps, PW_EAP_MESSAGE, 0, TAG_ANY);
 	if (!vp) return RLM_MODULE_NOOP;
@@ -615,12 +616,13 @@ static rlm_rcode_t CC_HINT(nonnull) mod_pre_proxy(UNUSED void *instance, REQUEST
 	/*
 	 *	Get length of all EAP-Message attributes
 	 */
-	for (eap_length = 0; vp != NULL; vp = vp->next) {
+	fr_cursor_init(&cursor, &request->packet->vps);
+	while ((vp = fr_cursor_next_by_num(&cursor, PW_EAP_MESSAGE, 0, TAG_ANY))) {
 		eap_length += vp->vp_length;
 	}
 
 	if (length != eap_length) {
-		RDEBUG("EAP length does not match attribute length");
+		RDEBUG("EAP length (%lu) does not match attribute length (%lu)", eap_length, length);
 		goto add_error_cause;
 	}
 


### PR DESCRIPTION
The calculation of EAP message length needs to total the length of all the EAP message attributes, rather than the length of the first EAP message attribute and all subsequent attributes of all types.  Also, enhance the error message to include the calculated lengths.

Fixes https://github.com/FreeRADIUS/freeradius-server/issues/5486