### PR TITLE
Fix radmin to parse named listen blocks

### DIFF
--- a/src/listen/control/radmin.c
+++ b/src/listen/control/radmin.c
@@ -718,7 +718,7 @@ static int check_server(CONF_SECTION *subcs, uid_t uid, gid_t gid, char const **
 	*server_p = server;	/* need this for error messages */
 
 	/*	listen {} */
-	cs = cf_section_find(subcs, "listen", NULL);
+	cs = cf_section_find(subcs, "listen", CF_IDENT_ANY);
 	if (!cs) {
 		fprintf(stderr, "%s: Failed parsing 'listen{}' section in 'server %s {...}'\n", progname, server);
 		return -1;
@@ -732,7 +732,7 @@ static int check_server(CONF_SECTION *subcs, uid_t uid, gid_t gid, char const **
 	if (!value) return 0;
 
 	/*	<transport> { ... } */
-	subcs = cf_section_find(cs, value, NULL);
+	subcs = cf_section_find(cs, value, CF_IDENT_ANY);
 	if (!subcs) {
 		fprintf(stderr, "%s: Failed parsing the '%s {}' section in 'server %s {...}'\n",
 			progname, value, server);


### PR DESCRIPTION
radmin was calling cf_section_find() with NULL for name2, matching only unlabeled sections. Using radmin -d /path/to/radius/configs where there were named listen blocks would fail. The fix uses CF_IDENT_ANY instead of NULL to match any name2