### PR TITLE
doc: add official Docker Hub image link to documentation

### DIFF
--- a/doc/antora/modules/howto/partials/get_the_source.adoc
+++ b/doc/antora/modules/howto/partials/get_the_source.adoc
@@ -2,3 +2,4 @@ Download the latest version of the FreeRADIUS source from one of these sites:
 
 *  https://www.freeradius.org/releases/[the FreeRADIUS web site]; or
 * from https://github.com/FreeRADIUS/freeradius-server/[GitHub].
+* from https://hub.docker.com/r/freeradius/freeradius-server/[Docker Hub].


### PR DESCRIPTION
I've noticed that you have an official (?) docker image at https://hub.docker.com/r/freeradius/freeradius-server/, but that it isn't

I had to go through the mailing list to see that it was promoted by maintainer mcnewton, in order to confirm that it is official.

This PR adds it to the documentation