### PR TITLE
rlm_dpsk: add generic reply attributes and optional VLAN replies

### DIFF
--- a/raddb/mods-available/dpsk
+++ b/raddb/mods-available/dpsk
@@ -53,7 +53,7 @@
 #			if (updated) {
 #				... cache &reply:Pre-Shared-Key
 #				... cache &reply:PSK-Identity
-#
+#				ok
 #			}
 #		}
 #
@@ -75,13 +75,20 @@
 #  * updated	if there are DPSK attributes which match a PSK, and the
 #		PSK was read from 'filename'.
 #
-#		It also updates the attributes &reply:Pre-Shared-Key
-#		with the found PSK, along with &reply:PSK-Identity
-#		with the found identity.
+#		It also creates &reply:Pairwise-Master-Key.  When the
+#		matching PSK is known, it also creates the attributes
+#		&reply:Pre-Shared-Key with the found PSK, along with
+#		&reply:PSK-Identity with the found identity.
 #
-#		You can then check the return code for "updated", and
-#		write those attributes into a database.  This step
-#		ensures that 'filename' is read only as a last resort.
+#		When the PSK is read from 'filename', an optional VLAN ID
+#		can also be returned via the standard reply attributes
+#		Tunnel-Type = VLAN, Tunnel-Medium-Type = IEEE-802, and
+#		Tunnel-Private-Group-Id.
+#
+#		You can then check the return code for "updated",
+#		write those attributes into a database, and return
+#		ok to continue processing.  This step ensures that
+#		'filename' is read only as a last resort.
 #		Since the file is read from top to bottom for every
 #		packet, this process is much slower than using a
 #		database which is keyed to the PSK Identity.
@@ -111,7 +118,8 @@ dpsk {
 	#
 	#  The cache entry is the PSK-Identity and Pre-Shared-Key,
 	#  and/or the PMK which are used to verify the information in
-	#  the Access-Request.
+	#  the Access-Request.  When VLAN information is read from the
+	#  file, it is also cached with the entry.
 	#
 	#  Caching entries can help, even when using a database.  It
 	#  is very slow to calculate the PMK from the PSK.
@@ -126,13 +134,19 @@ dpsk {
 	#
 	#  PSKs can also be stored in a CSV file.  The format of the file is:
 	#
-	#	identity,psk,mac
+	#	identity,psk[,mac[,vlanid]]
 	#
 	#  If there are commas in a field, then the field can be
 	#  double quoted: "psk".
 	#
 	#  The mac field is optional.  If it exists, then that PSK
-	#  will be used.  It is highly recommended that the MAC *not* be placed
+	#  will be used.  The vlanid field is also optional, and if it
+	#  exists then the module will return the standard reply
+	#  attributes Tunnel-Type = VLAN, Tunnel-Medium-Type = IEEE-802,
+	#  and Tunnel-Private-Group-Id.  The VLAN field may be present
+	#  even when the MAC field is empty, e.g. 'identity,psk,,2065'.
+	#
+	#  It is highly recommended that the MAC *not* be placed
 	#  into the CSV file.  Instead, the MAC and PSK should be placed into a
 	#  database.  The server can then be configured to look up the MAC in the
 	#  database, which returns the PSK.  That way this module will only ever
@@ -160,7 +174,8 @@ dpsk {
 	#
 	#  Both "cache_size" and "filename" can be configured at the
 	#  same time, which is recommended.  When an entry in the file
-	#  is found, the identity, PSK, and MAC are saved in the cache.
+	#  is found, the identity, PSK, optional MAC, and optional VLAN
+	#  are saved in the cache.
 	#
 	#  If a cache entry is found, then the filename is NOT read.
 	#
@@ -190,5 +205,5 @@ dpsk {
 	#  files by location, which can drastically reduce the overall
 	#  search space, and thus the CPU requirements.
 	#
-#	filename = "${modconfdir}/${..:name}/psk.csv"
+#	filename = "${modconfdir}/${.:name}/psk.csv"
 }

--- a/raddb/sites-available/default
+++ b/raddb/sites-available/default
@@ -591,6 +591,20 @@ authenticate {
 	}
 
 #	dpsk
+	#
+	#  The dpsk module can also return standard VLAN tunnel reply
+	#  attributes when a VLAN ID is supplied by the data source.
+	#  Vendor-specific reply attributes should be added in local
+	#  policy using those standard reply attributes.
+	#  Example:
+	#
+	#	Auth-Type dpsk {
+	#		dpsk
+	#		if (updated) {
+	#			ok
+	#		}
+	#	}
+	#
 
 	#
 	#  Most people want CHAP authentication

--- a/share/dictionary.meraki
+++ b/share/dictionary.meraki
@@ -11,5 +11,11 @@ ATTRIBUTE	Meraki-Device-Name			1	string
 ATTRIBUTE	Meraki-Network-Name			2	string
 ATTRIBUTE	Meraki-Ap-Name				3	string
 ATTRIBUTE	Meraki-Ap-Tags				4	string
+ATTRIBUTE	Meraki-IPSK				5	tlv
+ATTRIBUTE	Meraki-IPSK-Anonce			5.1	octets
+ATTRIBUTE	Meraki-IPSK-EAPOL			5.2	octets
+ATTRIBUTE	Meraki-IPSK-BSSID			5.3	octets
+ATTRIBUTE	Meraki-IPSK-AP-MAC			5.4	octets
+ATTRIBUTE	Meraki-IPSK-SSID			5.5	string
 
 END-VENDOR      Meraki

--- a/src/modules/rlm_dpsk/rlm_dpsk.c
+++ b/src/modules/rlm_dpsk/rlm_dpsk.c
@@ -33,6 +33,8 @@ RCSID("$Id$")
 #include <openssl/hmac.h>
 
 #include <ctype.h>
+#include <errno.h>
+#include <stdlib.h>
 
 #define PW_FREERADIUS_8021X_ANONCE		(1)
 #define PW_FREERADIUS_8021X_EAPOL_KEY_MSG	(2)
@@ -46,6 +48,10 @@ RCSID("$Id$")
 //#define PW_RUCKUS_DPSK_CIPHER	(PW_RUCKUS_DPSK_PARAMS | (2 << 8))
 #define PW_RUCKUS_DPSK_ANONCE	(PW_RUCKUS_DPSK_PARAMS | (3 << 8))
 #define PW_RUCKUS_DPSK_EAPOL_KEY_FRAME	(PW_RUCKUS_DPSK_PARAMS | (4 << 8))
+
+#define TUNNEL_TYPE_VLAN			(13)
+#define TUNNEL_MEDIUM_TYPE_IEEE_802	(6)
+#define VLAN_ID_MAX			(4094)
 
 
 /*
@@ -109,6 +115,8 @@ typedef struct {
 
 	char			*psk;
 	size_t			psk_len;
+	uint32_t		vlan_id;
+	bool			have_vlan;
 	time_t			expires;
 
 	fr_dlist_t		dlist;
@@ -283,6 +291,80 @@ static int generate_pmk(REQUEST *request, uint8_t *buffer, size_t buflen, VALUE_
 	return 0;
 }
 
+static int dpsk_parse_vlan_id(uint32_t *out, char const *value)
+{
+	char *end = NULL;
+	unsigned long parsed;
+
+	if (!value || !*value) return 0;
+
+	errno = 0;
+	parsed = strtoul(value, &end, 10);
+	if ((errno != 0) || (end == value) || !end || (*end != '\0')) return -1;
+	if ((parsed == 0) || (parsed > VLAN_ID_MAX)) return -1;
+
+	*out = (uint32_t) parsed;
+	return 1;
+}
+
+static int dpsk_add_reply_vlan(REQUEST *request, uint32_t vlan_id)
+{
+	VALUE_PAIR *vp;
+	char buffer[16];
+	int len;
+
+	vp = fr_pair_afrom_num(request->reply, PW_TUNNEL_TYPE, 0);
+	if (!vp) return -1;
+	vp->vp_integer = TUNNEL_TYPE_VLAN;
+	fr_pair_add(&request->reply->vps, vp);
+
+	vp = fr_pair_afrom_num(request->reply, PW_TUNNEL_MEDIUM_TYPE, 0);
+	if (!vp) return -1;
+	vp->vp_integer = TUNNEL_MEDIUM_TYPE_IEEE_802;
+	fr_pair_add(&request->reply->vps, vp);
+
+	len = snprintf(buffer, sizeof(buffer), "%u", vlan_id);
+	if ((len <= 0) || ((size_t) len >= sizeof(buffer))) return -1;
+
+	vp = fr_pair_afrom_num(request->reply, PW_TUNNEL_PRIVATE_GROUP_ID, 0);
+	if (!vp) return -1;
+	fr_pair_value_bstrncpy(vp, buffer, len);
+	fr_pair_add(&request->reply->vps, vp);
+
+	return 0;
+}
+
+static int dpsk_add_reply_psk(REQUEST *request, char const *psk_identity, char const *psk, size_t psk_len)
+{
+	VALUE_PAIR *vp;
+
+	if (!psk || !psk_identity) return 0;
+
+	vp = fr_pair_afrom_num(request->reply, PW_PRE_SHARED_KEY, 0);
+	if (!vp) return -1;
+	fr_pair_value_bstrncpy(vp, psk, psk_len);
+	fr_pair_add(&request->reply->vps, vp);
+
+	vp = fr_pair_afrom_num(request->reply, PW_PSK_IDENTITY, 0);
+	if (!vp) return -1;
+	fr_pair_value_bstrncpy(vp, psk_identity, strlen(psk_identity));
+	fr_pair_add(&request->reply->vps, vp);
+
+	return 0;
+}
+
+static int dpsk_add_reply_pmk(REQUEST *request, uint8_t const *pmk, size_t pmk_len)
+{
+	VALUE_PAIR *vp;
+
+	vp = fr_pair_afrom_num(request->reply, PW_PAIRWISE_MASTER_KEY, 0);
+	if (!vp) return -1;
+	fr_pair_value_memcpy(vp, pmk, pmk_len);
+	fr_pair_add(&request->reply->vps, vp);
+
+	return 0;
+}
+
 /*
  *	Verify the DPSK information.
  */
@@ -311,6 +393,8 @@ static rlm_rcode_t CC_HINT(nonnull) mod_authenticate(void *instance, REQUEST *re
 	char token_identity[256];
 	char token_psk[256];
 	char filename_buffer[1024];
+	uint32_t vlan_id = 0;
+	bool have_vlan = false;
 
 	/*
 	 *	Search for the information in a bunch of attributes.
@@ -449,6 +533,8 @@ static rlm_rcode_t CC_HINT(nonnull) mod_authenticate(void *instance, REQUEST *re
 			psk_identity = entry->identity;
 			psk = entry->psk;
 			psk_len = entry->psk_len;
+			have_vlan = entry->have_vlan;
+			vlan_id = entry->vlan_id;
 			goto make_digest;
 		}
 	}
@@ -519,6 +605,7 @@ stage2:
 		FR_TOKEN token;
 		char const *q;
 		char token_mac[256];
+		char token_vlan[64];
 		char buffer[1024];
 
 		if (inst->dynamic) {
@@ -547,68 +634,96 @@ stage2:
 		}
 
 stage2a:
+		have_vlan = false;
+		vlan_id = 0;
+		token_mac[0] = '\0';
+		token_vlan[0] = '\0';
+
 		q = fgets(buffer, sizeof(buffer), fp);
 		if (!q) {
-			RDEBUG("Failed to find matching PSK or MAC in %s", filename);
+			RDEBUG("Failed to find matching PSK or MAC in %s after checking %d lines", filename, lineno);
 		fail_file:
 			fclose(fp);
 			return RLM_MODULE_FAIL;
 		}
+
+		lineno++;
 
 		/*
 		 *	Split the line on commas, paying attention to double quotes.
 		 */
 		token = getstring(&q, token_identity, sizeof(token_identity), true);
 		if (token == T_INVALID) {
-			RDEBUG("%s[%d] Failed parsing identity", filename, lineno);
+			RDEBUG("%s[%d] Failed parsing identity field", filename, lineno);
 			goto fail_file;
 		}
 
 		if (*q != ',') {
-			RDEBUG("%s[%d] Failed to find ',' after identity", filename, lineno);
+			RDEBUG("%s[%d] Expected ',' after identity field", filename, lineno);
 			goto fail_file;
 		}
 		q++;
 
 		token = getstring(&q, token_psk, sizeof(token_psk), true);
 		if (token == T_INVALID) {
-			RDEBUG("%s[%d] Failed parsing PSK", filename, lineno);
+			RDEBUG("%s[%d] Failed parsing PSK field", filename, lineno);
 			goto fail_file;
 		}
 
 		/*
-		 *	The MAC is optional.  If there is a MAC, we
-		 *	loop over the file until we find a matching
-		 *	one.
+		 *	The MAC and VLAN are optional.  If there is a MAC, we
+		 *	loop over the file until we find a matching one.
 		 */
 		if (*q == ',') {
+			int vlan_rcode;
+
 			q++;
 
 			token = getstring(&q, token_mac, sizeof(token_mac), true);
 			if (token == T_INVALID) {
-				RDEBUG("%s[%d] Failed parsing MAC", filename, lineno);
+				RDEBUG("%s[%d] Failed parsing MAC field", filename, lineno);
 				goto fail_file;
 			}
 
-			/*
-			 *	See if the MAC matches.  If not, skip
-			 *	this entry.  That's a basic negative cache.
-			 */
-			if ((strlen(token_mac) != 12) ||
-			    (fr_hex2bin((uint8_t *) token_mac, 6, token_mac, 12) != 12)) {
-				RDEBUG("%s[%d] Failed parsing MAC", filename, lineno);
-				goto fail_file;
+			if (token_mac[0] != '\0') {
+				/*
+				 *	See if the MAC matches.  If not, skip
+				 *	this entry.  That's a basic negative cache.
+				 */
+				if ((strlen(token_mac) != 12) ||
+				    (fr_hex2bin((uint8_t *) token_mac, 6, token_mac, 12) != 6)) {
+					RDEBUG("%s[%d] Failed parsing MAC field (expected 12 hex characters)", filename, lineno);
+					goto fail_file;
+				}
+
+				/*
+				 *	The MAC doesn't match, don't even bother trying to generate the PMK.
+				 */
+				if (memcmp(s_mac, token_mac, 6) != 0) {
+					goto stage2a;
+				}
+
+				RDEBUG3("Found matching MAC");
+				stage = 3;
 			}
 
-			/*
-			 *	The MAC doesn't match, don't even bother trying to generate the PMK.
-			 */
-			if (memcmp(s_mac, token_mac, 6) != 0) {
-				goto stage2a;
-			}
+			if (*q == ',') {
+				q++;
 
-			RDEBUG3("Found matching MAC");
-			stage = 3;
+				token = getstring(&q, token_vlan, sizeof(token_vlan), true);
+				if (token == T_INVALID) {
+					RDEBUG("%s[%d] Failed parsing VLAN field", filename, lineno);
+					goto fail_file;
+				}
+
+				vlan_rcode = dpsk_parse_vlan_id(&vlan_id, token_vlan);
+				if (vlan_rcode < 0) {
+					RDEBUG("%s[%d] Failed parsing VLAN field (expected 1..%u)", filename, lineno, VLAN_ID_MAX);
+					goto fail_file;
+				}
+
+				have_vlan = (vlan_rcode > 0);
+			}
 		}
 
 		/*
@@ -660,6 +775,8 @@ make_digest:
 		psk_identity = NULL;
 		psk = NULL;
 		psk_len = 0;
+		have_vlan = false;
+		vlan_id = 0;
 
 		/*
 		 *	Found a cached entry, but it didn't match.  Go
@@ -775,6 +892,8 @@ make_digest:
 
 			MEM(entry->psk = talloc_memdup(entry, psk, psk_len));
 			entry->psk_len = psk_len;
+			entry->have_vlan = have_vlan;
+			entry->vlan_id = vlan_id;
 
 			entry->identity_len = strlen(psk_identity);
 			MEM(entry->identity = talloc_memdup(entry, psk_identity, entry->identity_len));
@@ -790,47 +909,32 @@ make_digest:
 		}
 
 	update_entry:
+		entry->have_vlan = have_vlan;
+		entry->vlan_id = vlan_id;
+
 		PTHREAD_MUTEX_LOCK(&inst->mutex);
 		entry->expires = request->timestamp + inst->cache_lifetime;
 		fr_dlist_entry_unlink(&entry->dlist);
 		fr_dlist_insert_tail(&inst->head, &entry->dlist);
 		PTHREAD_MUTEX_UNLOCK(&inst->mutex);
 
-		/*
-		 *	Add the PSK to the reply items, if it was cached.
-		 */
-		if (entry->psk) {
-			MEM(vp = fr_pair_afrom_num(request->reply, PW_PRE_SHARED_KEY, 0));
-			fr_pair_value_bstrncpy(vp, entry->psk, entry->psk_len);
-
-			fr_pair_add(&request->reply->vps, vp);
-		}
 	}
 
 update_attributes:
-	/*
-	 *	We found a cache entry, or an external PSK.  Don't
-	 *	create new attributes.
-	 */
-	if (rcode == RLM_MODULE_OK) return RLM_MODULE_OK;
+	RDEBUG("Creating &reply:Pairwise-Master-Key");
+	if (dpsk_add_reply_pmk(request, pmk, sizeof(pmk)) < 0) return RLM_MODULE_FAIL;
 
-	fr_assert(psk != NULL);
-	fr_assert(psk_identity != NULL);
+	if (psk && psk_identity) {
+		RDEBUG("Creating &reply:PSK-Identity and &reply:Pre-Shared-Key");
+		if (dpsk_add_reply_psk(request, psk_identity, psk, psk_len) < 0) return RLM_MODULE_FAIL;
+	}
 
-	/*
-	 *	Create the attributes which the caller can then save
-	 *	in the database.
-	 */
-	RDEBUG("Creating &reply:PSK-Identity and &reply:Pre-Shared-Key");
-	MEM(vp = fr_pair_afrom_num(request->reply, PW_PRE_SHARED_KEY, 0));
-	fr_pair_value_bstrncpy(vp, psk, psk_len);
-	fr_pair_add(&request->reply->vps, vp);
+	if (have_vlan) {
+		RDEBUG("Creating VLAN reply attributes for VLAN %u", vlan_id);
+		if (dpsk_add_reply_vlan(request, vlan_id) < 0) return RLM_MODULE_FAIL;
+	}
 
-	MEM(vp = fr_pair_afrom_num(request->reply, PW_PSK_IDENTITY, 0));
-	fr_pair_value_bstrncpy(vp, psk_identity, strlen(psk_identity));
-	fr_pair_add(&request->reply->vps, vp);
-
-	return RLM_MODULE_UPDATED;
+	return rcode;
 }
 
 /*

--- a/src/tests/auth/dpsk-pmk.attrs
+++ b/src/tests/auth/dpsk-pmk.attrs
@@ -8,3 +8,4 @@ Class = 0xd6175aed517504c40b8831d7ce7b7d1fe24c65ce0f92c2816ca14ba7acb47b13
 
 # and the response
 Response-Packet-Type == Access-Accept
+Pairwise-Master-Key == 0xd6175aed517504c40b8831d7ce7b7d1fe24c65ce0f92c2816ca14ba7acb47b13

--- a/src/tests/auth/dpsk-psk.attrs
+++ b/src/tests/auth/dpsk-psk.attrs
@@ -11,3 +11,5 @@ Filter-ID = "Pancakes1124"
 # and the response
 Response-Packet-Type == Access-Accept
 Pre-Shared-Key == "Pancakes1124"
+PSK-Identity == "8ab3a0ebd5e5"
+Pairwise-Master-Key == 0x44a4f34b6270fccb7dffa8c9e610e3b80f021c8165bcf53c99c3f818167982ab


### PR DESCRIPTION
## Summary
This change improves `rlm_dpsk` so that local policy can build vendor-specific replies from standard reply attributes, while keeping the module itself vendor-neutral.

In particular, the module now exposes `Pairwise-Master-Key` in addition to the existing `PSK-Identity` and `Pre-Shared-Key`, so local policy has access to all three reply attributes when it needs to construct vendor-specific responses.

This change also adds an optional fourth CSV column for VLAN assignment, adds Meraki IPSK test attributes to `dictionary.meraki`, and updates the comments in `raddb/mods-available/dpsk` and `raddb/sites-available/default` accordingly.

## Details
`rlm_dpsk` now accepts CSV entries in the following format:

`identity,psk[,mac[,vlanid]]`

This is backwards compatible with the existing file format:
- `identity,psk`
- `identity,psk,mac`

The VLAN field may also be used when the MAC field is empty, for example:

`identity,psk,,2065`

If `vlanid` is present, the module returns the standard tunnel reply attributes:
- `Tunnel-Type = VLAN`
- `Tunnel-Medium-Type = IEEE-802`
- `Tunnel-Private-Group-Id = "<vlanid>"`

The VLAN metadata is cached together with the other DPSK data, so cache hits return the same reply behavior as file lookups.

The sample `filename` expansion in `raddb/mods-available/dpsk` is also updated from `${..:name}` to `${.:name}` intentionally, so the example references the current module instance directly.

The Meraki dictionary update provides the IPSK test attributes needed for Meraki request handling and validation in the test environment.

## Fix included
While validating MAC-constrained CSV entries, I found that the MAC parsing path compared the decoded output length against `12` instead of `6`. This caused valid 12-hex-character MAC entries to be rejected. This patch corrects that check so MAC-constrained CSV rows work as intended.

## Documentation
The patch updates:
- `raddb/mods-available/dpsk`
- `raddb/sites-available/default`

The documentation now describes:
- the extended CSV format
- optional VLAN replies
- the updated sample `filename` expansion
- an example `Auth-Type dpsk` stanza showing the usual pattern for handling the module returning `updated`

## Validation
Tested against upstream v3.2.

Verified:
- legacy CSV rows without MAC or VLAN still work
- CSV rows with `identity,psk,,2065` return standard VLAN tunnel reply attributes
- CSV rows with `identity,psk,mac` now parse and match correctly
- Ruckus DPSK flow works with MAC-constrained rows
- Meraki IPSK flow works with optional VLAN replies alongside the existing `Tunnel-Password` reply
- the Meraki IPSK validation uses the attributes added in `dictionary.meraki`
- `freeradius -XC` passes with the updated module and configuration