### PR TITLE
rlm_cache: fix documentation error

### DIFF
--- a/raddb/mods-available/cache
+++ b/raddb/mods-available/cache
@@ -20,6 +20,10 @@
 #	The module returns "noop" if it did nothing.
 #	The module returns "fail" on error.
 #
+#	NOTE: return codes are statements about the status as well as
+#	      any changes being made to the cache. They are not about
+#	      if any changes were made to the attributes of the request.
+#
 cache {
 	#  The backend datastore used to store the cache entries.
 	#  Current datastores are
@@ -137,8 +141,8 @@ cache {
 	#  &control:Cache-Read-Only - If present and set to 'yes' will
 	#  prevent a new entry from being created, but will allow existing
 	#  entries to be merged.  It will also alter the module's return codes.
-	#    - The module will return "updated" if a cache entry was found.
-	#    - The module will return "notfound" if no cache was found.
+	#    - The module will return "ok" if a cache entry was found.
+	#    - The module will return "notfound" if no cache entry was found.
 	#
 	#  &control:Cache-Merge - If present and set to 'yes' will merge new
 	#  cache entries into the current request. Useful if results


### PR DESCRIPTION
Reviewing the code, the return code is a statement about the status as well as any changes being made to the cache but not to the request.

For this 'ok' makes more sense than 'updated' as nothing was updated. We also avoid the perils of backwards compatibility if we were to change it. So this is just a documentation fix.

Resolves #5627