### PR TITLE
rlm_krb5: assume thread-safety when cross-compiling

### DIFF
--- a/src/modules/rlm_krb5/configure
+++ b/src/modules/rlm_krb5/configure
@@ -4637,6 +4637,7 @@ fi
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cross compiling: not checking" >&5
 printf "%s\n" "$as_me: WARNING: cross compiling: not checking" >&2;}
+			 krb5threadsafe="-DKRB5_IS_THREAD_SAFE"
 else $as_nop
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */

--- a/src/modules/rlm_krb5/configure.ac
+++ b/src/modules/rlm_krb5/configure.ac
@@ -143,7 +143,8 @@ if test "$krb5threadsafe" != "no"; then
 	if test "x$ac_cv_lib_krb5_krb5_is_thread_safe" = xyes; then
 		AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <krb5.h>]], [[return krb5_is_thread_safe() ? 0 : 1]])],
 			[krb5threadsafe="-DKRB5_IS_THREAD_SAFE"], [AC_MSG_WARN([[libkrb5 is not threadsafe]])],
-			[AC_MSG_WARN(cross compiling: not checking)])
+			[AC_MSG_WARN(cross compiling: not checking)
+			 krb5threadsafe="-DKRB5_IS_THREAD_SAFE"])
 	fi
 else
 	krb5threadsafe=""


### PR DESCRIPTION
When cross-compiling, the autoconf test program for krb5_is_thread_safe() cannot be run on the host. Previously this left krb5threadsafe empty, which is incorrect for all modern krb5 builds.

Fix by defaulting to thread-safety when the test cannot be performed.