### PR TITLE
Consider 'c' an expected character in an IP(v6) address; output "IPv6 address" rather than "IPv 6 address"

### DIFF
--- a/src/main/conffile.c
+++ b/src/main/conffile.c
@@ -1316,11 +1316,11 @@ static inline int fr_item_validate_ipaddr(CONF_SECTION *cs, char const *name, PW
 
 	if (strcmp(value, "*") == 0) {
 		cf_log_info(cs, "%.*s\t%s = *", cs->depth, parse_spaces, name);
-	} else if (strspn(value, ".0123456789abdefABCDEF:%[]/") == strlen(value)) {
+	} else if (strspn(value, ".0123456789abcdefABCDEF:%[]/") == strlen(value)) {
 		cf_log_info(cs, "%.*s\t%s = %s", cs->depth, parse_spaces, name, value);
 	} else {
 		cf_log_info(cs, "%.*s\t%s = %s IPv%s address [%s]", cs->depth, parse_spaces, name, value,
-			    (ipaddr->af == AF_INET ? "4" : " 6"), ip_ntoh(ipaddr, ipbuf, sizeof(ipbuf)));
+			    (ipaddr->af == AF_INET ? "4" : "6"), ip_ntoh(ipaddr, ipbuf, sizeof(ipbuf)));
 	}
 
 	switch (type) {


### PR DESCRIPTION
Without these, debug output looks surprisingly different for addresses containing 'c':
ipv6addr = 1111:111:3c:c000::139 IPv 6 address [1111:111:3c:c000::139]
vs
ipv6addr = 1111:111:1:132::34