### PR TITLE
Update noop for accounting handling in buffered-sql

### DIFF
--- a/raddb/sites-available/buffered-sql
+++ b/raddb/sites-available/buffered-sql
@@ -145,6 +145,19 @@ server buffered-sql {
 	#
 	accounting {
 		#
+		#  If you receive stop packets with zero session length,
+		#  they will NOT be logged in the database.  The SQL module
+		#  will print a message (only in debugging mode), and will
+		#  return "noop".
+		#
+		#  You can ignore these packets by uncommenting the following
+		#  three lines.  Otherwise, the server will not respond to the
+		#  accounting request, and the NAS will retransmit.
+		#
+	#	if (noop) {
+	#		ok
+	#	}
+		#
 		#  Log traffic to an SQL database.
 		#
 		#  See "Accounting queries" in mods-config/sql/main/$driver/queries.conf


### PR DESCRIPTION
Added noop for buffered-sql that is present in 'default' site. Otherwise, this causes detail to hang on the below when encountering zero session length. 

This brings the same functionality from 'default' to 'buffered-sql' for ease.

For example, the below will be logged repeatably:detail (/var/log/freeradius/radacct/detail*): Read packet from /var/log/freeradius/radacct/detail.work
detail (/var/log/freeradius/radacct/detail*): Read packet from /var/log/freeradius/radacct/detail.work
detail (/var/log/freeradius/radacct/detail*): Read packet from /var/log/freeradius/radacct/detail.work
detail (/var/log/freeradius/radacct/detail*): Renaming /var/log/freeradius/radacct/detail -> /var/log/freeradius/radacct/detail.work
detail (/var/log/freeradius/radacct/detail*): Read packet from /var/log/freeradius/radacct/detail.work
detail (/var/log/freeradius/radacct/detail*): Polling for detail filedetail (/var/log/freeradius/radacct/detail*): Read packet from /var/log/freeradius/radacct/detail.work