### PR TITLE
[v3.2.x] Debian systemd: MemoryLimit -> MemoryMax

### DIFF
--- a/debian/freeradius.service
+++ b/debian/freeradius.service
@@ -20,7 +20,7 @@ Environment=HOSTNAME=%H
 # Limit memory to 2G this is fine for %99.99 of deployments.  FreeRADIUS
 # is not memory hungry, if it's using more than this, then there's probably
 # a leak somewhere.
-MemoryLimit=2G
+MemoryMax=2G
 
 # Ensure the daemon can still write its pidfile after it drops
 # privileges. Combination of options that work on a variety of


### PR DESCRIPTION
MemoryMax has been introduced with systemd 231
MemoryLimit has been marked deprecated with systemd 252