### PR TITLE
docs-v4: moved network security best practices page to `Introduction …

### DIFF
--- a/doc/antora/modules/ROOT/nav.adoc
+++ b/doc/antora/modules/ROOT/nav.adoc
@@ -6,6 +6,7 @@
 *** xref:gethelp.adoc[Get Help]
 ** xref:bestpractices.adoc[Best Practices]
 *** xref:troubleshooting:eap_certificates.adoc[EAP Certificates]
+*** xref:troubleshooting:network/security.adoc[Network Security]
 ** xref:faq.adoc[Frequently Asked Question (FAQ)]
 
 

--- a/doc/antora/modules/troubleshooting/nav.adoc
+++ b/doc/antora/modules/troubleshooting/nav.adoc
@@ -1,7 +1,6 @@
 * xref:index.adoc[Troubleshooting]
 
 ** xref:network/index.adoc[Network Errors]
-*** xref:network/security.adoc[Security Best Practices]
 
 *** Server does not start
 **** xref:network/bind.adoc[Failed binding to socket]

--- a/doc/antora/modules/troubleshooting/pages/index.adoc
+++ b/doc/antora/modules/troubleshooting/pages/index.adoc
@@ -92,11 +92,18 @@ Some of the more common issues are covered in the
 xref:ROOT:faq.adoc[FAQ]. The section is divided into the following
 areas:
 
+* xref:network/index.adoc[Network Errors]
 * xref:user.adoc[User Management]
 * xref:server.adoc[Server Configuration]
 * xref:client.adoc[Client Configuration]
 * xref:connect_nas.adoc[Connectivity-NAS]
 * xref:datastore.adoc[Datastores]
+
+== Further Readings
+
+* https://www.inkbridgenetworks.com/blog/blog-10/what-does-unresponsive-child-error-message-mean-116[What does unresponsive child error message mean]
+* https://www.inkbridgenetworks.com/blog/blog-10/common-freeradius-debug-messages-96[Common FreeRADIUS debug messages]
+
 
 // Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/troubleshooting/pages/network/security.adoc
+++ b/doc/antora/modules/troubleshooting/pages/network/security.adoc
@@ -1,4 +1,4 @@
-= Security Best Practices
+= Network Security 
 
 In general, you should not have your RADIUS server on the public
 Internet.  While the server is secure, placing it on the Internet


### PR DESCRIPTION
…>> Best Practices`.
Added `Further Reading` section to the top-level Troubleshooting page (index.adoc) and network troubleshooting link