### PR TITLE
fix: da->dict == NULL

### DIFF
--- a/src/lib/util/dict_tokenize.c
+++ b/src/lib/util/dict_tokenize.c
@@ -437,12 +437,12 @@ static int dict_process_type_field(dict_tokenize_ctx_t *dctx, char const *name, 
 	if (fr_type_is_null(type)) {
 		fr_dict_attr_t *da = *da_p;
 
-		if (!da->dict->proto->attr.type_parse) {
+		if (!dctx->dict->proto->attr.type_parse) {
 			fr_strerror_printf("Unknown data type '%s'", name);
 			return -1;
 		}
 
-		if (!da->dict->proto->attr.type_parse(&type, &da->flags, name)) {
+		if (!dctx->dict->proto->attr.type_parse(&type, &da->flags, name)) {
 			return -1;
 		}
 	}


### PR DESCRIPTION
Updated reference to attr.type_parse to use the dict of the decode context, since the da->dict is not set until shortly after this call is made in dict_read_process_common