### PR TITLE
Fix IP address typo in authz docs

### DIFF
--- a/doc/antora/modules/concepts/pages/aaa/authz.adoc
+++ b/doc/antora/modules/concepts/pages/aaa/authz.adoc
@@ -21,7 +21,7 @@ The NAS "request" is really a set of statements. For example, the NAS may send t
 ```
 "user name is Bob"
 "password is Hello"
-"ip address is 192.02.34"
+"ip address is 192.0.2.34"
 ```
 
 Once the RADIUS server receives the request, it uses that information to figure out what properties the user should have (i.e., "Bob" is saying he/she has IP address 192.0.2.34, do the server records contradict this statement?).
@@ -34,7 +34,7 @@ The RADIUS server then sends a reply to the NAS. The reply contains a series of 
 
 [NOTE]
 ====
-The RADIUS server can't request further information from the NAS. In contrast with SQL systems, RADIUS is limited in that it cannot make complicated queries. In SQL, queries such as "SELECT name from table where ipaddress = 192.02.34" are common. RADIUS does not have that capability. Instead, RADIUS
+The RADIUS server can't request further information from the NAS. In contrast with SQL systems, RADIUS is limited in that it cannot make complicated queries. In SQL, queries such as "SELECT name from table where ipaddress = 192.0.2.34" are common. RADIUS does not have that capability. Instead, RADIUS
 only makes statements about what is, and what should be.
 ====
 


### PR DESCRIPTION
Fixes two occurrences of `192.02.34` in the authorization documentation.
The surrounding examples use `192.0.2.34`, so these appear to be typos.
