### PR TITLE
Prefers `MemoryMax` over deprecated `MemoryLimit` service directive

### DIFF
--- a/debian/freeradius.service
+++ b/debian/freeradius.service
@@ -25,7 +25,7 @@ Environment=SNMP_PERSISTENT_DIR=/var/lib/freeradius/snmp
 # Limit memory to 2G this is fine for %99.99 of deployments.  FreeRADIUS
 # is not memory hungry, if it's using more than this, then there's probably
 # a leak somewhere.
-MemoryLimit=2G
+MemoryMax=2G
 
 # Ensure the daemon can still write its pidfile after it drops
 # privileges. Combination of options that work on a variety of


### PR DESCRIPTION
See #5638 for rationale (and #5588 for v3.2 backport).