### PR TITLE
rlm_ftp: fix write and read, make DISCARD sticky

### DIFF
--- a/src/modules/rlm_ftp/rlm_ftp.c
+++ b/src/modules/rlm_ftp/rlm_ftp.c
@@ -249,6 +249,11 @@ static size_t ftp_response_body(void *in, size_t size, size_t nmemb, void *userd
 		ctx->alloc = needed;
 	}
 
+    /* Should never happen, but quiet static analyzers */
+	if (unlikely(!ctx->buffer)) {
+		MEM(ctx->buffer = talloc_bstr_realloc(NULL, NULL, ctx->alloc ? ctx->alloc : needed));
+	}
+
 	out_p = ctx->buffer + ctx->used;
 	memcpy(out_p, p, chunk_len);
 	ctx->used = total;


### PR DESCRIPTION
Make DISCARD sticky. If state is DISCARD, drop subsequent chunks early.

When switching to DISCARD, free buffer and reset alloc and used to 0.

Fix 1 byte OOB write caused by talloc_bstr_realloc semantics on NULL. Allocate space for data plus the trailing NUL. For non NULL buffers request needed - 1 since bstr adds the NUL. For NULL buffers request full needed since bstr allocates exactly inlen bytes (no + 1).

Prevent uninitialized data exposure after DISCARD by clearing stale used when buffer is NULL before writing.

Always NUL terminate at buffer[used].

This removes the truncated tail return, prevents reading uninitialized bytes, and eliminates the off by one write on first allocation.

This bug was found with ZeroPath.