### PR TITLE
fix detail listener failing to process any packets

### DIFF
--- a/src/main/process.c
+++ b/src/main/process.c
@@ -1450,7 +1450,7 @@ static int request_pre_handler(REQUEST *request, UNUSED int action)
 	 *
 	 *	FIXME: check for correct state.
 	 */
-	if (request->packet->vps) return 0;
+	if (request->packet->vps) return 1;
 
 	rcode = request->listener->decode(request->listener, request);
 	if (rcode < 0) {


### PR DESCRIPTION
The refactoring of request_pre_handler() inadvertently changed its return value from 1 to 0 in the case where request->packet->vps already existed. This change broke the detail listener, failing to process any requests:

  detail (/foo/radius/spool/detail*): No response to request.  Will retry in 30 seconds

Fixes: 5691cbc615e5 ("rearrange request_pre_handler() to do less work")