### PR TITLE
bounds-check packet code before indexing fr_radius_packet_name[]

### DIFF
--- a/src/bin/radclient-ng.c
+++ b/src/bin/radclient-ng.c
@@ -1196,7 +1196,7 @@ static void client_read(fr_event_list_t *el, int fd, UNUSED int flags, void *uct
 	 *	packet matched that.
 	 */
 	if ((request->filter_code != FR_RADIUS_CODE_UNDEFINED) && (reply->code != request->filter_code)) {
-		if (FR_RADIUS_PACKET_CODE_VALID(reply->code)) {
+		if (FR_RADIUS_PACKET_CODE_VALID(request->filter_code) && FR_RADIUS_PACKET_CODE_VALID(reply->code)) {
 			REDEBUG("%s: Expected %s got %s", request->name, fr_radius_packet_name[request->filter_code],
 				fr_radius_packet_name[reply->code]);
 		} else {

--- a/src/bin/radclient.c
+++ b/src/bin/radclient.c
@@ -1255,7 +1255,7 @@ static int recv_coa_packet(fr_time_delta_t wait_time)
 	 *	packet matched that.
 	 */
 	if (request->packet->code != request->filter_code) {
-		if (FR_RADIUS_PACKET_CODE_VALID(request->reply->code)) {
+		if (FR_RADIUS_PACKET_CODE_VALID(request->filter_code) && FR_RADIUS_PACKET_CODE_VALID(request->packet->code)) {
 			REDEBUG("%s: Expected %s got %s", request->name, fr_radius_packet_name[request->filter_code],
 				fr_radius_packet_name[request->packet->code]);
 		} else {
@@ -1625,7 +1625,7 @@ retry:
 	 *	packet matched that.
 	 */
 	if ((request->filter_code != FR_RADIUS_CODE_UNDEFINED) && (request->reply->code != request->filter_code)) {
-		if (FR_RADIUS_PACKET_CODE_VALID(request->reply->code)) {
+		if (FR_RADIUS_PACKET_CODE_VALID(request->filter_code) && FR_RADIUS_PACKET_CODE_VALID(request->reply->code)) {
 			REDEBUG("%s: Expected %s got %s", request->name, fr_radius_packet_name[request->filter_code],
 				fr_radius_packet_name[request->reply->code]);
 		} else {

--- a/src/bin/radsniff.c
+++ b/src/bin/radsniff.c
@@ -2908,7 +2908,9 @@ int main(int argc, char *argv[])
 			DEBUG2("  RADIUS secret           : [%s]", conf->radius_secret);
 
 		if (conf->filter_request_code) {
-			DEBUG2("  RADIUS request code     : [%s]", fr_radius_packet_name[conf->filter_request_code]);
+			DEBUG2("  RADIUS request code     : [%s]",
+			       FR_RADIUS_PACKET_CODE_VALID(conf->filter_request_code) ?
+			       fr_radius_packet_name[conf->filter_request_code] : "unknown");
 		}
 
 		if (!fr_pair_list_empty(&conf->filter_request_vps)){
@@ -2917,7 +2919,9 @@ int main(int argc, char *argv[])
 		}
 
 		if (conf->filter_response_code) {
-			DEBUG2("  RADIUS response code    : [%s]", fr_radius_packet_name[conf->filter_response_code]);
+			DEBUG2("  RADIUS response code    : [%s]",
+			       FR_RADIUS_PACKET_CODE_VALID(conf->filter_response_code) ?
+			       fr_radius_packet_name[conf->filter_response_code] : "unknown");
 		}
 
 		if (conf->to_output_dir) {


### PR DESCRIPTION
fr_radius_packet_name[] has FR_RADIUS_CODE_MAX (53) entries:

    radius.h: extern char const *fr_radius_packet_name[FR_RADIUS_CODE_MAX];

Was reading the "Expected %s got %s" mismatch path in radclient. The
validity test guards reply->code, but the index that gets used is
filter_code:

    if (FR_RADIUS_PACKET_CODE_VALID(request->reply->code))
            REDEBUG(..., fr_radius_packet_name[request->filter_code], ...);

filter_code is taken straight from the request/filter file as a uint32
(Packet-Type, vp->vp_uint32), so it is never range checked. A filter
whose Packet-Type is 200, with any in-range reply, reads 200 entries
into a 53-entry array and hands the result to %s.

recv_one_packet() and radclient-ng client_read() have the same shape.
The radsniff startup banner prints filter_request_code and
filter_response_code (also Packet-Type values), guarded only against
zero.

Each guard now validates the code that is actually used as the index.
Behaviour is unchanged for valid codes; out-of-range codes fall through
to the numeric branch, or to "unknown" in the radsniff banner.
