### PR TITLE
don't load legacy provider on --enable-fips-workaround.

### DIFF
--- a/src/main/radclient.c
+++ b/src/main/radclient.c
@@ -168,7 +168,9 @@ static int _rc_request_free(rc_request_t *request)
 #  include <openssl/provider.h>
 
 static OSSL_PROVIDER *openssl_default_provider = NULL;
+#ifndef WITH_FIPS
 static OSSL_PROVIDER *openssl_legacy_provider = NULL;
+#endif
 
 static int openssl3_init(void)
 {
@@ -181,6 +183,7 @@ static int openssl3_init(void)
 		return -1;
 	}
 
+#ifndef WITH_FIPS
 	/*
 	 *	Needed for MD4
 	 *
@@ -191,6 +194,7 @@ static int openssl3_init(void)
 		ERROR("(TLS) Failed loading legacy provider");
 		return -1;
 	}
+#endif
 
 	return 0;
 }
@@ -202,10 +206,12 @@ static void openssl3_free(void)
 	}
 	openssl_default_provider = NULL;
 
+#ifndef WITH_FIPS
 	if (openssl_legacy_provider && !OSSL_PROVIDER_unload(openssl_legacy_provider)) {
 		ERROR("Failed unloading legacy provider");
 	}
 	openssl_legacy_provider = NULL;
+#endif
 }
 #else
 #define openssl3_init()

--- a/src/modules/rlm_mschap/smbencrypt.c
+++ b/src/modules/rlm_mschap/smbencrypt.c
@@ -43,7 +43,9 @@ static char const hex[] = "0123456789ABCDEF";
 #  include <openssl/provider.h>
 
 static OSSL_PROVIDER *openssl_default_provider = NULL;
+#ifndef WITH_FIPS
 static OSSL_PROVIDER *openssl_legacy_provider = NULL;
+#endif
 
 #define ERROR(_x) fprintf(stderr, _x)
 
@@ -58,6 +60,7 @@ static int openssl3_init(void)
 		return -1;
 	}
 
+#ifndef WITH_FIPS
 	/*
 	 *	Needed for MD4
 	 *
@@ -68,6 +71,7 @@ static int openssl3_init(void)
 		ERROR("(TLS) Failed loading legacy provider");
 		return -1;
 	}
+#endif
 
 	return 0;
 }
@@ -79,10 +83,12 @@ static void openssl3_free(void)
 	}
 	openssl_default_provider = NULL;
 
+#ifndef WITH_FIPS
 	if (openssl_legacy_provider && !OSSL_PROVIDER_unload(openssl_legacy_provider)) {
 		ERROR("Failed unloading legacy provider");
 	}
 	openssl_legacy_provider = NULL;
+#endif
 }
 #else
 #define openssl3_init()


### PR DESCRIPTION
Fixes #5775