### PR TITLE
fix: compilation error when building with an openssl that was compiled without psk support

### DIFF
--- a/src/main/tls.c
+++ b/src/main/tls.c
@@ -1308,9 +1308,11 @@ void tls_session_information(tls_session_t *tls_session)
 
 				case SSL3_AD_ILLEGAL_PARAMETER:
 					str_details2 = " illegal_parameter";
+					#ifdef PSK_MAX_IDENTITY_LEN
 					if (tls_session->conf->psk_identity || tls_session->conf->psk_query) {
 						details = "the client and server have different values for the PSK";
 					}
+					#endif
 					break;
 
 				case TLS1_AD_UNKNOWN_CA:


### PR DESCRIPTION
When building against a version of OpenSSL that was compiled without PSK support, compilation of 3.2.7 fails.

```
./src/src/main/tls.c: In function ‘tls_session_information’:
./src/src/main/tls.c:1311:27: error: ‘fr_tls_server_conf_t {aka const struct fr_tls_server_conf_t}’ has no member named ‘psk_identity’
      if (tls_session->conf->psk_identity || tls_session->conf->psk_query) {
                           ^~
./src/src/main/tls.c:1311:62: error: ‘fr_tls_server_conf_t {aka const struct fr_tls_server_conf_t}’ has no member named ‘psk_query’
      if (tls_session->conf->psk_identity || tls_session->conf->psk_query) {
                                                              ^~
make: *** [scripts/boiler.mk:646: ./src/src/main/tls.lo] Error 1
make: *** Waiting for unfinished jobs....
```
The issue is that `psk_identity` and `psk_query` are only defined if `PSK_MAX_IDENTITY_LEN` is set.

[Those struct members are defined here](https://github.com/FreeRADIUS/freeradius-server/blob/32c123a6e7eaad2bd38207e28178c87b35770ab6/src/include/tls-h#L446-L450).

[Relevant commit is here](https://github.com/FreeRADIUS/freeradius-server/commit/7f1a1580b17a3bf794324bacf9af6a243bc6678f).