### PR TITLE
PBKDF2: Update debug message to give correct context

### DIFF
--- a/src/modules/rlm_pap/rlm_pap.c
+++ b/src/modules/rlm_pap/rlm_pap.c
@@ -892,7 +892,7 @@ static inline unlang_action_t CC_HINT(nonnull) pap_auth_pbkdf2_sha256_legacy(rlm
 				&FR_SBUFF_IN((char const *) p, (char const *)end), false, false);
 
 	if (slen <= 0) {
-		RPEDEBUG("Failed decoding Password.PBKDF2 hash component");
+		RPEDEBUG("Failed decoding Password.With-Header {PBKDF2_SHA256}: \"%.*s\"", (int)(end -p), p);
 		RETURN_MODULE_INVALID;
 	}
 


### PR DESCRIPTION
`pap_auth_pbkdf2_sha256_legacy` works on the legacy `{PBKDF2_SHA256}` header which comes in `Password.With-Header` and not in `Password.PBKDF2`. (It now matches the code for v3.2.x).