### PR TITLE
rlm_rest: support UNIX (including abstract) sockets

### DIFF
--- a/raddb/mods-available/rest
+++ b/raddb/mods-available/rest
@@ -50,6 +50,21 @@ rest {
 	connect_uri = "http://127.0.0.1"
 
 	#
+	# When set, connects to the server over a UNIX socket which may be
+	# helpful for those with (pseudo)security constraints that make it
+	# easier to use an UNIX socket than explain to an auditor the use of
+	# non-TLS HTTP localhost connections.
+	#
+	# NOTE: This is not allowed to be an xlat as it can lead to security issues.
+	#
+#	connect_uri_socket = "/run/myprogram.sock"
+
+	#
+	# When set, connect_uri_socket is an abstract UNIX socket
+	#
+#	connect_uri_socket_abstract = "no"
+
+	#
 	#  How long before new connection attempts timeout, defaults to 4.0 seconds.
 	#
 #	connect_timeout = 4.0

--- a/src/modules/rlm_rest/rest.c
+++ b/src/modules/rlm_rest/rest.c
@@ -413,6 +413,12 @@ void *mod_conn_create(TALLOC_CTX *ctx, void *instance)
 		SET_OPTION(CURLOPT_SSL_VERIFYHOST, 0);
 		SET_OPTION(CURLOPT_CONNECT_ONLY, 1);
 		SET_OPTION(CURLOPT_URL, inst->connect_uri);
+		/* libcurl ignores this when connect_uri_socket is NULL */
+		SET_OPTION(
+			inst->connect_uri_socket_abstract
+				? CURLOPT_ABSTRACT_UNIX_SOCKET
+				: CURLOPT_UNIX_SOCKET_PATH,
+			inst->connect_uri_socket);
 		SET_OPTION(CURLOPT_NOSIGNAL, 1);
 
 		DEBUG("rlm_rest (%s): Connecting to \"%s\"", inst->xlat_name, inst->connect_uri);
@@ -2062,6 +2068,12 @@ int rest_request_config(rlm_rest_t *instance, rlm_rest_section_t *section,
 	 *	Setup any header options and generic headers.
 	 */
 	SET_OPTION(CURLOPT_URL, uri);
+	/* libcurl ignores this when connect_uri_socket is NULL */
+	SET_OPTION(
+		instance->connect_uri_socket_abstract
+			? CURLOPT_ABSTRACT_UNIX_SOCKET
+			: CURLOPT_UNIX_SOCKET_PATH,
+		instance->connect_uri_socket);
 	SET_OPTION(CURLOPT_NOSIGNAL, 1);
 	SET_OPTION(CURLOPT_USERAGENT, "FreeRADIUS " RADIUSD_VERSION_STRING);
 

--- a/src/modules/rlm_rest/rest.h
+++ b/src/modules/rlm_rest/rest.h
@@ -166,6 +166,8 @@ typedef struct rlm_rest_t {
 
 	char const		*connect_uri;	//!< URI we attempt to connect to, to pre-establish
 						//!< TCP connections.
+	char const		*connect_uri_socket;		//!< UNIX socket path we connect to.
+	bool			connect_uri_socket_abstract;	//!< If the UNIX socket is an abstract socket.
 
 	struct timeval		connect_timeout_tv;	//!< Connection timeout timeval.
 	long			connect_timeout;	//!< Connection timeout ms.

--- a/src/modules/rlm_rest/rlm_rest.c
+++ b/src/modules/rlm_rest/rlm_rest.c
@@ -29,6 +29,7 @@ RCSID("$Id$")
 #include <freeradius-devel/rad_assert.h>
 
 #include <ctype.h>
+#include <sys/un.h>
 #include "rest.h"
 
 /*
@@ -57,7 +58,7 @@ static CONF_PARSER tls_config[] = {
  *	buffer over-flows.
  */
 static const CONF_PARSER section_config[] = {
-	{ "uri", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_rest_section_t, uri), ""   },
+	{ "uri", FR_CONF_OFFSET(PW_TYPE_STRING | PW_TYPE_XLAT, rlm_rest_section_t, uri), "" },
 	{ "method", FR_CONF_OFFSET(PW_TYPE_STRING, rlm_rest_section_t, method_str), "GET" },
 	{ "body", FR_CONF_OFFSET(PW_TYPE_STRING, rlm_rest_section_t, body_str), "none" },
 	{ "attr_num", FR_CONF_OFFSET(PW_TYPE_BOOLEAN, rlm_rest_section_t, attr_num), "no" },
@@ -85,6 +86,8 @@ static const CONF_PARSER section_config[] = {
 
 static const CONF_PARSER module_config[] = {
 	{ "connect_uri", FR_CONF_OFFSET(PW_TYPE_STRING, rlm_rest_t, connect_uri), NULL },
+	{ "connect_uri_socket", FR_CONF_OFFSET(PW_TYPE_STRING, rlm_rest_t, connect_uri_socket), NULL },
+	{ "connect_uri_socket_abstract", FR_CONF_OFFSET(PW_TYPE_BOOLEAN, rlm_rest_t, connect_uri_socket_abstract), "no" },
 	{ "connect_timeout", FR_CONF_OFFSET(PW_TYPE_TIMEVAL, rlm_rest_t, connect_timeout_tv), "4.0" },
 	{ "http_negotiation", FR_CONF_OFFSET(PW_TYPE_STRING, rlm_rest_t, http_negotiation_str), "default" },
 
@@ -938,6 +941,17 @@ static int mod_instantiate(CONF_SECTION *conf, void *instance)
 		(parse_sub_section(conf, &inst->post_auth, section_type_value[MOD_POST_AUTH].section) < 0))
 	{
 		return -1;
+	}
+
+	if (inst->connect_uri_socket) {
+		// UNIX_PATH_MAX is not portable so bounce off the struct
+		struct sockaddr_un sa;
+		// -1 for the trailing (or for abstract leading) NUL
+		size_t max_len = sizeof(sa.sun_path) - 1;
+		if (strlen(inst->connect_uri_socket) > max_len) {
+			cf_log_err_cs(conf, "connect_uri_socket too long, limit is %ld bytes.", max_len);
+			return -1;
+		}
 	}
 
 	inst->http_negotiation = fr_str2int(http_negotiation_table, inst->http_negotiation_str, -1);


### PR DESCRIPTION
Allow for `rlm_rest` to connect to HTTP servers over a UNIX socket meaning you can sidestep explaining to auditors about non-TLS HTTP servers pointing to `localhost`[1], plus it can be faster to use a UNIX socket than TCP socket.

Tested with `socat` (both `UNIX-LISTEN` and `ABSTRACT-LISTEN`) proxying to `python3 -m http.server`:
```shell
$ socat UNIX-LISTEN:/tmp/test.sock,fork TCP:192.0.2.1:8000
```

```shell
$ python3 -m http.server
Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
192.0.2.232 - - [11/Mar/2026 07:18:29] code 404, message File not found
192.0.2.232 - - [11/Mar/2026 07:18:29] "GET /user/bob/mac/?action=authorize HTTP/1.1" 404 -
```

Notes:
 * no testing for `NUL` in `connect_uri_socket` as `PW_TYPE_STRING` covers us for this
 * xlat not supported, as a bad actor against a bad config might be able to talk to other daemons
 * [curl ignores the configuration option](https://curl.se/libcurl/c/CURLOPT_UNIX_SOCKET_PATH.html) when `connect_uri_socket` is `NULL`
 * check for the length limit (effectively `UNIX_PATH_MAX`)
    * if we do not check it, we get back from curl an unclear error and the server refuses to start, so we check to bubble up a friendly actionable message
    * [curl provides an example as a way around this limit (for Linux)](https://curl.se/libcurl/c/CURLOPT_UNIX_SOCKET_PATH.html) but `rlm_smsotp` does not do this and sysadmins for now can just create a softlink if they need a workaround

[1] of course to run `tcpdump` you need privileges in a similar way to use `ptrace()` but with this we can be technically correct in stating "packet sniffing is not possible".