### PR TITLE
Use of MemoryLimit is deprecated

### DIFF
--- a/redhat/radiusd.service
+++ b/redhat/radiusd.service
@@ -20,7 +20,7 @@ Environment=HOSTNAME=%H
 # Limit memory to 2G this is fine for %99.99 of deployments.  FreeRADIUS
 # is not memory hungry, if it's using more than this, then there's probably
 # a leak somewhere.
-MemoryLimit=2G
+MemoryMax=2G
 
 RuntimeDirectory=radiusd radiusd/tmp
 RuntimeDirectoryMode=0775


### PR DESCRIPTION
When starting freeradius from systemd there is a warning logged:

```
systemd[1]: /usr/lib/systemd/system/radiusd.service:23: Unit uses MemoryLimit=; please use MemoryMax= instead. Support for MemoryLimit= will be removed soon.
```

MemoryMax is supported with el8 and el9. This would break it for el7 and before, but el7 is end-of-life.

Backport of #5638 