### PR TITLE
radtest: allow overriding NAS name via HOSTNAME env var

### DIFF
--- a/src/bin/radtest.in
+++ b/src/bin/radtest.in
@@ -105,7 +105,12 @@ if [ "$7" ]
 then
 	nas=$7
 else
-	nas=`(hostname || uname -n) 2>/dev/null | sed 1q`
+	if [ -n "$HOSTNAME" ]
+	then
+		nas=$HOSTNAME
+	else
+		nas=`(hostname || uname -n) 2>/dev/null | sed 1q`
+	fi
 fi
 
 (


### PR DESCRIPTION
Use HOSTNAME when set, retaining the portable hostname/uname fallback.