### PR TITLE
Add OCSP verifycert boolean to 3.2.x

### DIFF
--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -774,6 +774,13 @@ eap {
 			# is not available. Use with caution.
 			#
 		#	softfail = no
+
+			# If you are testing with an OCSP server with a
+			# certificate that does not have the OCSP OID 
+                        # ocspSigning, you can set this flag to no to
+			# disable that verification. 
+		#	verifycert = no
+
 		}
 
 		#

--- a/src/include/tls-h
+++ b/src/include/tls-h
@@ -435,6 +435,7 @@ struct fr_tls_server_conf_t {
 	X509_STORE	*ocsp_store;
 	uint32_t	ocsp_timeout;
 	bool		ocsp_softfail;
+	bool		ocsp_verifycert;
 #endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x0090800fL


### PR DESCRIPTION
This is a back port of the 'verifycert' flag for OCSP that we submitted and was accepted previously for the 4.x line.  I also added a blurb to the mods-available/eap file explaining the flag, I'm happy to update that text if what I submitted isn't sufficient for documentation.
