### PR TITLE
updated valgrind.h path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1061,7 +1061,7 @@ AC_CHECK_HEADERS( \
   utime.h \
   utmp.h \
   utmpx.h \
-  valgrind.h
+  valgrind/valgrind.h
 )
 
 dnl #

--- a/src/lib/server/dependency.c
+++ b/src/lib/server/dependency.c
@@ -54,8 +54,8 @@ static CONF_SECTION *default_version_cs;		//!< Default configuration section to 
 #  include <gperftools/profiler.h>
 #endif
 
-#ifdef HAVE_VALGRIND_H
-#  include <valgrind.h>
+#ifdef HAVE_VALGRIND_VALGRIND_H
+#  include <valgrind/valgrind.h>
 #endif
 
 /** Check if the application linking to the library has the correct magic number

--- a/src/lib/util/dl.c
+++ b/src/lib/util/dl.c
@@ -34,8 +34,8 @@ RCSID("$Id$")
 #include <freeradius-devel/util/syserror.h>
 
 
-#ifdef HAVE_VALGRIND_H
-#  include <valgrind.h>
+#ifdef HAVE_VALGRIND_VALGRIND_H
+#  include <valgrind/valgrind.h>
 #else
 #  define RUNNING_ON_VALGRIND 0
 #endif


### PR DESCRIPTION
Updates to the valgrind.h header file based on testing with new profiling build from [https://github.com/marc-casavant/freeradius-server/tree/new-profiling-image-build](https://github.com/marc-casavant/freeradius-server/tree/new-profiling-image-build)