### PR TITLE
Profiling CI: deterministic load pacing + automatic regression flagging (notify-only)

### DIFF
--- a/.github/workflows/ci-multi-server-tests.yml
+++ b/.github/workflows/ci-multi-server-tests.yml
@@ -38,9 +38,11 @@ jobs:
 
     #  id-token: write lets the profiling leg mint a GitHub OIDC token, which
     #  authenticates the prof-results publish. Listing any permission drops
-    #  the unlisted ones, so contents: read is stated to keep checkout working.
+    #  the unlisted ones, so the others are stated explicitly.
+    #  contents: write (up from read) is needed so the profiling leg can post a
+    #  commit comment flagging a CEst regression; it also keeps checkout working.
     permissions:
-      contents: read
+      contents: write
       id-token: write
 
     strategy:
@@ -229,23 +231,59 @@ jobs:
         run: scripts/ci/publish-profiling-results.sh "https://cinfra-ca.inkbridge.io/profiling/data"
 
       #
-      #  Check latest profiling results vs each suite's previous run on the store.
+      #  Check latest profiling results vs each suite's previous run on the
+      #  store, and write a markdown + JSON report for the flagging step below.
       #
       #  cest-analyzer exit codes;
       #   0 - clean
       #   1 - latest result performance flagged
       #   2 - tool error
       #
+      #  continue-on-error keeps a regression (or a tool error) from failing the
+      #  build: the decision is to FLAG regressions (job summary + commit
+      #  comment), not to block CI. The verdict is passed on as the `rc` output.
+      #
       - name: Check latest profiling results vs previous runs
+        id: cest-gate
         if: ${{ matrix.mode == 'profiling' && success() }}
         continue-on-error: true
         run: |
           curl -fsSL -o cest-analyzer \
             "https://cinfra-ca.inkbridge.io/profiling/dashboard/bin/cest-analyzer"
           chmod +x ./cest-analyzer
+          #  Gate settings calibrated from the measured noise floor (see
+          #  docs/noise-floor.md in cinfra-profiling-server): 10M size floor
+          #  so run-to-run noise in small functions can't flag, total-CEst
+          #  gating for broad shallow regressions, and a degenerate-reference
+          #  guard so a partial reference run can't emit hundreds of false
+          #  flags.
           rc=0
-          ./cest-analyzer --latest -d prof-results --filter fr_ --gate 15 || rc=$?
+          ./cest-analyzer --latest -d prof-results --filter fr_ --gate 15 \
+            --gate-scope both --min-cest 10000000 --max-total-delta 100 \
+            --md cest-report.md --json cest-report.json || rc=$?
           echo "cest-analyzer exit code: $rc"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+
+      #
+      #  Flag the result: the script writes the regression table to the job
+      #  summary and, on a regression (rc=1), posts a commit comment on this
+      #  commit (this workflow runs on push, so there is no PR context; the flag
+      #  lives on the commit). See scripts/ci/flag-profiling-results.sh. The
+      #  step is continue-on-error and the script treats commenting as advisory,
+      #  so a permissions restriction never fails CI.
+      #
+      #  NOTE: commit commenting is intentionally OFF while this is being tested
+      #  on a branch, so no commit comments land on the upstream repo. Without
+      #  GH_TOKEN the script writes the job summary and skips the comment (with a
+      #  warning). To enable commenting, uncomment the env block below; GH_TOKEN
+      #  is the job token, which needs contents: write (declared above).
+      #
+      - name: Flag profiling regression (job summary + commit comment)
+        if: ${{ matrix.mode == 'profiling' && always() && steps.cest-gate.outputs.rc != '' }}
+        continue-on-error: true
+        # env:
+        #   GH_TOKEN: ${{ github.token }}
+        run: scripts/ci/flag-profiling-results.sh "${{ steps.cest-gate.outputs.rc }}" cest-report.md
 
       #
       #  If the CI has failed and the branch is ci-debug

--- a/scripts/ci/flag-profiling-results.sh
+++ b/scripts/ci/flag-profiling-results.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+#
+#  Flag the latest profiling results. Writes the cest-analyzer regression report
+#  to the GitHub Actions job summary, and on a regression posts (or updates) a
+#  commit comment on the current commit. Advisory only: a commenting failure
+#  warns but never fails the build, so this is safe to run continue-on-error
+#  after the cest-analyzer gate step.
+#
+#  This workflow runs on push, so there is no PR context; the flag lives on the
+#  commit. The comment carries a hidden marker so re-runs update the same
+#  comment instead of stacking duplicates, and a later clean run resolves it.
+#
+#  cest-analyzer exit codes, passed in as the first argument:
+#    0  clean       - summary says clean; resolve any prior flag comment
+#    1  regression  - summary + a commit comment flagging the commit
+#    2  tool error  - summary notes the error; no comment
+#
+#  Uses the standard GitHub Actions environment (GITHUB_STEP_SUMMARY,
+#  GITHUB_REPOSITORY, GITHUB_SHA, GITHUB_REF_NAME, GITHUB_API_URL) plus a repo
+#  token in GH_TOKEN (pass ${{ github.token }}). Posting a commit comment needs
+#  the job's contents: write permission; without a usable token the script
+#  still writes the job summary and skips the comment with a warning.
+#
+#  Usage: flag-profiling-results.sh <cest-exit-code> <report-md-file> [dashboard-url] [store-url]
+
+set -eu
+
+[ $# -ge 2 ] || { echo "usage: $0 <cest-exit-code> <report-md-file> [dashboard-url] [store-url]" >&2; exit 2; }
+rc=$1
+report_file=$2
+#  The default dashboard link carries the gate's size floor (?floor=), so a
+#  reader clicking through from a flag sees the same view the gate scored.
+#  Keep the value in sync with the workflow's --min-cest.
+dashboard=${3:-https://cinfra-ca.inkbridge.io/profiling/dashboard/?floor=10M}
+store=${4:-https://cinfra-ca.inkbridge.io/profiling/data/}
+
+#  Footer links shown in the summary and the commit comment: the dashboard to
+#  read the run, and the raw result store to browse the published files.
+links="[InkScope dashboard]($dashboard) | [Result store]($store)"
+
+marker='<!-- cest-perf-flag -->'
+sha=${GITHUB_SHA:-unknown}
+short=$(printf '%s' "$sha" | cut -c1-7)
+ref=${GITHUB_REF_NAME:-${GITHUB_REF:-unknown}}
+header="### CPU-cycle profiling (CEst): \`$ref\` @ \`$short\`"
+
+#  The report body may be absent (e.g. a tool error produced no file).
+report=""
+[ -f "$report_file" ] && report=$(cat "$report_file")
+
+#  ---- 1. Job summary, written every run ----------------------------------
+summary=$(mktemp)
+trap 'rm -f "$summary"' EXIT
+{
+	printf '%s\n\n' "$header"
+	case "$rc" in
+	1)
+		if [ -n "$report" ]; then printf '%s\n' "$report"
+		else printf '%s\n' "_A regression was flagged but no report file was produced._"; fi
+		printf '\n%s\n' "$links"
+		;;
+	2)
+		printf '%s\n' ":warning: cest-analyzer reported a tool error (exit 2); no regression verdict this run."
+		;;
+	0)
+		printf '%s\n\n%s\n' \
+			"No CEst regressions past the gate. :white_check_mark:" "$links"
+		;;
+	*)
+		printf '%s\n' "cest-analyzer produced no verdict (exit ${rc:-unknown})."
+		;;
+	esac
+} >"$summary"
+
+[ -n "${GITHUB_STEP_SUMMARY:-}" ] && cat "$summary" >>"$GITHUB_STEP_SUMMARY"
+cat "$summary"
+
+#  ---- 2. Commit comment, best effort -------------------------------------
+#  Only a regression creates a flag; a clean run resolves an existing one; a
+#  tool error leaves any existing flag untouched.
+if [ "$rc" != "1" ] && [ "$rc" != "0" ]; then
+	exit 0
+fi
+
+warn() { echo "::warning::flag-profiling-results: $*"; }
+
+if [ -z "${GH_TOKEN:-}" ]; then warn "GH_TOKEN not set; skipping commit comment"; exit 0; fi
+repo=${GITHUB_REPOSITORY:-}
+if [ -z "$repo" ]; then warn "GITHUB_REPOSITORY not set; skipping commit comment"; exit 0; fi
+api=${GITHUB_API_URL:-https://api.github.com}
+
+#  Find an existing flag comment on this commit (by the hidden marker).
+existing_id=$(curl -sS \
+	-H "Authorization: Bearer $GH_TOKEN" \
+	-H "Accept: application/vnd.github+json" \
+	"$api/repos/$repo/commits/$sha/comments?per_page=100" \
+	| jq -r --arg m "$marker" 'map(select(.body != null and (.body | contains($m)))) | .[0].id // empty') || existing_id=""
+
+#  Build the comment body and JSON-encode it (jq handles all escaping).
+if [ "$rc" = "1" ]; then
+	if [ -n "$report" ]; then body="$marker
+$header
+
+$report
+
+$links"
+	else body="$marker
+$header
+
+_A regression was flagged._
+
+$links"; fi
+else
+	#  rc = 0: nothing to say unless we are resolving a prior flag.
+	[ -n "$existing_id" ] || exit 0
+	body="$marker
+$header
+
+Previously flagged CEst regressions are no longer present; latest run is clean. :white_check_mark:
+
+$links"
+fi
+payload=$(printf '%s' "$body" | jq -Rs '{body: .}')
+
+resp=$(mktemp); trap 'rm -f "$summary" "$resp"' EXIT
+if [ -n "$existing_id" ]; then
+	code=$(curl -sS -o "$resp" -w '%{http_code}' \
+		-X PATCH -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+		-d "$payload" "$api/repos/$repo/comments/$existing_id") || code=000
+	action="update"
+else
+	code=$(curl -sS -o "$resp" -w '%{http_code}' \
+		-X POST -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+		-d "$payload" "$api/repos/$repo/commits/$sha/comments") || code=000
+	action="create"
+fi
+
+case "$code" in
+2??) echo "commit comment ${action}d (HTTP $code)" ;;
+*)
+	warn "could not $action commit comment (HTTP $code)"
+	[ -s "$resp" ] && cat "$resp" >&2
+	;;
+esac
+
+#  Advisory: never fail the build on a commenting problem.
+exit 0

--- a/src/tests/multi-server/all.mk
+++ b/src/tests/multi-server/all.mk
@@ -15,12 +15,17 @@
 #                                     ci:  PROFILING_RESULT_ROOT/<suite>/<test>/<branch>/<commit>/<run-index>
 #                                     dev: PROFILING_RESULT_ROOT/<suite>/<test>  (flat)
 #
+# Profiling tests are their own params files, profiling.<test>.test.yml,
+# with valgrind-paced loadgen keys. Only the profiling targets run them;
+# results publish without the profiling_ prefix (accept/short_ci).
+#
 # Usage:
 #   make -f src/tests/multi-server/all.mk test.multi-server                       # all suites, service image
 #   make -f src/tests/multi-server/all.mk test.multi-server.ci                    # CI subset, service image
-#   make -f src/tests/multi-server/all.mk test.multi-server.profiling             # all suites, profiling image
-#   make -f src/tests/multi-server/all.mk test.multi-server.profiling.ci          # CI subset, profiling image
+#   make -f src/tests/multi-server/all.mk test.multi-server.profiling             # profiling.* tests, profiling image
+#   make -f src/tests/multi-server/all.mk test.multi-server.profiling.ci          # profiling.* CI subset, profiling image
 #   make -f src/tests/multi-server/all.mk test.multi-server.accept.short_ci       # single test
+#   make -f src/tests/multi-server/all.mk test.multi-server.accept.profiling_short_ci MODE=profiling   # single profiling test
 #   make -f src/tests/multi-server/all.mk clean.test.multi-server                 # clean logs
 #
 
@@ -189,12 +194,12 @@ test.multi-server.${1}.${2}: $$(TEST_MULTI_SERVER_RENDERED.${1}.${2}) ${4}/start
 		FREERADIUS_IMAGE=$(FREERADIUS_PROFILING_IMAGE); \
 		PROFILING=yes; \
 		if [ "$(PROFILING_RESULT_MODE)" = "dev" ]; then \
-			PROFILING_RESULT_PATH="$(PROFILING_RESULT_ROOT)/${1}/${2}"; \
+			PROFILING_RESULT_PATH="$(PROFILING_RESULT_ROOT)/${1}/$(patsubst profiling_%,%,${2})"; \
 		else \
 			RUN_BASE="$(PROFILING_RESULT_ROOT)/$(GIT_BRANCH)/$(GIT_COMMIT)"; \
 			EXISTING=$$$$( find "$$$$RUN_BASE" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ' ); \
 			RUN_INDEX=$$$$((EXISTING + 1)); \
-			PROFILING_RESULT_PATH="$$$$RUN_BASE/$$$$RUN_INDEX/${1}/${2}"; \
+			PROFILING_RESULT_PATH="$$$$RUN_BASE/$$$$RUN_INDEX/${1}/$(patsubst profiling_%,%,${2})"; \
 		fi; \
 		mkdir -p "$$$$PROFILING_RESULT_PATH"; \
 		echo "PROFILING_RESULT_PATH: $$$$PROFILING_RESULT_PATH"; \
@@ -268,6 +273,13 @@ $(foreach s,$(TEST_MULTI_SERVER_SUITES),$(eval $(call TEST_MULTI_SERVER,$s)))
 
 TEST_MULTI_SERVER_ALL_TESTS := $(foreach s,$(TEST_MULTI_SERVER_SUITES),$(TEST_MULTI_SERVER_TESTS.$(s)))
 
+#
+#  Partition: profiling.*.test.yml files (test names profiling_*) run only
+#  under the profiling targets; everything else is a service test.
+#
+TEST_MULTI_SERVER_PROFILING_TESTS := $(foreach t,$(TEST_MULTI_SERVER_ALL_TESTS),$(if $(findstring .profiling_,$t),$t))
+TEST_MULTI_SERVER_SERVICE_TESTS   := $(filter-out $(TEST_MULTI_SERVER_PROFILING_TESTS),$(TEST_MULTI_SERVER_ALL_TESTS))
+
 ######################################################################
 #
 #  Top-level targets
@@ -275,30 +287,39 @@ TEST_MULTI_SERVER_ALL_TESTS := $(foreach s,$(TEST_MULTI_SERVER_SUITES),$(TEST_MU
 ######################################################################
 
 #
-#  All tests
+#  All service tests
 #
 .PHONY: test.multi-server
-test.multi-server: $(TEST_MULTI_SERVER_ALL_TESTS)
+test.multi-server: $(TEST_MULTI_SERVER_SERVICE_TESTS)
 
 #
-#  CI tests only - matches *.ci.test.yml param files
+#  CI subsets - *.ci.test.yml param files (test names ending _ci), split
+#  the same way: service files for the service CI run, profiling.* files
+#  for the profiling CI run.
 #
-TEST_MULTI_SERVER_CI_TESTS := $(filter %_ci,$(TEST_MULTI_SERVER_ALL_TESTS))
+TEST_MULTI_SERVER_CI_TESTS           := $(filter %_ci,$(TEST_MULTI_SERVER_SERVICE_TESTS))
+TEST_MULTI_SERVER_PROFILING_CI_TESTS := $(filter %_ci,$(TEST_MULTI_SERVER_PROFILING_TESTS))
 
 .PHONY: test.multi-server.ci
 test.multi-server.ci: $(TEST_MULTI_SERVER_CI_TESTS)
 
 #
-#  Profiling pass: same suites, profiling image, valgrind wrapper. Forces
-#  MODE=profiling via a recursive sub-make so the per-test recipes pick up
-#  the right image / env without needing the operator to set MODE manually.
+#  Profiling pass: the profiling.* tests only, profiling image, valgrind
+#  wrapper. Forces MODE=profiling via a recursive sub-make so the per-test
+#  recipes pick up the right image / env without needing the operator to set
+#  MODE manually. The -tests aggregates exist for the recursive make; call
+#  the outer targets, which build the image first.
 #
+.PHONY: test.multi-server.profiling-tests test.multi-server.profiling-tests.ci
+test.multi-server.profiling-tests: $(TEST_MULTI_SERVER_PROFILING_TESTS)
+test.multi-server.profiling-tests.ci: $(TEST_MULTI_SERVER_PROFILING_CI_TESTS)
+
 .PHONY: test.multi-server.profiling test.multi-server.profiling.ci
 test.multi-server.profiling: freeradius-prof.image
-	$(Q)$(MAKE) -f $(DIR)/all.mk test.multi-server MODE=profiling
+	$(Q)$(MAKE) -f $(DIR)/all.mk test.multi-server.profiling-tests MODE=profiling
 
 test.multi-server.profiling.ci: freeradius-prof.image
-	$(Q)$(MAKE) -f $(DIR)/all.mk test.multi-server.ci MODE=profiling
+	$(Q)$(MAKE) -f $(DIR)/all.mk test.multi-server.profiling-tests.ci MODE=profiling
 
 #
 #  Profiling image: build the standard freeradius4-profiling/<image>:<sha>

--- a/src/tests/multi-server/tests/accept/profiling.extended.test.yml
+++ b/src/tests/multi-server/tests/accept/profiling.extended.test.yml
@@ -1,0 +1,26 @@
+# Topology - N/A for profiling test
+
+# Routing - N/A for profiling test
+
+# Load generator configuration
+#
+# Extended profiling run (the nightly test.multi-server.profiling, which
+# forces MODE=profiling): the profiling.short.ci pacing with double the send
+# window (25 pps x 480s = 12,000 messages), for a longer look at steady-state
+# cost. The native send window stretches far longer under valgrind, hence
+# "extended". Publishes to the store leaf <suite>/extended (all.mk strips the
+# profiling_ prefix from the result path).
+loadgen:
+  start_pps: 25
+  max_pps: 25
+  duration: 480
+  step: 25
+  parallel: 1
+  max_backlog: 1000
+  repeat: "no"
+
+# Test framework
+# Send window is 12,000 messages / 25 pps = 480s; the timeouts must cover
+# 480s plus startup and shutdown.
+test_timeout: 540
+test_verify_timeout: 530

--- a/src/tests/multi-server/tests/accept/profiling.short.ci.test.yml
+++ b/src/tests/multi-server/tests/accept/profiling.short.ci.test.yml
@@ -1,0 +1,23 @@
+# Topology - N/A for profiling test
+
+# Routing - N/A for profiling test
+
+# Load generator configuration
+#
+# Profiling flavor of short_ci (run by test.multi-server.profiling.ci, which
+# forces MODE=profiling): the server runs under valgrind/callgrind, so the
+# load is paced slower than short.ci.test.yml so proto_load doesn't gate and
+# the CEst total stays deterministic. Results publish to the same store leaf
+# as short_ci (all.mk strips the profiling_ prefix from the result path).
+loadgen:
+  start_pps: 25
+  max_pps: 25
+  duration: 240
+  step: 25
+  parallel: 1
+  max_backlog: 1000
+  repeat: "no"
+
+# Test framework
+test_timeout: 300
+test_verify_timeout: 290

--- a/src/tests/multi-server/tests/accept/short.ci.test.yml
+++ b/src/tests/multi-server/tests/accept/short.ci.test.yml
@@ -3,6 +3,9 @@
 # Routing - N/A for profiling test
 
 # Load generator configuration
+#
+# Service-mode pacing. The profiling flavor lives in
+# profiling.short.ci.test.yml, paced slower for valgrind/callgrind.
 loadgen:
   start_pps: 100
   max_pps: 100
@@ -13,5 +16,5 @@ loadgen:
   repeat: "no"
 
 # Test framework
-test_timeout: 125
-test_verify_timeout: 120
+test_timeout: 300
+test_verify_timeout: 290

--- a/src/tests/multi-server/tests/ldap/profiling.extended.test.yml
+++ b/src/tests/multi-server/tests/ldap/profiling.extended.test.yml
@@ -1,0 +1,27 @@
+# Topology - N/A for profiling test
+
+# Routing - N/A for profiling test
+
+# Load generator configuration
+#
+# Extended profiling run (the nightly test.multi-server.profiling, which
+# forces MODE=profiling): the profiling.short.ci pacing with double the send
+# window (25 pps x 480s = 12,000 messages), for a longer look at steady-state
+# cost. The native send window stretches far longer under valgrind, hence
+# "extended". Publishes to the store leaf <suite>/extended (all.mk strips the
+# profiling_ prefix from the result path).
+# Backend suite: 25 pps may still gate - check the stats CSV and lower if so.
+loadgen:
+  start_pps: 25
+  max_pps: 25
+  duration: 480
+  step: 25
+  parallel: 1
+  max_backlog: 1000
+  repeat: "no"
+
+# Test framework
+# Send window is 12,000 messages / 25 pps = 480s; the timeouts must cover
+# 480s plus startup and shutdown.
+test_timeout: 540
+test_verify_timeout: 530

--- a/src/tests/multi-server/tests/ldap/profiling.short.ci.test.yml
+++ b/src/tests/multi-server/tests/ldap/profiling.short.ci.test.yml
@@ -1,0 +1,24 @@
+# Topology - N/A for profiling test
+
+# Routing - N/A for profiling test
+
+# Load generator configuration
+#
+# Profiling flavor of short_ci (run by test.multi-server.profiling.ci, which
+# forces MODE=profiling): the server runs under valgrind/callgrind, so the
+# load is paced slower than short.ci.test.yml so proto_load doesn't gate and
+# the CEst total stays deterministic. Results publish to the same store leaf
+# as short_ci (all.mk strips the profiling_ prefix from the result path).
+# Backend suite: 25 pps may still gate - check the stats CSV and lower if so.
+loadgen:
+  start_pps: 25
+  max_pps: 25
+  duration: 240
+  step: 25
+  parallel: 1
+  max_backlog: 1000
+  repeat: "no"
+
+# Test framework
+test_timeout: 300
+test_verify_timeout: 290

--- a/src/tests/multi-server/tests/ldap/short.ci.test.yml
+++ b/src/tests/multi-server/tests/ldap/short.ci.test.yml
@@ -3,6 +3,9 @@
 # Routing - N/A for profiling test
 
 # Load generator configuration
+#
+# Service-mode pacing. The profiling flavor lives in
+# profiling.short.ci.test.yml, paced slower for valgrind/callgrind.
 loadgen:
   start_pps: 100
   max_pps: 100
@@ -13,5 +16,5 @@ loadgen:
   repeat: "no"
 
 # Test framework
-test_timeout: 125
-test_verify_timeout: 120
+test_timeout: 300
+test_verify_timeout: 290

--- a/src/tests/multi-server/tests/mysql/profiling.extended.test.yml
+++ b/src/tests/multi-server/tests/mysql/profiling.extended.test.yml
@@ -1,0 +1,28 @@
+# Topology - N/A for profiling test
+
+# Routing - N/A for profiling test
+
+# Load generator configuration
+#
+# Extended profiling run (the nightly test.multi-server.profiling, which
+# forces MODE=profiling): the profiling.short.ci pacing with double the send
+# window (15 pps x 800s = 12,000 messages), for a longer look at steady-state
+# cost. The native send window stretches far longer under valgrind, hence
+# "extended". Publishes to the store leaf <suite>/extended (all.mk strips the
+# profiling_ prefix from the result path).
+# Backend suite: 15 pps, the rate profiling.short.ci settled on after 25 pps
+# still gated.
+loadgen:
+  start_pps: 15
+  max_pps: 15
+  duration: 800
+  step: 15
+  parallel: 1
+  max_backlog: 1000
+  repeat: "no"
+
+# Test framework
+# Send window is 12,000 messages / 15 pps = 800s; the timeouts must cover
+# 800s plus startup and shutdown.
+test_timeout: 880
+test_verify_timeout: 870

--- a/src/tests/multi-server/tests/mysql/profiling.short.ci.test.yml
+++ b/src/tests/multi-server/tests/mysql/profiling.short.ci.test.yml
@@ -1,0 +1,27 @@
+# Topology - N/A for profiling test
+
+# Routing - N/A for profiling test
+
+# Load generator configuration
+#
+# Profiling flavor of short_ci (run by test.multi-server.profiling.ci, which
+# forces MODE=profiling): the server runs under valgrind/callgrind, so the
+# load is paced slower than short.ci.test.yml so proto_load doesn't gate and
+# the CEst total stays deterministic. Results publish to the same store leaf
+# as short_ci (all.mk strips the profiling_ prefix from the result path).
+# Backend suite: 25 pps still gated (same-commit CV ~6%), so profiling runs
+# at 15 pps / 400s (~6,000 messages).
+loadgen:
+  start_pps: 15
+  max_pps: 15
+  duration: 400
+  step: 15
+  parallel: 1
+  max_backlog: 1000
+  repeat: "no"
+
+# Test framework
+# Send window is 6000 messages / 15 pps = 400s; the timeouts must cover 400s
+# plus startup and shutdown.
+test_timeout: 480
+test_verify_timeout: 470

--- a/src/tests/multi-server/tests/mysql/short.ci.test.yml
+++ b/src/tests/multi-server/tests/mysql/short.ci.test.yml
@@ -3,6 +3,9 @@
 # Routing - N/A for profiling test
 
 # Load generator configuration
+#
+# Service-mode pacing. The profiling flavor lives in
+# profiling.short.ci.test.yml, paced slower for valgrind/callgrind.
 loadgen:
   start_pps: 100
   max_pps: 100
@@ -13,5 +16,5 @@ loadgen:
   repeat: "no"
 
 # Test framework
-test_timeout: 125
-test_verify_timeout: 120
+test_timeout: 300
+test_verify_timeout: 290

--- a/src/tests/multi-server/tests/pap-auth/profiling.extended.test.yml
+++ b/src/tests/multi-server/tests/pap-auth/profiling.extended.test.yml
@@ -1,0 +1,26 @@
+# Topology - N/A for profiling test
+
+# Routing - N/A for profiling test
+
+# Load generator configuration
+#
+# Extended profiling run (the nightly test.multi-server.profiling, which
+# forces MODE=profiling): the profiling.short.ci pacing with double the send
+# window (25 pps x 480s = 12,000 messages), for a longer look at steady-state
+# cost. The native send window stretches far longer under valgrind, hence
+# "extended". Publishes to the store leaf <suite>/extended (all.mk strips the
+# profiling_ prefix from the result path).
+loadgen:
+  start_pps: 25
+  max_pps: 25
+  duration: 480
+  step: 25
+  parallel: 1
+  max_backlog: 1000
+  repeat: "no"
+
+# Test framework
+# Send window is 12,000 messages / 25 pps = 480s; the timeouts must cover
+# 480s plus startup and shutdown.
+test_timeout: 540
+test_verify_timeout: 530

--- a/src/tests/multi-server/tests/pap-auth/profiling.short.ci.test.yml
+++ b/src/tests/multi-server/tests/pap-auth/profiling.short.ci.test.yml
@@ -1,0 +1,23 @@
+# Topology - N/A for profiling test
+
+# Routing - N/A for profiling test
+
+# Load generator configuration
+#
+# Profiling flavor of short_ci (run by test.multi-server.profiling.ci, which
+# forces MODE=profiling): the server runs under valgrind/callgrind, so the
+# load is paced slower than short.ci.test.yml so proto_load doesn't gate and
+# the CEst total stays deterministic. Results publish to the same store leaf
+# as short_ci (all.mk strips the profiling_ prefix from the result path).
+loadgen:
+  start_pps: 25
+  max_pps: 25
+  duration: 240
+  step: 25
+  parallel: 1
+  max_backlog: 1000
+  repeat: "no"
+
+# Test framework
+test_timeout: 300
+test_verify_timeout: 290

--- a/src/tests/multi-server/tests/pap-auth/short.ci.test.yml
+++ b/src/tests/multi-server/tests/pap-auth/short.ci.test.yml
@@ -3,6 +3,9 @@
 # Routing - N/A for profiling test
 
 # Load generator configuration
+#
+# Service-mode pacing. The profiling flavor lives in
+# profiling.short.ci.test.yml, paced slower for valgrind/callgrind.
 loadgen:
   start_pps: 100
   max_pps: 100
@@ -13,5 +16,5 @@ loadgen:
   repeat: "no"
 
 # Test framework
-test_timeout: 125
-test_verify_timeout: 120
+test_timeout: 300
+test_verify_timeout: 290


### PR DESCRIPTION
Two pieces that together make per-commit CPU-cycle (CEst) regression flagging trustworthy.

**Deterministic profiling pacing** (multi-server tests):

- Each suite's profiling run is its own params file (`profiling.short.ci.test.yml`,
  `profiling.extended.test.yml`)
- proto_load configuration adjusted to send packets at a slower rate which allows us to more consistent profiling results when using Valgrind. 
- all.mk partitions the targets: profiling targets run only the profiling.* tests.
- Results measured across 10 CI runs of one commit has now has a cycle estimate spread of 0.11-0.32% per suite. It was previously up to 7.4%, and the mysql profiling runs generated unusable results for accurate profiling analysis.

**Regression flagging** (workflow + `scripts/ci/flag-profiling-results.sh`):

- The profiling leg compares each suite's fresh results against the store's previous run,
  with thresholds calibrated from the measured noise floor; 

> --gate 15 sets the failure threshold at 15% (for example)
> --min-cest 10000000 (minimum amount of cycles a function needs in a run before its results get checked)
> --gate-scope \<value\>
>  - function (function cycles checked)
>  - total (total cycles of run checked)
>  - both (total cycles of the run and per function cycles checked)

- CI status includes a link to the dashboard UI
- Commit commenting is implemented (sticky comment, updated on re-runs, resolved by a clean
  run, degrades gracefully without a token) but switched OFF by default for now

**Verified**:

- Verified new make targets
- Analyzed the consistency of the profiling results on 10 CI runs
- Verified new script that checks latest CI run results with previous
