### PR TITLE
ci: publish profiling results to cinfra-ca.inkbridge.io

### DIFF
--- a/.github/workflows/ci-multi-server-tests.yml
+++ b/.github/workflows/ci-multi-server-tests.yml
@@ -36,8 +36,9 @@ jobs:
     runs-on: self-hosted
     if: github.repository_owner == 'FreeRADIUS'
 
-    #  id-token lets the profiling leg mint a GitHub OIDC token to authenticate
-    #  uploads to the prof-results store which is validated by its access.lua.
+    #  id-token: write lets the profiling leg mint a GitHub OIDC token, which
+    #  authenticates the prof-results publish. Listing any permission drops
+    #  the unlisted ones, so contents: read is stated to keep checkout working.
     permissions:
       contents: read
       id-token: write
@@ -218,22 +219,14 @@ jobs:
           if-no-files-found: ignore
 
       #
-      #  Push the same prof-results/ tree into the durable prof-results store
-      #  so the browser UI can read it. The script tars the tree and POSTs the
-      #  tarball to the store's ingest endpoint, which numbers the runs,
-      #  updates its indexes, and refreshes its manifest server-side; see the
-      #  script header for the auth and proxy details. A failed publish fails
-      #  the leg.
-      #
-      #  Gated on the artifact step having found files: with if-no-files-found:
-      #  ignore, upload-artifact leaves artifact-id empty when the tree is
-      #  absent/empty, so this step is skipped rather than publishing nothing.
+      #  Publish the same prof-results/ tree to the durable store: the script
+      #  tars the tree and POSTs it, with a GitHub OIDC token, to the given
+      #  URL (see the script header). Skipped when the artifact step found no
+      #  files (empty artifact-id).
       #
       - name: Publish profiling results to the prof-results store
         if: ${{ matrix.mode == 'profiling' && always() && steps.upload-prof-results.outputs.artifact-id != '' }}
-        env:
-          PROF_RESULTS_URL: "https://cinfra-ca.inkbridge.io"
-        run: scripts/ci/publish-profiling-results.sh
+        run: scripts/ci/publish-profiling-results.sh "https://cinfra-ca.inkbridge.io/profiling/data"
 
       #
       #  If the CI has failed and the branch is ci-debug

--- a/.github/workflows/ci-multi-server-tests.yml
+++ b/.github/workflows/ci-multi-server-tests.yml
@@ -229,6 +229,25 @@ jobs:
         run: scripts/ci/publish-profiling-results.sh "https://cinfra-ca.inkbridge.io/profiling/data"
 
       #
+      #  Check latest profiling results vs each suite's previous run on the store.
+      #
+      #  cest-analyzer exit codes;
+      #   0 - clean
+      #   1 - latest result performance flagged
+      #   2 - tool error
+      #
+      - name: Check latest profiling results vs previous runs
+        if: ${{ matrix.mode == 'profiling' && success() }}
+        continue-on-error: true
+        run: |
+          curl -fsSL -o cest-analyzer \
+            "https://cinfra-ca.inkbridge.io/profiling/dashboard/bin/cest-analyzer"
+          chmod +x ./cest-analyzer
+          rc=0
+          ./cest-analyzer --latest -d prof-results --filter fr_ --gate 15 || rc=$?
+          echo "cest-analyzer exit code: $rc"
+
+      #
       #  If the CI has failed and the branch is ci-debug
       #  then start a tmate session for interactive debugging.
       #

--- a/.github/workflows/ci-multi-server-tests.yml
+++ b/.github/workflows/ci-multi-server-tests.yml
@@ -36,6 +36,12 @@ jobs:
     runs-on: self-hosted
     if: github.repository_owner == 'FreeRADIUS'
 
+    #  id-token lets the profiling leg mint a GitHub OIDC token to authenticate
+    #  uploads to the prof-results store which is validated by its access.lua.
+    permissions:
+      contents: read
+      id-token: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -203,12 +209,31 @@ jobs:
       #  mode. Skipped in service mode (nothing to upload).
       #
       - name: Upload profiling results
+        id: upload-prof-results
         if: ${{ matrix.mode == 'profiling' && always() }}
         uses: actions/upload-artifact@v6
         with:
           name: prof-results-${{ github.sha }}
           path: prof-results/
           if-no-files-found: ignore
+
+      #
+      #  Push the same prof-results/ tree into the durable prof-results store
+      #  so the browser UI can read it. The script tars the tree and POSTs the
+      #  tarball to the store's ingest endpoint, which numbers the runs,
+      #  updates its indexes, and refreshes its manifest server-side; see the
+      #  script header for the auth and proxy details. A failed publish fails
+      #  the leg.
+      #
+      #  Gated on the artifact step having found files: with if-no-files-found:
+      #  ignore, upload-artifact leaves artifact-id empty when the tree is
+      #  absent/empty, so this step is skipped rather than publishing nothing.
+      #
+      - name: Publish profiling results to the prof-results store
+        if: ${{ matrix.mode == 'profiling' && always() && steps.upload-prof-results.outputs.artifact-id != '' }}
+        env:
+          PROF_RESULTS_URL: "https://cinfra-ca.inkbridge.io"
+        run: scripts/ci/publish-profiling-results.sh
 
       #
       #  If the CI has failed and the branch is ci-debug

--- a/scripts/ci/publish-profiling-results.sh
+++ b/scripts/ci/publish-profiling-results.sh
@@ -1,151 +1,64 @@
 #!/bin/sh
 #
-#  What this does
-#  --------------
-#  After a profiling CI run finishes, look for a prof-results/ directory and,
-#  if it is there, publish it to the long-lived prof-results store so the
-#  profiling web UI can show the new run. The store is run by the
-#  cinfra-profiling-server container, which the cinfra platform sits in front
-#  of.
+#  Tar up the prof-results/ directory (if any) and POST the tarball, with a
+#  GitHub OIDC bearer token, to the URL given as the only argument. A missing
+#  or empty prof-results/ is a quiet exit 0; any other failure exits non-zero
+#  so the CI leg fails with it.
 #
-#  The publish is a single request: we tar.gz the whole prof-results/ tree and
-#  POST it to the store's ingest endpoint. Everything stateful happens
-#  server-side, inside the container: it validates and unpacks the tarball,
-#  allocates the store run indexes (renumbering this run's local indexes to
-#  follow whatever the store already holds for the same <branch>/<sha>, under
-#  a lock so concurrent publishes cannot collide), records the publish in the
-#  run-index-map.json ledger, and rebuilds manifest.json for the UI. This
-#  script only packs and ships; the cinfra-profiling-server README documents
-#  the store side.
+#  The runner sets ACTIONS_ID_TOKEN_REQUEST_TOKEN / ACTIONS_ID_TOKEN_REQUEST_URL
+#  automatically when the job has "id-token: write"; the script uses them to
+#  mint an OIDC token whose audience is the target URL's origin.
 #
-#  A small routing detail worth knowing: we POST to /profiling/data/_ingest,
-#  but Traefik removes the /profiling prefix on the way in, so the container
-#  sees /data/_ingest.
-#
-#  How we authenticate
-#  -------------------
-#  No shared password. The runner mints a GitHub OIDC token whose audience is
-#  the store URL, and the store's access.lua checks the token's signature and
-#  the repo it came from. That is the only credential involved. The server
-#  also reads the GitHub run id / attempt / number for its ledger from that
-#  verified token, so nothing here needs to send them.
-#
-#  When we stop and fail
-#  ---------------------
-#  No prof-results/ directory (or no files in it)? Nothing to do, so we exit 0
-#  quietly. Otherwise the publish is all-or-nothing: any non-2xx response (or
-#  no response) fails this script and the CI leg with it. A failed publish is
-#  safe to re-run; the server derives run numbering so that a retry of a
-#  half-landed publish overwrites the half-landed files rather than
-#  duplicating them.
-#
-#  Why everything goes through a proxy
-#  -----------------------------------
-#  The runner cannot reach the store directly (egress is firewalled), so both
-#  the token mint and the upload go through the squid proxy. The connect
-#  timeout keeps us from hanging when the store is down; it does not limit the
-#  transfer itself.
-#
-#  The upload size cap
-#  -------------------
-#  The proxy in front of the store caps request bodies, so we check the
-#  tarball size before uploading and fail with a clear message instead of an
-#  opaque 413. The store's README documents the cap and the options if
-#  publishes outgrow it.
-#
-#  Usage
-#  -----
-#    publish-profiling-results.sh
-#
-#  Environment variables
-#  ---------------------
-#    PROF_RESULTS_URL                 Base URL of the store (required).
-#    ACTIONS_ID_TOKEN_REQUEST_TOKEN   } GitHub OIDC request credentials, set by
-#    ACTIONS_ID_TOKEN_REQUEST_URL     } the runner when id-token: write is on.
-#    PROF_MAX_UPLOAD_MB               Pre-upload tarball size limit in MB
-#                                     (default 45, just under the proxy's
-#                                     request-body cap).
+#  Usage: publish-profiling-results.sh <url>
 
 set -eu
 
-: "${PROF_RESULTS_URL:?store URL required}"
+[ $# -eq 1 ] || { echo "usage: $0 <url>" >&2; exit 2; }
+url=$1
+
+#  The OIDC audience is the URL's origin (scheme://host).
+host_path=${url#*://}
+audience="${url%%://*}://${host_path%%/*}"
 
 [ -d prof-results ] || { echo "no prof-results/ tree; skipping"; exit 0; }
 
-#
-#  Pack the tree. We tar an explicit file list (not the directory) so empty
-#  run directories - a test can claim a run index and then write nothing - and
-#  editor droppings never travel; the server only ever sees real result files.
-#
-list=$(mktemp)
-tarball=$(mktemp).tar.gz
-find prof-results -type f ! -name '.DS_Store' | sed 's#^prof-results/##' >"$list"
-if ! [ -s "$list" ]; then
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+#  Tar an explicit file list (not the directory) so empty directories and
+#  editor droppings never travel.
+file_list="$tmpdir/files"
+tarball="$tmpdir/prof-results.tar.gz"
+find prof-results -type f ! -name '.DS_Store' | sed 's#^prof-results/##' >"$file_list"
+if ! [ -s "$file_list" ]; then
 	echo "prof-results/ holds no files; skipping"
-	rm -f "$list" "$tarball"
 	exit 0
 fi
-#  COPYFILE_DISABLE stops tar implementations that honour it from adding
-#  synthetic ._* metadata members for extended attributes; GNU tar on the CI
-#  runner ignores the variable entirely.
-COPYFILE_DISABLE=1 tar -czf "$tarball" -C prof-results -T "$list"
-rm -f "$list"
+tar -czf "$tarball" -C prof-results -T "$file_list"
 
-#
-#  Refuse to ship a tarball the front proxy would 413. The check is
-#  client-side only, so a raised proxy limit just needs a bigger
-#  PROF_MAX_UPLOAD_MB here.
-#
-max_mb=${PROF_MAX_UPLOAD_MB:-45}
-size=$(wc -c <"$tarball")
-size_mb=$(( (size + 1048575) / 1048576 ))
-if [ "$size_mb" -gt "$max_mb" ]; then
-	echo "ERROR: publish tarball is ${size_mb} MB, over the ${max_mb} MB limit" >&2
-	echo "ERROR: the proxy in front of the store caps request bodies; raise that cap" >&2
-	echo "ERROR: (and PROF_MAX_UPLOAD_MB), or split the publish per run" >&2
-	rm -f "$tarball"
-	exit 1
-fi
-
-#
-#  Mint an OIDC token whose audience is the store URL. The `|| true` is
-#  deliberate: it stops set -e from killing us on a hiccup so the check just
-#  below can print a friendly message instead of a bare non-zero exit.
-#
+#  The || true keeps set -e out of the way so the check below can print a
+#  clear message on a failed mint.
 token=$(curl -sS \
 	-H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-	"$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${PROF_RESULTS_URL}" \
+	"$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${audience}" \
 	| jq -r '.value') || true
 if [ -z "$token" ] || [ "$token" = null ]; then
 	echo "ERROR: could not obtain OIDC token" >&2
-	rm -f "$tarball"
 	exit 1
 fi
 
-#
-#  Ship it. One POST; the server answers with a JSON summary of what it
-#  published (or an { "error": ... } explaining why it refused). No automatic
-#  retry: if the server succeeded but the response got lost, a blind retry
-#  would append a duplicate set of runs, so leave retrying to a human re-run
-#  of the CI leg.
-#
 echo "publishing $(du -h "$tarball" | cut -f1 | tr -d ' ') prof-results tarball"
-resp=$(mktemp)
+resp="$tmpdir/response"
 code=$(curl -sS --connect-timeout 10 -o "$resp" -w '%{http_code}' \
 	-X POST -H "Authorization: Bearer $token" \
 	--data-binary @"$tarball" \
-	"${PROF_RESULTS_URL}/profiling/data/_ingest") || code=000
-rm -f "$tarball"
+	"$url") || code=000
 
-cat "$resp"; echo
 case "$code" in
-	2??)
-		rm -f "$resp"
-		exit 0
-		;;
+	2??) exit 0 ;;
 	*)
 		echo "ERROR: publish failed (HTTP $code)" >&2
-		rm -f "$resp"
+		[ -s "$resp" ] && { cat "$resp" >&2; echo >&2; }
 		exit 1
 		;;
 esac

--- a/scripts/ci/publish-profiling-results.sh
+++ b/scripts/ci/publish-profiling-results.sh
@@ -1,0 +1,151 @@
+#!/bin/sh
+#
+#  What this does
+#  --------------
+#  After a profiling CI run finishes, look for a prof-results/ directory and,
+#  if it is there, publish it to the long-lived prof-results store so the
+#  profiling web UI can show the new run. The store is run by the
+#  cinfra-profiling-server container, which the cinfra platform sits in front
+#  of.
+#
+#  The publish is a single request: we tar.gz the whole prof-results/ tree and
+#  POST it to the store's ingest endpoint. Everything stateful happens
+#  server-side, inside the container: it validates and unpacks the tarball,
+#  allocates the store run indexes (renumbering this run's local indexes to
+#  follow whatever the store already holds for the same <branch>/<sha>, under
+#  a lock so concurrent publishes cannot collide), records the publish in the
+#  run-index-map.json ledger, and rebuilds manifest.json for the UI. This
+#  script only packs and ships; the cinfra-profiling-server README documents
+#  the store side.
+#
+#  A small routing detail worth knowing: we POST to /profiling/data/_ingest,
+#  but Traefik removes the /profiling prefix on the way in, so the container
+#  sees /data/_ingest.
+#
+#  How we authenticate
+#  -------------------
+#  No shared password. The runner mints a GitHub OIDC token whose audience is
+#  the store URL, and the store's access.lua checks the token's signature and
+#  the repo it came from. That is the only credential involved. The server
+#  also reads the GitHub run id / attempt / number for its ledger from that
+#  verified token, so nothing here needs to send them.
+#
+#  When we stop and fail
+#  ---------------------
+#  No prof-results/ directory (or no files in it)? Nothing to do, so we exit 0
+#  quietly. Otherwise the publish is all-or-nothing: any non-2xx response (or
+#  no response) fails this script and the CI leg with it. A failed publish is
+#  safe to re-run; the server derives run numbering so that a retry of a
+#  half-landed publish overwrites the half-landed files rather than
+#  duplicating them.
+#
+#  Why everything goes through a proxy
+#  -----------------------------------
+#  The runner cannot reach the store directly (egress is firewalled), so both
+#  the token mint and the upload go through the squid proxy. The connect
+#  timeout keeps us from hanging when the store is down; it does not limit the
+#  transfer itself.
+#
+#  The upload size cap
+#  -------------------
+#  The proxy in front of the store caps request bodies, so we check the
+#  tarball size before uploading and fail with a clear message instead of an
+#  opaque 413. The store's README documents the cap and the options if
+#  publishes outgrow it.
+#
+#  Usage
+#  -----
+#    publish-profiling-results.sh
+#
+#  Environment variables
+#  ---------------------
+#    PROF_RESULTS_URL                 Base URL of the store (required).
+#    ACTIONS_ID_TOKEN_REQUEST_TOKEN   } GitHub OIDC request credentials, set by
+#    ACTIONS_ID_TOKEN_REQUEST_URL     } the runner when id-token: write is on.
+#    PROF_MAX_UPLOAD_MB               Pre-upload tarball size limit in MB
+#                                     (default 45, just under the proxy's
+#                                     request-body cap).
+
+set -eu
+
+: "${PROF_RESULTS_URL:?store URL required}"
+
+[ -d prof-results ] || { echo "no prof-results/ tree; skipping"; exit 0; }
+
+#
+#  Pack the tree. We tar an explicit file list (not the directory) so empty
+#  run directories - a test can claim a run index and then write nothing - and
+#  editor droppings never travel; the server only ever sees real result files.
+#
+list=$(mktemp)
+tarball=$(mktemp).tar.gz
+find prof-results -type f ! -name '.DS_Store' | sed 's#^prof-results/##' >"$list"
+if ! [ -s "$list" ]; then
+	echo "prof-results/ holds no files; skipping"
+	rm -f "$list" "$tarball"
+	exit 0
+fi
+#  COPYFILE_DISABLE stops tar implementations that honour it from adding
+#  synthetic ._* metadata members for extended attributes; GNU tar on the CI
+#  runner ignores the variable entirely.
+COPYFILE_DISABLE=1 tar -czf "$tarball" -C prof-results -T "$list"
+rm -f "$list"
+
+#
+#  Refuse to ship a tarball the front proxy would 413. The check is
+#  client-side only, so a raised proxy limit just needs a bigger
+#  PROF_MAX_UPLOAD_MB here.
+#
+max_mb=${PROF_MAX_UPLOAD_MB:-45}
+size=$(wc -c <"$tarball")
+size_mb=$(( (size + 1048575) / 1048576 ))
+if [ "$size_mb" -gt "$max_mb" ]; then
+	echo "ERROR: publish tarball is ${size_mb} MB, over the ${max_mb} MB limit" >&2
+	echo "ERROR: the proxy in front of the store caps request bodies; raise that cap" >&2
+	echo "ERROR: (and PROF_MAX_UPLOAD_MB), or split the publish per run" >&2
+	rm -f "$tarball"
+	exit 1
+fi
+
+#
+#  Mint an OIDC token whose audience is the store URL. The `|| true` is
+#  deliberate: it stops set -e from killing us on a hiccup so the check just
+#  below can print a friendly message instead of a bare non-zero exit.
+#
+token=$(curl -sS \
+	-H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+	"$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${PROF_RESULTS_URL}" \
+	| jq -r '.value') || true
+if [ -z "$token" ] || [ "$token" = null ]; then
+	echo "ERROR: could not obtain OIDC token" >&2
+	rm -f "$tarball"
+	exit 1
+fi
+
+#
+#  Ship it. One POST; the server answers with a JSON summary of what it
+#  published (or an { "error": ... } explaining why it refused). No automatic
+#  retry: if the server succeeded but the response got lost, a blind retry
+#  would append a duplicate set of runs, so leave retrying to a human re-run
+#  of the CI leg.
+#
+echo "publishing $(du -h "$tarball" | cut -f1 | tr -d ' ') prof-results tarball"
+resp=$(mktemp)
+code=$(curl -sS --connect-timeout 10 -o "$resp" -w '%{http_code}' \
+	-X POST -H "Authorization: Bearer $token" \
+	--data-binary @"$tarball" \
+	"${PROF_RESULTS_URL}/profiling/data/_ingest") || code=000
+rm -f "$tarball"
+
+cat "$resp"; echo
+case "$code" in
+	2??)
+		rm -f "$resp"
+		exit 0
+		;;
+	*)
+		echo "ERROR: publish failed (HTTP $code)" >&2
+		rm -f "$resp"
+		exit 1
+		;;
+esac

--- a/src/tests/multi-server/scripts/profiling/start_valgrind_profiling.sh
+++ b/src/tests/multi-server/scripts/profiling/start_valgrind_profiling.sh
@@ -40,7 +40,8 @@ valgrind \
   --log-file=/etc/prof-results/valgrind.log \
   --callgrind-out-file=/etc/prof-results/callgrind.out.%p \
   --trace-children=yes \
-  --separate-threads=yes \
+  --separate-threads=no \
+  --separate-callers=6 \
   --dump-instr=yes \
   --collect-jumps=yes \
   --cache-sim=yes \

--- a/src/tests/multi-server/scripts/profiling/start_valgrind_profiling.sh
+++ b/src/tests/multi-server/scripts/profiling/start_valgrind_profiling.sh
@@ -32,9 +32,20 @@ SEND_DURATION=$(( TEST_LOADGEN_NUM_MESSAGES / TEST_LOADGEN_START_PPS ))
 
 # Start freeradius under valgrind with instrumentation off.
 #
-# valgrind writes its own log to --log-file and freeradius stdout/stderr
-# go directly to freeradius.log. Avoiding `| tee` here so $! is the
-# valgrind PID rather than tee's — the fallback kill paths below rely on it.
+# valgrind logs to --log-file; freeradius stdout/stderr go to freeradius.log.
+# No `| tee`: the fallback kill paths below need $! to be the valgrind PID,
+# not tee's.
+#
+# --trace-children=yes    profile exec()'d children too (own callgrind.out.%p)
+# --separate-threads=no   one profile per process, not per thread
+# --separate-callers=6    split a function's costs by up to 6 callers deep
+# --dump-instr=yes        per-instruction counts (assembly-level inspection)
+# --collect-jumps=yes     record jumps for intra-function control flow
+# --cache-sim=yes         cache counters (Dr/Dw + L1/LL misses) for CEst
+# --branch-sim=yes        branch mispredict counters (Bc/Bi) for CEst
+# --keep-debuginfo=yes    keep symbols of dlclose'd code for late dumps
+# --instr-atstart=no      start uninstrumented; enabled below once the server
+#                         is ready, keeping startup out of the profile
 valgrind \
   --tool=callgrind \
   --log-file=/etc/prof-results/valgrind.log \


### PR DESCRIPTION
## Summary

The multi-server CI's profiling leg (`mode: profiling`) already produces a
Callgrind tree under `prof-results/` and uploads that tree as a short-lived
workflow artifact. The workflow artifact expires, so the history is lost and
nothing can browse profiling trends across runs.

The commit adds a publish step: after the artifact upload, the profiling leg
packs the same `prof-results/` tree into one gzipped tarball and POSTs it
over HTTPS to a durable profiling store, which ingests it server-side. The
results are then browsable per branch / commit / run in the profiling
dashboard:

- Store (raw data): https://cinfra-ca.inkbridge.io/profiling/data
- Dashboard (analyzer UI): https://cinfra-ca.inkbridge.io/profiling/dashboard
- Dashboard V2: https://cinfra-ca.inkbridge.io/profiling/dashboard/v2

Both endpoints are live. The ingest flow has been verified end to end against
the store container, including concurrent publishes for the same commit,
re-runs, and malformed archives.

## What changed

| File | Change |
|---|---|
| `.github/workflows/ci-multi-server-tests.yml` | Adds `permissions: id-token: write` to the job and a "Publish profiling results" step on the profiling leg (+23 lines) |
| `scripts/ci/publish-profiling-results.sh` | New POSIX shell script that tars the tree and POSTs it to the store's ingest endpoint; the header comment documents the behaviour |
| `src/tests/multi-server/scripts/profiling/start_valgrind_profiling.sh` | Callgrind flags: `--separate-threads=no` and `--separate-callers=6` |

## How the publish works

1. The runner mints a GitHub OIDC id-token whose audience is the store URL.
   The store validates the token in-process (signature against GitHub's JWKS,
   plus issuer, audience, and a repository allow-list). **No repository secret
   is added**; `id-token: write` is the only new permission.
2. The script tars an explicit file list (so empty run directories and editor
   droppings never travel), checks the tarball against the front proxy's
   request-body cap so an oversized publish fails with a clear message
   instead of an opaque 413, and POSTs it to the store's `_ingest` endpoint.
   That single request is the whole publish.
3. Everything stateful happens server-side in the store, not in CI: it
   validates and unpacks the tarball, renumbers the run indexes so each
   `<branch>/<sha>` reads as a gapless 1..K (under a lock, so two publishes
   for the same sha cannot collide; a re-run appends after the existing runs
   instead of overwriting them), records the publish in a ledger
   (`run-index-map.json`) using the run id/attempt claims from the verified
   token, and rebuilds the manifest the dashboard reads.
4. The store answers with a JSON summary of what it published (run-index
   mapping included), which lands in the CI log.

A missing or empty `prof-results/` tree skips the step cleanly (the step is
gated on the artifact upload having found files, and the script also exits 0
on a missing tree). The whole job is already gated on
`github.repository_owner == 'FreeRADIUS'`, so forks never attempt to publish.

## Callgrind flag change

`--separate-threads=yes` becomes `--separate-threads=no`, and
`--separate-callers=6` is added: per-thread output split the counts for the
same functions across thread-specific files, while the analyzer wants
combined per-function totals; the 6 levels of caller context let the analyzer
distinguish call paths when attributing cost.

## Failure behaviour

- No `prof-results/` tree: publish step is skipped, leg stays green.
- Tarball over the proxy's request-body cap: fails before uploading, with a
  message saying so.
- Token mint failure or any non-2xx from the store (bad archive, unreadable
  store state, ...): the script exits non-zero and the profiling leg fails,
  with the store's JSON error in the log.
- The store only refreshes its manifest when an ingest fully succeeds, so a
  retry of a half-landed publish re-derives the same run indexes and
  overwrites the half-landed files instead of duplicating them. The script
  deliberately never retries on its own: after a lost success response, a
  blind retry would append a duplicate set of runs.

## Store-side counterpart

The ingest endpoint (archive validation, locked run-index allocation, ledger,
manifest rebuild) lives in the store's own repo, `cinfra-profiling-server`,
and is deployed separately before this change is merged. The previous
revision of this PR did the numbering and index bookkeeping client-side in
the publish script; that (and the concurrent same-sha collision it could not
prevent) moved into the store.
