### PR TITLE
TEAP: optional method support for Windows 11

### DIFF
--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -1228,6 +1228,11 @@ eap {
 		#  chosen identity.  You can set &session-state:FreeRADIUS-EAP-TEAP-TLV-Identity-Type
 		#  manually, but doing that is substantially more complicated.
 		#
+		#  &session-state:TEAP-Type-{Machine,User} will be set
+		#  with the EAP type used (set to 'NAK' if skipped and
+		#  'None' for Basic Password Authentication) as each
+		#  method completes allowing you to determine with
+		#  unlang within post-auth what happened.
 	#	identity_types = "machine,user"
 
 		#

--- a/raddb/mods-available/eap
+++ b/raddb/mods-available/eap
@@ -825,7 +825,7 @@ eap {
 		#  WARNING: This configuration should only be used
 		#  when the users are placed into a "captive portal"
 		#  or "walled garden", where they have limited network
-		#  access.  Otherwise the configuraton will allow
+		#  access.  Otherwise the configuration will allow
 		#  anyone on the network, without authenticating them!
 		#
 #		configurable_client_cert = no
@@ -1109,7 +1109,7 @@ eap {
 		#  'cipher_list' configuration from the 'tls-common'
 		#  configuration.  The EAP-FAST module has it's own
 		#  over-ride for 'cipher_list' because the
-		#  specifications mandata a different set of ciphers
+		#  specifications mandate a different set of ciphers
 		#  than are used by the other EAP methods.
 		#
 		#  cipher_list though must include "ADH" for anonymous provisioning.
@@ -1148,16 +1148,137 @@ eap {
 	#
 	#  The TEAP module implements the EAP-TEAP protocol
 	#
-	#  Note that for Windows:
+	#  #### Notes regarding Microsoft Windows 11 ####
 	#
-	#  * "machine" authentication is ALWAYS EAP-TLS.
-	#  * "user" authentication is almost always EAP-MSCHAPv2,
-	#    except when Windows is configured for "smartcard"
-	#    authentication.
+	#  This supplicant is *extremely* temperamental, seemingly across
+	#  all EAP methods but especially so for TEAP.
 	#
-	#  If you configure FreeRADIUS to do anything else, then
-	#  Windows will either fail, or will just return one of the
-	#  methods listed above.
+	#  We cannot help you here in configuration of Windows other than
+	#  to provide an account of our observations with a stock, non-updated
+	#  Windows 11 25H2 install with the usual caveat "your mileage may vary".
+	#
+	#  By not configuring Microsoft Windows 11 or FreeRADIUS in accordance
+	#  to the observations listed here, then TEAP is unlikely to work.
+	#
+	#   * We found the new style 802.1X UI is unusable and you should
+	#     use the old UI; found by searching for 'View network connections'
+	#     using the search bar, right clicking on your network interface,
+	#     selecting 'Properties' and then go to the 'Authentication' tab.
+	#
+	#   * You are not able to configure the supplicant to skip verifying
+	#     the CA or server name, they both should be configured.
+	#
+	#   * Due to a bug known to Microsoft since 2022, when using wired
+	#     802.1X you may find no traffic is sent to the RADIUS server,
+	#     this can be resolved by disabling and re-enabling the interface.
+	#
+	#   * 'machine' authentication is ALWAYS EAP-TLS; if you set EAP-MSCHAPv2
+	#     the authentication starts, but the identity used is for the machine
+	#     whilst the credentials come from some non-interactive process.
+	#
+	#   * 'user' authentication is almost always EAP-MSCHAPv2 or if EAP-TLS
+	#     then a 'smartcard'; which can (in theory) be Windows Hello.
+	#
+	#   * For user based authentication, the 'Sign in' button may not
+	#     appear or stop functioning resulting in no further RADIUS
+	#     traffic. The workaround we found was to close completely the
+	#     new UI page and let the 'Sign in' toast popup open the UI.
+	#
+	#     Failing this, make sure you have checked 'Fall-back to
+	#     unauthorized network access', otherwise you may never see the
+	#     'Sign in' button or toast popup window to enter credentials; as
+	#     such we recommend you leave this enabled.
+	#
+	#   * Interactive authentications (such as EAP-MSCHAPv2) can lead to
+	#     the credentials prompt, but after providing your credentials
+	#     Windows does not send them to your RADIUS server. If this
+	#     happens, disable and re-enable your network interface.
+	#
+	#   * If you wish to use both EAP-TLS for machine and user authentication
+	#     you will need to configure one of the methods to use a Smartcard.
+	#
+	#      - Attempting to use an installed client certificate seemingly
+	#        stalls from the perspective of the user but for the RADIUS
+	#        server it receives a non-standard empty EAP identity and
+	#        responds with an Access-Reject.
+	#
+	#      - After selecting the Smartcard identity to use, Windows
+	#        may immediately claim authentication failed but send
+	#        no traffic to the RADIUS server. To resolve this, re-insert
+	#        your Smartcard.
+	#
+	#      - We have only tested this using QEMU's CCID emulation and
+	#        with the Smartcard functionality in UNIX 'spicy' client.
+	#
+	#   * The configuration of the methods used must match the value you
+	#     set 'identity_types' below to.
+	#
+	#     If you use 'none' as the secondary method then you must set
+	#     'identity_types' to a single value; using optional methods
+	#     for 'identity_types' will lead to an authentication failure
+	#     as Windows will send to the RADIUS server with Unexpected-TLVs
+	#
+	#     For Windows, though the language 'primary' and 'secondary'
+	#     imply preference, the implementation is in fact ordering based.
+	#
+	#     The order you provide to Windows must be the same order of
+	#     methods you set in 'identity_types' and the values you use
+	#     for machine_eap_type and user_eap_type.
+	#
+	#   * The value used for 'Specify authentication mode', which is found
+	#     under 'Additional settings', must be appropriately set for the
+	#     value of 'identity_types' you want to use below:
+	#
+	#      - unchecked leads to automatic detection and selection of
+	#        one of the following settings. It often incorrectly
+	#        selects something you do not desire, especially when
+	#        optional methods are in use.
+	#
+	#      - User or computer authentication:
+	#
+	#         * Supports 'machine,user' and 'user,machine'
+	#
+	#      - Computer authentication
+	#
+	#         * Supports 'machine'
+	#
+	#         * Supports 'machine,?user' if you have a dummy EAP-MSCHAPv2
+	#           secondary method configured on Windows
+	#
+	#         * Does not support '?user,machine'
+	#
+	#      - User authentication
+	#
+	#         * Supports 'user'
+	#
+	#         * Supports 'user,?machine' if you have a dummy EAP-TLS
+	#           secondary method configured on Windows
+	#
+	#         * Does not support '?machine,user'
+	#
+	#      - Guest authentication
+	#
+	#         * Unsupported (assumed to mean use "no inner methods")
+	#           as it Windows sends to the RADIUS server a non-compliant
+	#           zero length EAP-Identity before TEAP is negotiated.
+	#
+	#   * EAP-TLS followed by either EAP-TLS or EAP-MSCHAPv2 is supported
+	#
+	#      - EAP-MSCHAPv2 followed by EAP-TLS is unsupported (see RFC 9930,
+	#        sections 5.1 and 6.2.5, and leads to Tunnel-Compromise).
+	#
+	#   * When selecting the the 'primary' and 'secondary' EAP methods in
+	#     Windows to use they must match your configuration here for
+	#     'user_eap_type' and 'machine_eap_type' with the constraint:
+	#
+	#      - 'machine' can be EAP-TLS with 'Use a certificate on this computer'
+	#
+	#      - 'user' may be EAP-MSCHAPV2 or EAP-TLS with 'Use my smart card'
+	#
+	#         * It may be possible to use Windows Hello here to provide
+	#           a non-smartcard EAP-TLS (ie. TPM) secured certificate
+	#
+	#  ##############################################
 	#
 	#teap {
 		#  Point to the common TLS configuration
@@ -1233,6 +1354,7 @@ eap {
 		#  'None' for Basic Password Authentication) as each
 		#  method completes allowing you to determine with
 		#  unlang within post-auth what happened.
+		#
 	#	identity_types = "machine,user"
 
 		#
@@ -1289,7 +1411,7 @@ eap {
 		#  'cipher_list' configuration from the 'tls-common'
 		#  configuration.  The EAP-TEAP module has it's own
 		#  over-ride for 'cipher_list' because the
-		#  specifications mandata a different set of ciphers
+		#  specifications mandate a different set of ciphers
 		#  than are used by the other EAP methods.
 		#
 		#  cipher_list though must include "ADH" for anonymous provisioning.

--- a/src/modules/rlm_eap/types/rlm_eap_teap/eap_teap.c
+++ b/src/modules/rlm_eap/types/rlm_eap_teap/eap_teap.c
@@ -93,6 +93,7 @@ static void eap_teap_derive_imck(REQUEST *request, tls_session_t *tls_session,
 {
 	teap_tunnel_t *t = tls_session->opaque;
 
+	t->imck_emsk_available = emsklen > 0;
 	t->imckc++;
 	RDEBUG2("Phase 2: Calculating ICMK for round (j = %d)", t->imckc);
 
@@ -264,9 +265,7 @@ static void eap_teap_append_eap_identity_request(REQUEST *request, tls_session_t
  * so just do what hostapd does...which the IETF probably agree with anyway:
  * https://mailarchive.ietf.org/arch/msg/emu/mXzpSGEn86Zx_fa4f1uULYMhMoM/
  */
-static void eap_teap_append_crypto_binding(REQUEST *request, tls_session_t *tls_session,
-					   uint8_t *msk, size_t msklen,
-					   uint8_t *emsk, size_t emsklen)
+static void eap_teap_append_crypto_binding(REQUEST *request, tls_session_t *tls_session)
 {
 	teap_tunnel_t			*t = tls_session->opaque;
 	uint8_t				mac_msk[EVP_MAX_MD_SIZE], mac_emsk[EVP_MAX_MD_SIZE];
@@ -275,10 +274,6 @@ static void eap_teap_append_crypto_binding(REQUEST *request, tls_session_t *tls_
 	size_t				olen, buflen;
 	struct crypto_binding_buffer	*cbb;
 	uint8_t				*outer_tlvs;
-
-	eap_teap_derive_imck(request, tls_session, msk, msklen, emsk, emsklen);
-
-	t->imck_emsk_available = emsklen > 0;
 
 	olen = tls_session->outer_tlvs_octets_server ? talloc_array_length(tls_session->outer_tlvs_octets_server) : 0;
 	olen += tls_session->outer_tlvs_octets_peer ? talloc_array_length(tls_session->outer_tlvs_octets_peer) : 0;
@@ -294,9 +289,9 @@ static void eap_teap_append_crypto_binding(REQUEST *request, tls_session_t *tls_
 	cbb->binding.version = EAP_TEAP_VERSION;
 	cbb->binding.received_version = t->received_version;
 
-	cbb->binding.subtype = ((emsklen ? EAP_TEAP_TLV_CRYPTO_BINDING_FLAGS_CMAC_BOTH : EAP_TEAP_TLV_CRYPTO_BINDING_FLAGS_CMAC_MSK) << 4) | EAP_TEAP_TLV_CRYPTO_BINDING_SUBTYPE_REQUEST;
+	cbb->binding.subtype = ((t->imck_emsk_available ? EAP_TEAP_TLV_CRYPTO_BINDING_FLAGS_CMAC_BOTH : EAP_TEAP_TLV_CRYPTO_BINDING_FLAGS_CMAC_MSK) << 4) | EAP_TEAP_TLV_CRYPTO_BINDING_SUBTYPE_REQUEST;
 
-	RDEBUG("Phase 2: Sending Crypto-Binding Flags=%d", emsklen ? EAP_TEAP_TLV_CRYPTO_BINDING_FLAGS_CMAC_BOTH : EAP_TEAP_TLV_CRYPTO_BINDING_FLAGS_CMAC_MSK);
+	RDEBUG("Phase 2: Sending Crypto-Binding Flags=%d", t->imck_emsk_available ? EAP_TEAP_TLV_CRYPTO_BINDING_FLAGS_CMAC_BOTH : EAP_TEAP_TLV_CRYPTO_BINDING_FLAGS_CMAC_MSK);
 
 	RAND_bytes(cbb->binding.nonce, sizeof(cbb->binding.nonce));
 	cbb->binding.nonce[sizeof(cbb->binding.nonce) - 1] &= ~0x01; /* RFC 7170, Section 4.2.13 */
@@ -1053,8 +1048,14 @@ static rlm_rcode_t CC_HINT(nonnull) process_reply(eap_handler_t *eap_session,
 			fr_pair_delete_by_num(&reply->vps, PW_EAP_SESSION_ID, 0, TAG_ANY);
 		}
 
+		// RFC7170 section 5.2 and 5.4, only on a successful inner EAP method do we increment
+		// NOTE: hostapd for now incorrectly derives IMCK when an EAP method is skipped so this
+		//       allows interop with Windows but not with wpa_supplicant
+		if ((msk1 && msk2) || emsklen) eap_teap_derive_imck(request, tls_session, msk, msklen, emsk, emsklen);
+
+		eap_teap_append_crypto_binding(request, tls_session);
+
 		eap_teap_append_result(request, tls_session, reply->code);
-		eap_teap_append_crypto_binding(request, tls_session, msk, msklen, emsk, emsklen);
 
 		vp = fr_pair_find_by_num(request->state, PW_EAP_TEAP_TLV_IDENTITY_TYPE, VENDORPEC_FREERADIUS, TAG_ANY);
 		if (vp) {
@@ -1108,8 +1109,9 @@ static rlm_rcode_t CC_HINT(nonnull) process_reply(eap_handler_t *eap_session,
 
 		RDEBUG("Phase 2: All inner authentications have succeeded");
 
-		t->result_final = true;
 		t->sent_basic_password = false;
+
+		t->result_final = true;
 		eap_teap_append_result(request, tls_session, reply->code);
 
 		tls_session->authentication_success = true;

--- a/src/modules/rlm_eap/types/rlm_eap_teap/eap_teap.c
+++ b/src/modules/rlm_eap/types/rlm_eap_teap/eap_teap.c
@@ -22,6 +22,12 @@ RCSID("$Id$")
 #include <openssl/ssl.h>
 #include <openssl/rand.h>
 
+/*
+ * TEAP-Type-{Machine,User} values from dictionary.freeradius.internal
+ */
+#define TEAP_TYPE_NONE		0
+#define TEAP_TYPE_NAK		3
+
 #define EAPTLS_MPPE_KEY_LEN 32
 
 #define RDEBUGHEX(_label, _data, _length) \
@@ -207,6 +213,11 @@ static void eap_teap_append_identity_type(REQUEST *request, tls_session_t *tls_s
 	 *      We can send something, even if it isn't required.
 	 */
 	t->identity_types[value].sent = true;
+
+	/*
+	 *	We use this to populate &session-state:TEAP-Type-{Machine,User}
+	 */
+	t->identity_type = value;
 
 	eap_teap_tlv_append(request, tls_session, EAP_TEAP_TLV_IDENTITY_TYPE, false, sizeof(identity), &identity);
 }
@@ -1062,6 +1073,8 @@ static rlm_rcode_t CC_HINT(nonnull) process_reply(eap_handler_t *eap_session,
 			talloc_free(t->username);
 			t->username = NULL;
 
+			t->sent_basic_password = false;
+
 			/* RFC7170, Appendix C.6 */
 			eap_teap_append_identity_type(request, tls_session, vp->vp_short);
 			sent_identity_type = true;
@@ -1078,7 +1091,9 @@ static rlm_rcode_t CC_HINT(nonnull) process_reply(eap_handler_t *eap_session,
 
 				vp = fr_pair_afrom_num(reply, PW_EAP_TEAP_TLV_BASIC_PASSWORD_AUTH_REQ, VENDORPEC_FREERADIUS);
 				if (vp) {
+					RDEBUG("Phase 2: Sending Basic-Password-Auth-Req");
 					fr_pair_add(&reply->vps, vp);
+					t->sent_basic_password = true;
 				} else {
 					RERROR("Failed adding attribute &reply:FreeRADIUS-EAP-TEAP-Basic-Password-Auth-Req");
 					goto fail;
@@ -1184,13 +1199,12 @@ static PW_CODE eap_teap_phase2(REQUEST *request, eap_handler_t *eap_session,
 {
 	PW_CODE			code = PW_CODE_ACCESS_REJECT;
 	rlm_rcode_t		rcode;
-	VALUE_PAIR		*vp;
-	teap_tunnel_t		*t;
+	VALUE_PAIR		*tvp;
+	teap_tunnel_t		*t = (teap_tunnel_t *)tls_session->opaque;
 	int			eap_method = 0;
+	uint16_t		result_attr = t->identity_type == EAP_TEAP_IDENTITY_TYPE_MACHINE ? PW_TEAP_TYPE_MACHINE : PW_TEAP_TYPE_USER;
 
 	RDEBUG3("Phase 2: Processing received EAP Payload");
-
-	t = (teap_tunnel_t *) tls_session->opaque;
 
 	RDEBUG("Phase 2: Got tunneled request");
 	rdebug_pair_list(L_DBG_LVL_1, request, fake->packet->vps, NULL);
@@ -1205,19 +1219,19 @@ static PW_CODE eap_teap_phase2(REQUEST *request, eap_handler_t *eap_session,
 	 * an EAP-Identity, and pull it out of there.
 	 */
 	if (!t->username) {
-		vp = fr_pair_find_by_num(fake->packet->vps, PW_EAP_MESSAGE, 0, TAG_ANY);
-		if (vp &&
-		    (vp->vp_length >= EAP_HEADER_LEN + 2) &&
-		    (vp->vp_strvalue[0] == PW_EAP_RESPONSE) &&
-		    (vp->vp_strvalue[EAP_HEADER_LEN] == PW_EAP_IDENTITY) &&
-		    (vp->vp_strvalue[EAP_HEADER_LEN + 1] != 0)) {
+		tvp = fr_pair_find_by_num(fake->packet->vps, PW_EAP_MESSAGE, 0, TAG_ANY);
+		if (tvp &&
+		    (tvp->vp_length >= EAP_HEADER_LEN + 2) &&
+		    (tvp->vp_strvalue[0] == PW_EAP_RESPONSE) &&
+		    (tvp->vp_strvalue[EAP_HEADER_LEN] == PW_EAP_IDENTITY) &&
+		    (tvp->vp_strvalue[EAP_HEADER_LEN + 1] != 0)) {
 			/*
 			 * Create & remember a User-Name
 			 */
 			t->username = fr_pair_make(t, NULL, "User-Name", NULL, T_OP_EQ);
 			rad_assert(t->username != NULL);
 
-			fr_pair_value_bstrncpy(t->username, vp->vp_octets + 5, vp->vp_length - 5);
+			fr_pair_value_bstrncpy(t->username, tvp->vp_octets + 5, tvp->vp_length - 5);
 
 			RDEBUG("Phase 2: Got tunneled identity of %s", t->username->vp_strvalue);
 
@@ -1232,21 +1246,23 @@ static PW_CODE eap_teap_phase2(REQUEST *request, eap_handler_t *eap_session,
 	} /* else there WAS a t->username */
 
 	if (t->username && !fake->username) {
-		vp = fr_pair_list_copy(fake->packet, t->username);
-		fr_pair_add(&fake->packet->vps, vp);
-		fake->username = vp;
+		tvp = fr_pair_list_copy(fake->packet, t->username);
+		if (tvp) {
+			fr_pair_add(&fake->packet->vps, tvp);
+			fake->username = tvp;
+		}
 	}
 
 	/*
 	 *	Add the State attribute, too, if it exists.
 	 */
 	if (t->state) {
-		vp = fr_pair_list_copy(fake->packet, t->state);
-		if (vp) fr_pair_add(&fake->packet->vps, vp);
+		tvp = fr_pair_list_copy(fake->packet, t->state);
+		if (tvp) fr_pair_add(&fake->packet->vps, tvp);
 	}
 
 	if (t->stage == AUTHENTICATION) {
-		VALUE_PAIR *tvp;
+		VALUE_PAIR *vp;
 
 		eap_method = t->default_method;
 
@@ -1263,8 +1279,7 @@ static PW_CODE eap_teap_phase2(REQUEST *request, eap_handler_t *eap_session,
 		}
 
 		if (vp) {
-			VALUE_PAIR *vp_config, *teap_type;
-
+			VALUE_PAIR *vp_config;
 repeat:
 			vp_config = fr_pair_find_by_num(request->state, PW_EAP_TEAP_TLV_IDENTITY_TYPE, VENDORPEC_FREERADIUS, TAG_ANY);
 
@@ -1274,7 +1289,7 @@ repeat:
 			}
 
 			if (vp_config) {
-				const char *identity_type = vp_config->vp_short == EAP_TEAP_IDENTITY_TYPE_USER ? "User" : "Machine";
+				const char *identity_type_str = vp_config->vp_short == EAP_TEAP_IDENTITY_TYPE_USER ? "User" : "Machine";
 				uint16_t identity_type_requested = vp_config->vp_short;
 
 				/*
@@ -1286,7 +1301,7 @@ repeat:
 				if (t->identity_types[identity_type_requested].sent &&
 				    (vp->vp_short != identity_type_requested)) {
 					if (t->identity_types[identity_type_requested].required) {
-						REDEBUG("Phase 2: We sent Identity-Type = %s, but the supplicant did not use that method - rejecting the session", identity_type);
+						REDEBUG("Phase 2: We sent Identity-Type = %s, but the supplicant did not use that method - rejecting the session", identity_type_str);
 fail:
 						vp = fr_pair_afrom_num(fake, PW_AUTH_TYPE, 0);
 						if (vp) {
@@ -1296,9 +1311,16 @@ fail:
 						goto done;
 					}
 
-					RWDEBUG("Phase 2: We sent Identity-Type = %s, but the supplicant did not use that method - skipping optional method", identity_type);
-					RDEBUG("Phase 2: Deleting &session-state:FreeRADIUS-EAP-TEAP-Identity-Type += %s", identity_type);
+					RWDEBUG("Phase 2: We sent Identity-Type = %s, but the supplicant did not use that method - skipping optional method", identity_type_str);
+					RDEBUG("Phase 2: Deleting &session-state:FreeRADIUS-EAP-TEAP-Identity-Type += %s", identity_type_str);
 					fr_pair_delete(&request->state, vp_config);
+
+					tvp = fr_pair_afrom_num(request->state_ctx, result_attr, 0);
+					if (tvp) {
+						fr_pair_add(&request->state, tvp);
+						tvp->vp_integer = TEAP_TYPE_NAK;
+					}
+
 					goto repeat;
 				}
 
@@ -1329,12 +1351,19 @@ fail:
 						goto fail;
 					}
 
-					RWDEBUG("Phase 2: We sent Identity-Type = %s, but the supplicant did not send any authentication material - skipping optional method", identity_type);
+					RWDEBUG("Phase 2: We sent Identity-Type = %s, but the supplicant did not send any authentication material - skipping optional method", identity_type_str);
 					vp = fr_pair_afrom_num(fake, PW_AUTH_TYPE, 0);
 					if (vp) {
 						fr_pair_add(&fake->config, vp);
 						vp->vp_integer = PW_AUTH_TYPE_ACCEPT;
 					}
+
+					tvp = fr_pair_afrom_num(request->state_ctx, result_attr, 0);
+					if (tvp) {
+						fr_pair_add(&request->state, tvp);
+						tvp->vp_integer = TEAP_TYPE_NAK;
+					}
+
 					goto done;
 				}
 			}
@@ -1357,9 +1386,9 @@ fail:
 			 *		* otherwise ???
 			 */
 			if (vp->vp_short == EAP_TEAP_IDENTITY_TYPE_USER) {
-				teap_type = fr_pair_find_by_num(request->state, PW_TEAP_TYPE_USER, 0, TAG_ANY);
-				if (teap_type) {
-					eap_method = teap_type->vp_integer;
+				tvp = fr_pair_find_by_num(request->state, PW_TEAP_TYPE_USER, 0, TAG_ANY);
+				if (tvp) {
+					eap_method = tvp->vp_integer;
 
 					RDEBUG("Phase 2: Setting User EAP-Type = %s from &config:TEAP-Type-User",
 					       eap_type2name(eap_method));
@@ -1383,9 +1412,9 @@ fail:
 			}
 
 			if (vp->vp_short == EAP_TEAP_IDENTITY_TYPE_MACHINE) {
-				teap_type = fr_pair_find_by_num(request->state, PW_TEAP_TYPE_MACHINE, 0, TAG_ANY);
-				if (teap_type) {
-					eap_method = teap_type->vp_integer;
+				tvp = fr_pair_find_by_num(request->state, PW_TEAP_TYPE_MACHINE, 0, TAG_ANY);
+				if (tvp) {
+					eap_method = tvp->vp_integer;
 
 					RDEBUG("Phase 2: Setting Machine EAP-Type = %s from &config:TEAP-Type-Machine",
 					       eap_type2name(eap_method));
@@ -1416,12 +1445,16 @@ fail:
 			 */
 			if (eap_method == PW_EAP_MSCHAPV2 && t->mode == EAP_TEAP_PROVISIONING_ANON) {
 				tvp = fr_pair_afrom_num(fake, PW_MSCHAP_CHALLENGE, VENDORPEC_MICROSOFT);
-				//fr_pair_value_memcpy(tvp, t->keyblock->server_challenge, CHAP_VALUE_LENGTH);
-				fr_pair_add(&fake->config, tvp);
+				if (tvp) {
+					//fr_pair_value_memcpy(tvp, t->keyblock->server_challenge, CHAP_VALUE_LENGTH);
+					fr_pair_add(&fake->config, tvp);
+				}
 
 				tvp = fr_pair_afrom_num(fake, PW_MS_CHAP_PEER_CHALLENGE, 0);
-				//fr_pair_value_memcpy(tvp, t->keyblock->client_challenge, CHAP_VALUE_LENGTH);
-				fr_pair_add(&fake->config, tvp);
+				if (tvp) {
+					//fr_pair_value_memcpy(tvp, t->keyblock->client_challenge, CHAP_VALUE_LENGTH);
+					fr_pair_add(&fake->config, tvp);
+				}
 			}
 
 			/*
@@ -1445,8 +1478,8 @@ done:
 		eapteap_copy_request_to_tunnel(request, fake);
 	}
 
-	if ((vp = fr_pair_find_by_num(request->config, PW_VIRTUAL_SERVER, 0, TAG_ANY)) != NULL) {
-		fake->server = vp->vp_strvalue;
+	if ((tvp = fr_pair_find_by_num(request->config, PW_VIRTUAL_SERVER, 0, TAG_ANY)) != NULL) {
+		fake->server = tvp->vp_strvalue;
 
 	} else if (t->virtual_server) {
 		fake->server = t->virtual_server;
@@ -1464,8 +1497,8 @@ done:
 	 */
 	switch (fake->reply->code) {
 	case 0:
-		vp = fr_pair_find_by_num(fake->config, PW_RESPONSE_PACKET_TYPE, 0, TAG_ANY);
-		if (vp && (vp->vp_integer == PW_CODE_ACCESS_CHALLENGE)) {
+		tvp = fr_pair_find_by_num(fake->config, PW_RESPONSE_PACKET_TYPE, 0, TAG_ANY);
+		if (tvp && (tvp->vp_integer == PW_CODE_ACCESS_CHALLENGE)) {
 			fake->reply->code = PW_CODE_ACCESS_CHALLENGE;
 			goto do_reply;
 		}
@@ -1473,6 +1506,18 @@ done:
 		RDEBUG("Phase 2: No tunneled reply was found, rejecting the user.");
 		code = PW_CODE_ACCESS_REJECT;
 		break;
+
+	case PW_CODE_ACCESS_ACCEPT:
+		tvp = fr_pair_find_by_num(fake->packet->vps, PW_EAP_TYPE, 0, TAG_ANY);
+		if (tvp) {
+			eap_method = tvp->vp_integer;
+			tvp = fr_pair_afrom_num(request->state_ctx, result_attr, 0);
+			if (tvp) {
+				fr_pair_add(&request->state, tvp);
+				tvp->vp_integer = t->sent_basic_password ? TEAP_TYPE_NONE : eap_method;
+			}
+		}
+		/* FALL-THROUGH */
 
 	default:
 	do_reply:

--- a/src/modules/rlm_eap/types/rlm_eap_teap/eap_teap.c
+++ b/src/modules/rlm_eap/types/rlm_eap_teap/eap_teap.c
@@ -942,7 +942,6 @@ static rlm_rcode_t CC_HINT(nonnull) process_reply(eap_handler_t *eap_session,
 	case PW_CODE_ACCESS_ACCEPT:
 		RDEBUG("Phase 2: Got tunneled Access-Accept");
 		msk1 = msk2 = false;
-		t->authenticated = true;
 
 		for (vp = fr_cursor_init(&cursor, &reply->vps); vp; vp = fr_cursor_next(&cursor)) {
 			if (vp->da->vendor == 0) {
@@ -1038,6 +1037,7 @@ static rlm_rcode_t CC_HINT(nonnull) process_reply(eap_handler_t *eap_session,
 				break;
 			}
 		}
+		if ((msk1 && msk2) || emsklen || t->sent_basic_password) t->authenticated = true;
 
 		if (t->use_tunneled_reply) {
 			/*
@@ -1048,14 +1048,30 @@ static rlm_rcode_t CC_HINT(nonnull) process_reply(eap_handler_t *eap_session,
 			fr_pair_delete_by_num(&reply->vps, PW_EAP_SESSION_ID, 0, TAG_ANY);
 		}
 
-		// RFC7170 section 5.2 and 5.4, only on a successful inner EAP method do we increment
-		// NOTE: hostapd for now incorrectly derives IMCK when an EAP method is skipped so this
-		//       allows interop with Windows but not with wpa_supplicant
-		if ((msk1 && msk2) || emsklen) eap_teap_derive_imck(request, tls_session, msk, msklen, emsk, emsklen);
+		/*
+		 * RFC7170 section 5.2 and 5.4, only on a successful inner EAP method do we increment
+		 *
+		 * NOTE: hostapd for now incorrectly derives IMCK when an EAP method is skipped so this
+		 *       allows interop with Windows but not with wpa_supplicant
+		 */
+		if ((msk1 && msk2) || emsklen) {
+			eap_teap_derive_imck(request, tls_session, msk, msklen, emsk, emsklen);
+		}
 
-		eap_teap_append_crypto_binding(request, tls_session);
+		if (t->authenticated) {
+			/*
+			 * When skipping the first round, Windows uses an unknown crypto-binding
+			 * calculation if you send it one. So we do not.
+			 */
+			eap_teap_append_crypto_binding(request, tls_session);
 
-		eap_teap_append_result(request, tls_session, reply->code);
+			/*
+			 * The effect of sending an Intermediate-Result (even failure) causes
+			 * Windows to respond with a Error=Unexpected-TLVs and Result=Failure
+			 * so only send this when we include a crypto-binding.
+			 */
+			eap_teap_append_result(request, tls_session, reply->code);
+		}
 
 		vp = fr_pair_find_by_num(request->state, PW_EAP_TEAP_TLV_IDENTITY_TYPE, VENDORPEC_FREERADIUS, TAG_ANY);
 		if (vp) {
@@ -1282,6 +1298,7 @@ static PW_CODE eap_teap_phase2(REQUEST *request, eap_handler_t *eap_session,
 
 		if (vp) {
 			VALUE_PAIR *vp_config;
+			uint16_t identity_type_received = vp->vp_short;
 repeat:
 			vp_config = fr_pair_find_by_num(request->state, PW_EAP_TEAP_TLV_IDENTITY_TYPE, VENDORPEC_FREERADIUS, TAG_ANY);
 
@@ -1301,7 +1318,7 @@ repeat:
 				 *	response.
 				 */
 				if (t->identity_types[identity_type_requested].sent &&
-				    (vp->vp_short != identity_type_requested)) {
+				    (identity_type_received != identity_type_requested)) {
 					if (t->identity_types[identity_type_requested].required) {
 						REDEBUG("Phase 2: We sent Identity-Type = %s, but the supplicant did not use that method - rejecting the session", identity_type_str);
 fail:
@@ -1338,13 +1355,53 @@ fail:
 				fr_pair_delete(&request->state, vp_config);
 
 				/*
-				 *	wpa_supplicant continues the authentication even when there are no remaining
-				 *	methods configured for it, so we skip only if this is the last round
+				 *	handle differing implementation behaviour around optional methods
 				 */
-				if ((t->identities_remaining == 1) &&
-				    !t->identity_types[identity_type_requested].required &&
-				    !(fr_pair_find_by_num(fake->packet->vps, PW_EAP_MESSAGE, 0, TAG_ANY) ||
-				      fr_pair_find_by_num(fake->packet->vps, PW_USER_PASSWORD, 0, TAG_ANY))) {
+				if (!t->identity_types[identity_type_requested].required) {
+					vp = fr_pair_find_by_num(fake->packet->vps, PW_EAP_MESSAGE, 0, TAG_ANY);
+
+					/*
+					 * wpa_supplicant continues the authentication even when there are no remaining
+					 * methods configured for it but without providing any credentials, so we finish
+					 */
+					if (t->identities_remaining == 1 && !vp &&
+					    !fr_pair_find_by_num(fake->packet->vps, PW_USER_PASSWORD, 0, TAG_ANY)) {
+						RDEBUG("QUIRK: optional inner authentication method workaround for wpa_supplicant");
+						goto quirk_wpa_supplicant;
+					}
+
+					/*
+					 * Win11 returns a non-standard empty (zero length) EAP Identity when it
+					 * does not have suitable credentials for the type being requested. It exhibits
+					 * this behavior for both for the first and second inner methods.
+					 *
+					 * Another observation is moving to the next credential (eg. '?user,machine')
+					 * Windows again returns an empty EAP Identity. It does not seem possible
+					 * to move the authentication beyound this point.
+					 *
+					 * Unfortunately attempting to skip the method causes Windows to return
+					 * Error=Unexpected-TLVs and it also includes a Result=Fail; this seemingly
+					 * is due to our sending of EAP-TEAP-Identity-Type to attempt to start the
+					 * following method.
+					 *
+					 * All this means 'identity_types' may not contain an optional credential for
+					 * the first method (ie. '?machine,user' or '?user,machine') unless you know
+					 * all Windows supplicants are correctly for two inner methods, which then
+					 * makes using an optional method pointless as no other supplicants support
+					 * TEAP (hostapd is behind a 'here be dragons' compile time flag).
+					 */
+					if (vp &&
+					    (vp->vp_length == EAP_HEADER_LEN + 1) &&
+					    (vp->vp_strvalue[0] == PW_EAP_RESPONSE) &&
+					    (vp->vp_strvalue[EAP_HEADER_LEN] == PW_EAP_IDENTITY)) {
+						RDEBUG("QUIRK: optional inner authentication method workaround for Microsoft Windows 11");
+						// prevent Auth-Type=eap being added
+						fr_pair_delete(&fake->packet->vps, vp);
+						goto quirk_win11;
+					}
+
+					goto no_quirk;
+quirk_wpa_supplicant:
 					/*
 					 *	If we didn't have at least one authentication success, we fail.
 					 */
@@ -1353,7 +1410,9 @@ fail:
 						goto fail;
 					}
 
+quirk_win11:
 					RWDEBUG("Phase 2: We sent Identity-Type = %s, but the supplicant did not send any authentication material - skipping optional method", identity_type_str);
+
 					vp = fr_pair_afrom_num(fake, PW_AUTH_TYPE, 0);
 					if (vp) {
 						fr_pair_add(&fake->config, vp);
@@ -1367,12 +1426,17 @@ fail:
 					}
 
 					goto done;
+no_quirk:
+					/*
+					 * hush the C compiler
+					 */
+					(void)0;
 				}
 			}
 			vp_config = NULL;
 
-			if (!t->identity_types[vp->vp_short].received) {
-				t->identity_types[vp->vp_short].received = true;
+			if (!t->identity_types[identity_type_received].received) {
+				t->identity_types[identity_type_received].received = true;
 				if (t->identities_remaining == 0) {
 					RDEBUG("Phase 2: Configured to send too many identities, failing the session");
 					goto fail;
@@ -1387,16 +1451,16 @@ fail:
 			 *		* otherwise default_eap_type
 			 *		* otherwise ???
 			 */
-			if (vp->vp_short == EAP_TEAP_IDENTITY_TYPE_USER) {
-				tvp = fr_pair_find_by_num(request->state, PW_TEAP_TYPE_USER, 0, TAG_ANY);
+			if (identity_type_received == EAP_TEAP_IDENTITY_TYPE_USER) {
+				tvp = fr_pair_find_by_num(request->config, PW_TEAP_TYPE_USER, 0, TAG_ANY);
 				if (tvp) {
 					eap_method = tvp->vp_integer;
 
 					RDEBUG("Phase 2: Setting User EAP-Type = %s from &config:TEAP-Type-User",
 					       eap_type2name(eap_method));
 
-				} else if (t->eap_method[vp->vp_short]) {
-					eap_method = t->eap_method[vp->vp_short];
+				} else if (t->eap_method[identity_type_received]) {
+					eap_method = t->eap_method[identity_type_received];
 
 					RDEBUG("Phase 2: Setting User EAP-Type = %s from TEAP configuration user_eap_type",
 					       eap_type2name(eap_method));
@@ -1413,16 +1477,16 @@ fail:
 				}
 			}
 
-			if (vp->vp_short == EAP_TEAP_IDENTITY_TYPE_MACHINE) {
-				tvp = fr_pair_find_by_num(request->state, PW_TEAP_TYPE_MACHINE, 0, TAG_ANY);
+			if (identity_type_received == EAP_TEAP_IDENTITY_TYPE_MACHINE) {
+				tvp = fr_pair_find_by_num(request->config, PW_TEAP_TYPE_MACHINE, 0, TAG_ANY);
 				if (tvp) {
 					eap_method = tvp->vp_integer;
 
 					RDEBUG("Phase 2: Setting Machine EAP-Type = %s from &config:TEAP-Type-Machine",
 					       eap_type2name(eap_method));
 
-				} else if (t->eap_method[vp->vp_short]) {
-					eap_method = t->eap_method[vp->vp_short];
+				} else if (t->eap_method[identity_type_received]) {
+					eap_method = t->eap_method[identity_type_received];
 
 					RDEBUG("Phase 2: Setting Machine EAP-Type = %s from TEAP configuration machine_eap_type",
 					       eap_type2name(eap_method));

--- a/src/modules/rlm_eap/types/rlm_eap_teap/eap_teap.h
+++ b/src/modules/rlm_eap/types/rlm_eap_teap/eap_teap.h
@@ -130,6 +130,7 @@ typedef struct teap_tunnel_t {
 
 	int			identities_remaining;	//!< how many rounds have we allow
 	teap_auth_t		identity_types[3];	//!< index is identity type (user=1 or machine=2) - zero is unused
+	int			identity_type;		//!< which identity type is being currently processed
 
 	int			imckc;
 	bool			imck_emsk_available;


### PR DESCRIPTION
These commits allow some degree of flexibility in optional authentication with Windows 11. Limitations are described, including for a developer spelunking the codebase.

As a bonus, included are hooks that set `session-state:TEAP-Type-{Machine,User}` as the inner methods complete (we change the code to read administrative overrides from `config` instead) so unlang can be used to determine an authorization policy based on what actually happened during authentication.

There are hints we might be able to get Windows to allow those other currently unsupported optional method combinations, as well as support the Windows specific crypto-binding calculation, this needs more experimentation though and we are fighting with an opaque state machine.

A crucial note, this breaks support with `wpa_supplicant` (and thus also `eapol_test`), but as TEAP support there is behind a compile time flag marked "here be dragons", we need to implement the defacto standard. One day this may all be fixed by TEAPv2.