### PR TITLE
listen: resolve status sockets leak connection limits

### DIFF
--- a/src/main/listen.c
+++ b/src/main/listen.c
@@ -2935,7 +2935,7 @@ static int proxy_socket_decode(RADIUSV11_UNUSED rad_listen_t *listener, REQUEST 
 fr_protocol_t master_listen[RAD_LISTEN_MAX] = {
 #ifdef WITH_STATS
 	{ RLM_MODULE_INIT, "status", sizeof(listen_socket_t), NULL,
-	  common_socket_parse, NULL,
+	  common_socket_parse, common_socket_free,
 	  stats_socket_recv, common_socket_send,
 	  common_socket_print, client_socket_encode, client_socket_decode },
 #else


### PR DESCRIPTION
Whilst using the virtual server 'aws-nlb', you very quickly hit:
```
Feb 16 22:19:41 service0 freeradius[31737]: Ignoring new connection from client localhost due to client max_connections (16)
Feb 16 22:19:41 service0 freeradius[31737]: Waking up in 28.8 seconds.
Feb 16 22:19:46 service0 freeradius[31737]: Ignoring new connection from client localhost due to client max_connections (16)
Feb 16 22:19:46 service0 freeradius[31737]: Waking up in 23.8 seconds.
```

This is just by using the simple client:
```
echo | nc -w0 192.0.2.232 8000
```

The issue is we are not calling `common_socket_free` for status sockets so when the client disconnects, we hit the `max_connections` limit very quickly.