### PR TITLE
rlm_cache_memcached: fix date deserialize

### DIFF
--- a/src/lib/value.c
+++ b/src/lib/value.c
@@ -1655,12 +1655,17 @@ char *value_data_aprints(TALLOC_CTX *ctx,
 	{
 		time_t t;
 		struct tm s_tm;
+		size_t o = 0;
 
 		t = data->date;
 
 		p = talloc_zero_array(ctx, char, 64);
-		strftime(p, 63, "%b %e %Y %H:%M:%S %Z",
-			 localtime_r(&t, &s_tm));
+		if (!p) return NULL;
+
+		if (quote) { p[o] = quote; o++; }
+		o += strftime(&p[o], 64 - 1 - (quote ? 2 : 0), "%b %e %Y %H:%M:%S %Z", localtime_r(&t, &s_tm));
+		if (quote) p[o] = quote;
+
 		break;
 	}
 


### PR DESCRIPTION
dates are stored unquoted which trips `map_afrom_attr_str` so:
```
&reply:Event-Timestamp := Apr  6 2026 13:59:50 UTC
```

Turns into:
```
&reply:Event-Timestamp := Apr
```

Which then emits:
```
(1) cache: &Cache-Expires = 1775484257 &Cache-Created = 1775484197 &reply:Reply-Message += 'Cache last updated at Mon Apr  6 14:03:17 2026' &reply:Class := 0x6838512f563977644f754e76436d56505167594d57513871673376544d2e5549 &reply:Event-Timestamp := Apr  6 2026 14:03:17 UTC
(1) cache: ERROR: failed to parse time string "Apr"
----> request then fails
```

Fix this by adding quoting around date (the call to `map_afrom_attr_str` already says 'please quote'), giving us:
```
(1) cache: Retrieved 265 bytes from memcached
(1) cache: &Cache-Expires = 1775484334 &Cache-Created = 1775484274 &reply:Reply-Message += 'Cache last updated at Mon Apr  6 14:04:34 2026' &reply:Class := 0x614c366d4c474f573536514c34737a67632e4b674f342e336645614530617a32 &reply:Event-Timestamp := 'Apr  6 2026 14:04:34 UTC'
(1) cache: Found entry for "bob"
(1) cache: Merging cache entry into request
(1) cache:   &reply:Reply-Message = "Cache last updated at Mon Apr  6 14:04:34 2026"
(1) cache:   &reply:Event-Timestamp = "Apr  6 2026 14:04:34 UTC"
rlm_cache (cache): Released connection (2)
```