### PR TITLE
rlm_ocsp: correct timeout comparison in OCSP_sendreq_nbio retry loop

### DIFF
--- a/src/modules/rlm_ocsp/ocsp.c
+++ b/src/modules/rlm_ocsp/ocsp.c
@@ -533,9 +533,9 @@ int fr_tls_ocsp_check(request_t *request, SSL *ssl,
 	start = fr_time();
 	do {
 		rc = OCSP_sendreq_nbio(&resp, ctx);
-		if (conf->timeout) {
-			if (conf->timeout > (fr_time() - start)) break;
-		}
+    if (conf->timeout && (fr_time() - start) >= conf->timeout) {
+        break;
+    }
 	} while ((rc == -1) && BIO_should_retry(conn));
 
 	if (conf->timeout && (rc == -1) && BIO_should_retry(conn)) {


### PR DESCRIPTION
Previously broke out while elapsed < timeout, causing early exit and treating OCSP as timed out. Break only when elapsed >= timeout so we retry until the deadline. Prevents unintended skips and softfail acceptance of revoked certs.

This bug was found with ZeroPath.