### PR TITLE
Add instance of files mod to do mac-auth

### DIFF
--- a/raddb/mods-available/files
+++ b/raddb/mods-available/files
@@ -70,3 +70,12 @@ files files_accounting {
 #	key = "%{Stripped-User-Name || User-Name}"
 	filename = ${modconfdir}/files/accounting
 }
+
+#
+#  ## An instance of the `files` module for authorizing access for WiFi clients
+#  ## via their MAC address
+#  ## Based on https://wiki.freeradius.org/guide/Mac-Auth
+#
+files authorized_macs {
+	key = "%{Calling-Station-ID}"
+}

--- a/raddb/mods-config/authorized_macs/accounting
+++ b/raddb/mods-config/authorized_macs/accounting
@@ -1,0 +1,5 @@
+#  This is like the 'users' file, but it is processed only for
+#  accounting packets.
+#
+#  See the `accounting` file in the files mod for examples
+

--- a/raddb/mods-config/authorized_macs/authorize
+++ b/raddb/mods-config/authorized_macs/authorize
@@ -1,0 +1,14 @@
+#
+# 	Configuration file for the rlm_files module.
+# 	Please see rlm_files documentation for more information.
+#
+# 	This file contains authentication security and configuration
+#	information for each user.  Accounting requests are NOT processed
+#	through this file.  Instead, see the 'accounting' file in this directory.
+#
+#	This file follows the same format as other instances of the files mod, see
+#	the `files/authorize` for more details and examples
+#
+#	An example entry is below
+#00-00-5E-00-53-FF
+#        Reply-Message = "Device with MAC Address %{Calling-Station-Id} authorized for network access"


### PR DESCRIPTION
This is based on https://wiki.freeradius.org/guide/Mac-Auth updated to the latest syntax. This does not include changes to the default site to enable it nor is a mac-auth-only site added (this could be added in the future).