### PR TITLE
multi-server tests: profiling test packet rate adjustments

### DIFF
--- a/src/tests/multi-server/tests/accept/short.ci.test.yml
+++ b/src/tests/multi-server/tests/accept/short.ci.test.yml
@@ -4,14 +4,14 @@
 
 # Load generator configuration
 loadgen:
-  start_pps: 100
-  max_pps: 100
-  duration: 60
+  start_pps: 50
+  max_pps: 50
+  duration: 120
   step: 100
   parallel: 1
   max_backlog: 1000
   repeat: "no"
 
 # Test framework
-test_timeout: 125
-test_verify_timeout: 120
+test_timeout: 300
+test_verify_timeout: 290

--- a/src/tests/multi-server/tests/ldap/short.ci.test.yml
+++ b/src/tests/multi-server/tests/ldap/short.ci.test.yml
@@ -4,14 +4,14 @@
 
 # Load generator configuration
 loadgen:
-  start_pps: 100
-  max_pps: 100
-  duration: 60
+  start_pps: 50
+  max_pps: 50
+  duration: 120
   step: 100
   parallel: 1
   max_backlog: 1000
   repeat: "no"
 
 # Test framework
-test_timeout: 125
-test_verify_timeout: 120
+test_timeout: 300
+test_verify_timeout: 290

--- a/src/tests/multi-server/tests/mysql/short.ci.test.yml
+++ b/src/tests/multi-server/tests/mysql/short.ci.test.yml
@@ -4,14 +4,14 @@
 
 # Load generator configuration
 loadgen:
-  start_pps: 100
-  max_pps: 100
-  duration: 60
+  start_pps: 50
+  max_pps: 50
+  duration: 120
   step: 100
   parallel: 1
   max_backlog: 1000
   repeat: "no"
 
 # Test framework
-test_timeout: 125
-test_verify_timeout: 120
+test_timeout: 300
+test_verify_timeout: 290

--- a/src/tests/multi-server/tests/pap-auth/short.ci.test.yml
+++ b/src/tests/multi-server/tests/pap-auth/short.ci.test.yml
@@ -4,14 +4,14 @@
 
 # Load generator configuration
 loadgen:
-  start_pps: 100
-  max_pps: 100
-  duration: 60
+  start_pps: 50
+  max_pps: 50
+  duration: 120
   step: 100
   parallel: 1
   max_backlog: 1000
   repeat: "no"
 
 # Test framework
-test_timeout: 125
-test_verify_timeout: 120
+test_timeout: 300
+test_verify_timeout: 290


### PR DESCRIPTION
Here's what changed (replaces PR https://github.com/FreeRADIUS/freeradius-server/pull/5907):

- proto_load configuration adjusted to send packets at a slower rate which allows us to have more consistent profiling results when using Valgrind. 

- we attempted to increase the rate to 200pps to make the tests even quicker but that made things worse when profiling with Valgrind; tests like the mysql tests couldn't have all messages processed before the test ended.  Even at 100pps which was the original rate caused issues with more complex tests like the mysql test.

- 50pps seems to be a sweet spot for running tests and profiling with Valgrind.  Slower than our original short.ci test but gives us better results.
