### PR TITLE
dictionary.aptilo: Update vendor URL

### DIFF
--- a/share/dictionary/radius/dictionary.aptilo
+++ b/share/dictionary/radius/dictionary.aptilo
@@ -4,7 +4,8 @@
 # Version $Id$
 #
 ##############################################################################
-# Aptilo Access Controllers - https://www.aptilo.com/access-controller
+# Aptilo Access Controllers
+# - https://www.enea.com/solutions/service-provider-wifi/aptilo-wifi-access-controller/
 #
 # Version:      2.0
 #


### PR DESCRIPTION
The batch search and replace in commit dfe9f6a4 broke the URL, but also the canonical URL has changed.