### PR TITLE
Fix libbacktrace build when BUILD_DIR resolves to an absolute path

### DIFF
--- a/src/lib/util/libfreeradius-util.mk
+++ b/src/lib/util/libfreeradius-util.mk
@@ -150,7 +150,7 @@ TGT_LDFLAGS	+= -L$(top_builddir)/build/lib/local/.libs
 src/include/backtrace:
 	cd src/include && ln -s ../lib/backtrace
 
-build/objs/src/lib/util/backtrace.$(OBJ_EXT): | src/include/backtrace
+$(BUILD_DIR)/objs/src/lib/util/backtrace.$(OBJ_EXT): | src/include/backtrace
 
 # Actually call the 'sub'-make to build libbacktrace.
 #
@@ -166,19 +166,19 @@ src/lib/backtrace/libbacktrace.la src/lib/backtrace/.libs/libbacktrace.a &:
 	$(MAKE) -C $(top_srcdir)/src/lib/backtrace
 
 # We need to do this so jlibtool can find the library.
-build/lib/.libs/libbacktrace.a: src/lib/backtrace/.libs/libbacktrace.a
+$(BUILD_DIR)/lib/.libs/libbacktrace.a: src/lib/backtrace/.libs/libbacktrace.a
 	cp $< $@
 
 # Boilermake needs this target to exist
-build/lib/libbacktrace.la: src/lib/backtrace/libbacktrace.la build/lib/.libs/libbacktrace.a
+$(BUILD_DIR)/lib/libbacktrace.la: src/lib/backtrace/libbacktrace.la $(BUILD_DIR)/lib/.libs/libbacktrace.a
 	cp $< $@
 
 # We need to do this so jlibtool can find the library.
-build/lib/local/.libs/libbacktrace.a: src/lib/backtrace/.libs/libbacktrace.a
+$(BUILD_DIR)/lib/local/.libs/libbacktrace.a: src/lib/backtrace/.libs/libbacktrace.a
 	cp $< $@
 
 # Boilermake needs this target to exist
-build/lib/local/libbacktrace.la: src/lib/backtrace/libbacktrace.la build/lib/local/.libs/libbacktrace.a
+$(BUILD_DIR)/lib/local/libbacktrace.la: src/lib/backtrace/libbacktrace.la $(BUILD_DIR)/lib/local/.libs/libbacktrace.a
 	cp $< $@
 endif
 


### PR DESCRIPTION
## Summary

Fixes #5900. `src/lib/util/libfreeradius-util.mk` hardcodes the literal
string `build/` for the libbacktrace object/library targets instead of
using `$(BUILD_DIR)`. `scripts/boiler.mk` only sets `BUILD_DIR` to the
relative `build` when `top_builddir` string-matches `$(PWD)`; otherwise
(e.g. cross-builds like OpenWrt/Buildroot, where `top_builddir` doesn't
match `$(PWD)` as a literal string) it canonicalizes `BUILD_DIR` to an
absolute path.

That mismatch means the order-only prerequisite meant to build the
`src/include/backtrace -> ../lib/backtrace` symlink before compiling
`backtrace.c` names a different make target than the one `boiler.mk`
actually builds under an absolute `BUILD_DIR`, so the symlink is
silently never created, and the build fails with:

    src/lib/util/backtrace.c:32:12: fatal error:
    freeradius-devel/backtrace/backtrace.h: No such file or directory

## Fix

Replace the hardcoded `build/` paths with `$(BUILD_DIR)` in the five
affected rules (the backtrace.c object prerequisite, and the four
libbacktrace.a/.la copy rules), matching the convention already used
elsewhere in the build (`scripts/install.mk`, `scripts/libtool.mk`).

## Test plan

- [x] Confirmed `WITH_BACKTRACE = yes` and `HAVE_BACKTRACE` defined
- [x] Confirmed `src/include/backtrace` symlink is created before
      `backtrace.c` is compiled when `BUILD_DIR` resolves absolute
- [x] Full build succeeds with libbacktrace enabled under an
      OpenWrt/Buildroot-style cross-compile where `top_builddir` is
      passed as an absolute path