### PR TITLE
docs-v4: Adjusted level 1 headings to level 2 headings in adoc files …

### DIFF
--- a/doc/antora/modules/reference/pages/raddb/radiusd.conf.adoc
+++ b/doc/antora/modules/reference/pages/raddb/radiusd.conf.adoc
@@ -364,7 +364,7 @@ cleaned up. The server does not do this automatically.
 
 
 
-= ENVIRONMENT VARIABLES
+== ENVIRONMENT VARIABLES
 
 You can reference environment variables using an expansion like
 `$ENV{PATH}`. However it is sometimes useful to be able to also set
@@ -420,7 +420,7 @@ entries.
 
 
 
-= Templates
+== Templates
 
 Template files hold common definitions that can be used in other
 server sections. When a template is referenced, the configuration
@@ -435,7 +435,7 @@ referencing syntax.
 
 
 
-= Security Configuration
+== Security Configuration
 
 There may be multiple methods of attacking on the server. This
 section holds the configuration items which minimize the impact of
@@ -553,7 +553,7 @@ Setting this number to 0 means "allow any number of attributes"
 
 
 
-= Clients Configuration
+== Clients Configuration
 
 Client configuration is defined in `clients.conf`.
 
@@ -570,7 +570,7 @@ information from the old-style configuration files.
 
 
 
-= Thread Pool Configuration
+== Thread Pool Configuration
 
 In v4, the thread pool does not change size dynamically. Instead,
 there are a small number of threads which read from the network,
@@ -610,7 +610,7 @@ restarted.
 
 
 
-= Triggers and SNMP notifications.
+== Triggers and SNMP notifications.
 
 Uncomment the following line to enable snmptraps. Note that you
 MUST also configure the full path to the `snmptrap` command in the
@@ -626,7 +626,7 @@ configuration file in global.d
 
 
 
-= Migration Flags
+== Migration Flags
 
 These flags are only for the "alpha" release of v4. They will be
 removed (and made into errors!) in the final release.
@@ -639,7 +639,7 @@ Dictionary migration instructions can be found in
 
 
 
-= Module Configuration
+== Module Configuration
 
 The names and configuration of each module is located in this
 section.
@@ -695,7 +695,7 @@ authenticate, accounting, pre/post-proxy, etc.
 
 
 
-= Policies
+== Policies
 
 Policies are virtual modules.
 
@@ -709,7 +709,7 @@ If policy A calls policy B, then B MUST be defined before A.
 
 
 
-= Load virtual servers.
+== Load virtual servers.
 
 This next $INCLUDE line loads files in the directory that match the
 regular expression: /[a-zA-Z0-9_.]+/

--- a/doc/antora/modules/reference/pages/raddb/sites-available/eap-psk.adoc
+++ b/doc/antora/modules/reference/pages/raddb/sites-available/eap-psk.adoc
@@ -20,8 +20,8 @@ of mods-available/eap:
 ----
 psk {
 ----
-#       virtual_server = eap-psk
 ----
+     virtual_server = eap-psk
 }
 ----
 


### PR DESCRIPTION
…to prevent `build-docsite` errors.

Source files in raddb need updating with these changes.