### PR TITLE
Feature: Optional Octets Encoding in JSON Blobs

### DIFF
--- a/raddb/mods-available/json
+++ b/raddb/mods-available/json
@@ -156,6 +156,7 @@ json {
 			#
 			#  Controls the representation of binary data in JSON output.
 			#  - "raw" (default): write bytes directly as a JSON string
+			#  - "base16": base16(hex)-encode the binary data
 			#  - "base64": base64-encode the binary data
 			#
 #			binary_format = raw

--- a/src/lib/json/base.h
+++ b/src/lib/json/base.h
@@ -54,6 +54,7 @@ extern size_t fr_json_format_table_len;
  */
 typedef enum {
 	JSON_BINARY_FORMAT_RAW = 0,	//!< Current behaviour — raw bytes as JSON string.
+	JSON_BINARY_FORMAT_BASE16,	//!< Base16-encode octets values.
 	JSON_BINARY_FORMAT_BASE64	//!< Base64-encode octets values.
 } fr_json_binary_format_t;
 

--- a/src/modules/rlm_json/rlm_json.c
+++ b/src/modules/rlm_json/rlm_json.c
@@ -106,8 +106,24 @@ static xlat_action_t json_escape(TALLOC_CTX *ctx, fr_dcursor_t *out,
 	}
 
 	fr_value_box_list_foreach(&in_head->vb_group, vb_in) {
+		fr_value_box_t	vb_b16 = FR_VALUE_BOX_INITIALISER_NULL(vb_b16);
 		fr_value_box_t	vb_b64 = FR_VALUE_BOX_INITIALISER_NULL(vb_b64);
 		fr_value_box_t	*vb_to_encode = UNCONST(fr_value_box_t *, vb_in);
+
+		/*
+		 *	Base16-encode octets values when requested.
+		 */
+		if ((format->value.binary_format == JSON_BINARY_FORMAT_BASE16) &&
+		    (vb_in->type == FR_TYPE_OCTETS)) {
+			fr_sbuff_t	*b16_sbuff;
+
+			FR_SBUFF_TALLOC_THREAD_LOCAL(&b16_sbuff, 256, SIZE_MAX);
+
+			fr_base16_encode(b16_sbuff, &FR_DBUFF_TMP(vb_in->vb_octets, vb_in->vb_length));
+			fr_value_box_bstrndup(ctx, &vb_b16, NULL,
+					      fr_sbuff_start(b16_sbuff), fr_sbuff_used(b16_sbuff), vb_in->tainted);
+			vb_to_encode = &vb_b16;
+		}
 
 		/*
 		 *	Base64-encode octets values when requested.
@@ -126,10 +142,12 @@ static xlat_action_t json_escape(TALLOC_CTX *ctx, fr_dcursor_t *out,
 
 		MEM(vb_out = fr_value_box_alloc_null(ctx));
 		if (fr_json_str_from_value(agg, vb_to_encode, quote) < 0) {
+			fr_value_box_clear(&vb_b16);
 			fr_value_box_clear(&vb_b64);
 			RPERROR("Failed creating escaped JSON value");
 			return XLAT_ACTION_FAIL;
 		}
+		fr_value_box_clear(&vb_b16);
 		fr_value_box_clear(&vb_b64);
 		if (fr_value_box_bstrndup(vb_out, vb_out, NULL, fr_sbuff_start(agg), fr_sbuff_used(agg), vb_in->tainted) < 0) {
 			RPERROR("Failed assigning escaped JSON value to output box");

--- a/src/tests/modules/json/encode.unlang
+++ b/src/tests/modules/json/encode.unlang
@@ -193,4 +193,21 @@ group {
 	}
 }
 
+# 8a. binary_format = base16 tests
+group {
+	octets local_octets
+
+	local_octets := 0xdeadbeef
+
+	if (%str.utf8(local_octets)) {
+		test_fail
+	}
+
+	# With binary_format = base16, octets should be base16 encoded
+	test_string1 := %json_object_base16.encode("local_octets")
+	if !(test_string1 == '{"local_octets":{"type":"octets","value":"deadbeef"}}') {
+		test_fail
+	}
+}
+
 test_pass

--- a/src/tests/modules/json/module.conf
+++ b/src/tests/modules/json/module.conf
@@ -164,6 +164,19 @@ json json_object_b64 {
 	}
 }
 
+#
+#  Output mode "object" with binary_format = base16
+#
+json json_object_base16 {
+	encode {
+		output_mode = object
+
+		value {
+			binary_format = base16
+		}
+	}
+}
+
 test {
 
 }


### PR DESCRIPTION
Allow octets boxes to be encoded as base16 (hex) or base64 in JSON blobs