### PR TITLE
typo: "ownership" and "directory" -> "socket"

### DIFF
--- a/src/lib/bio/fd_open.c
+++ b/src/lib/bio/fd_open.c
@@ -642,7 +642,7 @@ static int fr_bio_fd_socket_bind_unix(fr_bio_fd_t *my, fr_bio_fd_config_t const 
 	 *	Otherwise if we're running as root, it will set ownership to the correct user.
 	 */
 	if (fchown(my->info.socket.fd, cfg->uid, cfg->gid) < 0) {
-		fr_strerror_printf("Failed changing ownershipt for domain directory %s: %s", cfg->path, fr_syserror(errno));
+		fr_strerror_printf("Failed changing ownership for domain socket %s: %s", cfg->path, fr_syserror(errno));
 		goto fail;
 	}
 

--- a/src/lib/bio/fd_open.c
+++ b/src/lib/bio/fd_open.c
@@ -478,7 +478,7 @@ static int fr_bio_fd_socket_unix_mkdir(int *dirfd, char const **filename, fr_bio
 	}
 
 	if (fchmod(fd, perm) < 0) {
-		fr_strerror_printf("Failed changing permission for directory %s: %s", dir, fr_syserror(errno));
+		fr_strerror_printf("Failed changing permission for socket %s: %s", dir, fr_syserror(errno));
 	close_fd:
 		close(fd);
 		goto close_parent;
@@ -490,7 +490,7 @@ static int fr_bio_fd_socket_unix_mkdir(int *dirfd, char const **filename, fr_bio
 	 *	Otherwise if we're running as root, it will set ownership to the correct user.
 	 */
 	if (fchown(fd, cfg->uid, cfg->gid) < 0) {
-		fr_strerror_printf("Failed changing ownership for directory %s: %s", dir, fr_syserror(errno));
+		fr_strerror_printf("Failed changing ownership for socket %s: %s", dir, fr_syserror(errno));
 		goto close_fd;
 	}
 


### PR DESCRIPTION
Fixed typo for "ownership" and corrected "directory" to "socket" in this context