### PR TITLE
docs: Add howto/Datastore section & AD/LDAP/SQL/REDIS subsections. 

### DIFF
--- a/doc/antora/modules/howto/nav.adoc
+++ b/doc/antora/modules/howto/nav.adoc
@@ -56,6 +56,12 @@
 **** xref:modules/sqlippool/populating.adoc[Generating IPs]
 **** xref:modules/sqlippool/insert.adoc[Inserting IPs into SQL]
 
+** xref:datastores/setup_datastores.adoc[Setting up Datastores]
+*** xref:datastores/ad_datastores.adoc[AD]
+*** xref:datastores/ldap_datastores.adoc[LDAP]
+*** xref:datastores/redis_datastores.adoc[REDIS]
+*** xref:datastores/sql_datastores.adoc[SQL]
+
 ** xref:protocols/index.adoc[Protocols]
 *** xref:protocols/dhcp/index.adoc[DHCP]
 **** xref:protocols/dhcp/prepare.adoc[Preparation]

--- a/doc/antora/modules/howto/pages/datastores/ad_datastores.adoc
+++ b/doc/antora/modules/howto/pages/datastores/ad_datastores.adoc
@@ -1,0 +1,9 @@
+= Active Directory (AD)
+
+== What is it?
+
+== How to connect
+
+== Why use AD
+
+== Setting up an AD Datastore

--- a/doc/antora/modules/howto/pages/datastores/ldap_datastores.adoc
+++ b/doc/antora/modules/howto/pages/datastores/ldap_datastores.adoc
@@ -1,0 +1,9 @@
+= Lightweight Directory Access Protocol (LDAP)
+
+== What is it?
+
+== How to connect
+
+== Why use LDAP
+
+== Setting up a LDAP Datastore

--- a/doc/antora/modules/howto/pages/datastores/redis_datastores.adoc
+++ b/doc/antora/modules/howto/pages/datastores/redis_datastores.adoc
@@ -1,0 +1,7 @@
+== What is it?
+
+== How to connect
+
+== Why use REDIS?
+
+== Setting up a REDIS Datastore

--- a/doc/antora/modules/howto/pages/datastores/setup_datastores.adoc
+++ b/doc/antora/modules/howto/pages/datastores/setup_datastores.adoc
@@ -1,0 +1,26 @@
+= Datastores
+
+Datastores store data and are accessed by the FreeRADIUS server to retrieve that data. Datastores do not perform authentications and possess limited decision making capabilities.
+
+The key differences between RADIUS servers and datastores are the way they support policies and authentication. The role of a datastore is to provide data to a RADIUS server. The RADIUS server authenticates the user with a select authentication method on the retrieved data.
+
+When a RADIUS server authenticates a user or stores accounting data for that user, it reads from or writes to a datastore. User information (i.e., user name, password, credit amount) and session data (i.e., total session time and statistics for total traffic to and from the user) are stored on this datastore or directory. We use the term "datastore" to mean that some of the storage methods are not traditional databases, but they do still store data.
+
+
+== Setting up Datastores
+
+To set up a datastore, you'll need to install the software, configure the data storage location, and connect the datastore with FreeRADIUS. The main steps to complete are:
+
+* Install the datastore software and relevant tools to manage your information.
+* Create the storage location whether it's in the cloud, network, or local drive.
+* Provision the datastore and populate records.
+* Connect the datastore with FreeRADIUS.
+
+== Integrate Datastore with FreeRADIUS
+
+To configure a datastore with FreeRADIUS, you'll need to edit the FreeRADIUS configuration files and enable the relevant modules. This section outlines the supported datastores, how to connect, and implementations. See the following sub-sections for your specific datastore application instructions:
+
+* xref:datastores/ad_datastores.adoc[AD]
+* xref:datastores/ldap_datastores.adoc[LDAP]
+* xref:datastores/redis_datastores.adoc[REDIS]
+* xref:datastores/sql_datastores.adoc[SQL]

--- a/doc/antora/modules/howto/pages/datastores/sql_datastores.adoc
+++ b/doc/antora/modules/howto/pages/datastores/sql_datastores.adoc
@@ -1,0 +1,9 @@
+= Structured Query Language (SQL)
+
+== What is it?
+
+== How to connect
+
+== Why use SQL?
+
+== Setting up a SQL Datastore


### PR DESCRIPTION
The <type>_datastore.adoc files are stubs with headings only. If topology OK - AD info will be copied over.