### PR TITLE
 docs-v4: Updated copyright message to current year using Alan's perl …

### DIFF
--- a/doc/all.mk
+++ b/doc/all.mk
@@ -282,6 +282,10 @@ doc.fixascii:
 	@perl -p -i -e "s,‘,',g;s,’,',g;s,–,-,g;s,—,-,g;s, , ,g;s:…:,:g;s,“,\",g;s,”,\",g;s,≤,<=,g;s,≥,>=,g;s,→,->,g" $$(find doc/antora -name "*.adoc" -print)
 
 
+.PHONY: doc.copyright
+doc.copyright:
+	perl -p -i -e "s/Copyright \(C\) 2.../Copyright (C) $$(date +%Y)/"  $$(git grep -l 'Copyright' $$(find doc/antora/ -name "*.adoc" -print))
+
 doc: build/docsite/sitemap.xml
 
 # end of WITH_DOC

--- a/doc/antora/modules/ROOT/nav.adoc
+++ b/doc/antora/modules/ROOT/nav.adoc
@@ -11,5 +11,5 @@
 
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/ROOT/pages/debugging/radiusd_X.adoc
+++ b/doc/antora/modules/ROOT/pages/debugging/radiusd_X.adoc
@@ -56,5 +56,5 @@ The next section xref:debugging/processing.adoc[*Packet Processing*] is where th
 . Server completes the post-authorisation processes for the current packet.
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/ROOT/pages/directories.adoc
+++ b/doc/antora/modules/ROOT/pages/directories.adoc
@@ -67,5 +67,5 @@ The directories in the server source are laid out as follows:
 | `src/modules/`   | Dynamic backend plug-in modules.
 |===
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/ROOT/pages/faq.adoc
+++ b/doc/antora/modules/ROOT/pages/faq.adoc
@@ -252,5 +252,5 @@ The NAS doesn't know which RADIUS server you use, and it doesn't care. The entir
 
 Use http://www.tcpdump.org[tcpdump] to snoop the RADIUS responses from each server. Once you discover which attributes are missing from the response of FreeRADIUS, you can add them to it's configuration. Re-start the server, and your users should have full access to the network again.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/ROOT/pages/gethelp.adoc
+++ b/doc/antora/modules/ROOT/pages/gethelp.adoc
@@ -45,5 +45,5 @@ We can configure multiple forms of authorisation on the same system simultaneous
 
 Existing systems can be migrated to our product or we can configure our product to work with your databases. The final result is a system that is robust, high performance, and easy to maintain. Contact us at sales@networkradius.com for more information.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/ROOT/pages/getstarted.adoc
+++ b/doc/antora/modules/ROOT/pages/getstarted.adoc
@@ -122,5 +122,5 @@ types, etc. used in the `unlang` policy language.
 There is also xref:developers:index.adoc[Developers] documentation
 that includes the APIs references.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/ROOT/pages/index.adoc
+++ b/doc/antora/modules/ROOT/pages/index.adoc
@@ -287,5 +287,5 @@ are available to help you with your software deployments,
 configurations, and ongoing support. See xref:gethelp.adoc[Get Help]
 for more information and details.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/nav.adoc
+++ b/doc/antora/modules/concepts/nav.adoc
@@ -19,5 +19,5 @@
 *** xref:modules/ldap/novell.adoc[Integrate Novell]
 ** xref:resources.adoc[Resources]
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/aaa/aaa.adoc
+++ b/doc/antora/modules/concepts/pages/aaa/aaa.adoc
@@ -29,5 +29,5 @@ The police officer may also ask you to prove that you are authorized to drive. I
 
 The authorization process combines the policy on the RADIUS server and the information in the request from the NAS. The NAS may add additional information to the request, such as the user's Media Access Control (MAC) address. The NAS sends the information to the RADIUS server, where an authorization decision is made.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/components/architecture.adoc
+++ b/doc/antora/modules/concepts/pages/components/architecture.adoc
@@ -18,5 +18,5 @@ return configuration parameters to the NAS. Receives accounting information from
 | Optional datastore such as a database or directory containing user authentication and authorization information.| RADIUS server communicates with the datastore using a database API or LDAP.                | SQL Database, Kerberos Service Server, or an LDAP Directory.
 |===
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/components/datastore.adoc
+++ b/doc/antora/modules/concepts/pages/components/datastore.adoc
@@ -20,5 +20,5 @@ such as LDAP "bind as user"                     | Support authentication protoco
 |===
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/components/nac.adoc
+++ b/doc/antora/modules/concepts/pages/components/nac.adoc
@@ -28,5 +28,5 @@ Policy decision may be separate from policy enforcement - this architecture is o
 * Network Admission Control
 * Trusted Network Connect
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/components/nas.adoc
+++ b/doc/antora/modules/concepts/pages/components/nas.adoc
@@ -21,5 +21,5 @@ Network Access Servers (NAS) don't have to use AAA servers, but they almost alwa
 -   https://datatracker.ietf.org/doc/html/rfc2881[RFC 2881] Network Access Server Requirements Next Generation NAS Model
 -   https://datatracker.ietf.org/doc/html/rfc2881[RFC 2882] Network Access Servers Requirements: Extended RADIUS Practices
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/components/radius.adoc
+++ b/doc/antora/modules/concepts/pages/components/radius.adoc
@@ -27,5 +27,5 @@ UDP: RADIUS uses UDP as its underlying protocol. The registered UDP port for RAD
 * RADIUS-Clients
 * Other RADIUS Servers
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/index.adoc
+++ b/doc/antora/modules/concepts/pages/index.adoc
@@ -29,5 +29,5 @@ Provides links to further help, mailing lists, and related documentation to supp
 
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/modules/ldap/authentication.adoc
+++ b/doc/antora/modules/concepts/pages/modules/ldap/authentication.adoc
@@ -105,5 +105,5 @@ recommendations, see the InkBridge article on
 https://www.inkbridgenetworks.com/blog/blog-10/pap-vs-chap-is-pap-less-secure-55[PAP
 vs CHAP]
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/modules/ldap/ldap_authentication.adoc
+++ b/doc/antora/modules/concepts/pages/modules/ldap/ldap_authentication.adoc
@@ -134,5 +134,5 @@ authentication method, or to relax the security requirements on LDAP
 and on password storage.  The final decision as to which choice is
 best can only be made by a local administrator.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/os.adoc
+++ b/doc/antora/modules/concepts/pages/os.adoc
@@ -36,5 +36,5 @@ FreeRADIUS is reported to run on the following Operating Systems:
 
 Porting to other unix-like platforms should be easy. Due to the limited resources of the FreeRADIUS development team, we are not able to test each version on all platforms before release.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/overview.adoc
+++ b/doc/antora/modules/concepts/pages/overview.adoc
@@ -71,5 +71,5 @@ In summary, the RADIUS client-server protocol provides these advantages:
 * Adaptable to most security systems.
 * Workable with any communication device that supports RADIUS client protocol.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/performance.adoc
+++ b/doc/antora/modules/concepts/pages/performance.adoc
@@ -38,5 +38,5 @@ portion, and then builds more complex functionality on top of that. It
 can be used to simulate user logins, and can auto-generate accounting
 packets for user sessions.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/protocol/authproto.adoc
+++ b/doc/antora/modules/concepts/pages/protocol/authproto.adoc
@@ -145,5 +145,5 @@ The relevant RFCs are:
 * https://datatracker.ietf.org/doc/html/rfc3579[RFC 3579] RADIUS (Remote Authentication Dial In User Service) Support For Extensible Authentication Protocol (EAP)
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/protocol/peap.adoc
+++ b/doc/antora/modules/concepts/pages/protocol/peap.adoc
@@ -59,5 +59,5 @@ Ultimately, PEAPv0/EAP-MSCHAPv2 is the only form of PEAP that most people will e
 
 * EAP
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/protocol/wep.adoc
+++ b/doc/antora/modules/concepts/pages/protocol/wep.adoc
@@ -84,5 +84,5 @@ The most widely recommended solution to WEP security problems is to switch to WP
 **[http://sourceforge.net/projects/weplab Weplab]
 **[http://kismac.binaervarianz.de/ KisMAC]
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/protocol/wpa.adoc
+++ b/doc/antora/modules/concepts/pages/protocol/wpa.adoc
@@ -73,5 +73,5 @@ Other EAP types may be supported by 802.1X clients and servers developed by spec
 * Steve Gibson's Perfect Passwords(https://www.grc.com/passwords/)
 * GRC's Ultra High Security Password Generators(http://darkvoice.dyndns.org/wlankeygen/ Online WEP-/WPA-Key Generator)
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/resources.adoc
+++ b/doc/antora/modules/concepts/pages/resources.adoc
@@ -25,5 +25,5 @@ include::ROOT:partial$mailinglist.adoc[]
 * *https://www.iana.org/assignments/radius-types/radius-types.xhtml[RADIUS Packet Types]*
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/session/processing.adoc
+++ b/doc/antora/modules/concepts/pages/session/processing.adoc
@@ -122,5 +122,5 @@ In this case, the mschap module looks at the request, and finds the MS-CHAP attr
 
 But now the server has run out of options! Its only choice was mschap because that's what the client sent in the request.  The mschap module can't do anything because you didn't give it a useful "known good" password . So the server has no choice but to reject the request.  The MSCHAP data might be correct, but the server has no way to know that.  So it replies with a reject.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/concepts/pages/virtual_servers.adoc
+++ b/doc/antora/modules/concepts/pages/virtual_servers.adoc
@@ -199,5 +199,5 @@ More examples
 For more examples, see the `sites-enabled/` directory that is
 included in the server distribution.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/nav.adoc
+++ b/doc/antora/modules/developers/nav.adoc
@@ -32,5 +32,5 @@
 *** xref:rfc/tacacs.adoc[TACACS+]
 ** xref:guidelines.adoc[Documentation Guidelines]
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/coccinelle.adoc
+++ b/doc/antora/modules/developers/pages/coccinelle.adoc
@@ -82,5 +82,5 @@ index 6fff875fb3..d172db865a 100644
 $
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/coding-methods.adoc
+++ b/doc/antora/modules/developers/pages/coding-methods.adoc
@@ -234,5 +234,5 @@ unrelated things, write two functions. Mashing two kinds of work into one
 function makes the server difficult to debug and maintain.
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/coding_standards.adoc
+++ b/doc/antora/modules/developers/pages/coding_standards.adoc
@@ -728,5 +728,5 @@ DIAG_ON(DIAG_UNKNOWN_PRAGMAS)
 The macro calls above disable and re-enable the `-Wdocumentation` diagnostic for mruby headers. `-Wdocumentation` will produce a warning if doxygen style comment blocks are not correctly composed.  We don't control the mruby headers and we will not be calling doxygen to build documentation based on them, so it's fine to disable the warning.  `-Wdocumentation` is only emitted by clang hence the use of `DIAG_(OFF|ON)_OPTIONAL`.
 ====
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/contributing.adoc
+++ b/doc/antora/modules/developers/pages/contributing.adoc
@@ -52,5 +52,5 @@ patches that modify a number of files MUST be submitted as a
 https://github.com/FreeRADIUS/freeradius-server/pulls[pull-request via GitHub].
 ====
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/coverage.adoc
+++ b/doc/antora/modules/developers/pages/coverage.adoc
@@ -10,5 +10,5 @@ $ make coverage
 
 If completed with success, a pretty report will be available in `${source_tree}/build/coverage/index.html`
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/coverity.adoc
+++ b/doc/antora/modules/developers/pages/coverity.adoc
@@ -165,5 +165,5 @@ CID 1503954 (#1 of 1): Untrusted loop bound (TAINTED_SCALAR)
 Customizing Coverity. Look especially at the sections "Identifying vulnerable data" and "Models and Primitives" (and in turn the section in "Models and Primitives" on C and C++ primitives).
 * https://www.synopsys.com/blogs/software-security/detecting-heartbleed-with-static-analysis/ "On detecting Heartbleed with static analysis". Describes the method Synopsys developed to detect errors like Heartbleed in a way "that scale[s] to large programs with low false positive rates, yet find[s] critical defects."
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/dbuff.adoc
+++ b/doc/antora/modules/developers/pages/dbuff.adoc
@@ -175,5 +175,5 @@ if ((val = fr_dbuff_foo(dbuff, ...) < 0) return val;
 
 letting one return an error to the caller without cluttering the code.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/gdb.adoc
+++ b/doc/antora/modules/developers/pages/gdb.adoc
@@ -64,5 +64,5 @@ After that, you can type `newcmd foo` and the command will run.
 * https://sourceware.org/gdb/current/onlinedocs/gdb.html/Python.html#Python [The "Extending GDB using Python" section of Debugging with GDB]
 * https://interrupt.memfault.com/blog/automate-debugging-with-gdb-python-api ["Automate Debugging with GDB Python API" from Interrupt by Memfault] The first section is about writing prettypriters, which isn't of interest to us. Later they get into adding custom gdb commands with Python, our current interest.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/github.adoc
+++ b/doc/antora/modules/developers/pages/github.adoc
@@ -197,5 +197,5 @@ The FreeRAIDUS project now requires all contributions to be signed. Refer to the
 * https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work[Git Tools Signing]
 * https://help.github.com/en/github/authenticating-to-github/signing-commits[Sign Commits]
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/lldb.adoc
+++ b/doc/antora/modules/developers/pages/lldb.adoc
@@ -83,5 +83,5 @@ There are various lldb "cheat sheets", other tutorials, and answered questions o
 
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/message.adoc
+++ b/doc/antora/modules/developers/pages/message.adoc
@@ -311,5 +311,5 @@ empty, so that the originator can poke the receiver that another message is read
 Or, the even loop / FD has to be exposed to the queue API, so that the
 queue code can do this signalling itself.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/module_interface.adoc
+++ b/doc/antora/modules/developers/pages/module_interface.adoc
@@ -184,5 +184,5 @@ int destroy(void)
 
 It should release resources that were acquired by the `init()` method.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/profile.adoc
+++ b/doc/antora/modules/developers/pages/profile.adoc
@@ -40,5 +40,5 @@ or as cachgrind output
 pprof --cachegrind /path/to/freeradius /tmp/freeradius.prof
 ----
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/release-method.adoc
+++ b/doc/antora/modules/developers/pages/release-method.adoc
@@ -54,5 +54,5 @@ this to work.
 # make dist-publish
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/sbuff-ng.adoc
+++ b/doc/antora/modules/developers/pages/sbuff-ng.adoc
@@ -245,5 +245,5 @@ In this way we still get rich, contextful errors, but without passing an offset 
 
 All parse functions can revert to returning `int (0, -1)` instead of `fr_slen_t` (as they do now).
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/sbuff-parsing.adoc
+++ b/doc/antora/modules/developers/pages/sbuff-parsing.adoc
@@ -76,5 +76,5 @@ Private functions (static functions in the same source file) don't have the same
 There's no reason for these functions to return the number of parsed bytes, and they can return `0`
 for success, or `-1` for failure like other functions in the server.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/sbuff.adoc
+++ b/doc/antora/modules/developers/pages/sbuff.adoc
@@ -319,5 +319,5 @@ depending on the type of the pointer. (There are no
 read any integral type using octal or hexadecimal.)
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/scheduler.adoc
+++ b/doc/antora/modules/developers/pages/scheduler.adoc
@@ -151,5 +151,5 @@ possible".
 
 !Diagram of yield / resume timing
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/developers/pages/udp.adoc
+++ b/doc/antora/modules/developers/pages/udp.adoc
@@ -45,5 +45,5 @@ In short, we can emulate (mostly) TCP connections via UDP.
 
 We do not need to use connected sockets for DHCP.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/nav.adoc
+++ b/doc/antora/modules/howto/nav.adoc
@@ -153,5 +153,5 @@
 *** xref:tuning/tuning_guide.adoc[Tuning Guide]
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/eap_sim_aka.adoc
+++ b/doc/antora/modules/howto/pages/eap_sim_aka.adoc
@@ -114,5 +114,5 @@ But that is outside the scope of this page (for now).
 ### Windows
 Should work out of the box
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/eduroam_config.adoc
+++ b/doc/antora/modules/howto/pages/eduroam_config.adoc
@@ -604,5 +604,5 @@ network={
 }
 ----
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/eduroam_logging.adoc
+++ b/doc/antora/modules/howto/pages/eduroam_logging.adoc
@@ -133,5 +133,5 @@ place. An example linelog configuration could be something like
         }
     }
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/git.adoc
+++ b/doc/antora/modules/howto/pages/git.adoc
@@ -159,5 +159,5 @@ done
 
 .. _example: https://raw.githubusercontent.com/FreeRADIUS/freeradius-server/v4.0.x/scripts/git/post-receive
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/index.adoc
+++ b/doc/antora/modules/howto/pages/index.adoc
@@ -42,5 +42,5 @@ The full documentation is now maintained by [InkBridge
 Networks](https://inkbridgenetworks.com) (previously Network
 RADIUS).
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/installation/debian.adoc
+++ b/doc/antora/modules/howto/pages/installation/debian.adoc
@@ -207,5 +207,5 @@ make
 sudo make install
 ----
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/installation/dependencies.adoc
+++ b/doc/antora/modules/howto/pages/installation/dependencies.adoc
@@ -69,5 +69,5 @@ include::partial$upgrade_gcc.adoc[]
 
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/installation/index.adoc
+++ b/doc/antora/modules/howto/pages/installation/index.adoc
@@ -116,5 +116,5 @@ https://packages.inkbridgenetworks.com/[pre-built packages]
 ====
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/installation/osx.adoc
+++ b/doc/antora/modules/howto/pages/installation/osx.adoc
@@ -59,5 +59,5 @@ cp ./org.freeradius.radius.plist /Library/LaunchDaemons
 launchctl load -w Library/LaunchDaemons/org.freeradius.radiusd.plist
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/installation/packages.adoc
+++ b/doc/antora/modules/howto/pages/installation/packages.adoc
@@ -29,5 +29,5 @@ the most convenient to install, we do not usually recommend using
 them.
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/installation/redhat.adoc
+++ b/doc/antora/modules/howto/pages/installation/redhat.adoc
@@ -75,5 +75,5 @@ sudo make install
 
 include:RPMs-with-Oracle-support
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/installation/redhat_faq.adoc
+++ b/doc/antora/modules/howto/pages/installation/redhat_faq.adoc
@@ -663,5 +663,5 @@ This tell us at the minimum we have to update the packages freeradius, freeradiu
 
 If figuring out what has to be simultaneously updated, including any missing dependencies, seems onerous then you're right. Normally this work is performed by a package updater such as yum which automatically does all this work for you. But because we've just locally built the packages we do not have the luxury of using the package updater because our local packages are not known to it. However, even though we didn't use the package updater we did use rpm to perform the installation and as a consequence we retain all the advantages of a rpm installation.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/installation/solaris.adoc
+++ b/doc/antora/modules/howto/pages/installation/solaris.adoc
@@ -160,5 +160,5 @@ gmake install
 ## Running
 SMF manifest and installation instructions for Solaris 10 can be found [here](https://github.com/freeradius/freeradius-server/tree/master/scripts/solaris).
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/installation/suse.adoc
+++ b/doc/antora/modules/howto/pages/installation/suse.adoc
@@ -29,5 +29,5 @@ rpmbuild -ba /usr/src/packages/SPECS/freeradius.spec
 
 include:RPMs-with-Oracle-support
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/chap/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/chap/index.adoc
@@ -132,5 +132,5 @@ process CHAP authentication requests.  All `Access-Request` packets
 that contain a `CHAP-Password` attribute will then result in an
 `Access-Reject`.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/configuring_modules.adoc
+++ b/doc/antora/modules/howto/pages/modules/configuring_modules.adoc
@@ -116,5 +116,5 @@ searching through other configuration files or third-party web sites.
 Instead, change and test the module configuration until the server
 works.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/eap/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/eap/index.adoc
@@ -521,5 +521,5 @@ encrypted using the session WEP key.
 * EAP-SIM - Michael Richardson mailto:mcr@sandelman.ottawa.on.ca[mcr@sandelman.ottawa.on.ca]
 * The development of the EAP/SIM support was funded by Internet Foundation Austria (http://www.nic.at/ipa).
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/expiration/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/expiration/index.adoc
@@ -25,5 +25,5 @@ Example entry (users files):
 
 The `expiration` policy is located in `policy.d/time`
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/krb5/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/krb5/index.adoc
@@ -49,5 +49,5 @@ Auth-Type Kerberos {
     krb5
 }
 ```
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/ldap/accounting.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/accounting.adoc
@@ -1,4 +1,4 @@
 = Configure Accounting
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/ldap/authentication.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/authentication.adoc
@@ -207,5 +207,5 @@ Here FreeRADIUS is describes it:
  ** successful so `ok` is returned
  . we return `Access-Accept` as `ok` was returned to unlang
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/ldap/authorization/groups.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/authorization/groups.adoc
@@ -183,5 +183,5 @@ One exception to this, is if nested group checks are being performed.
 In this case `group.cacheable_dn` must be set, as the full path of the group
 objects is required.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/ldap/authorization/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/authorization/index.adoc
@@ -48,5 +48,5 @@ This section describes how to configure the LDAP module to perform group
 membership checks, and to make policy decisions based on the results of those
 checks.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/ldap/authorization/locating_the_user.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/authorization/locating_the_user.adoc
@@ -46,5 +46,5 @@ disambiguation] for strategies for limiting the number of user object entries
 returned.
 ====
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/ldap/authorization/user_account_controls.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/authorization/user_account_controls.adoc
@@ -69,5 +69,5 @@ ldap {
     If the attribute is present or set to true then the user will be
     "locked out".
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/ldap/authorization/user_disambiguation.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/authorization/user_disambiguation.adoc
@@ -76,5 +76,5 @@ ldap {
     a meaningful way.  If the LDAP server allows 'dn' to be specified as a sorting
     attribute, it's recommended to use that.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/ldap/base_configuration/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/base_configuration/index.adoc
@@ -172,5 +172,5 @@ information on configuring LDAP authentication.
 
 include::howto:partial$post_test.adoc[]
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/ldap/bootstrap_openldap/docker.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/bootstrap_openldap/docker.adoc
@@ -119,5 +119,5 @@ radiusClientRequireMa: TRUE
 ----
 ====
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/ldap/bootstrap_openldap/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/bootstrap_openldap/index.adoc
@@ -21,5 +21,5 @@ OpenLDAP is available pre-packaged for many distributions.  We recommend
 using the OpenLDAP LTB packages available under the
 "Packaging and OpenLDAP extensions" heading https://ltb-project.org/documentation[here].
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/ldap/bootstrap_openldap/packages.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/bootstrap_openldap/packages.adoc
@@ -251,5 +251,5 @@ radiusClientRequireMa: TRUE
 ----
 ====
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/ldap/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/index.adoc
@@ -62,5 +62,5 @@ Examples of configuring different methods of LDAP based authentication
 Examples of updating objects in LDAP after authentication completes, or when
 accounting data is received.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/ldap/ldapsearch/before_starting.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/ldapsearch/before_starting.adoc
@@ -19,5 +19,5 @@ certificate is required.
 * Determine the Base DN, the object deepest in the tree that contains the object
 representing users, groups, clients etc...
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/ldap/ldapsearch/connection_parameters.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/ldapsearch/connection_parameters.adoc
@@ -249,5 +249,5 @@ this https://github.com/openssl/openssl/pull/2293[GitHub Pull Request] for detai
 
 ****
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/ldap/ldapsearch/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/ldapsearch/index.adoc
@@ -31,5 +31,5 @@ Discover where users and groups are located within the directory.
 Translate LDAP search arguments and the results from previous sections
 into LDAP module configuration items.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/ldap/ldapsearch/locating_objects.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/ldapsearch/locating_objects.adoc
@@ -275,5 +275,5 @@ user object search with '+' set as the second positional argument.
 ldapsearch -z 10 -x -H ldap://localhost:389 -b "dc=example,dc=com" "(ObjectClass=posixAccount)" "*" "+"
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/ldap/ldapsearch/translating_to_the_ldap_module.adoc
+++ b/doc/antora/modules/howto/pages/modules/ldap/ldapsearch/translating_to_the_ldap_module.adoc
@@ -99,5 +99,5 @@ membership_filter = "(|(<group_membership_filter_by_uid>=%{control.Ldap-UserDn})
 ----
 ****
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/lua/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/lua/index.adoc
@@ -128,5 +128,5 @@ Functions should return a FreeRADIUS rcode using values from the `fr.rcode` tabl
 return fr.rcode.ok
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/mschap/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/mschap/index.adoc
@@ -209,5 +209,5 @@ eap {
 
 Otherwise password changes for PEAP/MSCHAPv2 will not work.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/pam/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/pam/index.adoc
@@ -98,5 +98,5 @@ PPP, Framed-IP-Address = 255.255.255.254, Filter-Id = std.ppp,
 Framed-MTU = 1500, Framed-Compression = Van-Jacobson-TCP-IP
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/passwd/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/passwd/index.adoc
@@ -40,5 +40,5 @@ A: set `ignore_empty` to `no` in module configuration.
 * ZARAZA, mailto:3APA3A@security.nnov.ru[3APA3A@security.nnov.ru]
 * Michael Chernyakhovsky mailto:mike@mgn.ru[mike@mgn.ru]
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/python/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/python/index.adoc
@@ -141,5 +141,5 @@ Its arguments are:
   * (optional) log level - the FreeRADIUS debug level at which this message
     should be logged. (e.g. L_DBG_LVL_2)
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/rest/bootstrap_nginx.adoc
+++ b/doc/antora/modules/howto/pages/modules/rest/bootstrap_nginx.adoc
@@ -70,5 +70,5 @@ systemctl reload nginx
 exit
 ----
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/rest/configuration.adoc
+++ b/doc/antora/modules/howto/pages/modules/rest/configuration.adoc
@@ -148,5 +148,5 @@ rest {
 
 include::howto:partial$post_test.adoc[]
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/rest/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/rest/index.adoc
@@ -34,5 +34,5 @@ hints on how to accomplish this.
 
 == xref:modules/rest/configuration.adoc[Base Configuration]
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/sql/data-usage-reporting.adoc
+++ b/doc/antora/modules/howto/pages/modules/sql/data-usage-reporting.adoc
@@ -266,5 +266,5 @@ ongoing sessions in order to obtain the necessary information. The collection
 and reporting of the additional data required for time-period based data usage
 accounting can be performed efficiently out of band.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/sql/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/sql/index.adoc
@@ -344,5 +344,5 @@ process Accounting-Request {
 }
 ----
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/sql/odbc.adoc
+++ b/doc/antora/modules/howto/pages/modules/sql/odbc.adoc
@@ -370,5 +370,5 @@ If ODBC tracing has been enabled during testing then you should
 remember to disable this before moving into production.
 ====
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/sqlcounter/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/sqlcounter/index.adoc
@@ -82,5 +82,5 @@ time to the next period.  If it is, then the value returned in the reply
 attribute will be the number of seconds until the next period plus the value of
 the limit.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/sqlippool/index.adoc
+++ b/doc/antora/modules/howto/pages/modules/sqlippool/index.adoc
@@ -195,5 +195,5 @@ FreeRADIUS sends an Accounting-Response to the NAS.
 
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/sqlippool/insert.adoc
+++ b/doc/antora/modules/howto/pages/modules/sqlippool/insert.adoc
@@ -42,5 +42,5 @@ The output of this script is a sequence of SQL commands which update
 the pool to match with the definition provided. We recommending
 reviewing this file before running it against your database.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/modules/sqlippool/populating.adoc
+++ b/doc/antora/modules/howto/pages/modules/sqlippool/populating.adoc
@@ -207,5 +207,5 @@ each of the ranges first being populated with entries from the
 with random addresses to the defined capacity.
 =============================================
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/optimization/tools/raduat.adoc
+++ b/doc/antora/modules/howto/pages/optimization/tools/raduat.adoc
@@ -282,5 +282,5 @@ The tests to run can be filtered using glob patterns:
 This can be used to drill down, and only run the failing tests.
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/os/letsencrypt.adoc
+++ b/doc/antora/modules/howto/pages/os/letsencrypt.adoc
@@ -297,5 +297,5 @@ that may help.
   devices may not. Install the LetsEncrypt root CA certificate on
   those devices if needed.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/protocols/index.adoc
+++ b/doc/antora/modules/howto/pages/protocols/index.adoc
@@ -1,4 +1,4 @@
 Documentation regarding frontend modules such as as `proto_radius` should go here.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/protocols/radius/coa.adoc
+++ b/doc/antora/modules/howto/pages/protocols/radius/coa.adoc
@@ -56,5 +56,5 @@ where -r 1 means retry only once and give up.
 `RFC 3576
 <http://www.ietf.org/rfc/rfc3576.txt>`_
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/protocols/radius/using_coa.adoc
+++ b/doc/antora/modules/howto/pages/protocols/radius/using_coa.adoc
@@ -21,5 +21,5 @@ The RADIUS server and the NAS exchange messages using UDP (default ports 1812/18
 If the request is malformed, or the request is missing attributes, the NAS 'quietly' ignores the request. See xref:reference:raddb/sites-available/originate-coa.adoc[CoA/Disconnect] for more details.
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/radsniff.adoc
+++ b/doc/antora/modules/howto/pages/radsniff.adoc
@@ -212,5 +212,5 @@ Although the majority of GAUGE values are created using the AVERAGE consolidatio
 ![Accounting Request latency](radsniff_accounting_latency-day.png "Accounting Request latency")
 ![Accounting Request RTC](radsniff_accounting_rtx-day.png "Accounting RTX")
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/tuning/performance-testing.adoc
+++ b/doc/antora/modules/howto/pages/tuning/performance-testing.adoc
@@ -194,5 +194,5 @@ best base to start from, which is key to an efficient server.
 
 The testing results vary tremendouslywith other system-specific configurations. This is exactly the reason you should run tests of this nature, to find what's best for _your_ system. Good luck!
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/tuning/tuning_guide.adoc
+++ b/doc/antora/modules/howto/pages/tuning/tuning_guide.adoc
@@ -53,5 +53,5 @@ very random Session-Ids. That way you will always have one candidate row
 to search for, instead of all the rows that have the same
 `AcctSessionId`.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/twitter.adoc
+++ b/doc/antora/modules/howto/pages/twitter.adoc
@@ -133,5 +133,5 @@ twitter_tweet {
 }
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/upgrade/attribute_names.adoc
+++ b/doc/antora/modules/howto/pages/upgrade/attribute_names.adoc
@@ -71,5 +71,5 @@ remain the same.
 The output file still has be checked manually.  The rewrite process is
 automatic, but is not perfect.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/upgrade/index.adoc
+++ b/doc/antora/modules/howto/pages/upgrade/index.adoc
@@ -95,5 +95,5 @@ The xref:reference:xlat/index.adoc[xlat] expansions have been changed from synta
 
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/vendors/alcatel-lucent.adoc
+++ b/doc/antora/modules/howto/pages/vendors/alcatel-lucent.adoc
@@ -319,5 +319,5 @@ Brainstorm/TODO by Benny:
 * User Community @ http://www.alcatelunleashed.com
 * German DokuWiki @ http://dokuwiki.alu4u.com
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/vendors/alvarion.adoc
+++ b/doc/antora/modules/howto/pages/vendors/alvarion.adoc
@@ -25,5 +25,5 @@ Note that you *cannot* build an RPM or other package if you are using Alvarion. 
 
 The reason for the above changes is that they have non-standard versions of the dictionaries.  These dictionaries are incompatible with all other WiMAX equipment, so they are not enabled by default.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/vendors/ascend.adoc
+++ b/doc/antora/modules/howto/pages/vendors/ascend.adoc
@@ -57,5 +57,5 @@ becomes the OLD Ascend attribute using the `X-` prefix:
  X-Ascend-Data-Filter
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/vendors/bay.adoc
+++ b/doc/antora/modules/howto/pages/vendors/bay.adoc
@@ -15,5 +15,5 @@ Received packet from xxx.xxx.xxx.xxx with invalid Message-Authenticator!
 
 Then you MUST upgrade the software on your Bay Annex. There is NO other solution to the problem.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/vendors/cisco.adoc
+++ b/doc/antora/modules/howto/pages/vendors/cisco.adoc
@@ -247,5 +247,5 @@ More information about this process can be seen http://www.cisco.com/en/US/docs/
 
 For more information, see the http://www.cisco.com/univercd/cc/td/doc/product/access/acs_serv/vapp_dev/vsaig3.htm[Cisco web site].
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/vendors/hp.adoc
+++ b/doc/antora/modules/howto/pages/vendors/hp.adoc
@@ -573,5 +573,5 @@ Many, always update to the latest firmware.
 * Linksys
 * Mac-Auth
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/pages/vendors/proxim.adoc
+++ b/doc/antora/modules/howto/pages/vendors/proxim.adoc
@@ -14,5 +14,5 @@ possible with this NAS. Note that this NAS is OEMed to several vendors,
 including Avaya, and may be listed under different names with different
 vendors.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/partials/post_test.adoc
+++ b/doc/antora/modules/howto/partials/post_test.adoc
@@ -61,5 +61,5 @@ searching through other configuration files or third-party web sites.
 Instead, change and test the module configuration until the server
 works.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/howto/partials/pre_test.adoc
+++ b/doc/antora/modules/howto/partials/pre_test.adoc
@@ -19,5 +19,5 @@ and all errors before proceeding to the next step.  It is a good idea
 to ensure that the current configuration works _before_ making changes
 to it.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/installation/nav.adoc
+++ b/doc/antora/modules/installation/nav.adoc
@@ -9,5 +9,5 @@
 *** xref:howto:installation/attribute_names.adoc[Attribute Name Changes from v3 to v4]
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/installation/oracle.adoc
+++ b/doc/antora/modules/installation/oracle.adoc
@@ -19,5 +19,5 @@ to:
 %define _oracle_support 1
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/nav.adoc
+++ b/doc/antora/modules/reference/nav.adoc
@@ -303,5 +303,5 @@
 *** xref:man/radsniff.adoc[radsniff]
 *** xref:man/unlang.adoc[unlang]
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/alias.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/alias.adoc
@@ -102,5 +102,5 @@ ongoing support.  Complex upgrades make ongoing support easier, but
 also make it less likely that people will upgrade.
 
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/attribute.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/attribute.adoc
@@ -85,5 +85,5 @@ Fixed Size types and meanings
 |=====
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/begin-protocol.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/begin-protocol.adoc
@@ -28,5 +28,5 @@ Note that unlike xref:dictionary/begin-vendor.adoc[END-VENDOR] and
 xref:dictionary/begin.adoc[END], it is not possible to omit
 the `BEGIN-PROTOCOL` keyword.
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/begin-vendor.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/begin-vendor.adoc
@@ -43,5 +43,5 @@ example.
 ATTRIBUTE Cisco.AVPair 1 string
 ----
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/begin.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/begin.adoc
@@ -75,5 +75,5 @@ For short entries, it can be simpler to use the full name an OID.
 However, for complex dictionaries, it is almost always clearer to use
 `BEGIN` and xref:dictionary/end.adoc[END].
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/define.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/define.adoc
@@ -46,5 +46,5 @@ DEFINE Foo string
 DEFINE Bar ipv4addr
 ----
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/end-protocol.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/end-protocol.adoc
@@ -16,5 +16,5 @@ for a particular xref:dictionary/protocol.adoc[PROTOCOL].
 The dictionary must have previously contained a matching
 xref:dictionary/begin-protocol.adoc[BEGIN-PROTOCOL].
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/end-vendor.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/end-vendor.adoc
@@ -16,5 +16,5 @@ for a particular xref:dictionary/vendor.adoc[VENDOR].
 The dictionary must have previously contained a matching
 xref:dictionary/begin-vendor.adoc[BEGIN-VENDOR].
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/end.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/end.adoc
@@ -17,5 +17,5 @@ for validation purposes, but may be omitted.
 The dictionary must have previously contained a matching
 xref:dictionary/begin.adoc[BEGIN].
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/enum.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/enum.adoc
@@ -47,5 +47,5 @@ ATTRIBUTE Other-Thing  6809 uint16 enum=Ethernet-Type
 
 See the xref:dictionary/reference.adoc[reference] page for the syntax of references in the dictionary.
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/flags.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/flags.adoc
@@ -21,5 +21,5 @@ For now, only `internal` is supported.
 FLAG internal
 ----
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/include.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/include.adoc
@@ -24,5 +24,5 @@ NOTE: Attribute definitions cannot span multiple files.  This include `BEGIN-` a
 $INCLUDE dictionary.foo
 ----
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/index.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/index.adoc
@@ -171,5 +171,5 @@ The following keywords define logical nesting of attributes.
 |=====
 
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/member.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/member.adoc
@@ -71,5 +71,5 @@ Fixed Size types and meanings
 | `string[n]`  | Declare that this attribute uses `n` bytes of `string` data
 |=====
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/protocol.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/protocol.adoc
@@ -30,5 +30,5 @@ only be used by the FreeRADIUS developers.
 PROTOCOL RADIUS 1 verify=lib
 ----
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/reference.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/reference.adoc
@@ -71,5 +71,5 @@ dictionary.
 
 The `ref=` flag can only be used for the data type `group`.  The destination of the reference must be of data type `group` or `tlv`.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/value.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/value.adoc
@@ -40,5 +40,5 @@ VALUE Service-Type Login-User 1
 VALUE Framed-IP-Address broadcast 255.255.255.255
 ----
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/dictionary/vendor.adoc
+++ b/doc/antora/modules/reference/pages/dictionary/vendor.adoc
@@ -28,5 +28,5 @@ and those options are only valid for that protocol dictionary.
 VENDOR Cisco 1
 ----
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/index.adoc
+++ b/doc/antora/modules/reference/pages/index.adoc
@@ -44,5 +44,5 @@ These man pages are for quick reference and maintaining compatibility over time.
 
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/man/dictionary.adoc
+++ b/doc/antora/modules/reference/pages/man/dictionary.adoc
@@ -20,5 +20,5 @@ radiusd(8) radiusd.conf(5)
 
 The FreeRADIUS Server Project (https://freeradius.org)
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/man/index.adoc
+++ b/doc/antora/modules/reference/pages/man/index.adoc
@@ -22,5 +22,5 @@ A simple summary of xref:man/unlang.adoc[unlang].
 
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/man/radclient.adoc
+++ b/doc/antora/modules/reference/pages/man/radclient.adoc
@@ -186,5 +186,5 @@ radiusd(8)
 
 The FreeRADIUS Server Project (https://freeradius.org)
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/man/radiusd.adoc
+++ b/doc/antora/modules/reference/pages/man/radiusd.adoc
@@ -206,5 +206,5 @@ radiusd.conf(5), dictionary(5), unlang(5), raddebug(8)
 
 The FreeRADIUS Server Project (https://freeradius.org)
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/man/radmin.adoc
+++ b/doc/antora/modules/reference/pages/man/radmin.adoc
@@ -129,5 +129,5 @@ unlang(5), radiusd.conf(5), raddb/sites-available/control-socket
 
 Alan DeKok <aland@freeradius.org>
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/man/radsniff.adoc
+++ b/doc/antora/modules/reference/pages/man/radsniff.adoc
@@ -126,5 +126,5 @@ radiusd(8), pcap(3)
 
 The FreeRADIUS Server Project (https://freeradius.org)
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/man/unlang.adoc
+++ b/doc/antora/modules/reference/pages/man/unlang.adoc
@@ -30,5 +30,5 @@ radiusd(8) radiusd.conf(5)
 
 The FreeRADIUS Server Project (https://freeradius.org)
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/policy/different.adoc
+++ b/doc/antora/modules/reference/pages/policy/different.adoc
@@ -71,5 +71,5 @@ from the procedural nature of the `unlang` configuration language.
 The remainder of the difficulty is almost always because of poorly
 specified requirements.
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/policy/index.adoc
+++ b/doc/antora/modules/reference/pages/policy/index.adoc
@@ -127,5 +127,5 @@ The second concept to understand in creating policies is that a
 methodical approach is critical.
 
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/certs/index.adoc
+++ b/doc/antora/modules/reference/pages/raddb/certs/index.adoc
@@ -223,5 +223,5 @@ with ALL operating systems. Some common issues are:
   This includes Linux, *BSD, Mac OS X, Solaris, etc. along with all
   known embedded systems, phones, WiFi devices, etc.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/format.adoc
+++ b/doc/antora/modules/reference/pages/raddb/format.adoc
@@ -401,5 +401,5 @@ blogs = "this ${foo} is ${baz}"
 
 Will set variable `blogs` to the string `this bar is bug`.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/global.d/index.adoc
+++ b/doc/antora/modules/reference/pages/raddb/global.d/index.adoc
@@ -21,5 +21,5 @@ once, and not in each module.
 | xref:raddb/global.d/python.adoc[python]  | Python path variables
 |=====
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/global.d/ldap.adoc
+++ b/doc/antora/modules/reference/pages/raddb/global.d/ldap.adoc
@@ -51,5 +51,5 @@ ldap {
 }
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/global.d/python.adoc
+++ b/doc/antora/modules/reference/pages/raddb/global.d/python.adoc
@@ -21,5 +21,5 @@ python {
 }
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/index.adoc
+++ b/doc/antora/modules/reference/pages/raddb/index.adoc
@@ -159,5 +159,5 @@ Take your time. It is better to make small incrementatal progress, than
 to make massive changes, and then to spend weeks debugging it.
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/mods-available/all_modules.adoc
+++ b/doc/antora/modules/reference/pages/raddb/mods-available/all_modules.adoc
@@ -25,5 +25,5 @@ include::partial$utility_table.adoc[]
 
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/mods-available/doc.adoc
+++ b/doc/antora/modules/reference/pages/raddb/mods-available/doc.adoc
@@ -4,5 +4,5 @@
 ```
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/mods-available/index.adoc
+++ b/doc/antora/modules/reference/pages/raddb/mods-available/index.adoc
@@ -171,5 +171,5 @@ allow for policies to be placed in the module configuration file,
 which helps to better organize module-specific configurations and
 policies.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/mods-config/index.adoc
+++ b/doc/antora/modules/reference/pages/raddb/mods-config/index.adoc
@@ -19,5 +19,5 @@ For example, the `users` file is now located in
 * The file is used by the `files` module.
 * It is a `module configuration` file, which is a specific format.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/panic.gdb.adoc
+++ b/doc/antora/modules/reference/pages/raddb/panic.gdb.adoc
@@ -3,5 +3,5 @@ info args
 thread apply all bt full
 quit
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/policy.d/at_reference.adoc
+++ b/doc/antora/modules/reference/pages/raddb/policy.d/at_reference.adoc
@@ -133,5 +133,5 @@ happening:
 
 In general, the benefits of this solution outweigh the downsides.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/sites-available/bfd2.adoc
+++ b/doc/antora/modules/reference/pages/raddb/sites-available/bfd2.adoc
@@ -161,5 +161,5 @@ recv Up {
 ```
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/sites-available/detail-debugging.adoc
+++ b/doc/antora/modules/reference/pages/raddb/sites-available/detail-debugging.adoc
@@ -41,5 +41,5 @@ do nothing
 ```
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/sites-available/index.adoc
+++ b/doc/antora/modules/reference/pages/raddb/sites-available/index.adoc
@@ -357,5 +357,5 @@ server.
 * xref:raddb/sites-available/virtual.example.com.adoc[virtual example com]
 * xref:raddb/sites-available/vmps.adoc[vmps]
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/sites-available/test_load.adoc
+++ b/doc/antora/modules/reference/pages/raddb/sites-available/test_load.adoc
@@ -186,5 +186,5 @@ send Access-Reject {
 ```
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/tacclient.conf.adoc
+++ b/doc/antora/modules/reference/pages/raddb/tacclient.conf.adoc
@@ -72,5 +72,5 @@ server default {
 }
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/raddb/templates.conf.adoc
+++ b/doc/antora/modules/reference/pages/raddb/templates.conf.adoc
@@ -71,5 +71,5 @@ sql-common {
 }
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/type/all_types.adoc
+++ b/doc/antora/modules/reference/pages/type/all_types.adoc
@@ -132,5 +132,5 @@ matter.
 A `vsa` data type can only be a contain children of the `vendor` data type.
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/type/cast.adoc
+++ b/doc/antora/modules/reference/pages/type/cast.adoc
@@ -214,5 +214,5 @@ For compatibility with version 3, the `<cast>` syntax is also
 supported.  We recommend, however, that people use the new syntax.
 The old syntax will eventually be removed, and will create an error.
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/type/index.adoc
+++ b/doc/antora/modules/reference/pages/type/index.adoc
@@ -72,5 +72,5 @@ change the data's _value_.  That is, a cast allows you to convert an
 `octets` data type to a `string`, but the resulting `string` may still
 contain non-printable characters.
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/type/ip.adoc
+++ b/doc/antora/modules/reference/pages/type/ip.adoc
@@ -11,5 +11,5 @@ interpreted as an IPv4 or an IPv6 address. This interpretation is
 usually done when the string is used in the context of an attribute,
 or to compare two addresses or assign an address to an attribute.
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/type/numb.adoc
+++ b/doc/antora/modules/reference/pages/type/numb.adoc
@@ -7,5 +7,5 @@
 
 Numbers are unsigned integers that are composed of decimal digits.
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/type/string/backticks.adoc
+++ b/doc/antora/modules/reference/pages/type/string/backticks.adoc
@@ -34,5 +34,5 @@ programming language such as `lua`, `perl` or `python` may be better.
 
 `{backtick}/bin/echo hello{backtick}`
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/type/string/double.adoc
+++ b/doc/antora/modules/reference/pages/type/string/double.adoc
@@ -138,6 +138,6 @@ string is being used.
 `"The result of 'SELECT * FROM foo WHERE 1' is: %sql(SELECT * FROM foo WHERE 1)"`
 
 // Licenced under CC-by-NC 4.0.
-// Copyright (C) 2019 Arran Cudbard-Bell <a.cudbardb@freeradius.org>
-// Copyright (C) 2019 The FreeRADIUS project.
-// Copyright (C) 2021 Network RADIUS SAS.
+// Copyright (C) 2026 Arran Cudbard-Bell <a.cudbardb@freeradius.org>
+// Copyright (C) 2026 The FreeRADIUS project.
+// Copyright (C) 2026 Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/type/string/escaping.adoc
+++ b/doc/antora/modules/reference/pages/type/string/escaping.adoc
@@ -10,5 +10,5 @@ line feeds can be created by using `\n` and `\r`.
 `"I say \"hello\" to you"` +
 `"This is split\nacross two lines"`
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/type/string/index.adoc
+++ b/doc/antora/modules/reference/pages/type/string/index.adoc
@@ -95,5 +95,5 @@ examples of using this format.
 Triple quoted strings do _not_ support spanning multiple
 lines.  That limitation is likely to be fixed in a future release.
 
-// Copyright (C) 2024 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/type/string/single.adoc
+++ b/doc/antora/modules/reference/pages/type/string/single.adoc
@@ -18,5 +18,5 @@ it with a backslash.
 `'foo\\'bar'` +
 `'this is a long string'`
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/type/string/triple.adoc
+++ b/doc/antora/modules/reference/pages/type/string/triple.adoc
@@ -24,7 +24,7 @@ quotes in them, because the quotes do not need to be escaped.
 `'''This is a string with 'embedded' quotes'''`
 
 // Licenced under CC-by-NC 4.0.
-// Copyright (C) 2025 Network RADIUS SAS.
+// Copyright (C) 2026 Network RADIUS SAS.
 
 
 

--- a/doc/antora/modules/reference/pages/type/string/unquoted.adoc
+++ b/doc/antora/modules/reference/pages/type/string/unquoted.adoc
@@ -17,5 +17,5 @@ usually defined by an attribute which has a xref:type/index.adoc[data type].
 `192.168.0.1` +
 `00:01:02:03:04:05`
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/actions.adoc
+++ b/doc/antora/modules/reference/pages/unlang/actions.adoc
@@ -104,5 +104,5 @@ time until the first retransmission attempt. It is not set on
 section-level retries.
 ====
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/attr.adoc
+++ b/doc/antora/modules/reference/pages/unlang/attr.adoc
@@ -198,5 +198,5 @@ documentation and configuration files have been updated to remove the
 remove that backwards compatibility, and at some future time, using
 `&` will result in an error.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/break.adoc
+++ b/doc/antora/modules/reference/pages/unlang/break.adoc
@@ -51,5 +51,5 @@ switch User-Name {
 }
 ----
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/caller.adoc
+++ b/doc/antora/modules/reference/pages/unlang/caller.adoc
@@ -67,5 +67,5 @@ caller dhcpv4 {
 }
 ----
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/case.adoc
+++ b/doc/antora/modules/reference/pages/unlang/case.adoc
@@ -46,5 +46,5 @@ switch User-Name {
 
 The last entry in a `case` section can also be an xref:unlang/actions.adoc[action].
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/condition/eq.adoc
+++ b/doc/antora/modules/reference/pages/unlang/condition/eq.adoc
@@ -26,5 +26,5 @@ if (User-Name == "bob") {
 }
 ----
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/condition/expression.adoc
+++ b/doc/antora/modules/reference/pages/unlang/condition/expression.adoc
@@ -17,5 +17,5 @@ See the main xref:unlang/expression.adoc[expressions] page for a list
 of supported operators.  In short, mathematical operations will work,
 and will do what you expect.
 
-// Copyright (C) 2022 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/condition/not.adoc
+++ b/doc/antora/modules/reference/pages/unlang/condition/not.adoc
@@ -15,5 +15,5 @@ when _condition_ returns `true`.
 `(! (foo == bar))` +
 `! User-Name`
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/condition/para.adoc
+++ b/doc/antora/modules/reference/pages/unlang/condition/para.adoc
@@ -15,5 +15,5 @@ conditional precedence.
 `(foo)` +
 `(bar || (baz && dub))`
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/condition/return_codes.adoc
+++ b/doc/antora/modules/reference/pages/unlang/condition/return_codes.adoc
@@ -31,5 +31,5 @@ if (notfound) {
 }
 ----
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/continue.adoc
+++ b/doc/antora/modules/reference/pages/unlang/continue.adoc
@@ -32,5 +32,5 @@ foreach i (%range(10)) {
 }
 ----
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/default.adoc
+++ b/doc/antora/modules/reference/pages/unlang/default.adoc
@@ -33,5 +33,5 @@ switch User-Name {
 }
 ----
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/elsif.adoc
+++ b/doc/antora/modules/reference/pages/unlang/elsif.adoc
@@ -41,5 +41,5 @@ elsif (User-Name == "doug") {
 
 The last entry in an `elsif` section can also be an xref:unlang/actions.adoc[actions] subsection.
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/expression.adoc
+++ b/doc/antora/modules/reference/pages/unlang/expression.adoc
@@ -148,5 +148,5 @@ NAS-Port-Id = (5 - "foo") || 6
 
 Will return `6`, as the left side expression of the `||` operator evaluates to `null`.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/filter.adoc
+++ b/doc/antora/modules/reference/pages/unlang/filter.adoc
@@ -25,5 +25,5 @@ group {
 
 See the new xref:unlang/edit.adoc[edit] syntax for more details.
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/finally.adoc
+++ b/doc/antora/modules/reference/pages/unlang/finally.adoc
@@ -200,5 +200,5 @@ Timeouts in `finally` sections of subrequests should therefore
 be set extremely short, in order to ensure that the parent request
 isn't cancelled due to an excessively long running subrequest.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/group.adoc
+++ b/doc/antora/modules/reference/pages/unlang/group.adoc
@@ -37,5 +37,5 @@ group {
 
 The last entry in a `group` section can also be an xref:unlang/actions.adoc[actions] subsection.
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/guide.adoc
+++ b/doc/antora/modules/reference/pages/unlang/guide.adoc
@@ -1,5 +1,5 @@
 # A Helpful Guide with Hints
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/if.adoc
+++ b/doc/antora/modules/reference/pages/unlang/if.adoc
@@ -105,5 +105,5 @@ if (User-Name ==
 
 The last entry in an `if` section can also be an xref:unlang/actions.adoc[actions] subsection.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/index.adoc
+++ b/doc/antora/modules/reference/pages/unlang/index.adoc
@@ -172,5 +172,5 @@ if (User-Name == "bob") {
 }
 ----
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/interpreter.adoc
+++ b/doc/antora/modules/reference/pages/unlang/interpreter.adoc
@@ -170,5 +170,5 @@ return (code, priority)
 ```
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/keywords.adoc
+++ b/doc/antora/modules/reference/pages/unlang/keywords.adoc
@@ -118,5 +118,5 @@ pages for information on configuring and using the modules.
 | xref:unlang/module_rcode.adoc[<rcode>]            | Force return codes, e.g., `reject`, or `ok`, etc.
 |=====
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/list.adoc
+++ b/doc/antora/modules/reference/pages/unlang/list.adoc
@@ -65,5 +65,5 @@ finishes, it is deleted, and is no longer accessible to the parent.
 `parent.reply.Reply-Message` +
 `parent.parent.session-state.Filter-Id`
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/load-balance.adoc
+++ b/doc/antora/modules/reference/pages/unlang/load-balance.adoc
@@ -94,5 +94,5 @@ Reply-Message := %sql_all("SELECT message FROM table WHERE name='%{User-Name}'")
 The expansion works exactly like a `load-balance` block.  One of the
 modules is chosen to run the expansion, in load-balance fashion.
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/local.adoc
+++ b/doc/antora/modules/reference/pages/unlang/local.adoc
@@ -101,5 +101,5 @@ The variable declaration and assignment must be separated.
 Constructions like `uint32 len = %length(%{User-Name})` are not
 allowed.
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/map.adoc
+++ b/doc/antora/modules/reference/pages/unlang/map.adoc
@@ -52,5 +52,5 @@ map sql "SELECT column1, column2, column3 from table WHERE user=%{User-Name}" {
 }
 ----
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/module_method.adoc
+++ b/doc/antora/modules/reference/pages/unlang/module_method.adoc
@@ -24,5 +24,5 @@ sql.recv.Accounting-Request
 files.recv.Access-Request
 ----
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/module_rcode.adoc
+++ b/doc/antora/modules/reference/pages/unlang/module_rcode.adoc
@@ -51,5 +51,5 @@ The following table defines the meaning of each module return code.
 
 include::partial$rcode_table.adoc[]
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/parallel.adoc
+++ b/doc/antora/modules/reference/pages/unlang/parallel.adoc
@@ -232,5 +232,5 @@ parallel {
 ----
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/redundant-load-balance.adoc
+++ b/doc/antora/modules/reference/pages/unlang/redundant-load-balance.adoc
@@ -92,5 +92,5 @@ modules are expanded again _for each call_.  If the expansion
 arguments have side effects, then those side effects can be applied
 multiple times, once for each `redundant-load-balance` attempt.
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/redundant.adoc
+++ b/doc/antora/modules/reference/pages/unlang/redundant.adoc
@@ -156,5 +156,5 @@ with _all_ the module expansions it would call, the server will log an
 error and either fail to start, or stop processing the expression which
 called the redundant expansion.
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/return.adoc
+++ b/doc/antora/modules/reference/pages/unlang/return.adoc
@@ -34,5 +34,5 @@ if (reply.Filter-Id == "hello") {
 ...
 ----
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/return_codes.adoc
+++ b/doc/antora/modules/reference/pages/unlang/return_codes.adoc
@@ -16,5 +16,5 @@ associated with the request, then the request rcode is overwritten.
 Return code priorities are assigned by the section the module call, expansion or
 keyword was used in.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/subrequest.adoc
+++ b/doc/antora/modules/reference/pages/unlang/subrequest.adoc
@@ -292,5 +292,5 @@ authenticate radius.example.com {
 
 ===
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/switch.adoc
+++ b/doc/antora/modules/reference/pages/unlang/switch.adoc
@@ -174,5 +174,5 @@ switch (ipaddr) %sql.query("SELECT ...") {
 }
 ----
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/timeout.adoc
+++ b/doc/antora/modules/reference/pages/unlang/timeout.adoc
@@ -83,5 +83,5 @@ If the timeout value is taken from a dynamic expansion or attribute
 reference which fails, the entire `timeout` block returns `fail`.
 ====
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/try.adoc
+++ b/doc/antora/modules/reference/pages/unlang/try.adoc
@@ -46,5 +46,5 @@ The `catch` block can be triggered on any rcode and not just failures. A `catch 
 
 There is some overlap in functionality between `try` / xref:unlang/catch.adoc[catch] and xref:unlang/redundant.adoc[redundant].  See the xref:unlang/catch.adoc[catch] documentation for more details.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/unlang/update.adoc
+++ b/doc/antora/modules/reference/pages/unlang/update.adoc
@@ -211,5 +211,5 @@ allowed the separation of list assignments from value modifications,
 which meant that xref:unlang/expression.adoc[expressions] became
 became simpler.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/alternation.adoc
+++ b/doc/antora/modules/reference/pages/xlat/alternation.adoc
@@ -36,5 +36,5 @@ Reply-Message := "Hello %{NAS-Identifier || User-Name || 'none'}"
 Unlike version 3, any strings used in `||` alternation must be quoted.  Numbers and IP addresses do not need to be quoted.
 ====
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/attribute.adoc
+++ b/doc/antora/modules/reference/pages/xlat/attribute.adoc
@@ -80,5 +80,5 @@ array entries of the `request` list.  This is a change from previous
 versions of the server.  When upgrading, you should just add a `.`
 between the list name and the array reference `[`.
 
-// Copyright (C) 2022 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/conversion.adoc
+++ b/doc/antora/modules/reference/pages/xlat/conversion.adoc
@@ -138,5 +138,5 @@ reply += {
 The urlunquote of http%3A%2F%2Fexample.org%2F is http://example.org/
 ```
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/deprecated.adoc
+++ b/doc/antora/modules/reference/pages/xlat/deprecated.adoc
@@ -45,5 +45,5 @@ reply.Reply-Message := "The printable version of Class is %{(string) Class}"
 
 This expansion is deprecated and has been be removed.  Just use `%length(...)` instead.
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/dict.adoc
+++ b/doc/antora/modules/reference/pages/xlat/dict.adoc
@@ -4,5 +4,5 @@ The dictionary functions are defined in the
 xref:raddb/mods-available/dict.adoc[dict] module.  It must be listed
 in the `mods-enabled/` directory in order for the expansions to work.
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/file/index.adoc
+++ b/doc/antora/modules/reference/pages/xlat/file/index.adoc
@@ -19,5 +19,5 @@ For example, the "unsafe" string `user@freeradius.org/..` will turn into the fil
 | xref:xlat/file/tail.adoc[tail]		        | Return the last line of a file or the last number(n) of lines of a file.
 |===
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/function.adoc
+++ b/doc/antora/modules/reference/pages/xlat/function.adoc
@@ -38,5 +38,5 @@ if (User-Name == %hash.md5(NAS-Identifier)) {
 reply.Reply-Message := %sql(SELECT name FROM mytable WHERE username = %{User-Name})
 ----
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/hash.adoc
+++ b/doc/antora/modules/reference/pages/xlat/hash.adoc
@@ -51,5 +51,5 @@ The md5 of Caipirinha in octal is \024\204\013md||\230\243\3472\3703\330n\251
 The md5 of Caipirinha in hex is 14840b6d647c7c98a3e732f833d86ea9
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/hmac.adoc
+++ b/doc/antora/modules/reference/pages/xlat/hmac.adoc
@@ -66,5 +66,5 @@ The HMAC-SHA1 of Caipirinha in octets is \311\007\212\234j\355\207\035\225\256\3
 The HMAC-SHA1 of Caipirinha in hex is 636f6e74726f6c3a546d702d4f63746574732d30
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/index.adoc
+++ b/doc/antora/modules/reference/pages/xlat/index.adoc
@@ -53,5 +53,5 @@ information.
 Reply-Message := "%{User-Name} with a literal %%"
 ----
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/interpreter.adoc
+++ b/doc/antora/modules/reference/pages/xlat/interpreter.adoc
@@ -108,5 +108,5 @@ current client. See the sections `client { ... }` in `clients.conf`.
 The client ipaddr is 192.168.5.9
 ```
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/ipv4/broadcast.adoc
+++ b/doc/antora/modules/reference/pages/xlat/ipv4/broadcast.adoc
@@ -22,5 +22,5 @@ reply.Broadcast-Address := %ip.v4.broadcast(Network-Subnet)
 192.168.1.255
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/ipv4/index.adoc
+++ b/doc/antora/modules/reference/pages/xlat/ipv4/index.adoc
@@ -11,5 +11,5 @@ The following functions perform manipulation of IPv4 addresses / subnets.
 | xref:xlat/ipv4/netmask.adoc[netmask]       | Get the netmask from an IPv4 prefix
 |=====
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/ipv4/netmask.adoc
+++ b/doc/antora/modules/reference/pages/xlat/ipv4/netmask.adoc
@@ -22,5 +22,5 @@ reply.Subnet-Mask := %ip.v4.netmask(Network-Subnet)
 255.255.255.0
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/log.adoc
+++ b/doc/antora/modules/reference/pages/xlat/log.adoc
@@ -80,5 +80,5 @@ Logs a message at a WARN level.  This function returns nothing.
 
 The WARN messages are always logged.
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/misc/index.adoc
+++ b/doc/antora/modules/reference/pages/xlat/misc/index.adoc
@@ -15,5 +15,5 @@ which operate on inputs, and produce an output.
 | xref:xlat/misc/uuid.adoc[UUID]                    | Generation of UUIDs
 |===
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/misc/length.adoc
+++ b/doc/antora/modules/reference/pages/xlat/misc/length.adoc
@@ -29,5 +29,5 @@ The length of 192.168.0.2 is 4
 ....
 ====
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/misc/rand.adoc
+++ b/doc/antora/modules/reference/pages/xlat/misc/rand.adoc
@@ -19,5 +19,5 @@ The random number is 347
 ====
 
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/misc/uuid.adoc
+++ b/doc/antora/modules/reference/pages/xlat/misc/uuid.adoc
@@ -24,5 +24,5 @@ A version 7 UUID is 019a58d8-8524-7342-aa07-c0fa2bba6a4e
 ....
 ====
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/pairs/debug.adoc
+++ b/doc/antora/modules/reference/pages/xlat/pairs/debug.adoc
@@ -32,5 +32,5 @@ recv Access-Request {
 ...
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/pairs/immutable.adoc
+++ b/doc/antora/modules/reference/pages/xlat/pairs/immutable.adoc
@@ -15,5 +15,5 @@ respect the `immutable` flag.
 %pairs.immutable(control.[*])
 ----
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/pairs/index.adoc
+++ b/doc/antora/modules/reference/pages/xlat/pairs/index.adoc
@@ -11,5 +11,5 @@ These functions manipulate attribute-value pairs.
 | xref:xlat/pairs/print.adoc[print]		| Print attribute name and value to string.
 |===
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/pairs/print.adoc
+++ b/doc/antora/modules/reference/pages/xlat/pairs/print.adoc
@@ -24,5 +24,5 @@ reply.Reply-Message := "Serialize output: %pairs.print(control.[*])"
 Serialize output: Filter-Id = "\"This is a string\", Filter-Id = \"This is another one\""
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/protocol.adoc
+++ b/doc/antora/modules/reference/pages/xlat/protocol.adoc
@@ -84,5 +84,5 @@ data = %radius.encode(reply)
 0x010641424344
 ```
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/str/index.adoc
+++ b/doc/antora/modules/reference/pages/xlat/str/index.adoc
@@ -17,5 +17,5 @@ The following functions perform string manipulation.
 | xref:xlat/str/upper.adoc[upper]       | Convert the input string to uppercase
 |=====
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/str/lower.adoc
+++ b/doc/antora/modules/reference/pages/xlat/str/lower.adoc
@@ -21,5 +21,5 @@ reply.Reply-Message := "lowercase of %{User-Name} is %str.lower(User-Name)"
 lowercase of BOB is bob
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/str/lpad.adoc
+++ b/doc/antora/modules/reference/pages/xlat/str/lpad.adoc
@@ -21,5 +21,5 @@ reply.Reply-Message := "Maximum should be %str.lpad(test, 11, '0')"
 Maximum should be 00000000123
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/str/rand.adoc
+++ b/doc/antora/modules/reference/pages/xlat/str/rand.adoc
@@ -54,5 +54,5 @@ reply.Reply-Message := "The random string output is %hex(%str.rand('1b'))"
 The random string output is ad
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/str/rpad.adoc
+++ b/doc/antora/modules/reference/pages/xlat/str/rpad.adoc
@@ -21,5 +21,5 @@ reply.Reply-Message := "Maximum should be %str.rpad(test, 11, '0')"
 Maximum should be 12300000000
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/str/split.adoc
+++ b/doc/antora/modules/reference/pages/xlat/str/split.adoc
@@ -25,5 +25,5 @@ reply.Reply-Message := "Welcome %{name}"
 Welcome bob.toba
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/str/upper.adoc
+++ b/doc/antora/modules/reference/pages/xlat/str/upper.adoc
@@ -20,5 +20,5 @@ reply.Reply-Message := "uppercase of %{User-Name} is " + %str.upper(User-Name)
 uppercase of bob is BOB
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/time/character.adoc
+++ b/doc/antora/modules/reference/pages/xlat/time/character.adoc
@@ -90,5 +90,5 @@ Request timestamp in ISO format, `YYYY-mm-ddTHH:MM:SS.000`.
 The xref:reference:raddb/mods-available/date.adoc[date] module should be used
 instead.
 
-// Copyright (C) 2023 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/time/generic.adoc
+++ b/doc/antora/modules/reference/pages/xlat/time/generic.adoc
@@ -123,5 +123,5 @@ This kind of math works well for "tomorrow", but it is less useful for
 "next week Monday", or "start of next month".  The `%time.next(...)`
 expansion above should be used for those time operations.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/time/index.adoc
+++ b/doc/antora/modules/reference/pages/xlat/time/index.adoc
@@ -17,5 +17,5 @@ including daylight savings and UTC offset.
 | xref:xlat/time/request.adoc[request]     | Return the time when the request. was received.
 |=====
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/time/is_dst.adoc
+++ b/doc/antora/modules/reference/pages/xlat/time/is_dst.adoc
@@ -3,5 +3,5 @@
 Return a `bool` indicating whether or not the system is currently
 operating in daylight savings.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/time/next.adoc
+++ b/doc/antora/modules/reference/pages/xlat/time/next.adoc
@@ -20,5 +20,5 @@ reply.Reply-Message := "You should wait for %time.next(1h)s"
 You should wait for 2520s
 ```
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/time/now.adoc
+++ b/doc/antora/modules/reference/pages/xlat/time/now.adoc
@@ -4,5 +4,5 @@ Return the current time.  This time should be used for actions which
 involve the file system, or for actions which happen after the request
 has been received.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/time/offset.adoc
+++ b/doc/antora/modules/reference/pages/xlat/time/offset.adoc
@@ -3,5 +3,5 @@
 Return a `time_delta` of the current offset from UTC.  This offset can
 change while the server is running, due to daylight savings updates.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/pages/xlat/time/request.adoc
+++ b/doc/antora/modules/reference/pages/xlat/time/request.adoc
@@ -4,5 +4,5 @@ Return the time when the request was received.  This time should be
 used as the basis any actions which involve the "start time of the
 request".
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/reference/partials/rcode_table.adoc
+++ b/doc/antora/modules/reference/partials/rcode_table.adoc
@@ -43,5 +43,5 @@ meaning. `disallow` will be returned in any instance where `userlock`
 was returned in v3.0.x or v3.2.x
 ====
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/troubleshooting/pages/troubleshoot.adoc
+++ b/doc/antora/modules/troubleshooting/pages/troubleshoot.adoc
@@ -69,5 +69,5 @@ The host system's CPU power and database determines how many accounting packets 
 handle per second. If the database is limited to a thousand writes per second, the FreeRADIUS accounting
 requests is also limited to a thousand writes per second.
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/nav.adoc
+++ b/doc/antora/modules/tutorials/nav.adoc
@@ -42,5 +42,5 @@
 
 *** xref:final_group_project.adoc[Final group project]
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/accounting.adoc
+++ b/doc/antora/modules/tutorials/pages/accounting.adoc
@@ -270,5 +270,5 @@ authentication request? Why?
 9.  What error message is produced on the second accounting stop, and
 why is it produced?
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/dictionary.adoc
+++ b/doc/antora/modules/tutorials/pages/dictionary.adoc
@@ -68,5 +68,5 @@ multiple names for one number?
 prefixed with the vendor name?
 3.  Why are vendor specific attributes useful?
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/eap-peap.adoc
+++ b/doc/antora/modules/tutorials/pages/eap-peap.adoc
@@ -78,5 +78,5 @@ tunnel for EAP-PEAP?
 3.  Would you use EAP-PEAP in a large deployment? If so, why? If not,
 why not?
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/eap-tls.adoc
+++ b/doc/antora/modules/tutorials/pages/eap-tls.adoc
@@ -108,5 +108,5 @@ not?
 4.  What is the purpose of the `MS-MPPE-Recv-Key` and `MS-MPPE-Send-Key`
 attributes in the final `Access-Accept` packet?
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/eap-ttls.adoc
+++ b/doc/antora/modules/tutorials/pages/eap-ttls.adoc
@@ -46,5 +46,5 @@ tunnel for EAP-TTLS?
 3.  Would you use EAP-TTLS in a large deployment? If so, why? If not,
 why not?
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/editing_attributes.adoc
+++ b/doc/antora/modules/tutorials/pages/editing_attributes.adoc
@@ -374,6 +374,6 @@ Service-Type = Framed-User" | radclient -x 127.0.0.1 auth testing123
     multiple conditions, where policies are being assigned to many different
     users?
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.
 

--- a/doc/antora/modules/tutorials/pages/failover.adoc
+++ b/doc/antora/modules/tutorials/pages/failover.adoc
@@ -327,5 +327,5 @@ but the latter is just a whole lot easier to read.
 
 * load balancing
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/final_group_project.adoc
+++ b/doc/antora/modules/tutorials/pages/final_group_project.adoc
@@ -231,5 +231,5 @@ If their server does not respond with an Access-Accept, work with the other
 participant to debug the issue.
 
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/module_fail_over.adoc
+++ b/doc/antora/modules/tutorials/pages/module_fail_over.adoc
@@ -110,5 +110,5 @@ $ more /var/log/radius/radacct/detail2
 1.  Could the configuration for the "group" section containing the
 "detail1" and "detail2" modules be simplified? If so, how?
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/new_client.adoc
+++ b/doc/antora/modules/tutorials/pages/new_client.adoc
@@ -124,5 +124,5 @@ file is edited?
 4.  What are the other fields in a client entry, and what are they used
 for?
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/proxy_failover.adoc
+++ b/doc/antora/modules/tutorials/pages/proxy_failover.adoc
@@ -65,5 +65,5 @@ the "realm2" server that has been stopped? If so, when? If not,
 why not?
 3.  What would happen if both servers for "realm2" failed?
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/proxy_load_balance.adoc
+++ b/doc/antora/modules/tutorials/pages/proxy_load_balance.adoc
@@ -36,5 +36,5 @@ home server to load balance to?
 again, will the proxying server ever send requests to it again? If so,
 when? If not, why not?
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/proxy_receive.adoc
+++ b/doc/antora/modules/tutorials/pages/proxy_receive.adoc
@@ -435,5 +435,5 @@ server in the `clients.conf` file?
 3.  What would happen if each user did not configure the realms to
 "strip" the realm from the proxied requests?
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/radmin.adoc
+++ b/doc/antora/modules/tutorials/pages/radmin.adoc
@@ -30,5 +30,5 @@ user?
 4.  Can you start the server in non-debugging mode (`radiusd -f`), and
 still see the debugging output? How?
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/simultaneous_use.adoc
+++ b/doc/antora/modules/tutorials/pages/simultaneous_use.adoc
@@ -57,5 +57,5 @@ lines, like MPP, or ISDN?
 5.  What would happen if the user tried to log in a second time, before
 the accounting start packet was received?
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/sql.adoc
+++ b/doc/antora/modules/tutorials/pages/sql.adoc
@@ -172,5 +172,5 @@ testing the ability to obtain user configuration from an SQL database?
 3.  What additional benefits, not mentioned here, do SQL databases have
 over the files module?
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/sql_user.adoc
+++ b/doc/antora/modules/tutorials/pages/sql_user.adoc
@@ -89,5 +89,5 @@ and how? If not, why not?
 5.  What other configuration entries in `sites-available/default`
     exist for the `sql` module, and why?
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/unlang_policies.adoc
+++ b/doc/antora/modules/tutorials/pages/unlang_policies.adoc
@@ -117,5 +117,5 @@ Received Access-Accept Id 246 from 127.0.0.1:1812 to 0.0.0.0:56242 via lo length
 2.  What are the main differences between a policy and a function in other
     languages?
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/unlang_return_codes.adoc
+++ b/doc/antora/modules/tutorials/pages/unlang_return_codes.adoc
@@ -64,5 +64,5 @@ If the policies are correct you will see that FreeRADIUS returns an
     configured above xref:reference:unlang/keywords.adoc[Keywords].
 
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/unlang_splitting_strings.adoc
+++ b/doc/antora/modules/tutorials/pages/unlang_splitting_strings.adoc
@@ -189,5 +189,5 @@ echo 'User-Name = "bob@realm2.com", User-Password = "hello"' | radclient -x 127.
 3.  What is an advantage of using expression based string splitting
     over the suffix module?
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/pages/variables.adoc
+++ b/doc/antora/modules/tutorials/pages/variables.adoc
@@ -199,5 +199,5 @@ bad idea?
 3.  How would you create an entry in the users file that matched users when
 their `Class` was the same as their `NAS-Port`?
 
-// Copyright (C) 2021 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/partials/common_control_attrs_sidebar.adoc
+++ b/doc/antora/modules/tutorials/partials/common_control_attrs_sidebar.adoc
@@ -6,5 +6,5 @@ Commonly used control attributes are:
 - `control.Auth-Type` specifies the `authenticate <name> {}` section to run
 ****
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.

--- a/doc/antora/modules/tutorials/partials/unlang_start.adoc
+++ b/doc/antora/modules/tutorials/partials/unlang_start.adoc
@@ -5,5 +5,5 @@ For this tutorial you should start with an empty authorization section
 in the virtual server you're using to process requests.
 ====
 
-// Copyright (C) 2025 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
+// Copyright (C) 2026 Network RADIUS SAS.  Licenced under CC-by-NC 4.0.
 // This documentation was developed by Network RADIUS SAS.


### PR DESCRIPTION
…magic

`perl -p -i -e 's/Copyright \(C\) 2.../Copyright (C) 2026/'  $(git grep -l 'Copyright' $(find doc/antora/ -name "*.adoc" -print))`