### PR TITLE
Add TLS-Cert-Serial-Number-And-Issuer / TLS-Client-Cert-Serial-Number-And-Issuer

### DIFF
--- a/share/dictionary.freeradius.internal
+++ b/share/dictionary.freeradius.internal
@@ -631,8 +631,11 @@ ATTRIBUTE	TLS-Server-Name-Indication		1951	string
 ATTRIBUTE	TLS-Cert-CRL-Distribution-Points	1960	string
 ATTRIBUTE	TLS-Client-Cert-CRL-Distribution-Points	1961	string
 
+ATTRIBUTE	TLS-Cert-Serial-Number-And-Issuer	1962	string
+ATTRIBUTE	TLS-Client-Cert-Serial-Number-And-Issuer	1963	string
+
 #
-#	Range:	1960-2099
+#	Range:	1964-2099
 #		Free
 #
 #	Range:	2100-2199


### PR DESCRIPTION
The Serial Number and Issuer is a string format defined in RFC4523 called a CertificateExactAssertion that allows a unique instance of an X509 certificate to be identified independently of the contents of the certificate.

This interoperates with the SSL_CLIENT_CERT_RFC4523_CEA variable in Apache httpd's mod_ssl.