### PR TITLE
Adopt a standard naming convention and signature for debug functions

### DIFF
--- a/src/bin/fuzzer.c
+++ b/src/bin/fuzzer.c
@@ -257,7 +257,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 	}
 
 	tp->func(ctx, &vps, buf, len, decode_ctx);
-	if (fr_debug_lvl > 3) fr_pair_list_debug(&vps);
+	if (fr_debug_lvl > 3) fr_pair_list_debug(stderr, &vps);
 
 	talloc_free(decode_ctx);
 	talloc_free(ctx);

--- a/src/bin/unit_test_attribute.c
+++ b/src/bin/unit_test_attribute.c
@@ -1023,7 +1023,7 @@ static int dictionary_load_common(command_result_t *result, command_file_ctx_t *
 	/*
 	 *	Dump the dictionary if we're in super debug mode
 	 */
-	if (fr_debug_lvl > 5) fr_dict_debug(cc->tmpl_rules.attr.dict_def);
+	if (fr_debug_lvl > 5) fr_dict_debug(stderr, cc->tmpl_rules.attr.dict_def);
 
 	RETURN_OK(0);
 }
@@ -1121,7 +1121,7 @@ static void command_print(void)
 	void *walk_ctx = NULL;
 
 	printf("Command hierarchy --------");
-	fr_command_debug(stdout, command_head);
+	fr_cmd_debug(stdout, command_head);
 
 	printf("Command list --------");
 	while (fr_command_walk(command_head, &walk_ctx, NULL, command_walk) == 1) {
@@ -1756,7 +1756,7 @@ static size_t command_dictionary_attribute_parse(command_result_t *result, comma
 static size_t command_dictionary_dump(command_result_t *result, command_file_ctx_t *cc,
 				      UNUSED char *data, size_t data_used, UNUSED char *in, UNUSED size_t inlen)
 {
-	fr_dict_debug(dictionary_current(cc));
+	fr_dict_debug(stderr, dictionary_current(cc));
 
 	/*
 	 *	Don't modify the contents of the data buffer

--- a/src/lib/io/atomic_queue.c
+++ b/src/lib/io/atomic_queue.c
@@ -169,7 +169,7 @@ bool fr_atomic_queue_push(fr_atomic_queue_t *aq, void *data)
 		 */
 		if (diff < 0) {
 #if 0
-			fr_atomic_queue_debug(aq, stderr);
+			fr_atomic_queue_debug(stderr, aq);
 #endif
 			return false;
 		}
@@ -298,7 +298,7 @@ typedef struct {
  * @param[in] aq	The atomic queue to debug.
  * @param[in] fp	where the debugging information will be printed.
  */
-void fr_atomic_queue_debug(fr_atomic_queue_t *aq, FILE *fp)
+void fr_atomic_queue_debug(FILE * fp, fr_atomic_queue_t *aq)
 {
 	size_t i;
 	int64_t head, tail;

--- a/src/lib/io/atomic_queue.h
+++ b/src/lib/io/atomic_queue.h
@@ -64,7 +64,7 @@ void			fr_atomic_queue_verify(fr_atomic_queue_t *aq);
 #endif
 
 #ifndef NDEBUG
-void			fr_atomic_queue_debug(fr_atomic_queue_t *aq, FILE *fp);
+void			fr_atomic_queue_debug(FILE *fp, fr_atomic_queue_t *aq);
 #endif
 
 

--- a/src/lib/io/message.c
+++ b/src/lib/io/message.c
@@ -1259,7 +1259,7 @@ void fr_message_set_gc(fr_message_set_t *ms)
  * @param[in] ms the message set
  * @param[in] fp the FILE where the messages are printed.
  */
-void fr_message_set_debug(fr_message_set_t *ms, FILE *fp)
+void fr_message_set_debug(FILE *fp, fr_message_set_t *ms)
 {
 	int i;
 

--- a/src/lib/io/message.h
+++ b/src/lib/io/message.h
@@ -64,7 +64,7 @@ fr_message_t *fr_message_localize(TALLOC_CTX *ctx, fr_message_t *m, size_t messa
 int fr_message_set_messages_used(fr_message_set_t *ms) CC_HINT(nonnull);
 void fr_message_set_gc(fr_message_set_t *ms) CC_HINT(nonnull);
 
-void fr_message_set_debug(fr_message_set_t *ms, FILE *fp) CC_HINT(nonnull);
+void fr_message_set_debug(FILE *fp, fr_message_set_t *ms) CC_HINT(nonnull);
 
 #ifdef __cplusplus
 }

--- a/src/lib/io/queue.c
+++ b/src/lib/io/queue.c
@@ -252,10 +252,10 @@ int fr_queue_localize_atomic(fr_queue_t *fq, fr_atomic_queue_t *aq)
 #ifndef NDEBUG
 /**  Dump a queue.
  *
- * @param[in] fq the queue
  * @param[in] fp where the debugging information will be printed.
+ * @param[in] fq the queue
  */
-void fr_queue_debug(fr_queue_t *fq, FILE *fp)
+void fr_queue_debug(FILE *fp, fr_queue_t *fq)
 {
 	int i;
 

--- a/src/lib/io/queue.h
+++ b/src/lib/io/queue.h
@@ -47,7 +47,7 @@ int fr_queue_num_elements(fr_queue_t *fq) CC_HINT(nonnull);
 int fr_queue_localize_atomic(fr_queue_t *fq, fr_atomic_queue_t *aq) CC_HINT(nonnull);
 
 #ifndef NDEBUG
-void fr_queue_debug(fr_queue_t *fq, FILE *fp) CC_HINT(nonnull);
+void fr_queue_debug(FILE *fp, fr_queue_t *fq) CC_HINT(nonnull);
 #endif
 
 

--- a/src/lib/io/ring_buffer.c
+++ b/src/lib/io/ring_buffer.c
@@ -482,7 +482,7 @@ int fr_ring_buffer_start(fr_ring_buffer_t *rb, uint8_t **p_start, size_t *p_size
  * @param[in] rb the ring buffer
  * @param[in] fp the FILE where the messages are printed.
  */
-void fr_ring_buffer_debug(fr_ring_buffer_t *rb, FILE *fp)
+void fr_ring_buffer_debug(FILE *fp, fr_ring_buffer_t *rb)
 {
 	fprintf(fp, "Buffer %p, write_offset %zu, data_start %zu, data_end %zu\n",
 		rb->buffer, rb->write_offset, rb->data_start, rb->data_end);

--- a/src/lib/io/ring_buffer.h
+++ b/src/lib/io/ring_buffer.h
@@ -52,7 +52,7 @@ size_t			fr_ring_buffer_size(fr_ring_buffer_t *rb) CC_HINT(nonnull);
 
 size_t 			fr_ring_buffer_used(fr_ring_buffer_t *rb) CC_HINT(nonnull);
 
-void			fr_ring_buffer_debug(fr_ring_buffer_t *rb, FILE *fp) CC_HINT(nonnull);
+void			fr_ring_buffer_debug(FILE *fp, fr_ring_buffer_t *rb) CC_HINT(nonnull);
 
 #ifdef __cplusplus
 }

--- a/src/lib/server/command.c
+++ b/src/lib/server/command.c
@@ -1599,7 +1599,7 @@ static void fr_command_debug_internal(FILE *fp, fr_cmd_t *head, int depth)
 	}
 }
 
-void fr_command_debug(FILE *fp, fr_cmd_t *head)
+void fr_cmd_debug(FILE *fp, fr_cmd_t *head)
 {
 	fr_command_debug_internal(fp, head, 0);
 }

--- a/src/lib/server/command.h
+++ b/src/lib/server/command.h
@@ -79,7 +79,7 @@ int fr_command_walk(fr_cmd_t *head, void **walk_ctx, void *ctx, fr_cmd_walk_t ca
 int fr_command_tab_expand(TALLOC_CTX *ctx, fr_cmd_t *head, fr_cmd_info_t *info, int max_expansions, char const **expansions);
 char const *fr_command_help(fr_cmd_t *head, int argc, char *argv[]);
 int fr_command_run(FILE *fp, FILE *fp_err, fr_cmd_info_t *info, bool read_only);
-void fr_command_debug(FILE *fp, fr_cmd_t *head);
+void fr_cmd_debug(FILE *fp, fr_cmd_t *head);
 int fr_command_str_to_argv(fr_cmd_t *head, fr_cmd_info_t *info, char const *str);
 int fr_command_clear(int new_argc, fr_cmd_info_t *info) CC_HINT(nonnull);
 

--- a/src/lib/server/tmpl.h
+++ b/src/lib/server/tmpl.h
@@ -1083,7 +1083,7 @@ typedef enum {
 #define tmpl_aexpand_type(_ctx, _out, _type, _request, _vpt, _escape, _escape_ctx) \
 			  _tmpl_to_atype(_ctx, (void *)(_out), _request, _vpt, _escape, _escape_ctx, _type)
 
-void			tmpl_debug(tmpl_t const *vpt) CC_HINT(nonnull);
+void			tmpl_debug(FILE *fp, tmpl_t const *vpt) CC_HINT(nonnull);
 
 fr_pair_list_t		*tmpl_list_head(request_t *request, fr_dict_attr_t const *list);
 
@@ -1181,11 +1181,11 @@ void			tmpl_set_xlat(tmpl_t *vpt, xlat_exp_head_t *xlat) CC_HINT(nonnull);
 
 int			tmpl_afrom_value_box(TALLOC_CTX *ctx, tmpl_t **out, fr_value_box_t *data, bool steal) CC_HINT(nonnull);
 
-void			tmpl_attr_ref_debug(const tmpl_attr_t *ar, int idx) CC_HINT(nonnull);
+void			tmpl_attr_ref_debug(FILE *fp, const tmpl_attr_t *ar, int idx) CC_HINT(nonnull);
 
-void			tmpl_attr_ref_list_debug(FR_DLIST_HEAD(tmpl_attr_list) const *ar_head) CC_HINT(nonnull);
+void			tmpl_attr_ref_list_debug(FILE *fp, FR_DLIST_HEAD(tmpl_attr_list) const *ar_head) CC_HINT(nonnull);
 
-void			tmpl_attr_debug(tmpl_t const *vpt) CC_HINT(nonnull);
+void			tmpl_attr_debug(FILE *fp, tmpl_t const *vpt) CC_HINT(nonnull);
 
 int			tmpl_attr_copy(tmpl_t *dst, tmpl_t const *src) CC_HINT(nonnull);
 
@@ -1328,7 +1328,7 @@ int			tmpl_extents_find(TALLOC_CTX *ctx,
 int			tmpl_extents_build_to_leaf_parent(fr_dlist_head_t *leaf, fr_dlist_head_t *interior,
 						   tmpl_t const *vpt) CC_HINT(nonnull);
 
-void			tmpl_extents_debug(fr_dlist_head_t *head) CC_HINT(nonnull);
+void			tmpl_extents_debug(FILE *fp, fr_dlist_head_t *head) CC_HINT(nonnull);
 
 int			tmpl_eval_pair(TALLOC_CTX *ctx, fr_value_box_list_t *out, request_t *request, tmpl_t const *vpt);
 

--- a/src/lib/server/tmpl_dcursor.c
+++ b/src/lib/server/tmpl_dcursor.c
@@ -742,7 +742,7 @@ int tmpl_extents_build_to_leaf_parent(fr_dlist_head_t *existing, fr_dlist_head_t
 	return 0;
 }
 
-void tmpl_extents_debug(fr_dlist_head_t *head)
+void tmpl_extents_debug(FILE *fp, fr_dlist_head_t *head)
 {
 	tmpl_attr_extent_t const *extent = NULL;
 	fr_pair_t *vp = NULL;
@@ -754,25 +754,25 @@ void tmpl_extents_debug(fr_dlist_head_t *head)
 	     	char const *ctx_name;
 
 	     	if (ar) {
-			FR_FAULT_LOG("extent-interior-attr");
-			tmpl_attr_ref_debug(extent->ar, 0);
+			fprintf(fp, "extent-interior-attr\n");
+			tmpl_attr_ref_debug(fp, extent->ar, 0);
 		} else {
-			FR_FAULT_LOG("extent-leaf");
+			fprintf(fp, "extent-leaf\n");
 		}
 
 		ctx_name = talloc_get_name(extent->list_ctx);
 		if (strcmp(ctx_name, "fr_pair_t") == 0) {
-			FR_FAULT_LOG("list_ctx     : %p (%s, %s)", extent->list_ctx, ctx_name,
+			fprintf(fp, "list_ctx     : %p (%s, %s)\n", extent->list_ctx, ctx_name,
 				     ((fr_pair_t *)extent->list_ctx)->da->name);
 		} else {
-			FR_FAULT_LOG("list_ctx     : %p (%s)", extent->list_ctx, ctx_name);
+			fprintf(fp, "list_ctx     : %p (%s)\n", extent->list_ctx, ctx_name);
 		}
-		FR_FAULT_LOG("list         : %p", extent->list);
+		fprintf(fp, "list         : %p", extent->list);
 		if (fr_pair_list_empty(extent->list)) {
-			FR_FAULT_LOG("list (first) : none (%p)", extent->list);
+			fprintf(fp, "list (first) : none (%p)\n", extent->list);
 		} else {
 			vp = fr_pair_list_head(extent->list);
-			FR_FAULT_LOG("list (first) : %s (%p)", vp->da->name, extent->list);
+			fprintf(fp, "list (first) : %s (%p)\n", vp->da->name, extent->list);
 		}
 	}
 

--- a/src/lib/server/tmpl_tokenize.c
+++ b/src/lib/server/tmpl_tokenize.c
@@ -206,7 +206,7 @@ static inline bool CC_HINT(always_inline) tmpl_substr_terminal_check(fr_sbuff_t 
 	return ret;
 }
 
-void tmpl_attr_ref_debug(const tmpl_attr_t *ar, int i)
+void tmpl_attr_ref_debug(FILE *fp, const tmpl_attr_t *ar, int i)
 {
 	char buffer[sizeof(STRINGIFY(INT16_MAX)) + 1];
 
@@ -217,29 +217,29 @@ void tmpl_attr_ref_debug(const tmpl_attr_t *ar, int i)
 	case TMPL_ATTR_TYPE_UNSPEC:
 	case TMPL_ATTR_TYPE_UNKNOWN:
 		if (!ar->da) {
-			FR_FAULT_LOG("\t[%u] %s null%s%s%s",
-				     i,
-				     fr_table_str_by_value(attr_table, ar->type, "<INVALID>"),
-				     ar->ar_num != NUM_UNSPEC ? "[" : "",
-				     ar->ar_num != NUM_UNSPEC ? fr_table_str_by_value(attr_num_table, ar->ar_num, buffer) : "",
-				     ar->ar_num != NUM_UNSPEC ? "]" : "");
+			fprintf(fp, "\t[%u] %s null%s%s%s\n",
+				i,
+				fr_table_str_by_value(attr_table, ar->type, "<INVALID>"),
+				ar->ar_num != NUM_UNSPEC ? "[" : "",
+				ar->ar_num != NUM_UNSPEC ? fr_table_str_by_value(attr_num_table, ar->ar_num, buffer) : "",
+				ar->ar_num != NUM_UNSPEC ? "]" : "");
 			return;
 		}
 
-		FR_FAULT_LOG("\t[%u] %s %s %s%s%s%s (%p) attr %u",
-			     i,
-			     fr_table_str_by_value(attr_table, ar->type, "<INVALID>"),
-			     fr_type_to_str(ar->da->type),
-			     ar->da->name,
-			     ar->ar_num != NUM_UNSPEC ? "[" : "",
-			     ar->ar_num != NUM_UNSPEC ? fr_table_str_by_value(attr_num_table, ar->ar_num, buffer) : "",
-			     ar->ar_num != NUM_UNSPEC ? "]" : "",
-			     ar->da,
-			     ar->da->attr
+		fprintf(fp, "\t[%u] %s %s %s%s%s%s (%p) attr %u\n ",
+			i,
+			fr_table_str_by_value(attr_table, ar->type, "<INVALID>"),
+			fr_type_to_str(ar->da->type),
+			ar->da->name,
+			ar->ar_num != NUM_UNSPEC ? "[" : "",
+			ar->ar_num != NUM_UNSPEC ? fr_table_str_by_value(attr_num_table, ar->ar_num, buffer) : "",
+			ar->ar_num != NUM_UNSPEC ? "]" : "",
+			ar->da,
+			ar->da->attr
 		);
-		FR_FAULT_LOG("\t    is_raw     : %s", ar_is_raw(ar) ? "yes" : "no");
-		FR_FAULT_LOG("\t    is_unknown : %s", ar_is_unknown(ar) ? "yes" : "no");
-		if (ar->ar_parent) FR_FAULT_LOG("\t    parent     : %s (%p)", ar->ar_parent->name, ar->ar_parent);
+		fprintf(fp, "\t    is_raw     : %s\n", ar_is_raw(ar) ? "yes" : "no");
+		fprintf(fp, "\t    is_unknown : %s", ar_is_unknown(ar) ? "yes" : "no");
+		if (ar->ar_parent) fprintf(fp, "\t    parent     : %s (%p)", ar->ar_parent->name, ar->ar_parent);
 		break;
 
 
@@ -248,40 +248,40 @@ void tmpl_attr_ref_debug(const tmpl_attr_t *ar, int i)
 		 *	Type reveals unresolved status
 		 *	so we don't need to add it explicitly
 		 */
-		FR_FAULT_LOG("\t[%u] %s %s%s%s%s",
-			     i,
-			     fr_table_str_by_value(attr_table, ar->type, "<INVALID>"),
-			     ar->ar_unresolved,
-			     ar->ar_num != NUM_UNSPEC ? "[" : "",
-			     ar->ar_num != NUM_UNSPEC ? fr_table_str_by_value(attr_num_table, ar->ar_num, buffer) : "",
-			     ar->ar_num != NUM_UNSPEC ? "]" : "");
-		if (ar->ar_parent) 			FR_FAULT_LOG("\t    parent     : %s", ar->ar_parent->name);
-		if (ar->ar_unresolved_namespace)	FR_FAULT_LOG("\t    namespace  : %s", ar->ar_unresolved_namespace->name);
+		fprintf(fp, "\t[%u] %s %s%s%s%s\n",
+			i,
+			fr_table_str_by_value(attr_table, ar->type, "<INVALID>"),
+			ar->ar_unresolved,
+			ar->ar_num != NUM_UNSPEC ? "[" : "",
+			ar->ar_num != NUM_UNSPEC ? fr_table_str_by_value(attr_num_table, ar->ar_num, buffer) : "",
+			ar->ar_num != NUM_UNSPEC ? "]" : "");
+		if (ar->ar_parent) 			fprintf(fp, "\t    parent     : %s", ar->ar_parent->name);
+		if (ar->ar_unresolved_namespace)	fprintf(fp, "\t    namespace  : %s", ar->ar_unresolved_namespace->name);
 		break;
 
 	default:
-		FR_FAULT_LOG("\t[%u] Bad type %s(%u)",
+		fprintf(fp, "\t[%u] Bad type %s(%u)",
 			     i, fr_table_str_by_value(attr_table, ar->type, "<INVALID>"), ar->type);
 		break;
 	}
 }
 
-void tmpl_attr_ref_list_debug(FR_DLIST_HEAD(tmpl_attr_list) const *ar_head)
+void tmpl_attr_ref_list_debug(FILE *fp, FR_DLIST_HEAD(tmpl_attr_list) const *ar_head)
 {
 	tmpl_attr_t		*ar = NULL;
 	unsigned int		i = 0;
 
-	FR_FAULT_LOG("attribute references:");
+	fprintf(fp, "attribute references:\n");
 	/*
 	 *	Print all the attribute references
 	 */
 	while ((ar = tmpl_attr_list_next(ar_head, ar))) {
-		tmpl_attr_ref_debug(ar, i);
+		tmpl_attr_ref_debug(fp, ar, i);
 		i++;
 	}
 }
 
-void tmpl_attr_debug(tmpl_t const *vpt)
+void tmpl_attr_debug(FILE *fp, tmpl_t const *vpt)
 {
 	tmpl_request_t		*rr = NULL;
 	unsigned int		i = 0;
@@ -292,64 +292,64 @@ void tmpl_attr_debug(tmpl_t const *vpt)
 		break;
 
 	default:
-		FR_FAULT_LOG("%s can't print tmpls of type %s", __FUNCTION__,
-			     tmpl_type_to_str(vpt->type));
+		fprintf(fp, "%s can't print tmpls of type %s\n", __FUNCTION__,
+			tmpl_type_to_str(vpt->type));
 		return;
 	}
 
-	FR_FAULT_LOG("tmpl_t %s (%.8x) \"%pV\" (%p)",
-		     tmpl_type_to_str(vpt->type),
-		     vpt->type,
-		     fr_box_strvalue_len(vpt->name, vpt->len), vpt);
+	fprintf(fp, "tmpl_t %s (%.8x) \"%pV\" (%p)\n",
+		tmpl_type_to_str(vpt->type),
+		vpt->type,
+		fr_box_strvalue_len(vpt->name, vpt->len), vpt);
 
-	FR_FAULT_LOG("\tcast       : %s", fr_type_to_str(tmpl_rules_cast(vpt)));
-	FR_FAULT_LOG("\tquote      : %s", fr_table_str_by_value(fr_token_quotes_table, vpt->quote, "<INVALID>"));
+	fprintf(fp, "\tcast       : %s\n", fr_type_to_str(tmpl_rules_cast(vpt)));
+	fprintf(fp, "\tquote      : %s\n", fr_table_str_by_value(fr_token_quotes_table, vpt->quote, "<INVALID>"));
 
-	FR_FAULT_LOG("request references:");
+	fprintf(fp, "request references:");
 
 	/*
 	 *	Print all the request references
 	 */
 	while ((rr = tmpl_request_list_next(&vpt->data.attribute.rr, rr))) {
-		FR_FAULT_LOG("\t[%u] %s (%u)", i,
+		fprintf(fp, "\t[%u] %s (%u)\n", i,
 			     fr_table_str_by_value(tmpl_request_ref_table, rr->request, "<INVALID>"), rr->request);
 		i++;
 	}
 
-	FR_FAULT_LOG("list: %s", tmpl_list_name(tmpl_list(vpt), "<INVALID>"));
-	tmpl_attr_ref_list_debug(tmpl_attr(vpt));
+	fprintf(fp, "list: %s\n", tmpl_list_name(tmpl_list(vpt), "<INVALID>"));
+	tmpl_attr_ref_list_debug(fp, tmpl_attr(vpt));
 }
 
-void tmpl_debug(tmpl_t const *vpt)
+void tmpl_debug(FILE *fp, tmpl_t const *vpt)
 {
 	switch (vpt->type) {
 	case TMPL_TYPE_ATTR:
 	case TMPL_TYPE_ATTR_UNRESOLVED:
-		tmpl_attr_debug(vpt);
+		tmpl_attr_debug(fp, vpt);
 		return;
 
 	default:
 		break;
 	}
 
-	FR_FAULT_LOG("tmpl_t %s (%.8x) \"%s\" (%p)",
-		     tmpl_type_to_str(vpt->type),
-		     vpt->type,
-		     vpt->name, vpt);
+	fprintf(fp, "tmpl_t %s (%.8x) \"%pR\" (%p)\n",
+		tmpl_type_to_str(vpt->type),
+		vpt->type,
+		vpt->name, vpt);
 
-	FR_FAULT_LOG("\tcast       : %s", fr_type_to_str(tmpl_rules_cast(vpt)));
-	FR_FAULT_LOG("\tquote      : %s", fr_table_str_by_value(fr_token_quotes_table, vpt->quote, "<INVALID>"));
+	fprintf(fp, "\tcast       : %s\n", fr_type_to_str(tmpl_rules_cast(vpt)));
+	fprintf(fp, "\tquote      : %s\n", fr_table_str_by_value(fr_token_quotes_table, vpt->quote, "<INVALID>"));
 	switch (vpt->type) {
 	case TMPL_TYPE_NULL:
 		return;
 
 	case TMPL_TYPE_DATA:
-		FR_FAULT_LOG("\ttype       : %s", fr_type_to_str(tmpl_value_type(vpt)));
-		FR_FAULT_LOG("\tlen        : %zu", tmpl_value_length(vpt));
-		FR_FAULT_LOG("\tvalue      : %pV", tmpl_value(vpt));
+		fprintf(fp, "\ttype       : %s\n", fr_type_to_str(tmpl_value_type(vpt)));
+		fprintf(fp, "\tlen        : %zu\n", tmpl_value_length(vpt));
+		fprintf(fp, "\tvalue      : %pV\n", tmpl_value(vpt));
 
-		if (tmpl_value_enumv(vpt)) FR_FAULT_LOG("\tenumv      : %s (%p)",
-							tmpl_value_enumv(vpt)->name, tmpl_value_enumv(vpt));
+		if (tmpl_value_enumv(vpt)) fprintf(fp, "\tenumv      : %s (%p)",
+						   tmpl_value_enumv(vpt)->name, tmpl_value_enumv(vpt));
 		return;
 
 	case TMPL_TYPE_XLAT:
@@ -360,7 +360,7 @@ void tmpl_debug(tmpl_t const *vpt)
 
 		xlat_aprint(NULL, &str, tmpl_xlat(vpt), NULL);
 
-		FR_FAULT_LOG("\texpansion  : %s", str);
+		fprintf(fp, "\texpansion  : %s\n", str);
 
 		talloc_free(str);
 	}
@@ -368,21 +368,21 @@ void tmpl_debug(tmpl_t const *vpt)
 
 	case TMPL_TYPE_REGEX:
 	{
-		FR_FAULT_LOG("\tpattern    : %s", vpt->name);
+		fprintf(fp, "\tpattern    : %s\n", vpt->name);
 	}
 		break;
 
 	default:
 		if (tmpl_needs_resolving(vpt)) {
 			if (tmpl_is_data_unresolved(vpt)) {
-				FR_FAULT_LOG("\tunescaped  : %s", vpt->data.unescaped);
-				FR_FAULT_LOG("\tlen        : %zu", talloc_array_length(vpt->data.unescaped) - 1);
+				fprintf(fp, "\tunescaped  : %s\n", vpt->data.unescaped);
+				fprintf(fp, "\tlen        : %zu\n", talloc_array_length(vpt->data.unescaped) - 1);
 			} else {
-				FR_FAULT_LOG("\tunresolved : %s", vpt->name);
-				FR_FAULT_LOG("\tlen        : %zu", vpt->len);
+				fprintf(fp, "\tunresolved : %s\n", vpt->name);
+				fprintf(fp, "\tlen        : %zu\n", vpt->len);
 			}
 		} else {
-			FR_FAULT_LOG("debug nyi");
+			fprintf(fp, "debug nyi\n");
 		}
 		break;
 	}
@@ -5131,7 +5131,7 @@ void tmpl_attr_verify(char const *file, int line, tmpl_t const *vpt)
 		switch (ar->type) {
 		case TMPL_ATTR_TYPE_NORMAL:
 			if (seen_unknown) {
-				tmpl_attr_debug(vpt);
+				tmpl_attr_debug(stderr, vpt);
 				fr_fatal_assert_fail("CONSISTENCY CHECK FAILED %s[%u]: "
 						     "TMPL_TYPE_ATTR known attribute \"%s\" "
 						     "occurred after unknown attribute %s "
@@ -5141,7 +5141,7 @@ void tmpl_attr_verify(char const *file, int line, tmpl_t const *vpt)
 						     ar->unknown.da->name);
 			}
 			if (seen_unresolved) {
-				tmpl_attr_debug(vpt);
+				tmpl_attr_debug(stderr, vpt);
 				fr_fatal_assert_fail("CONSISTENCY CHECK FAILED %s[%u]: "
 						     "TMPL_TYPE_ATTR known attribute \"%s\" "
 						     "occurred after unresolved attribute \"%s\""
@@ -5157,7 +5157,7 @@ void tmpl_attr_verify(char const *file, int line, tmpl_t const *vpt)
 
 		case TMPL_ATTR_TYPE_UNSPEC:
 			if (seen_unknown) {
-				tmpl_attr_debug(vpt);
+				tmpl_attr_debug(stderr, vpt);
 				fr_fatal_assert_fail("CONSISTENCY CHECK FAILED %s[%u]: "
 						     "TMPL_TYPE_ATTR unspecified attribute "
 						     "occurred after unknown attribute %s "
@@ -5166,7 +5166,7 @@ void tmpl_attr_verify(char const *file, int line, tmpl_t const *vpt)
 						     ar->unknown.da->name);
 			}
 			if (seen_unresolved) {
-				tmpl_attr_debug(vpt);
+				tmpl_attr_debug(stderr, vpt);
 				fr_fatal_assert_fail("CONSISTENCY CHECK FAILED %s[%u]: "
 						     "TMPL_TYPE_ATTR unspecified attribute "
 						     "occurred after unresolved attribute \"%s\""
@@ -5186,7 +5186,7 @@ void tmpl_attr_verify(char const *file, int line, tmpl_t const *vpt)
 		case TMPL_ATTR_TYPE_UNKNOWN:
 			seen_unknown = ar;
 			if (seen_unresolved) {
-				tmpl_attr_debug(vpt);
+				tmpl_attr_debug(stderr, vpt);
 				fr_fatal_assert_fail("CONSISTENCY CHECK FAILED %s[%u]: "
 						     "TMPL_TYPE_ATTR unknown attribute \"%s\" "
 						     "occurred after unresolved attribute %s "
@@ -5306,7 +5306,7 @@ void tmpl_verify(char const *file, int line, tmpl_t const *vpt)
 		if ((tmpl_attr_list_num_elements(tmpl_attr(vpt)) > 0) &&
 		    ((tmpl_attr_t *)tmpl_attr_list_tail(tmpl_attr(vpt)))->da) {
 #ifndef NDEBUG
-			tmpl_attr_debug(vpt);
+			tmpl_attr_debug(stderr, vpt);
 #endif
 			fr_fatal_assert_fail("CONSISTENCY CHECK FAILED %s[%u]: TMPL_TYPE_ATTR_UNRESOLVED contains %u "
 					     "references", file, line, tmpl_attr_list_num_elements(tmpl_attr(vpt)));

--- a/src/lib/unlang/edit.c
+++ b/src/lib/unlang/edit.c
@@ -175,7 +175,7 @@ static int tmpl_to_values(TALLOC_CTX *ctx, edit_result_t *out, request_t *reques
 		 *	The other tmpl types MUST have already been
 		 *	converted to the "realized" types.
 		 */
-		tmpl_debug(vpt);
+		tmpl_debug(stderr, vpt);
 		fr_assert(0);
 		break;
 	}

--- a/src/lib/unlang/xlat_expr.c
+++ b/src/lib/unlang/xlat_expr.c
@@ -2743,7 +2743,7 @@ static fr_slen_t tokenize_field(xlat_exp_head_t *head, xlat_exp_t **out, fr_sbuf
 			/*
 			 *	Regex?  Or something else weird?
 			 */
-			tmpl_debug(vpt);
+			tmpl_debug(stderr, vpt);
 			fr_assert(0);
 		}
 	}

--- a/src/lib/util/dict.h
+++ b/src/lib/util/dict.h
@@ -674,11 +674,11 @@ static inline CC_HINT(nonnull) int8_t fr_dict_attr_cmp_fields(const fr_dict_attr
  *
  * @{
  */
-void			fr_dict_namespace_debug(fr_dict_attr_t const *da);
+void			fr_dict_namespace_debug(FILE *fp, fr_dict_attr_t const *da);
 
-void			fr_dict_attr_debug(fr_dict_attr_t const *da);
+void			fr_dict_attr_debug(FILE *fp, fr_dict_attr_t const *da);
 
-void			fr_dict_debug(fr_dict_t const *dict);
+void			fr_dict_debug(FILE *fp, fr_dict_t const *dict);
 
 void			fr_dict_export(fr_dict_t const *dict);
 /** @} */
@@ -893,7 +893,7 @@ int			fr_dict_global_ctx_dir_set(char const *dict_dir);
 
 void			fr_dict_global_ctx_read_only(void);
 
-void			fr_dict_global_ctx_debug(fr_dict_gctx_t const *gctx);
+void			fr_dict_gctx_debug(FILE *fp, fr_dict_gctx_t const *gctx);
 
 char const		*fr_dict_global_ctx_dir(void);
 

--- a/src/lib/util/dict_util.c
+++ b/src/lib/util/dict_util.c
@@ -4366,7 +4366,7 @@ static int _dict_global_free(fr_dict_gctx_t *gctx)
 
 	if (still_loaded) {
 #ifndef NDEBUG
-		fr_dict_global_ctx_debug(gctx);
+		fr_dict_gctx_debug(stderr, gctx);
 #endif
 		return -1;
 	}
@@ -4531,7 +4531,7 @@ void fr_dict_global_ctx_read_only(void)
  *
  * Intended to be called from a debugger
  */
-void fr_dict_global_ctx_debug(fr_dict_gctx_t const *gctx)
+void fr_dict_gctx_debug(FILE *fp, fr_dict_gctx_t const *gctx)
 {
 	fr_hash_iter_t			dict_iter;
 	fr_dict_t			*dict;
@@ -4541,18 +4541,19 @@ void fr_dict_global_ctx_debug(fr_dict_gctx_t const *gctx)
 	if (gctx == NULL) gctx = dict_gctx;
 
 	if (!gctx) {
-		FR_FAULT_LOG("gctx not initialised");
+		fprintf(fp, "gctx not initialised\n");
 		return;
 	}
 
-	FR_FAULT_LOG("gctx %p report", dict_gctx);
+	fprintf(fp, "gctx %p report\n", dict_gctx);
 	for (dict = fr_hash_table_iter_init(gctx->protocol_by_num, &dict_iter);
 	     dict;
 	     dict = fr_hash_table_iter_next(gctx->protocol_by_num, &dict_iter)) {
 		for (dep = fr_rb_iter_init_inorder(&dep_iter, dict->dependents);
 		     dep;
 		     dep = fr_rb_iter_next_inorder(&dep_iter)) {
-			FR_FAULT_LOG("\t%s is referenced from %s count (%d)", dict->root->name, dep->dependent, dep->count);
+			fprintf(fp, "\t%s is referenced from %s count (%d)\n",
+				dict->root->name, dep->dependent, dep->count);
 		}
 	}
 
@@ -4560,7 +4561,8 @@ void fr_dict_global_ctx_debug(fr_dict_gctx_t const *gctx)
 		for (dep = fr_rb_iter_init_inorder(&dep_iter, gctx->internal->dependents);
 		     dep;
 		     dep = fr_rb_iter_next_inorder(&dep_iter)) {
-			FR_FAULT_LOG("\t%s is referenced from %s count (%d)", gctx->internal->root->name, dep->dependent, dep->count);
+			fprintf(fp, "\t%s is referenced from %s count (%d)\n",
+				gctx->internal->root->name, dep->dependent, dep->count);
 		}
 	}
 }

--- a/src/lib/util/dl.c
+++ b/src/lib/util/dl.c
@@ -959,26 +959,26 @@ bool dl_loader_set_static(dl_loader_t *dl_loader, bool do_static)
 /** Called from a debugger to print information about a dl_loader
  *
  */
-void dl_loader_debug(dl_loader_t *dl)
+void dl_loader_debug(FILE *fp, dl_loader_t *dl)
 {
-	FR_FAULT_LOG("dl_loader %p", dl);
-	FR_FAULT_LOG("lib_dir           : %s", dl->lib_dir);
-	FR_FAULT_LOG("do_dlclose        : %s", dl->do_dlclose ? "yes" : "no");
-	FR_FAULT_LOG("uctx              : %p", dl->uctx);
-	FR_FAULT_LOG("uctx_free         : %s", dl->do_dlclose ? "yes" : "no");
-	FR_FAULT_LOG("defer_symbol_init : %s", dl->defer_symbol_init ? "yes" : "no");
+	fprintf(fp, "dl_loader %p", dl);
+	fprintf(fp, "lib_dir           : %s\n", dl->lib_dir);
+	fprintf(fp, "do_dlclose        : %s\n", dl->do_dlclose ? "yes" : "no");
+	fprintf(fp, "uctx              : %p\n", dl->uctx);
+	fprintf(fp, "uctx_free         : %s\n", dl->do_dlclose ? "yes" : "no");
+	fprintf(fp, "defer_symbol_init : %s\n", dl->defer_symbol_init ? "yes" : "no");
 
 	fr_dlist_foreach(&dl->sym_init, dl_symbol_init_t, sym) {
-		FR_FAULT_LOG("symbol_init %s", sym->symbol ? sym->symbol : "<base>");
-		FR_FAULT_LOG("\tpriority : %u", sym->priority);
-		FR_FAULT_LOG("\tfunc     : %p", sym->func);
-		FR_FAULT_LOG("\tuctx     : %p", sym->uctx);
+		fprintf(fp, "symbol_init %s\n", sym->symbol ? sym->symbol : "<base>");
+		fprintf(fp, "\tpriority : %u\n", sym->priority);
+		fprintf(fp, "\tfunc     : %p\n", sym->func);
+		fprintf(fp, "\tuctx     : %p\n", sym->uctx);
 	}
 
 	fr_dlist_foreach(&dl->sym_free, dl_symbol_free_t, sym) {
-		FR_FAULT_LOG("symbol_free %s", sym->symbol ? sym->symbol : "<base>");
-		FR_FAULT_LOG("\tpriority : %u", sym->priority);
-		FR_FAULT_LOG("\tfunc     : %p", sym->func);
-		FR_FAULT_LOG("\tuctx     : %p", sym->uctx);
+		fprintf(fp, "symbol_free %s\n", sym->symbol ? sym->symbol : "<base>");
+		fprintf(fp, "\tpriority : %u\n", sym->priority);
+		fprintf(fp, "\tfunc     : %p\n", sym->func);
+		fprintf(fp, "\tuctx     : %p\n", sym->uctx);
 	}
 }

--- a/src/lib/util/dl.h
+++ b/src/lib/util/dl.h
@@ -129,7 +129,7 @@ dl_loader_t		*dl_loader_init(TALLOC_CTX *ctx, void *uctx, bool uctx_free, bool d
 
 bool			dl_loader_set_static(dl_loader_t *dl_loader, bool do_static) CC_HINT(nonnull);
 
-void			dl_loader_debug(dl_loader_t *dl);
+void			dl_loader_debug(FILE *fp, dl_loader_t *dl) CC_HINT(nonnull);
 #ifdef __cplusplus
 }
 #endif

--- a/src/lib/util/pair.h
+++ b/src/lib/util/pair.h
@@ -858,8 +858,10 @@ static inline fr_slen_t CC_HINT(nonnull(2,4))
 void		_fr_pair_list_log(fr_log_t const *log, int lvl, fr_pair_t *parent,
 				  fr_pair_list_t const *list, char const *file, int line) CC_HINT(nonnull(1,4));
 
-void		fr_pair_list_debug(fr_pair_list_t const *list) CC_HINT(nonnull);
-void		fr_pair_debug(fr_pair_t const *pair) CC_HINT(nonnull);
+void		fr_pair_list_debug(FILE *fp, fr_pair_list_t const *list) CC_HINT(nonnull);
+void		_fr_pair_list_debug(FILE *fp, int lvl, fr_pair_t *parent, fr_pair_list_t const *list)
+				    CC_HINT(nonnull(1, 4));
+void		fr_pair_debug(FILE *fp, fr_pair_t const *pair) CC_HINT(nonnull);
 
 /** @} */
 

--- a/src/lib/util/pair_print.c
+++ b/src/lib/util/pair_print.c
@@ -316,19 +316,69 @@ void _fr_pair_list_log(fr_log_t const *log, int lvl, fr_pair_t *parent, fr_pair_
 	fr_pair_list_log_sbuff(log, lvl, parent, list, file, line, &sbuff);
 }
 
+static void fr_pair_list_debug_sbuff(FILE *fp, int lvl, fr_pair_t *parent, fr_pair_list_t const *list, fr_sbuff_t *sbuff)
+{
+	fr_dict_attr_t const *parent_da = NULL;
+
+	fr_pair_list_foreach(list, vp) {
+		PAIR_VERIFY_WITH_LIST(list, vp);
+
+		fr_sbuff_set_to_start(sbuff);
+
+		if (vp->vp_raw) (void) fr_sbuff_in_strcpy(sbuff, "raw.");
+
+		if (parent && (parent->vp_type != FR_TYPE_GROUP)) parent_da = parent->da;
+		if (fr_dict_attr_oid_print(sbuff, parent_da, vp->da, false) <= 0) return;
+
+		/*
+		 *	Recursively print grouped attributes.
+		 */
+		switch (vp->vp_type) {
+		case FR_TYPE_STRUCTURAL:
+			fprintf(fp, "%*s%*s {\n", lvl * 2, "", (int) fr_sbuff_used(sbuff), fr_sbuff_start(sbuff));
+			_fr_pair_list_debug(fp, lvl + 1, vp, &vp->vp_group);
+			fprintf(fp, "%*s}\n", lvl * 2, "");
+			break;
+
+		default:
+			(void) fr_sbuff_in_strcpy(sbuff, " = ");
+			if (fr_value_box_print_quoted(sbuff, &vp->data, T_DOUBLE_QUOTED_STRING)< 0) break;
+
+			fprintf(fp, "%*s%*s\n", lvl * 2, "", (int) fr_sbuff_used(sbuff), fr_sbuff_start(sbuff));
+		}
+	}
+}
+
+/** Print a list of attributes and enumv
+ *
+ * @param[in] fp	to output to.
+ * @param[in] lvl	depth in structural attribute.
+ * @param[in] parent	parent attribute
+ * @param[in] list	to print.
+ */
+void _fr_pair_list_debug(FILE *fp, int lvl, fr_pair_t *parent, fr_pair_list_t const *list)
+{
+	fr_sbuff_t sbuff;
+	char buffer[1024];
+
+	fr_sbuff_init_out(&sbuff, buffer, sizeof(buffer));
+
+	fr_pair_list_debug_sbuff(fp, lvl, parent, list, &sbuff);
+}
+
 /** Dumps a list to the default logging destination - Useful for calling from debuggers
  *
  */
-void fr_pair_list_debug(fr_pair_list_t const *list)
+void fr_pair_list_debug(FILE *fp, fr_pair_list_t const *list)
 {
-	_fr_pair_list_log(&default_log, 0, NULL, list, "<internal>", 0);
+	_fr_pair_list_debug(fp, 0, NULL, list);
 }
 
 
 /** Dumps a pair to the default logging destination - Useful for calling from debuggers
  *
  */
-void fr_pair_debug(fr_pair_t const *pair)
+void fr_pair_debug(FILE *fp, fr_pair_t const *pair)
 {
 	fr_sbuff_t sbuff;
 	char buffer[1024];
@@ -337,6 +387,5 @@ void fr_pair_debug(fr_pair_t const *pair)
 
 	(void) fr_pair_print(&sbuff, NULL, pair);
 
-	fr_log(&default_log, L_DBG, __FILE__, __LINE__, "%pV",
-	       fr_box_strvalue_len(fr_sbuff_start(&sbuff), fr_sbuff_used(&sbuff)));
+	fprintf(fp, "%pV\n", fr_box_strvalue_len(fr_sbuff_start(&sbuff), fr_sbuff_used(&sbuff)));
 }

--- a/src/lib/util/sbuff.c
+++ b/src/lib/util/sbuff.c
@@ -2228,49 +2228,49 @@ static char const *sbuff_print_char(char c)
 	}
 }
 
-void fr_sbuff_unescape_debug(fr_sbuff_unescape_rules_t const *escapes)
+void fr_sbuff_unescape_debug(FILE *fp, fr_sbuff_unescape_rules_t const *escapes)
 {
 	uint8_t i;
 
-	FR_FAULT_LOG("Escape rules %s (%p)", escapes->name, escapes);
-	FR_FAULT_LOG("chr     : %c", escapes->chr ? escapes->chr : ' ');
-	FR_FAULT_LOG("do_hex  : %s", escapes->do_hex ? "yes" : "no");
-	FR_FAULT_LOG("do_oct  : %s", escapes->do_oct ? "yes" : "no");
+	fprintf(fp, "Escape rules %s (%p)\n", escapes->name, escapes);
+	fprintf(fp, "chr     : %c\n", escapes->chr ? escapes->chr : ' ');
+	fprintf(fp, "do_hex  : %s\n", escapes->do_hex ? "yes" : "no");
+	fprintf(fp, "do_oct  : %s\n", escapes->do_oct ? "yes" : "no");
 
-	FR_FAULT_LOG("substitutions:");
+	fprintf(fp, "substitutions:\n");
 	for (i = 0; i < UINT8_MAX; i++) {
-		if (escapes->subs[i]) FR_FAULT_LOG("\t%s -> %s",
+		if (escapes->subs[i]) FR_FAULT_LOG("\t%s -> %s\n",
 						   sbuff_print_char((char)i),
 						   sbuff_print_char((char)escapes->subs[i]));
 	}
-	FR_FAULT_LOG("skipes:");
+	fprintf(fp, "skipes:\n");
 	for (i = 0; i < UINT8_MAX; i++) {
-		if (escapes->skip[i]) FR_FAULT_LOG("\t%s", sbuff_print_char((char)i));
+		if (escapes->skip[i]) fprintf(fp, "\t%s\n", sbuff_print_char((char)i));
 	}
 }
 
-void fr_sbuff_terminal_debug(fr_sbuff_term_t const *tt)
+void fr_sbuff_terminal_debug(FILE *fp, fr_sbuff_term_t const *tt)
 {
 	size_t i;
 
-	FR_FAULT_LOG("Terminal count %zu", tt->len);
+	fprintf(fp, "Terminal count %zu\n", tt->len);
 
-	for (i = 0; i < tt->len; i++) FR_FAULT_LOG("\t\"%s\" (%zu)", tt->elem[i].str, tt->elem[i].len);
+	for (i = 0; i < tt->len; i++) fprintf(fp, "\t\"%s\" (%zu)\n", tt->elem[i].str, tt->elem[i].len);
 }
 
-void fr_sbuff_parse_rules_debug(fr_sbuff_parse_rules_t const *p_rules)
+void fr_sbuff_parse_rules_debug(FILE *fp, fr_sbuff_parse_rules_t const *p_rules)
 {
-	FR_FAULT_LOG("Parse rules %p", p_rules);
+	fprintf(fp, "Parse rules %p\n", p_rules);
 
 	if (p_rules->escapes) {
-		fr_sbuff_unescape_debug(p_rules->escapes);
+		fr_sbuff_unescape_debug(fp, p_rules->escapes);
 	} else {
-		FR_FAULT_LOG("No unescapes");
+		fprintf(fp, "No unescapes\n");
 	}
 
 	if (p_rules->terminals) {
-		fr_sbuff_terminal_debug(p_rules->terminals);
+		fr_sbuff_terminal_debug(fp, p_rules->terminals);
 	} else {
-		FR_FAULT_LOG("No terminals");
+		fprintf(fp, "No terminals\n");
 	}
 }

--- a/src/lib/util/sbuff.h
+++ b/src/lib/util/sbuff.h
@@ -1823,11 +1823,11 @@ SBUFF_IS_FUNC(hex, isxdigit((uint8_t) *p))
 
 /** @} */
 
-void	fr_sbuff_unescape_debug(fr_sbuff_unescape_rules_t const *escapes);
+void	fr_sbuff_unescape_debug(FILE *fp, fr_sbuff_unescape_rules_t const *escapes);
 
-void	fr_sbuff_terminal_debug(fr_sbuff_term_t const *tt);
+void	fr_sbuff_terminal_debug(FILE *fp, fr_sbuff_term_t const *tt);
 
-void 	fr_sbuff_parse_rules_debug(fr_sbuff_parse_rules_t const *p_rules);
+void 	fr_sbuff_parse_rules_debug(FILE *fp, fr_sbuff_parse_rules_t const *p_rules);
 
 /*
  *	...printf("foo %.*s", fr_sbuff_as_percent_s(&sbuff));

--- a/src/lib/util/value.c
+++ b/src/lib/util/value.c
@@ -6403,15 +6403,15 @@ bool fr_value_box_is_truthy(fr_value_box_t const *in)
 	}
 }
 
-#define INFO_INDENT(_fmt, ...)  FR_FAULT_LOG("%*s"_fmt, depth * 2, " ", ## __VA_ARGS__)
+#define INFO_INDENT(_fmt, ...)  fprintf(fp, "%*s" _fmt "\n", depth * 2, " ", ## __VA_ARGS__)
 
-static void _fr_value_box_debug(fr_value_box_t const *vb, int depth, int idx);
-static void _fr_value_box_list_debug(fr_value_box_list_t const *head, int depth)
+static void _fr_value_box_debug(FILE *fp, fr_value_box_t const *vb, int depth, int idx);
+static void _fr_value_box_list_debug(FILE *fp, fr_value_box_list_t const *head, int depth)
 {
 	int i = 0;
 
 	INFO_INDENT("{");
-	fr_value_box_list_foreach(head, vb) _fr_value_box_debug(vb, depth + 1, i++);
+	fr_value_box_list_foreach(head, vb) _fr_value_box_debug(fp, vb, depth + 1, i++);
 	INFO_INDENT("}");
 }
 
@@ -6419,17 +6419,17 @@ static void _fr_value_box_list_debug(fr_value_box_list_t const *head, int depth)
  *
  * @note Call directly from the debugger
  */
-void fr_value_box_list_debug(fr_value_box_list_t const *head)
+void fr_value_box_list_debug(FILE *fp, fr_value_box_list_t const *head)
 {
-	_fr_value_box_list_debug(head, 0);
+	_fr_value_box_list_debug(fp, head, 0);
 }
 
-static void _fr_value_box_debug(fr_value_box_t const *vb, int depth, int idx)
+static void _fr_value_box_debug(FILE *fp, fr_value_box_t const *vb, int depth, int idx)
 {
 	char *value;
 
 	if (fr_type_is_structural(vb->type)) {
-		_fr_value_box_list_debug(&vb->vb_group, depth + 1);
+		_fr_value_box_list_debug(fp, &vb->vb_group, depth + 1);
 		return;
 	}
 
@@ -6446,7 +6446,7 @@ static void _fr_value_box_debug(fr_value_box_t const *vb, int depth, int idx)
  *
  * @note Call directly from the debugger
  */
-void fr_value_box_debug(fr_value_box_t const *vb)
+void fr_value_box_debug(FILE *fp, fr_value_box_t const *vb)
 {
-	_fr_value_box_debug(vb, 0, -1);
+	_fr_value_box_debug(fp, vb, 0, -1);
 }

--- a/src/lib/util/value.h
+++ b/src/lib/util/value.h
@@ -1302,8 +1302,8 @@ void		fr_value_box_list_verify(char const *file, int line, fr_value_box_list_t c
  *
  * @{
  */
-void fr_value_box_list_debug(fr_value_box_list_t const *head);
-void fr_value_box_debug(fr_value_box_t const *vb);
+void fr_value_box_list_debug(FILE *fp, fr_value_box_list_t const *head);
+void fr_value_box_debug(FILE *fp, fr_value_box_t const *vb);
 /** @} */
 
 #undef _CONST

--- a/src/protocols/dns/encode.c
+++ b/src/protocols/dns/encode.c
@@ -465,7 +465,7 @@ ssize_t fr_dns_encode(fr_dbuff_t *dbuff, fr_pair_list_t *vps, fr_dns_ctx_t *pack
 	 */
 	vp = fr_pair_dcursor_by_da_init(&cursor, vps, attr_dns_packet);
 	if (!vp) {
-		fr_pair_list_debug(vps);
+		fr_pair_list_log(&default_log, 0, vps);
 
 		fr_strerror_const("attribute list does not include DNS packet header");
 		return -1;

--- a/src/tests/util/atomic_queue_test.c
+++ b/src/tests/util/atomic_queue_test.c
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
 #ifndef NDEBUG
 	if (debug_lvl) {
 		printf("Start\n");
-		fr_atomic_queue_debug(aq, stdout);
+		fr_atomic_queue_debug(stdout, aq);
 
 		if (debug_lvl > 1) printf("Filling with %d\n", size);
 	}
@@ -111,7 +111,7 @@ int main(int argc, char *argv[])
 #ifndef NDEBUG
 		if (debug_lvl > 1) {
 			printf("iteration %d\n", i);
-			fr_atomic_queue_debug(aq, stdout);
+			fr_atomic_queue_debug(stdout, aq);
 		}
 #endif
 	}
@@ -130,7 +130,7 @@ int main(int argc, char *argv[])
 #ifndef NDEBUG
 	if (debug_lvl) {
 		printf("Full\n");
-		fr_atomic_queue_debug(aq, stdout);
+		fr_atomic_queue_debug(stdout, aq);
 
 		if (debug_lvl > 1) printf("Emptying\n");
 	}
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
 #ifndef NDEBUG
 		if (debug_lvl > 1) {
 			printf("iteration %d\n", i);
-			fr_atomic_queue_debug(aq, stdout);
+			fr_atomic_queue_debug(stdout, aq);
 		}
 #endif
 	}
@@ -171,7 +171,7 @@ int main(int argc, char *argv[])
 #ifndef NDEBUG
 	if (debug_lvl) {
 		printf("Empty\n");
-		fr_atomic_queue_debug(aq, stdout);
+		fr_atomic_queue_debug(stdout, aq);
 	}
 #endif
 

--- a/src/tests/util/channel_test.c
+++ b/src/tests/util/channel_test.c
@@ -291,7 +291,7 @@ check_close:
 	MPRINT2("GC\n");
 	fr_message_set_gc(ms);
 
-	if (debug_lvl > 1) fr_message_set_debug(ms, stdout);
+	if (debug_lvl > 1) fr_message_set_debug(stdout, ms);
 
 	/*
 	 *	After the garbage collection, all messages marked "done" MUST also be marked "free".
@@ -466,7 +466,7 @@ static void *channel_worker(void *arg)
 	MPRINT2("Worker GC\n");
 	fr_message_set_gc(ms);
 
-	if (debug_lvl > 1) fr_message_set_debug(ms, stdout);
+	if (debug_lvl > 1) fr_message_set_debug(stdout, ms);
 
 	/*
 	 *	After the garbage collection, all messages marked "done" MUST also be marked "free".

--- a/src/tests/util/message_set_test.c
+++ b/src/tests/util/message_set_test.c
@@ -248,7 +248,7 @@ int main(int argc, char *argv[])
 
 	MPRINT1("TEST 1 used %d (%zu)\n", fr_message_set_messages_used(ms), used);
 
-	if (debug_lvl) fr_message_set_debug(ms, stdout);
+	if (debug_lvl) fr_message_set_debug(stdout, ms);
 
 	/*
 	 *	Double the size of the allocations
@@ -270,7 +270,7 @@ int main(int argc, char *argv[])
 
 	MPRINT1("TEST 2 used %d\n", fr_message_set_messages_used(ms));
 
-	if (debug_lvl) fr_message_set_debug(ms, stdout);
+	if (debug_lvl) fr_message_set_debug(stdout, ms);
 	/*
 	 *	Double the size of the allocations
 	 */
@@ -299,7 +299,7 @@ int main(int argc, char *argv[])
 
 	MPRINT1("TEST 3 used %d\n", fr_message_set_messages_used(ms));
 
-	if (debug_lvl) fr_message_set_debug(ms, stdout);
+	if (debug_lvl) fr_message_set_debug(stdout, ms);
 
 	/*
 	 *	Do another 1000 rounds of alloc / free.
@@ -313,7 +313,7 @@ int main(int argc, char *argv[])
 
 	MPRINT1("TEST 4 used %d\n", fr_message_set_messages_used(ms));
 
-	if (debug_lvl) fr_message_set_debug(ms, stdout);
+	if (debug_lvl) fr_message_set_debug(stdout, ms);
 
 #if 0
 
@@ -335,7 +335,7 @@ int main(int argc, char *argv[])
 
 	MPRINT1("TEST 5 used %d\n", fr_message_set_messages_used(ms));
 
-	if (debug_lvl) fr_message_set_debug(ms, stdout);
+	if (debug_lvl) fr_message_set_debug(stdout, ms);
 
 	/*
 	 *	Double the number of the allocations again,
@@ -355,7 +355,7 @@ int main(int argc, char *argv[])
 
 	MPRINT1("TEST 6 used %d\n", fr_message_set_messages_used(ms));
 
-	if (debug_lvl) fr_message_set_debug(ms, stdout);
+	if (debug_lvl) fr_message_set_debug(stdout, ms);
 #endif
 
 	my_alloc_size = end - start;
@@ -396,7 +396,7 @@ int main(int argc, char *argv[])
 	MPRINT1("GC\n");
 	fr_message_set_gc(ms);
 
-	if (debug_lvl) fr_message_set_debug(ms, stdout);
+	if (debug_lvl) fr_message_set_debug(stdout, ms);
 
 	/*
 	 *	After the garbage collection, all messages marked "done" MUST also be marked "free".

--- a/src/tests/util/radius1_test.c
+++ b/src/tests/util/radius1_test.c
@@ -502,7 +502,7 @@ static void master_process(TALLOC_CTX *ctx)
 	MPRINT2("GC\n");
 	fr_message_set_gc(ms);
 
-	if (debug_lvl > 1) fr_message_set_debug(ms, stdout);
+	if (debug_lvl > 1) fr_message_set_debug(stdout, ms);
 
 	/*
 	 *	After the garbage collection, all messages marked "done" MUST also be marked "free".

--- a/src/tests/util/worker_test.c
+++ b/src/tests/util/worker_test.c
@@ -455,7 +455,7 @@ check_close:
 	MPRINT2("GC\n");
 	fr_message_set_gc(ms);
 
-	if (debug_lvl > 1) fr_message_set_debug(ms, stdout);
+	if (debug_lvl > 1) fr_message_set_debug(stdout, ms);
 
 	/*
 	 *	After the garbage collection, all messages marked "done" MUST also be marked "free".


### PR DESCRIPTION
To get the "dd" debugger command to work without having to create an wxplicit mapping from type to function either by hand or by runtime inspection (the latter preventing setting up the command at debugger startup), the debug functions that dd calls should have a type of the form

    foo_debug(FILE *fp, foo_t const *)

We add the qualifier becausen
 * some support functions with extra parameters are meant to be called by these functions, which pass the additional parameters; the functions we do call can pass fp along, or in the case of src/lib/util/dict_print.c, add fp to the context
 * fe_dict_attr_t * has three debug functions
 * fr_pair_validate_debug() takes a pointer to an array, and thus can't follow the convention
 * virtual_server_{listen, process}_debug() and module_rlm_list_debug() have *no* parameters