### PR TITLE
Implement support for 389ds pbkdf2 password hashes in v3.2.x

### DIFF
--- a/share/dictionary.freeradius.internal
+++ b/share/dictionary.freeradius.internal
@@ -291,6 +291,11 @@ ATTRIBUTE	SSHA3-256-Password			1183	octets
 ATTRIBUTE	SSHA3-384-Password			1184	octets
 ATTRIBUTE	SSHA3-512-Password			1185	octets
 
+ATTRIBUTE	PBKDF2-SHA1-Password			1186	octets
+ATTRIBUTE	PBKDF2-SHA256-Password			1187	octets
+ATTRIBUTE	PBKDF2-SHA512-Password			1188	octets
+ATTRIBUTE	PBKDF2-SHA256-LEGACY-Password		1189	octets
+
 ATTRIBUTE	MS-CHAP-Peer-Challenge			1192	octets
 ATTRIBUTE	Home-Server-Name			1193	string
 ATTRIBUTE	Originating-Realm-Key			1194	string

--- a/src/tests/modules/pap/pbkfd2_sha1_389ds.attrs
+++ b/src/tests/modules/pap/pbkfd2_sha1_389ds.attrs
@@ -1,0 +1,10 @@
+#
+#  Input packet
+#
+User-Name = 'pbkfd2_sha1_389ds'
+User-Password = 'password'
+
+#
+#  Expected answer
+#
+Response-Packet-Type == Access-Accept

--- a/src/tests/modules/pap/pbkfd2_sha1_389ds.unlang
+++ b/src/tests/modules/pap/pbkfd2_sha1_389ds.unlang
@@ -1,0 +1,17 @@
+if ("${feature.tls}" == no) {
+	test_pass
+	return
+}
+
+if (User-Name == 'pbkfd2_sha1_389ds') {
+	update control {
+		&PBKDF2-Password := '{PBKDF2-SHA1}10000$13QEHaJHNKHjlJEXX3ddjG2PpUjx1a83$dzrOWMeLso6J/K+evi4eZbOMcOk='
+	}
+	pap.authorize
+	pap.authenticate
+	if (!ok) {
+		test_fail
+	} else {
+		test_pass
+	}
+}

--- a/src/tests/modules/pap/pbkfd2_sha1_389ds_with_header.attrs
+++ b/src/tests/modules/pap/pbkfd2_sha1_389ds_with_header.attrs
@@ -1,0 +1,10 @@
+#
+#  Input packet
+#
+User-Name = 'pbkfd2_sha1_389ds_with_header'
+User-Password = 'password'
+
+#
+#  Expected answer
+#
+Response-Packet-Type == Access-Accept

--- a/src/tests/modules/pap/pbkfd2_sha1_389ds_with_header.unlang
+++ b/src/tests/modules/pap/pbkfd2_sha1_389ds_with_header.unlang
@@ -1,0 +1,17 @@
+if ("${feature.tls}" == no) {
+	test_pass
+	return
+}
+
+if (User-Name == 'pbkfd2_sha1_389ds_with_header') {
+	update control {
+		Password-With-Header := '{PBKDF2-SHA1}10000$ooYqHQ0zx2JcxgadlJAVebeCOVYGxwz9$zh5v1+QTaJcRv3yqAuLn7ONN8VE='
+	}
+	pap.authorize
+	pap.authenticate
+	if (!ok) {
+		test_fail
+	} else {
+		test_pass
+	}
+}

--- a/src/tests/modules/pap/pbkfd2_sha256_389ds.attrs
+++ b/src/tests/modules/pap/pbkfd2_sha256_389ds.attrs
@@ -1,0 +1,10 @@
+#
+#  Input packet
+#
+User-Name = 'pbkfd2_sha256_389ds'
+User-Password = 'password'
+
+#
+#  Expected answer
+#
+Response-Packet-Type == Access-Accept

--- a/src/tests/modules/pap/pbkfd2_sha256_389ds.unlang
+++ b/src/tests/modules/pap/pbkfd2_sha256_389ds.unlang
@@ -1,0 +1,17 @@
+if ("${feature.tls}" == no) {
+	test_pass
+	return
+}
+
+if (User-Name == 'pbkfd2_sha256_389ds') {
+	update control {
+		&PBKDF2-Password := '{PBKDF2-SHA256}10000$9JjBuTTp9OCwANVzqUrq0QUvXnmDUJrm$f8Jrky2bX3z5eQ2SghxA38QSJ2PQwNenecmV4e4Ejyw='
+	}
+	pap.authorize
+	pap.authenticate
+	if (!ok) {
+		test_fail
+	} else {
+		test_pass
+	}
+}

--- a/src/tests/modules/pap/pbkfd2_sha256_389ds_with_header.attrs
+++ b/src/tests/modules/pap/pbkfd2_sha256_389ds_with_header.attrs
@@ -1,0 +1,10 @@
+#
+#  Input packet
+#
+User-Name = 'pbkfd2_sha256_389ds_with_header'
+User-Password = 'password'
+
+#
+#  Expected answer
+#
+Response-Packet-Type == Access-Accept

--- a/src/tests/modules/pap/pbkfd2_sha256_389ds_with_header.unlang
+++ b/src/tests/modules/pap/pbkfd2_sha256_389ds_with_header.unlang
@@ -1,0 +1,17 @@
+if ("${feature.tls}" == no) {
+	test_pass
+	return
+}
+
+if (User-Name == 'pbkfd2_sha256_389ds_with_header') {
+	update control {
+		Password-With-Header := '{PBKDF2-SHA256}10000$Y79u61tRN/dthaamikuxU/1PkOSprfbN$stej1qVq0CjglfdkLmwW2C94Hr5WQ20Nj6bIRumMy+E='
+	}
+	pap.authorize
+	pap.authenticate
+	if (!ok) {
+		test_fail
+	} else {
+		test_pass
+	}
+}

--- a/src/tests/modules/pap/pbkfd2_sha256_legacy_389ds_with_header.attrs
+++ b/src/tests/modules/pap/pbkfd2_sha256_legacy_389ds_with_header.attrs
@@ -1,0 +1,10 @@
+#
+#  Input packet
+#
+User-Name = 'pbkfd2_sha256_legacy_389ds_with_header'
+User-Password = 'password'
+
+#
+#  Expected answer
+#
+Response-Packet-Type == Access-Accept

--- a/src/tests/modules/pap/pbkfd2_sha256_legacy_389ds_with_header.unlang
+++ b/src/tests/modules/pap/pbkfd2_sha256_legacy_389ds_with_header.unlang
@@ -1,0 +1,17 @@
+if ("${feature.tls}" == no) {
+	test_pass
+	return
+}
+
+if (User-Name == 'pbkfd2_sha256_legacy_389ds_with_header') {
+	update control {
+		Password-With-Header := '{PBKDF2_SHA256}AAAgAC8OScrYDwaJYr29/qoQ/bcEf+WsQmkZjIFLSIKm1lxzNOSGPQEkueb1J5mWQy8a17m+UAM5jFKKuktMWSTDag9LNVfHTwHocrIsi4GGLf+PSn/eA3+lu5JHVXQo49gbZ+SALQ90cOvor+v+/xa4Q1VPUr42PuvmsdQln6i9jm/j9tVkO06W+CJXvTiCpR+oHiog9v/3s6bHUrWvwNksUe2r2d+MV5IaNdnil7P39qr1BxiKtDiG4d6HyI5aq1VEhJBg6S5ITYQ9iPlDbpoy2MHDLZHNqQduAVnwJuKuHVU3dU+VkynHWm3nGa2hfeV/bD8F8+WYehgL7bJndEzECx1QKuAZO+lK92vIMbZArdMvU6WRjncVlgoJbZtko6tFp1Ew+0VMVX+b6dGED0L391crdsudrTO+/fvU66xH515L'
+	}
+	pap.authorize
+	pap.authenticate
+	if (!ok) {
+		test_fail
+	} else {
+		test_pass
+	}
+}

--- a/src/tests/modules/pap/pbkfd2_sha512_389ds.attrs
+++ b/src/tests/modules/pap/pbkfd2_sha512_389ds.attrs
@@ -1,0 +1,10 @@
+#
+#  Input packet
+#
+User-Name = 'pbkfd2_sha512_389ds'
+User-Password = 'password'
+
+#
+#  Expected answer
+#
+Response-Packet-Type == Access-Accept

--- a/src/tests/modules/pap/pbkfd2_sha512_389ds.unlang
+++ b/src/tests/modules/pap/pbkfd2_sha512_389ds.unlang
@@ -1,0 +1,17 @@
+if ("${feature.tls}" == no) {
+	test_pass
+	return
+}
+
+if (User-Name == 'pbkfd2_sha512_389ds') {
+	update control {
+		&PBKDF2-Password := '{PBKDF2-SHA512}10000$N3A054iTXUWq4pN2r/2WuCdRFn6ZJ1G+$5MlwC7KpKbXvjIuCaMaDKYmXSVwbUsgzmovEx73cmuuuA1Vet3IOnV5Mj7nZhb9Y4VlDfT6XLJt0xJlBGWESjw=='
+	}
+	pap.authorize
+	pap.authenticate
+	if (!ok) {
+		test_fail
+	} else {
+		test_pass
+	}
+}

--- a/src/tests/modules/pap/pbkfd2_sha512_389ds_with_header.attrs
+++ b/src/tests/modules/pap/pbkfd2_sha512_389ds_with_header.attrs
@@ -1,0 +1,10 @@
+#
+#  Input packet
+#
+User-Name = 'pbkfd2_sha512_389ds_with_header'
+User-Password = 'password'
+
+#
+#  Expected answer
+#
+Response-Packet-Type == Access-Accept

--- a/src/tests/modules/pap/pbkfd2_sha512_389ds_with_header.unlang
+++ b/src/tests/modules/pap/pbkfd2_sha512_389ds_with_header.unlang
@@ -1,0 +1,17 @@
+if ("${feature.tls}" == no) {
+	test_pass
+	return
+}
+
+if (User-Name == 'pbkfd2_sha512_389ds_with_header') {
+	update control {
+		Password-With-Header := '{PBKDF2-SHA512}10000$N3A054iTXUWq4pN2r/2WuCdRFn6ZJ1G+$5MlwC7KpKbXvjIuCaMaDKYmXSVwbUsgzmovEx73cmuuuA1Vet3IOnV5Mj7nZhb9Y4VlDfT6XLJt0xJlBGWESjw=='
+	}
+	pap.authorize
+	pap.authenticate
+	if (!ok) {
+		test_fail
+	} else {
+		test_pass
+	}
+}


### PR DESCRIPTION
Implement support for 389ds password hashes PBKDF2-SHA{1,256,512} and legacy PBKDF2_SHA256 in v.3.2.x

Backport of PR #5564