### PR TITLE
protocols/der: unblock fuzzing harness by removing tautology

### DIFF
--- a/src/protocols/der/decode.c
+++ b/src/protocols/der/decode.c
@@ -2689,10 +2689,10 @@ static ssize_t fr_der_decode_proto(TALLOC_CTX *ctx, fr_pair_list_t *out, uint8_t
 {
 	fr_dbuff_t our_in = FR_DBUFF_TMP(data, data_len);
 
-	fr_dict_attr_t const *parent = fr_dict_root(dict_der);
+	fr_dict_attr_t const *parent = fr_dict_attr_by_name(NULL, fr_dict_root(dict_der), "Certificate");
 
-	if (unlikely(parent == fr_dict_root(dict_der))) {
-		fr_strerror_printf_push("Invalid dictionary. DER decoding requires a specific dictionary.");
+	if (unlikely(parent == NULL)) {
+		fr_strerror_printf_push("DER fuzzing: Certificate attribute not found in der dictionary");
 		return -1;
 	}
 

--- a/src/protocols/der/decode.c
+++ b/src/protocols/der/decode.c
@@ -2692,7 +2692,7 @@ static ssize_t fr_der_decode_proto(TALLOC_CTX *ctx, fr_pair_list_t *out, uint8_t
 	fr_dict_attr_t const *parent = fr_dict_attr_by_name(NULL, fr_dict_root(dict_der), "Certificate");
 
 	if (unlikely(parent == NULL)) {
-		fr_strerror_printf_push("DER fuzzing: Certificate attribute not found in der dictionary");
+		fr_strerror_printf_push("Invalid dictionary. DER decoding requires a specific dictionary.");
 		return -1;
 	}
 


### PR DESCRIPTION
The fuzzing harness is currently blocked due to a conditional tautology. Coverage report shows no actual fuzzing of the der decoding logic: https://storage.googleapis.com/oss-fuzz-coverage/freeradius/reports/20260513/linux/src/freeradius-server/src/protocols/der/decode.c.html#L2694

This fixes it.