### PR TITLE
docs: make docsite build fixes - 

### DIFF
--- a/doc/antora/modules/ROOT/pages/debugging/processing.adoc
+++ b/doc/antora/modules/ROOT/pages/debugging/processing.adoc
@@ -38,7 +38,7 @@ Each module prints out what it is doing, and why.  For example, the `suffix` mod
     (0) suffix: No such realm "NULL"
 ====
 
-The server core then prints out the xref:unlang/return_codes.adoc[return code] of the module.
+The server core then prints out the xref:reference:unlang/return_codes.adoc[return code] of the module.
 
     (0)     [suffix] = noop
     (0)     [files] = noop

--- a/doc/antora/modules/ROOT/pages/index.adoc
+++ b/doc/antora/modules/ROOT/pages/index.adoc
@@ -69,7 +69,7 @@ The result is that configuring the server is more difficult than it needs to be.
 Here is a _complete_ list of oddities and weirdness in v4, as compared to most programming languages:
 
 * modules are run in-place.  i.e. they act like language keywords on their own.
-* the interpreter tracks xref:unlang/return_codes.adoc[return codes] for each instruction it runs.
+* the interpreter tracks xref:reference:unlang/return_codes.adoc[return codes] for each instruction it runs.
 * function calls use a leading `%`, e.g. `%length('foo')`.
 
 That's it.
@@ -78,10 +78,10 @@ The result is that the server is much easier to understand and
 configure.  But we're not done explaining the benefits of v4.
 
 While the documentation in v3 was pretty good, the documentation in v4
-is _complete_.  Every single xref:unlang/keywords.adoc[keyword] has
-its own documentation page.  Every single xref:xlat/index.adoc[dynamic
+is _complete_.  Every single xref:reference:unlang/keywords.adoc[keyword] has
+its own documentation page.  Every single xref:reference:xlat/index.adoc[dynamic
 expansion] function has its own documentation page.  Every single
-xref:raddb/index.adoc[configuration file] is _automatically_ converted
+xref:reference:raddb/index.adoc[configuration file] is _automatically_ converted
 to HTML and placed into the documentation tree.
 
 Plus, all of the documentation is organized and cross referenced.

--- a/doc/antora/modules/reference/pages/dictionary/index.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/index.adoc
@@ -1,4 +1,4 @@
-= Dictionaries
+== Dictionaries
 
 The `dictionary` files define names, numbers, and
 xref:type/index.adoc[data types] for use in the server.  In general,

--- a/doc/antora/modules/reference/pages/unlang/keywords.adoc
+++ b/doc/antora/modules/reference/pages/unlang/keywords.adoc
@@ -1,4 +1,4 @@
-= Keywords
+== Keywords
 
 The following tables list the keywords used in `Unlang`.  These keywords
 implement the "flow control" of the policies.


### PR DESCRIPTION
Updated xrefs in ROOT/index.adoc and Reference files. Adjusted heading levels from 0 -> 1 to build error-free.