### PR TITLE
adds a hint message for users testing TEAP using eapol_test

### DIFF
--- a/src/tests/eap-teap-mschap-tls.conf
+++ b/src/tests/eap-teap-mschap-tls.conf
@@ -26,3 +26,6 @@ network={
 	machine_private_key="../../raddb/certs/client.key"
 	machine_private_key_passwd="whatever"
 }
+
+# TEAP is known to *not* work with some versions of eapol_test.
+# You may need to compile from the devel git repository.

--- a/src/tests/eap-teap-mschap-x2.conf
+++ b/src/tests/eap-teap-mschap-x2.conf
@@ -23,3 +23,6 @@ network={
 	machine_password="machine"
 	machine_phase2="autheap=MSCHAPv2"
 }
+
+# TEAP is known to *not* work with some versions of eapol_test.
+# You may need to compile from the devel git repository.

--- a/src/tests/eap-teap-mschap.conf
+++ b/src/tests/eap-teap-mschap.conf
@@ -16,3 +16,6 @@ network={
 	password="bob"
 	phase2="auth=MSCHAPV2"
 }
+
+# TEAP is known to *not* work with some versions of eapol_test.
+# You may need to compile from the devel git repository.

--- a/src/tests/eap-teap-password.conf
+++ b/src/tests/eap-teap-password.conf
@@ -15,3 +15,6 @@ network={
 	identity="bob"
 	password="bob"
 }
+
+# TEAP is known to *not* work with some versions of eapol_test.
+# You may need to compile from the devel git repository.


### PR DESCRIPTION
Describe the limitation of using some version of eapol_test in TEAP testing.
Give possible suggestions.