### PR TITLE
fix: Dictionary correction for CSR subject fields

### DIFF
--- a/share/dictionary/der/dictionary.rfc2986
+++ b/share/dictionary/der/dictionary.rfc2986
@@ -17,7 +17,7 @@ DEFINE	certificationRequestInfo			sequence
 BEGIN certificationRequestInfo
 DEFINE	version						integer
 
-DEFINE	subject						sequence
+DEFINE	subject						sequence  sequence_of=set
 BEGIN subject
 DEFINE	RelativeDistinguishedName			set clone=@.RelativeDistinguishedName
 END subject


### PR DESCRIPTION
Resolved issue where CSR's did not have the full subject field decoded since the dictionary did not denote that it is a sequence of sets.