### PR TITLE
EAP-TEAP Support Machine Only Authentication

### DIFF
--- a/src/modules/rlm_eap/types/rlm_eap_teap/eap_teap.c
+++ b/src/modules/rlm_eap/types/rlm_eap_teap/eap_teap.c
@@ -1217,6 +1217,7 @@ static PW_CODE eap_teap_phase2(REQUEST *request, eap_handler_t *eap_session,
 {
 	PW_CODE			code = PW_CODE_ACCESS_REJECT;
 	rlm_rcode_t		rcode;
+	bool			machine_only = false;
 	VALUE_PAIR		*tvp;
 	teap_tunnel_t		*t = (teap_tunnel_t *)tls_session->opaque;
 	int			eap_method = 0;
@@ -1252,6 +1253,17 @@ static PW_CODE eap_teap_phase2(REQUEST *request, eap_handler_t *eap_session,
 			fr_pair_value_bstrncpy(t->username, tvp->vp_octets + 5, tvp->vp_length - 5);
 
 			RDEBUG("Phase 2: Got tunneled identity of %s", t->username->vp_strvalue);
+
+		} else if (tvp &&
+		    (tvp->vp_length == EAP_HEADER_LEN + 1) &&
+		    (tvp->vp_strvalue[0] == PW_EAP_RESPONSE) &&
+		    (tvp->vp_strvalue[EAP_HEADER_LEN] == PW_EAP_IDENTITY)) {
+			/*
+			 * Empty inner EAP-Identity indicates machine-only auth: finish
+			 * with final TEAP Result TLV, then wait for client Result echo.
+			 */
+			RDEBUG2("Phase 2: Received empty inner EAP-Identity; treating as machine-only TEAP completion");
+			machine_only = true;
 
 		} else if (!fake->username) {
 			/*
@@ -1556,12 +1568,14 @@ done:
 	 * Call authentication recursively, which will
 	 * do PAP, CHAP, MS-CHAP, etc.
 	 */
-	rad_virtual_server(fake, true);
+	if (!machine_only) {
+		rad_virtual_server(fake, true);
+	}
 
 	/*
 	 * Decide what to do with the reply.
 	 */
-	switch (fake->reply->code) {
+	switch (machine_only ? PW_CODE_ACCESS_CHALLENGE : fake->reply->code) {
 	case 0:
 		tvp = fr_pair_find_by_num(fake->config, PW_RESPONSE_PACKET_TYPE, 0, TAG_ANY);
 		if (tvp && (tvp->vp_integer == PW_CODE_ACCESS_CHALLENGE)) {
@@ -1572,6 +1586,15 @@ done:
 		RDEBUG("Phase 2: No tunneled reply was found, rejecting the user.");
 		code = PW_CODE_ACCESS_REJECT;
 		break;
+
+	case PW_CODE_ACCESS_CHALLENGE:
+		if (machine_only) {
+			t->result_final = true;
+			eap_teap_append_result(request, tls_session, PW_CODE_ACCESS_ACCEPT);
+			code = PW_CODE_ACCESS_CHALLENGE;
+			break;
+		}
+		/* FALL-THROUGH */
 
 	case PW_CODE_ACCESS_ACCEPT:
 		tvp = fr_pair_find_by_num(fake->packet->vps, PW_EAP_TYPE, 0, TAG_ANY);


### PR DESCRIPTION
For EAP-TEAP devices, the device is being shared by multiple users and until the user login client expects to connect only with the Machine Cert.

The client sending Identity packet after Machine Successful authentication and wants to update Machine only Authentication

so we move on and accept the client and see if the client likes it.
When I tested

02 82 00 05 01 -> Sending the identity packet without any username for the client preferring Machine Only Authentication.

We are challenging the client with Accept, breaking the eap chain.

Client Responds with

TEAP tunnel data in 00: 80 03 00 02 00 01

Mon Jun 15 22:14:10 2026 : Auth: (136) Login OK: [anonymous] (from client localhost port 0 cli 7C-70-DB-19-AF-50)
Mon Jun 15 22:14:10 2026 : Debug: (136) Sent Access-Accept Id 37 from 0.0.0.0:3000 to 100.96.4.141:47160 length 183
Mon Jun 15 22:14:10 2026 : Debug: (136)   MS-MPPE-Recv-Key = 0xf39364e5bd767839ffc6b68f85ad95ff569e60ae4ec951c18b55205b4a59eca9
Mon Jun 15 22:14:10 2026 : Debug: (136)   MS-MPPE-Send-Key = 0x9e589cd8631c4ab6f43dcbf56f071413ea91fffb7cb85289fdfa5af9b5ff3f9e
Mon Jun 15 22:14:10 2026 : Debug: (136)   EAP-Message = 0x03830004
Mon Jun 15 22:14:10 2026 : Debug: (136)   Message-Authenticator = 0x00000000000000000000000000000000
Mon Jun 15 22:14:10 2026 : Debug: (136)   User-Name = "anonymous"
Mon Jun 15 22:14:10 2026 : Debug: (136)   Framed-MTU = 984
Mon Jun 15 22:14:10 2026 : Debug: (136)   Acct-Interim-Interval = 7200
Mon Jun 15 22:14:10 2026 : Debug: (136) Finished request