### PR TITLE
Add freeradius-prof.image as a conditional prerequisite to profiling test runs

### DIFF
--- a/src/tests/multi-server/all.mk
+++ b/src/tests/multi-server/all.mk
@@ -182,7 +182,7 @@ ${4}/start_valgrind_profiling.sh: $$(PROFILING_SCRIPT_SRC)
 render.test.multi-server.${1}.${2}: $$(TEST_MULTI_SERVER_RENDERED.${1}.${2}) ${4}/start_valgrind_profiling.sh
 
 .PHONY: test.multi-server.${1}.${2}
-test.multi-server.${1}.${2}: $$(TEST_MULTI_SERVER_RENDERED.${1}.${2}) ${4}/start_valgrind_profiling.sh
+test.multi-server.${1}.${2}: $$(TEST_MULTI_SERVER_RENDERED.${1}.${2}) ${4}/start_valgrind_profiling.sh $(if $(filter profiling,$(MODE)),freeradius-prof.image,)
 	${Q}mkdir -p "${4}/logs" "${4}/listener"
 	${Q}echo "MULTI-SERVER-TEST test.multi-server.${1}.${2} (MODE=$(MODE))"
 	${Q}if [ "$(MODE)" = "profiling" ]; then \


### PR DESCRIPTION
Running `make test.multi-server.<suite>.<test> MODE=profiling` directly would fail with a Docker pull error because the `freeradius4-profiling/ubuntu24:<sha>` image didn't exist locally.

The image build step (freeradius-prof.image) was only wired as a prerequisite on the top-level `test.multi-server.profiling` and `test.multi-server.profiling.ci` targets, and not on individual test targets.

The fix is to add `freeradius-prof.image` as a conditional prerequisite to each individual test target inside the TEST_MULTI_SERVER_INSTANCE macro.