### PR TITLE
Accept URIs for TLS certificates and private keys

### DIFF
--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -337,6 +337,16 @@ eap {
 			certificate_file = ${certdir}/rsa/server.pem
 
 			#
+			#  certificate_uri:: URI which contains the certificate presented
+			#  as the "server certificate" to the client.
+			#
+			#  At least one of `certificate_file` and `certificate_uri`
+			#  should be specified. If both are specified, then
+			#  `certificate_file` will be used.
+			#
+#			certificate_uri = "pkcs11:"
+
+			#
 			#  ca_file::  File which contains the root CA.
 			#
 			#  THis configuration item allows the server to load
@@ -378,6 +388,19 @@ eap {
 			#  same file name.
 			#
 			private_key_file = ${certdir}/rsa/server.key
+
+			#
+			#  private_key_file:: URI which contains the private key.
+			#
+			#  If the Private key & Certificate should be loaded with the same URI,
+			#  then `private_key_uri` & `certificate_uri` should contain the
+			#  same URI.
+			#
+			#  At least one of `private_key_file` and `certificate_uri`
+			#  should be specified. If both are specified, then
+			#  `certificate_file` will be used.
+			#
+#			private_key_uri = "pkcs11:"
 
 			#
 			#  verify_mode:: How we verify the certificate chain.

--- a/src/lib/tls/conf-h
+++ b/src/lib/tls/conf-h
@@ -66,9 +66,11 @@ typedef struct {
 									///< from a single file.
 
 	char const			*certificate_file;		//!< Path to certificate.
+	char const			*certificate_uri;		//!< URI to certificate.
 
-	char const			*password;			//!< Password to decrypt the certificate(s).
-	char const			*private_key_file;		//!< Path to certificate.
+	char const			*password;			//!< Password to decrypt the private key.
+	char const			*private_key_file;		//!< Path to private key.
+	char const			*private_key_uri;		//!< URI to private key.
 
 	char const			**ca_files;			//!< Extra certificates to load.
 	fr_tls_chain_verify_mode_t	verify_mode;			//!< How hard we try to build up a complete certificate

--- a/src/lib/tls/conf.c
+++ b/src/lib/tls/conf.c
@@ -116,9 +116,11 @@ static conf_parser_t tls_chain_config[] = {
 			 	.len = &certificate_format_table_len
 			 },
 			 .dflt = "pem" },
-	{ FR_CONF_OFFSET_FLAGS("certificate_file", CONF_FLAG_FILE_READABLE | CONF_FLAG_FILE_EXISTS | CONF_FLAG_REQUIRED, fr_tls_chain_conf_t, certificate_file) },
+	{ FR_CONF_OFFSET_FLAGS("certificate_file", CONF_FLAG_FILE_READABLE | CONF_FLAG_FILE_EXISTS, fr_tls_chain_conf_t, certificate_file) },
+	{ FR_CONF_OFFSET("certificate_uri", fr_tls_chain_conf_t, certificate_uri) },
 	{ FR_CONF_OFFSET_FLAGS("private_key_password", CONF_FLAG_SECRET, fr_tls_chain_conf_t, password) },
-	{ FR_CONF_OFFSET_FLAGS("private_key_file", CONF_FLAG_FILE_READABLE | CONF_FLAG_FILE_EXISTS | CONF_FLAG_REQUIRED, fr_tls_chain_conf_t, private_key_file) },
+	{ FR_CONF_OFFSET_FLAGS("private_key_file", CONF_FLAG_FILE_READABLE | CONF_FLAG_FILE_EXISTS, fr_tls_chain_conf_t, private_key_file) },
+	{ FR_CONF_OFFSET("private_key_uri", fr_tls_chain_conf_t, private_key_uri) },
 
 	{ FR_CONF_OFFSET_FLAGS("ca_file", CONF_FLAG_FILE_READABLE | CONF_FLAG_MULTI, fr_tls_chain_conf_t, ca_files) },
 

--- a/src/lib/tls/session.c
+++ b/src/lib/tls/session.c
@@ -1921,13 +1921,13 @@ fr_tls_session_t *fr_tls_session_alloc_server(TALLOC_CTX *ctx, SSL_CTX *ssl_ctx,
 	 *	on OpenSSL's opaque error messages.
 	 */
 	} else {
-		if (!conf->chains || !conf->chains[0]->private_key_file) {
-			ERROR("TLS Server requires a private key file");
+		if (!conf->chains || (!conf->chains[0]->private_key_file && !conf->chains[0]->private_key_uri)) {
+			ERROR("TLS Server requires a private key file or URI");
 			goto error;
 		}
 
-		if (!conf->chains || !conf->chains[0]->certificate_file) {
-			ERROR("TLS Server requires a certificate file");
+		if (!conf->chains || (!conf->chains[0]->certificate_file && !conf->chains[0]->certificate_uri)) {
+			ERROR("TLS Server requires a certificate file or URI");
 			goto error;
 		}
 	}


### PR DESCRIPTION
Inspired by #3942, which includes a fantastic explanation of the benefit of adding pkcs11 support.

This pull request added support for loading TLS certificates and private keys from URIs using the OSSL_STORE API, which works with OpenSSL providers. On systems where [libp11 OpenSSL provider (pkcs11prov)](https://github.com/OpenSC/libp11) is installed, we should be able to load objects with `pkcs11:` URIs.

Theoretically other URI schemes should also be supported if corresponding OpenSSL loaders are installed, but I did not test this.