### PR TITLE
docs-v4: Update path for users.adoc xref link in src/original file (replace PR 5677)

### DIFF
--- a/raddb/mods-available/files
+++ b/raddb/mods-available/files
@@ -9,7 +9,7 @@
 #
 #  The `users` file as located in `raddb/mods-config/files/authorize`. (Livingston-style format).
 #
-#  See the doc/antora/modules/reference/pages/raddb/mods-config/files/users.adoc file for information
+#  See the raddb/mods-config/files/users.adoc file for information
 #  on the format of the input file, and how it operates.
 #
 


### PR DESCRIPTION
Update/replace previous commit of this file because it was done in the generated *.adoc file on commit #https://github.com/nolade/freeradius-server/tree/master/doc#:~:text=for%20users.adoc-,e7823b8,-%C2%B7%C2%A0

