### PR TITLE
docs-v4: Fixed syntax on coding example for `limit with catch` (unter…

### DIFF
--- a/doc/antora/modules/reference/pages/unlang/limit.adoc
+++ b/doc/antora/modules/reference/pages/unlang/limit.adoc
@@ -52,6 +52,9 @@ proxy requests to a maximum of `4`. If the limit is hit, it returns
 instead.
 
 .Example using catch
+
+[source,unlang]
+----
 recv Access-Request {
     try {
         limit 4 {


### PR DESCRIPTION
…minated block)