### PR TITLE
Profiling images can now be generated from crossbuild images

### DIFF
--- a/scripts/docker/build/ubuntu24/Dockerfile.prof
+++ b/scripts/docker/build/ubuntu24/Dockerfile.prof
@@ -1,0 +1,113 @@
+# Auto generated for ubuntu24
+# from scripts/docker/m4/profiling.deb.m4
+#
+# Rebuild this file with `make crossbuild.ubuntu24.profile.regen`
+#
+ARG from=freeradius40x-build/ubuntu24
+FROM ${from}
+
+#
+#  Install profiling tools
+#
+#    Valgrind/cachegrind
+#    kcachegrind + KDE/Qt libs
+#    gperftools
+#    heaptrack
+#
+RUN apt-get update && \
+    apt-get install -y $APT_OPTS \
+        libgoogle-perftools-dev \
+        google-perftools \
+        valgrind \
+        heaptrack \
+        psmisc \
+        kcachegrind \
+        kio \
+        libkf5iconthemes5 \
+        libkf5parts5 \
+        libkf5textwidgets5 \
+        libqt5gui5 \
+        libqt5widgets5 && \
+    apt-get clean && \
+    rm -r /var/lib/apt/lists/*
+
+#
+#  Set up Ubuntu debug symbol repository and install OS library debug symbols.
+#  These allow profiling tools to resolve system library calls.
+#
+RUN apt-get update && \
+    apt-get install -y $APT_OPTS ubuntu-dbgsym-keyring && \
+    printf 'deb http://ddebs.ubuntu.com noble main restricted universe multiverse\ndeb http://ddebs.ubuntu.com noble-updates main restricted universe multiverse\n' \
+        > /etc/apt/sources.list.d/ddebs.list && \
+    apt-get update && \
+    for pkg in \
+        libc6-dbg \
+        zlib1g-dbgsym \
+        libreadline8t64-dbgsym \
+        libssl3t64-dbgsym \
+        libsasl2-2-dbgsym \
+        libpam0g-dbgsym \
+        libldap2-dbgsym \
+        libtalloc2-dbgsym \
+        libpcre2-8-0-dbgsym \
+        libpcap0.8t64-dbgsym \
+        libunbound8-dbgsym \
+        libsqlite3-0-dbgsym \
+        libpq5-dbgsym \
+        libmariadb3-dbgsym \
+        libgdbm6t64-dbgsym \
+        libjson-c5-dbgsym \
+        libbrotli1-dbgsym \
+        libhiredis1.1.0-dbgsym \
+        librdkafka1-dbgsym \
+        libwbclient0-dbgsym \
+        libcurl4t64-dbgsym; do \
+        apt-get install -y $APT_OPTS $pkg || echo "WARNING: could not install dbgsym package: $pkg"; \
+    done && \
+    apt-get clean && \
+    rm -r /var/lib/apt/lists/*
+
+#
+#  Rebuild libkqueue from source with debug symbols.
+#  CMAKE_BUILD_TYPE must be explicitly set to prevent
+#  the libkqueue project from overriding the flags.
+#  libkqueue source currently uses "-O2 -g -DNDEBUG" by default.
+#
+RUN apt-get update && \
+    apt-get install -y $APT_OPTS --no-install-recommends cmake git && \
+    apt-get clean && \
+    rm -r /var/lib/apt/lists/* && \
+    git clone --depth 1 https://github.com/mheily/libkqueue.git /tmp/libkqueue && \
+    cd /tmp/libkqueue && \
+    cmake -G "Unix Makefiles" \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_C_FLAGS_RELWITHDEBINFO="-g3 -O1 -fno-omit-frame-pointer -DNDEBUG" \
+        . && \
+    make && \
+    cpack -G DEB && \
+    dpkg -i *.deb && \
+    cd / && rm -rf /tmp/libkqueue
+
+#
+#  Install FlameGraph
+#
+RUN git clone --depth 1 https://github.com/brendangregg/FlameGraph /opt/flamegraph \
+    && chmod +x /opt/flamegraph/*.pl /opt/flamegraph/*.sh
+
+# Add FlameGraph to path
+ENV PATH="/opt/flamegraph:${PATH}"
+
+#
+#  Install Inferno for callgrind. Inferno is a Rust port of FlameGraph with broader format support
+#
+RUN apt-get update && \
+    apt-get install -y $APT_OPTS --no-install-recommends \
+        cargo && \
+    cargo install inferno --version 0.11.21 --locked --root /usr/local && \
+    apt-get clean && \
+    rm -r /var/lib/apt/lists/*
+
+EXPOSE 1812/udp 1813/udp
+CMD ["/bin/sh", "-c", "while true; do sleep 60; done"]

--- a/scripts/docker/crossbuild.mk
+++ b/scripts/docker/crossbuild.mk
@@ -299,7 +299,7 @@ $(DT)/${1}/Dockerfile.prof: $(DOCKER_TMPL) $(CB_DIR)/m4/profiling.deb.m4
 	${Q}m4 -I $(CB_DIR)/m4 \
 	    -D D_NAME=${1} \
 	    -D D_TYPE=profiling \
-	    -D CB_IMAGE=$(CB_IPREFIX)/${1}
+	    -D CB_IMAGE=$(CB_IPREFIX)/${1} \
 	    $$< > $$@
 
 # ubuntu24 profiling target end

--- a/scripts/docker/crossbuild.mk
+++ b/scripts/docker/crossbuild.mk
@@ -42,6 +42,8 @@ endif
 CB_IPREFIX:=freeradius40x-build
 CB_CPREFIX:=fr40x-crossbuild-
 
+PROFILE ?= default-profiling
+
 #
 #  This Makefile is included in-line, and not via the "boilermake"
 #  wrapper.  But it's still useful to use the same process for
@@ -91,6 +93,11 @@ crossbuild.help: crossbuild.info
 	@echo "    crossbuild.IMAGE.reset        - remove cache of docker state"
 	@echo "    crossbuild.IMAGE.clean        - stop container and tidy up"
 	@echo "    crossbuild.IMAGE.distclean    - remove Docker image"
+	@echo ""
+	@echo "Profiling targets (currently only for ubuntu24):"
+	@echo "    crossbuild.IMAGE.profile.regen                 - regenerate Dockerfile.prof"
+	@echo "    crossbuild.IMAGE.profile.build                 - build profiling image"
+	@echo "    crossbuild.IMAGE.profile.reset                 - remove profiling stamp to force rebuild"
 	@echo ""
 	@echo "Use 'make NOCACHE=1 ...' to disregard the Docker cache on build"
 
@@ -146,6 +153,27 @@ $(DD)/stamp-image.${1}:
 	${Q}echo "BUILD ${1} ($(CB_IPREFIX)/${1}) > $(DD)/build.${1}"
 	${Q}docker build $(DOCKER_BUILD_OPTS) $(if $(CB_FROM_${1}),--build-arg=from=$(CB_FROM_${1})) $(DT)/${1} -f $(DT)/${1}/Dockerfile.cb -t $(CB_IPREFIX)/${1} >$(DD)/build.${1} 2>&1
 	${Q}touch $(DD)/stamp-image.${1}
+
+
+#
+#  Build the profiling image
+#
+
+# ubuntu24 profiling target start
+ifeq (${1},ubuntu24)
+
+crossbuild.${1}.profile.build: $(DD)/stamp-image.${1}-profile.build
+
+$(DD)/stamp-image.${1}-profile.build: $(DD)/stamp-image.${1} $(DT)/${1}/Dockerfile.prof
+	${Q}echo "BUILD ${1} (freeradius4-$(PROFILE)/${1}) > $(DD)/build.${1}-profile.build"
+	${Q}docker build $(DOCKER_BUILD_OPTS) . \
+		-f $(DT)/${1}/Dockerfile.prof \
+		-t freeradius4-$(PROFILE)/${1} \
+		>$(DD)/build.${1}-profile.build 2>&1
+	${Q}touch $(DD)/stamp-image.${1}-profile.build
+
+# ubuntu24 profiling target end
+endif
 
 #
 #  Start up the docker container
@@ -255,6 +283,42 @@ crossbuild.${1}.regen: $(DT)/${1}/Dockerfile.cb
 $(DT)/${1}/Dockerfile.cb: $(DOCKER_TMPL) $(CB_DIR)/m4/crossbuild.deb.m4 $(CB_DIR)/m4/crossbuild.rpm.m4
 	${Q}echo REGEN ${1}
 	${Q}m4 -I $(CB_DIR)/m4 -D D_NAME=${1} -D D_TYPE=crossbuild $$< > $$@
+
+#
+#  Regenerate Dockerfile.prof from m4 template
+#
+
+# ubuntu24 profiling target start
+ifeq (${1},ubuntu24)
+
+.PHONY: crossbuild.${1}.profile.regen
+crossbuild.${1}.profile.regen: $(DT)/${1}/Dockerfile.prof
+
+$(DT)/${1}/Dockerfile.prof: $(DOCKER_TMPL) $(CB_DIR)/m4/profiling.deb.m4
+	${Q}echo REGEN ${1}
+	${Q}m4 -I $(CB_DIR)/m4 \
+	    -D D_NAME=${1} \
+	    -D D_TYPE=profiling \
+	    -D CB_IMAGE=$(CB_IPREFIX)/${1}
+	    $$< > $$@
+
+# ubuntu24 profiling target end
+endif
+
+#
+#  Remove profiling stamp so next profile.build starts clean
+#
+
+# ubuntu24 profiling target start
+ifeq (${1},ubuntu24)
+
+.PHONY: crossbuild.${1}.profile.reset
+crossbuild.${1}.profile.reset:
+	${Q}echo RESET profiling ${1}
+	${Q}rm -f $(DD)/stamp-image.${1}-profile.build
+
+# ubuntu24 profiling target end
+endif
 
 #
 #  Run the build test

--- a/scripts/docker/m4/Dockerfile.m4
+++ b/scripts/docker/m4/Dockerfile.m4
@@ -37,7 +37,9 @@ divert[]dnl
 [#] Auto generated for D_NAME
 [#] from scripts/docker/m4/D_TYPE.PKG_TYPE.m4
 [#]
-[#] Rebuild this file with `make D_TYPE.D_NAME.regen`
+ifelse(D_TYPE, [profiling],
+    [[#] Rebuild this file with `make crossbuild.D_NAME.profile.regen`],
+    [[#] Rebuild this file with `make D_TYPE.D_NAME.regen`])
 [#]
 changequote([`], ['])dnl
 include(D_TYPE.PKG_TYPE.m4)dnl

--- a/scripts/docker/m4/profiling.deb.m4
+++ b/scripts/docker/m4/profiling.deb.m4
@@ -1,0 +1,108 @@
+ARG from=CB_IMAGE
+FROM ${from}
+
+#
+#  Install profiling tools
+#
+#    Valgrind/cachegrind
+#    kcachegrind + KDE/Qt libs
+#    gperftools
+#    heaptrack
+#
+RUN apt-get update && \
+    apt-get install -y $APT_OPTS \
+        libgoogle-perftools-dev \
+        google-perftools \
+        valgrind \
+        heaptrack \
+        psmisc \
+        kcachegrind \
+        kio \
+        libkf5iconthemes5 \
+        libkf5parts5 \
+        libkf5textwidgets5 \
+        libqt5gui5 \
+        libqt5widgets5 && \
+    apt-get clean && \
+    rm -r /var/lib/apt/lists/*
+
+#
+#  Set up Ubuntu debug symbol repository and install OS library debug symbols.
+#  These allow profiling tools to resolve system library calls.
+#
+RUN apt-get update && \
+    apt-get install -y $APT_OPTS ubuntu-dbgsym-keyring && \
+    printf 'deb http://ddebs.ubuntu.com OS_CODENAME main restricted universe multiverse\ndeb http://ddebs.ubuntu.com OS_CODENAME-updates main restricted universe multiverse\n' \
+        > /etc/apt/sources.list.d/ddebs.list && \
+    apt-get update && \
+    for pkg in \
+        libc6-dbg \
+        zlib1g-dbgsym \
+        libreadline8t64-dbgsym \
+        libssl3t64-dbgsym \
+        libsasl2-2-dbgsym \
+        libpam0g-dbgsym \
+        libldap2-dbgsym \
+        libtalloc2-dbgsym \
+        libpcre2-8-0-dbgsym \
+        libpcap0.8t64-dbgsym \
+        libunbound8-dbgsym \
+        libsqlite3-0-dbgsym \
+        libpq5-dbgsym \
+        libmariadb3-dbgsym \
+        libgdbm6t64-dbgsym \
+        libjson-c5-dbgsym \
+        libbrotli1-dbgsym \
+        libhiredis1.1.0-dbgsym \
+        librdkafka1-dbgsym \
+        libwbclient0-dbgsym \
+        libcurl4t64-dbgsym; do \
+        apt-get install -y $APT_OPTS $pkg || echo "WARNING: could not install dbgsym package: $pkg"; \
+    done && \
+    apt-get clean && \
+    rm -r /var/lib/apt/lists/*
+
+#
+#  Rebuild libkqueue from source with debug symbols.
+#  CMAKE_BUILD_TYPE must be explicitly set to prevent
+#  the libkqueue project from overriding the flags.
+#  libkqueue source currently uses "-O2 -g -DNDEBUG" by default.
+#
+RUN apt-get update && \
+    apt-get install -y $APT_OPTS --no-install-recommends cmake git && \
+    apt-get clean && \
+    rm -r /var/lib/apt/lists/* && \
+    git clone --depth 1 https://github.com/mheily/libkqueue.git /tmp/libkqueue && \
+    cd /tmp/libkqueue && \
+    cmake -G "Unix Makefiles" \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_C_FLAGS_RELWITHDEBINFO="-g3 -O1 -fno-omit-frame-pointer -DNDEBUG" \
+        . && \
+    make && \
+    cpack -G DEB && \
+    dpkg -i *.deb && \
+    cd / && rm -rf /tmp/libkqueue
+
+#
+#  Install FlameGraph
+#
+RUN git clone --depth 1 https://github.com/brendangregg/FlameGraph /opt/flamegraph \
+    && chmod +x /opt/flamegraph/*.pl /opt/flamegraph/*.sh
+
+# Add FlameGraph to path
+ENV PATH="/opt/flamegraph:${PATH}"
+
+#
+#  Install Inferno for callgrind. Inferno is a Rust port of FlameGraph with broader format support
+#
+RUN apt-get update && \
+    apt-get install -y $APT_OPTS --no-install-recommends \
+        cargo && \
+    cargo install inferno --version 0.11.21 --locked --root /usr/local && \
+    apt-get clean && \
+    rm -r /var/lib/apt/lists/*
+
+EXPOSE 1812/udp 1813/udp
+CMD ["/bin/sh", "-c", "while true; do sleep 60; done"]


### PR DESCRIPTION
Main changes:

- Profiling images are built `FROM <CROSSBULD_IMAGE>`
- Profiling images install useful profiling tools
- Profiling images do not build FreeRADIUS

Remove stamp:
`make crossbuild.ubuntu24.profile.reset`

Generate the profiling Dockerfile.prof:
`make crossbuild.ubuntu24.profile.regen`

Build the profiling image:
`make crossbuild.ubuntu24.profile.build`