### PR TITLE
TLS 1.3 support for LDAP module

### DIFF
--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -2637,7 +2637,10 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 	}
 
 	if (inst->handle_config.tls_min_version_str) {
-		if (strcmp(inst->handle_config.tls_min_version_str, "1.2") == 0) {
+		if (strcmp(inst->handle_config.tls_min_version_str, "1.3") == 0) {
+			inst->tls_min_version = LDAP_OPT_X_TLS_PROTOCOL_TLS1_3;
+
+		} else if (strcmp(inst->handle_config.tls_min_version_str, "1.2") == 0) {
 			inst->handle_config.tls_min_version = LDAP_OPT_X_TLS_PROTOCOL_TLS1_2;
 
 		} else if (strcmp(inst->handle_config.tls_min_version_str, "1.1") == 0) {

--- a/src/modules/rlm_ldap/rlm_ldap.c
+++ b/src/modules/rlm_ldap/rlm_ldap.c
@@ -2638,7 +2638,7 @@ static int mod_instantiate(module_inst_ctx_t const *mctx)
 
 	if (inst->handle_config.tls_min_version_str) {
 		if (strcmp(inst->handle_config.tls_min_version_str, "1.3") == 0) {
-			inst->tls_min_version = LDAP_OPT_X_TLS_PROTOCOL_TLS1_3;
+			inst->handle_config.tls_min_version = LDAP_OPT_X_TLS_PROTOCOL_TLS1_3;
 
 		} else if (strcmp(inst->handle_config.tls_min_version_str, "1.2") == 0) {
 			inst->handle_config.tls_min_version = LDAP_OPT_X_TLS_PROTOCOL_TLS1_2;


### PR DESCRIPTION
Originally, I was receiving the error message:
Invalid 'tls.tls_min_version' value "1.3"

Test setup:
Freeradius server with mods-enabled/ldap configured. 
tls_start must be no and tls_min_version must be 1.3 to replicate the error message.

Decided to check it out and found it basically hardcoded to not accept 1.3. Added the option and freeradius will start now.

This code resolves that issue. 