### PR TITLE
Update dictionary.adva to align with the latest product release

### DIFF
--- a/share/dictionary/radius/dictionary.adva
+++ b/share/dictionary/radius/dictionary.adva
@@ -28,7 +28,10 @@ VALUE	User-Level			Retrieve		0
 
 ATTRIBUTE	UUM-User-Level				102	integer
 
-VALUE	UUM-User-Level			Root			5
+VALUE	UUM-User-Level			Sudoadmin		8
+#VALUE	UUM-User-Level			Ftponly			7
+VALUE	UUM-User-Level			Crypto			6
+#VALUE	UUM-User-Level			Root			5
 VALUE	UUM-User-Level			Admin			4
 VALUE	UUM-User-Level			Provision		3
 VALUE	UUM-User-Level			Operator		2


### PR DESCRIPTION
Updated UUM-User-Level list to align with the latest release of Fiber Service Platform product.

Please notice that ADVA (Optical Networking) and Adtran have been merged into Adtran Optical Networks and ADVA does not exist anymore, but this dictionary remains valid for ADVA's Fiber Service Platform product.

Commented out lines are for deprecated UUM-User-Level values. Maybe those should be removed?