### PR TITLE
CI test result matrix; fix latent dpsk module build issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,35 @@ jobs:
           openssl dhparam -out ./raddb/certs/dh -2 512 || \
           true
 
-        make ci-test
+        # Activate per-test result recording for the summary table.
+        mkdir -p build/tests && touch build/tests/results.tsv
+
+        make -k ci-test
+
+    - name: Test summary
+      if: ${{ always() }}
+      run: |
+        ./scripts/ci/ci-summary.sh build/tests/results.tsv >> "$GITHUB_STEP_SUMMARY" || :
+
+    - name: Stage failed test logs
+      if: ${{ failure() }}
+      run: |
+        mkdir -p build/tests/failed
+        [ -s build/tests/results.tsv ] && cp build/tests/results.tsv build/tests/failed/
+        awk -F'\t' '$3=="FAIL"{print $1"\t"$2"\t"$4}' build/tests/results.tsv 2>/dev/null | \
+        while IFS=$(printf '\t') read -r cat name logf; do
+          [ -n "$logf" ] && [ -f "$logf" ] || continue
+          mkdir -p "build/tests/failed/$cat"
+          cp "$logf" "build/tests/failed/$cat/$name.log"
+        done
+
+    - name: Upload failed test logs
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v6
+      with:
+        name: ci-test-logs-${{ matrix.os.name }}-${{ matrix.env.NAME }}
+        path: build/tests/failed
+        if-no-files-found: ignore
 
     - name: Show debug logs on failure
       if: ${{ failure() }}

--- a/raddb/all.mk
+++ b/raddb/all.mk
@@ -14,7 +14,7 @@ DEFAULT_MODULES :=	always attr_filter chap date \
 			radutmp realm replicate soh sradutmp totp unix unpack utf8
 
 ifneq "$(OPENSSL_LIBS)" ""
-DEFAULT_MODULE	+=	dpsk
+DEFAULT_MODULES	+=	dpsk
 endif
 
 LOCAL_MODULES :=	$(addprefix raddb/mods-enabled/,$(DEFAULT_MODULES))

--- a/scripts/ci/ci-summary.sh
+++ b/scripts/ci/ci-summary.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+#
+# scripts/ci/ci-summary.sh
+#
+# Wrapped awk script that reads the test record file and emits a markdown
+# summary to stdout, intended for piping into $GITHUB_STEP_SUMMARY.
+#
+
+set -eu
+
+file=${1:-${CI_TEST_RECORD_FILE:-build/tests/results.tsv}}
+
+if [ ! -s "$file" ]; then
+    echo "## Test results"
+    echo
+    echo "_No results recorded._"
+    exit 0
+fi
+
+awk -F'\t' '
+{
+    key = $1 "\t" $2
+    cat[key] = $1
+    name[key] = $2
+    status[key] = $3
+    logf[key] = $4
+    seen[key] = NR  # last-wins
+}
+END {
+    # Per-category counts
+    for (k in seen) {
+        c = cat[k]
+        cats[c] = 1
+        if (status[k] == "PASS") { cat_pass[c]++; total_pass++ }
+        else if (status[k] == "FAIL") { cat_fail[c]++; total_fail++ }
+        total++
+    }
+
+    # Header
+    printf("## Test results\n\n")
+    if (total_fail > 0) {
+        printf("**%d / %d passed** (%d failed)\n\n", total_pass, total, total_fail)
+    } else {
+        printf("**%d / %d passed**\n\n", total_pass, total)
+    }
+
+    # Failure logs as collapsible blocks
+    if (total_fail > 0) {
+        printf("### Failure logs (last 20 lines)\n\n")
+        for (k in seen) {
+            if (status[k] != "FAIL") continue
+            printf("<details><summary><code>%s/%s</code> &mdash; <code>%s</code></summary>\n\n",
+                   cat[k], name[k], (logf[k] != "" ? logf[k] : "(no log captured)"))
+            if (logf[k] != "") {
+                printf("```\n")
+                n = 0
+                while ((getline line < logf[k]) > 0) buf[++n % 20] = line
+                close(logf[k])
+                start = (n < 20) ? 1 : n - 19
+                for (j = start; j <= n; j++) print buf[j % 20]
+                delete buf
+                printf("```\n")
+            } else {
+                printf("_No log file recorded._\n")
+            }
+            printf("\n</details>\n\n")
+        }
+        printf("---\n\n")
+    }
+
+    # Per-category sections.  Categories with failures float to the top
+    # via a single insertion sort; otherwise alphabetical.
+    n = 0
+    for (c in cats) ordered[++n] = c
+    for (i = 2; i <= n; i++) {
+        cur = ordered[i]; j = i - 1
+        while (j >= 1) {
+            a = ordered[j]; b = cur
+            af = (cat_fail[a] ? 0 : 1); bf = (cat_fail[b] ? 0 : 1)
+            if (af < bf || (af == bf && a < b)) break
+            ordered[j+1] = ordered[j]; j--
+        }
+        ordered[j+1] = cur
+    }
+
+    for (i = 1; i <= n; i++) {
+        c = ordered[i]
+        cp = cat_pass[c] + 0; cf = cat_fail[c] + 0
+        ct = cp + cf
+        if (cf > 0)  printf("### %s (%d/%d, %d failed)\n\n", c, cp, ct, cf)
+        else         printf("### %s (%d/%d)\n\n", c, cp, ct)
+        printf("| Test | Status |\n|---|---|\n")
+        # FAIL rows first, then PASS, each in test-execution order.
+        for (k in seen) if (cat[k] == c && status[k] == "FAIL") emit(k)
+        for (k in seen) if (cat[k] == c && status[k] == "PASS") emit(k)
+        printf("\n")
+    }
+}
+
+function emit(k) {
+    printf("| `%s` | %s |\n", name[k], status[k])
+}
+' "$file"

--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -7,6 +7,7 @@
 ##
 #
 include ../../Make.inc
+include $(top_srcdir)/src/tests/test_record.mk
 
 #
 #  You can watch what it's doing by:
@@ -268,9 +269,11 @@ $(BUILD_PATH)/tests/eap/%.ok: $(top_builddir)/src/tests/%.conf | radiusd.kill $(
 		tail -10 $(LOG); \
 		echo "===================="; \
 		$(MAKE) radiusd.kill; \
+		$(call test_record,eap,$(notdir $(patsubst %.conf,%,$<)),FAIL,$(LOG)); \
 		exit 1; \
 	fi
 	@echo
+	${Q}$(call test_record,eap,$(notdir $(patsubst %.conf,%,$<)),PASS,$(LOG))
 	${Q}touch $@
 
 #
@@ -300,21 +303,25 @@ $(BUILD_PATH)/tests/eap/${1}-${2}.ok: $(BUILD_PATH)/tests/eap/${1}-${2}.conf
 		tail -10 $$(LOG); \
 		echo "===================="; \
 		$(MAKE) radiusd.kill; \
+		$$(call test_record,eap,$$(notdir $$(patsubst %.ok,%,$$@)),FAIL,$$(LOG)); \
 		exit 1; \
 	elif ! grep -q '^SSL: Using TLS version TLSv${2}$$$$' $$(patsubst %.ok,%,$$@).log; then \
 		echo " - " FAILED - not using TLS version ${2}; \
 		echo ">>> cmd -" $$(CMD) -r 1; \
 		echo ">>> log -" $$(LOG); \
 		$(MAKE) radiusd.kill; \
+		$$(call test_record,eap,$$(notdir $$(patsubst %.ok,%,$$@)),FAIL,$$(LOG)); \
 		exit 1; \
 	elif ! grep -q '^OpenSSL: Handshake finished - resumed=1$$$$' $$(patsubst %.ok,%,$$@).log; then \
 		echo " - " FAILED - did not use resumption; \
 		echo ">>> cmd -" $$(CMD) -r 1; \
 		echo ">>> log -" $$(LOG); \
 		$(MAKE) radiusd.kill; \
+		$$(call test_record,eap,$$(notdir $$(patsubst %.ok,%,$$@)),FAIL,$$(LOG)); \
 		exit 1; \
 	fi
 	@echo
+	${Q}$$(call test_record,eap,$$(notdir $$(patsubst %.ok,%,$$@)),PASS,$$(LOG))
 	${Q}touch $$@
 
 # EAP-FAST doesn't do TLS 1.3

--- a/src/tests/all.mk
+++ b/src/tests/all.mk
@@ -3,6 +3,8 @@ PORT := 12340
 SECRET := testing123
 DICT_PATH := $(top_srcdir)/share
 
+include $(top_srcdir)/src/tests/test_record.mk
+
 #
 #  Pull all of the autoconf stuff into here.
 #

--- a/src/tests/auth/all.mk
+++ b/src/tests/auth/all.mk
@@ -9,6 +9,10 @@
 #
 AUTH_FILES := $(filter-out %.conf %.md %.attrs %.mk %~ %.rej,$(subst $(DIR)/,,$(wildcard $(DIR)/*)))
 
+ifeq "$(OPENSSL_LIBS)" ""
+AUTH_FILES := $(filter-out dpsk-%,$(AUTH_FILES))
+endif
+
 #
 #  Create the output directory
 #
@@ -63,6 +67,9 @@ $(BUILD_DIR)/tests/auth/%.attrs: $(DIR)/%.attrs | $(BUILD_DIR)/tests/auth
 .PRECIOUS: $(BUILD_DIR)/tests/auth/%.attrs raddb/mods-enabled/wimax
 
 AUTH_MODULES	:= $(shell grep -- mods-enabled src/tests/auth/radiusd.conf  | sed 's,.*/,,')
+ifeq "$(OPENSSL_LIBS)" ""
+AUTH_MODULES	:= $(filter-out dpsk,$(AUTH_MODULES))
+endif
 AUTH_RADDB	:= $(addprefix raddb/mods-enabled/,$(AUTH_MODULES))
 AUTH_LIBS	:= $(addsuffix .la,$(addprefix rlm_,$(AUTH_MODULES)))
 

--- a/src/tests/auth/all.mk
+++ b/src/tests/auth/all.mk
@@ -89,6 +89,7 @@ $(BUILD_DIR)/tests/auth/%: $(DIR)/% $(BUILD_DIR)/tests/auth/%.attrs $(TESTBINDIR
 			cat $@.log; \
 			echo "# $@.log"; \
 			echo "TESTDIR=$(notdir $@) $(TESTBIN)/unittest -D share -d src/tests/auth/ -i $@.attrs -f $@.attrs -xxx > $@.log 2>&1"; \
+			$(call test_record,auth,$(notdir $@),FAIL,$@.log); \
 			exit 1; \
 		fi; \
 		FOUND=$$(grep ^$< $@.log | head -1 | sed 's/:.*//;s/.*\[//;s/\].*//'); \
@@ -97,9 +98,11 @@ $(BUILD_DIR)/tests/auth/%: $(DIR)/% $(BUILD_DIR)/tests/auth/%.attrs $(TESTBINDIR
 			cat $@.log; \
 			echo "# $@.log"; \
 			echo "TESTDIR=$(notdir $@) $(TESTBIN)/unittest -D share -d src/tests/auth/ -i $@.attrs -f $@.attrs -xxx > $@.log 2>&1"; \
+			$(call test_record,auth,$(notdir $@),FAIL,$@.log); \
 			exit 1; \
 		fi \
 	fi
+	@$(call test_record,auth,$(notdir $@),PASS,$@.log)
 	@touch $@
 
 #
@@ -112,7 +115,9 @@ TESTS.AUTH_FILES := $(addprefix $(BUILD_DIR)/tests/auth/,$(AUTH_FILES))
 #
 tests.auth: $(TESTS.AUTH_FILES)
 
+ifeq "$(RECORDING)" ""
 $(TESTS.AUTH_FILES): $(TESTS.KEYWORDS_FILES)
+endif
 
 .PHONY: clean.tests.auth
 clean.tests.auth:

--- a/src/tests/auth/radiusd.conf
+++ b/src/tests/auth/radiusd.conf
@@ -28,7 +28,7 @@ modules {
 
 	$INCLUDE ${raddb}/mods-enabled/digest
 
-	$INCLUDE ${raddb}/mods-enabled/dpsk
+	$-INCLUDE ${raddb}/mods-enabled/dpsk
 }
 
 server default {
@@ -52,6 +52,6 @@ server default {
 		digest
 		pap
 		chap
-		dpsk
+		-dpsk
 	}
 }

--- a/src/tests/keywords/all.mk
+++ b/src/tests/keywords/all.mk
@@ -102,6 +102,7 @@ $(BUILD_DIR)/tests/keywords/%: ${DIR}/% $(BUILD_DIR)/tests/keywords/%.attrs $(TE
 			cat $@.log; \
 			echo "# $@.log"; \
 			echo KEYWORD=$(notdir $@) $(TESTBIN)/unittest -D share -d src/tests/keywords/ -i $@.attrs -f $@.attrs -xx; \
+			$(call test_record,keywords,$(notdir $@),FAIL,$@.log); \
 			exit 1; \
 		fi; \
 		FOUND=$$(grep ^$< $@.log | head -1 | sed 's/:.*//;s/.*\[//;s/\].*//'); \
@@ -110,9 +111,11 @@ $(BUILD_DIR)/tests/keywords/%: ${DIR}/% $(BUILD_DIR)/tests/keywords/%.attrs $(TE
 			cat $@.log; \
 			echo "# $@.log"; \
 			echo KEYWORD=$(notdir $@) $(TESTBIN)/unittest -D share -d src/tests/keywords/ -i $@.attrs -f $@.attrs -xx; \
+			$(call test_record,keywords,$(notdir $@),FAIL,$@.log); \
 			exit 1; \
 		fi \
 	fi
+	@$(call test_record,keywords,$(notdir $@),PASS,$@.log)
 	@touch $@
 
 #
@@ -125,7 +128,9 @@ TESTS.KEYWORDS_FILES := $(addprefix $(BUILD_DIR)/tests/keywords/,$(KEYWORD_FILES
 #
 tests.keywords: $(TESTS.KEYWORDS_FILES)
 
+ifeq "$(RECORDING)" ""
 $(TESTS.KEYWORDS_FILES): $(TESTS.XLAT_FILES) $(TESTS.MAP_FILES)
+endif
 
 .PHONY: clean.tests.keywords
 clean.tests.keywords:

--- a/src/tests/modules/test.mk
+++ b/src/tests/modules/test.mk
@@ -57,6 +57,7 @@ $(BUILD_DIR)/tests/modules/%: src/tests/modules/%.unlang $(BUILD_DIR)/tests/modu
 			cat $@.log; \
 			echo "# $@.log"; \
 			echo LANG=C TZ=UTC MODULE_TEST_DIR=$(dir $<) MODULE_TEST_UNLANG=$< $(TESTBIN)/unittest -D share -d src/tests/modules/ -i $@.attrs -f $@.attrs -xx; \
+			$(call test_record,modules,$(lastword $(subst /, ,$(dir $@)))/$(basename $(notdir $@)),FAIL,$@.log); \
 			exit 1; \
 		fi; \
 		FOUND=$$(grep ^$< $@.log | head -1 | sed 's/:.*//;s/.*\[//;s/\].*//'); \
@@ -65,9 +66,11 @@ $(BUILD_DIR)/tests/modules/%: src/tests/modules/%.unlang $(BUILD_DIR)/tests/modu
 			cat $@.log; \
 			echo "# $@.log"; \
 			echo LANG=C TZ=UTC MODULE_TEST_DIR=$(dir $<) MODULE_TEST_UNLANG=$< $(TESTBIN)/unittest -D share -d src/tests/modules/ -i $@.attrs -f $@.attrs -xx; \
+			$(call test_record,modules,$(lastword $(subst /, ,$(dir $@)))/$(basename $(notdir $@)),FAIL,$@.log); \
 			exit 1; \
 		fi \
 	fi
+	@$(call test_record,modules,$(lastword $(subst /, ,$(dir $@)))/$(basename $(notdir $@)),PASS,$@.log)
 	@touch $@
 
 #
@@ -140,7 +143,9 @@ $(foreach x,$(MODULE_ATTRS_NEEDS),$(eval $(call MODULE_COPY_ATTR,$(subst src/,,$
 $(foreach x,$(MODULE_UNLANG),$(eval $(call MODULE_FILE_TARGET,$(patsubst %.unlang,%,$(subst src/,,$x)))))
 $(foreach x,$(MODULE_TESTS),$(eval $(call MODULE_TEST_TARGET,$x)))
 
+ifeq "$(RECORDING)" ""
 $(TESTS.MODULES_FILES): $(TESTS.AUTH_FILES)
+endif
 
 .PHONY: clean.modules.test
 clean.modules.test:

--- a/src/tests/sql_nas_table/all.mk
+++ b/src/tests/sql_nas_table/all.mk
@@ -52,7 +52,7 @@ sql_nas_table_bootstrap:
 $(OUTPUT)/%: $(DIR)/% | $(TEST).radiusd_kill sql_nas_table_bootstrap $(TEST).radiusd_start
 	${Q}echo "SQL_NASTABLE-TEST"
 	${Q}mkdir -p $(dir $@)
-	${Q}[ -f $(dir $@)/radiusd.pid ] || exit 1
+	${Q}if ! [ -f $(dir $@)/radiusd.pid ]; then $(call test_record,sql_nas_table,$(notdir $@),FAIL,); exit 1; fi
 	${Q}if ! $(TESTBIN)/radclient $(ARGV) -xf src/tests/sql_nas_table/auth.txt -D share/ 127.0.0.1:$(PORT) auth $(SECRET) 1> $(SQL_NASTABLE_BUILD_DIR)/radclient.log 2>&1; then \
 		echo "FAILED";                                              \
 		rm -f $(BUILD_DIR)/tests/test.sql_nas_table;		    \
@@ -62,9 +62,10 @@ $(OUTPUT)/%: $(DIR)/% | $(TEST).radiusd_kill sql_nas_table_bootstrap $(TEST).rad
 		echo ==============================;			    \
 		echo "RADIUSD:   $(RADIUSD_RUN)";                           \
 		echo "SQL_NASTABLE: $(TESTBIN)/radclient $(ARGV) -f $< -xF -d src/tests/sql_nas_table/config -D share/ 127.0.0.1:$(PORT) auth $(SECRET)"; \
+		$(call test_record,sql_nas_table,$(notdir $@),FAIL,$(SQL_NASTABLE_BUILD_DIR)/radclient.log); \
 		exit 1;                                                     \
 	fi
-
+	${Q}$(call test_record,sql_nas_table,$(notdir $@),PASS,$(SQL_NASTABLE_BUILD_DIR)/radclient.log)
 	${Q}touch $@
 
 $(TEST):

--- a/src/tests/test_record.mk
+++ b/src/tests/test_record.mk
@@ -1,0 +1,17 @@
+#
+#  Per-test result recorder.  Invoked from individual test recipes as:
+#
+#      $(call test_record,<category>,<name>,<status>,<logfile>)
+#
+#  Activated by touching $(BUILD_DIR)/tests/results.tsv
+#
+
+BUILD_DIR   ?= $(top_builddir)/build
+RESULTS_TSV ?= $(BUILD_DIR)/tests/results.tsv
+
+#  When the TSV exists, recording is on AND categories run independently
+#  (the inter-category file deps are skipped) so make -k can collect every
+#  test result instead of stopping at the first failed phase.
+RECORDING := $(wildcard $(RESULTS_TSV))
+
+test_record = [ -e $(RESULTS_TSV) ] && printf '%s\t%s\t%s\t%s\n' '$(1)' '$(2)' '$(3)' '$(4)' >> $(RESULTS_TSV) || true

--- a/src/tests/unit/all.mk
+++ b/src/tests/unit/all.mk
@@ -36,10 +36,13 @@ $(BUILD_DIR)/share/dictionary: $(top_srcdir)/share/dictionary $(top_srcdir)/shar
 #
 $(BUILD_DIR)/tests/unit/%: $(DIR)/% $(BUILD_DIR)/bin/radattr $(TESTBINDIR)/radattr $(BUILD_DIR)/share/dictionary | $(BUILD_DIR)/tests/unit
 	@echo UNIT-TEST $(notdir $@)
-	@if ! $(TESTBIN)/radattr -D $(BUILD_DIR)/share $<; then \
+	@if ! $(TESTBIN)/radattr -D $(BUILD_DIR)/share $< > $@.log 2>&1; then \
+		cat $@.log; \
 		echo "$(TESTBIN)/radattr -D $(BUILD_DIR)/share $<"; \
+		$(call test_record,unit,$(notdir $@),FAIL,$@.log); \
 		exit 1; \
 	fi
+	@$(call test_record,unit,$(notdir $@),PASS,$@.log)
 	@touch $@
 
 #

--- a/src/tests/xlat/all.mk
+++ b/src/tests/xlat/all.mk
@@ -36,8 +36,10 @@ $(BUILD_DIR)/tests/xlat/%: $(DIR)/% $(TESTBINDIR)/unittest | $(BUILD_DIR)/tests/
 	@if ! $(TESTBIN)/unittest -D share -d src/tests/xlat/ -i $< -xx -O xlat_only > $@.log 2>&1; then \
 		cat $@.log; \
 		echo "./$(TESTBIN)/unittest -D share -d src/tests/xlat/ -i $< -xx -O xlat_only"; \
+		$(call test_record,xlat,$(notdir $@),FAIL,$@.log); \
 		exit 1; \
 	fi
+	@$(call test_record,xlat,$(notdir $@),PASS,$@.log)
 	@touch $@
 
 #
@@ -50,7 +52,9 @@ TESTS.XLAT_FILES := $(addprefix $(BUILD_DIR)/tests/xlat/,$(XLAT_FILES))
 #
 tests.xlat: $(TESTS.XLAT_FILES)
 
+ifeq "$(RECORDING)" ""
 $(TESTS.XLAT_FILES): $(TESTS.UNIT_FILES)
+endif
 
 .PHONY: clean.tests.xlat
 clean.tests.xlat:


### PR DESCRIPTION
Runs all test, rather than stopping at first failure.

Reports failures in CI job summary:
- Pass/fail matrix
- Failure log extracts
- Full failure logs packaged as a downloadable assets

Example report here: https://github.com/terryburton/freeradius-server/actions/runs/25172640608