### PR TITLE
eap_aka_sim: fix SIM-SQN check that rejected every value

### DIFF
--- a/src/lib/eap_aka_sim/vector.c
+++ b/src/lib/eap_aka_sim/vector.c
@@ -690,12 +690,14 @@ static int vector_umts_from_quintuplets(request_t *request, fr_pair_list_t *vps,
 
 	/*
 	 *	Fetch (optional) SQN
+	 *
+	 *	SQN is 48 bits.  uint48_to_buff() silently truncates anything
+	 *	wider, so reject it rather than derive AK from a mangled SQN.
 	 */
 	sqn_vp = fr_pair_find_by_da(vps, NULL, attr_sim_sqn);
-	if (sqn_vp && (sqn_vp->vp_length != MILENAGE_SQN_SIZE)) {
-		REDEBUG("control.%s incorrect length.  Expected "
-			STRINGIFY(MILENAGE_SQN_SIZE) " bytes, got %zu bytes",
-			attr_sim_sqn->name, sqn_vp->vp_length);
+	if (sqn_vp && (sqn_vp->vp_uint64 > UINT64_C(0xffffffffffff))) {
+		REDEBUG("control.%s invalid.  Expected a %u-bit value, got %" PRIu64,
+			attr_sim_sqn->name, (unsigned int)(MILENAGE_SQN_SIZE * 8), sqn_vp->vp_uint64);
 		return -1;
 	}
 


### PR DESCRIPTION
vector_umts_from_quintuplets() checks control.SIM-SQN by comparing vp_length
against MILENAGE_SQN_SIZE. SIM-SQN is FR_TYPE_UINT64, and vp_length is 0 for
numeric boxes, so the check can never pass:

    control.SIM-SQN incorrect length.  Expected 6 bytes, got 0 bytes
    Failed retrieving UMTS vectors

vector_umts_from_ki() reads the same attribute as vp_uint64 with no length
check, and the SQN/AK derivations just below this check read vp_uint64 too,
so it looks left over from when SQN was octets.

I replaced it with a range check rather than dropping it: SQN is 48 bits and
uint48_to_buff() masks off anything wider, which would silently give a bad AK.

This is reachable when the server has no local Ki and the quintuplets come
from somewhere else - in our case an HSS over SWx, which owns the SQN. It
also breaks SQN resync: with no Ki the server never sets SIM-SQN itself, but
RESUME(recv_aka_synchronization_failure) requires it, so recv
Synchronization-Failure has to set it, and then the retried challenge dies on
the length check.

Compiles clean. Tested against a live HSS with real test SIMs: before, the
resync MAR succeeded and the retried AKA-CHALLENGE was still rejected; after,
EAP-AKA and EAP-AKA' both recover from a desynchronised USIM.