### PR TITLE
Fix typos in CI

### DIFF
--- a/.github/actions/build-freeradius/action.yml
+++ b/.github/actions/build-freeradius/action.yml
@@ -2,13 +2,13 @@ name: build-freeradius
 
 inputs:
   use_sanitizers:
-    desription: Enable sanitizers if true
+    description: Enable sanitizers if true
     default: false
   cc:
-    desription: Which CC to use
+    description: Which CC to use
     default: gcc
   test_type:
-    desription: What test is being run
+    description: What test is being run
     default: gcc
   platform:
     description: Platform the build is on

--- a/.github/actions/ci-tests/action.yml
+++ b/.github/actions/ci-tests/action.yml
@@ -62,7 +62,7 @@ inputs:
     default: 127.0.0.1
 
   use_docker:
-    desription: True if running in a Docker container
+    description: True if running in a Docker container
     default: false
 
 

--- a/.github/actions/freeradius-deps/action.yml
+++ b/.github/actions/freeradius-deps/action.yml
@@ -2,19 +2,19 @@ name: freeradius-deps
 
 inputs:
   use_docker:
-    desription: True if running in a Docker container
+    description: True if running in a Docker container
     default: false
   llvm_ver:
-    desription: Version of LLVM to use
+    description: Version of LLVM to use
     default: 18
   gcc_ver:
-    desription: Version of GCC to use
+    description: Version of GCC to use
     default: 14
   fuzzing:
-    desription: True if fuzzing is enabled
+    description: True if fuzzing is enabled
     default: false
   cc:
-    desription: Which CC to use
+    description: Which CC to use
     default: gcc
 
 

--- a/.github/workflows/ci-deb.yml
+++ b/.github/workflows/ci-deb.yml
@@ -1,4 +1,4 @@
-name: CI DEB
+name: FreeRADIUS Debian Packaging CI
 
 on:
   push:
@@ -167,7 +167,7 @@ jobs:
     #  If the CI has failed and the branch is ci-debug then start a tmate
     #  session. SSH rendezvous point is emited continuously in the job output.
     #
-    - name: "Debug: Package dependancies for tmate"
+    - name: "Debug: Package dependencies for tmate"
       run: |
         apt-get install -y --no-install-recommends xz-utils
       if: ${{ github.ref == 'refs/heads/ci-debug' && failure() }}
@@ -183,7 +183,7 @@ jobs:
   #
   #  Perform "post-install" testing of the FR packages that we have just built
   #  in a clean environment consisting of only the base OS and package
-  #  dependancies
+  #  dependencies
   #
   deb-test:
 
@@ -288,7 +288,7 @@ jobs:
     #
     #  See above comments for tmate
     #
-    - name: "Debug: Package dependancies for tmate"
+    - name: "Debug: Package dependencies for tmate"
       run: |
         apt-get install -y --no-install-recommends xz-utils
       if: ${{ github.ref == 'refs/heads/ci-debug' && failure() }}

--- a/.github/workflows/ci-deb.yml
+++ b/.github/workflows/ci-deb.yml
@@ -1,4 +1,4 @@
-name: FreeRADIUS Debian Packaging CI
+name: CI DEB
 
 on:
   push:

--- a/.github/workflows/ci-rpm.yml
+++ b/.github/workflows/ci-rpm.yml
@@ -153,7 +153,7 @@ jobs:
     #  If the CI has failed and the branch is ci-debug then start a tmate
     #  session. SSH rendezvous point is emited continuously in the job output.
     #
-    - name: "Debug: Package dependancies for tmate"
+    - name: "Debug: Package dependencies for tmate"
       run: |
         dnf install -y xz
         ln -s /bin/true /bin/apt-get
@@ -170,7 +170,7 @@ jobs:
   #
   #  Perform "post-install" testing of the FR packages that we have just built
   #  in a clean environment consisting of only the base OS and package
-  #  dependancies
+  #  dependencies
   #
   rpm-test:
 
@@ -266,7 +266,7 @@ jobs:
     #
     #  See above comments for tmate
     #
-    - name: "Debug: Package dependancies for tmate"
+    - name: "Debug: Package dependencies for tmate"
       run: |
         dnf install -y xz
         ln -s /bin/true /bin/apt-get


### PR DESCRIPTION
In GitHub CI code (actions and workflows):
* Fixes mistypes in des*c*ription tags
* Fixes depend*a*ncies in comments and steps names