### PR TITLE
multi-server: one profiling run index per make invocation

### DIFF
--- a/src/tests/multi-server/README.md
+++ b/src/tests/multi-server/README.md
@@ -42,7 +42,10 @@ make test.multi-server.profiling.ci    # CI subset
 ```
 
 Profiling results land under
-`prof-results/<suite>/<test>/<branch>/<commit>/<run-index>/`. Set
+`prof-results/<branch>/<commit>/<run-index>/<suite>/<test>/`. One make
+invocation is one run index, so every suite and test of a single run sits
+under the same one; in CI that index is the workflow run number, locally it
+is the highest run index already present plus one. Set
 `PROFILING_RESULT_MODE=dev` to use a flat per-suite layout that overwrites
 each run.
 

--- a/src/tests/multi-server/all.mk
+++ b/src/tests/multi-server/all.mk
@@ -12,7 +12,7 @@
 #                                   PROFILING_RESULT_PATH.
 # - PROFILING_RESULT_MODE=<ci|dev>      Profiling output layout (only meaningful when
 #                                   MODE=profiling). Default `ci`.
-#                                     ci:  PROFILING_RESULT_ROOT/<suite>/<test>/<branch>/<commit>/<run-index>
+#                                     ci:  PROFILING_RESULT_ROOT/<branch>/<commit>/<run-index>/<suite>/<test>
 #                                     dev: PROFILING_RESULT_ROOT/<suite>/<test>  (flat)
 #
 # Usage:
@@ -45,6 +45,18 @@ GIT_BRANCH         := $(or $(shell git -C $(top_srcdir) rev-parse --abbrev-ref H
 GIT_COMMIT         := $(or $(shell git -C $(top_srcdir) rev-parse --short HEAD 2>/dev/null),unknown-commit)
 PROFILING_RESULT_ROOT  := $(abspath $(top_srcdir)/prof-results)
 PROFILING_RESULT_MODE  ?= ci
+
+#
+#  One run index for the whole invocation, so every suite/test of a run lands
+#  under the same one. ':=' is evaluated once at parse time, before any recipe
+#  runs, so parallel recipes cannot each allocate their own index.
+#  CI uses the workflow run number; locally, the next number after the run
+#  dirs already under <branch>/<commit>.
+#
+PROFILING_RUN_BASE  := $(PROFILING_RESULT_ROOT)/$(GIT_BRANCH)/$(GIT_COMMIT)
+PROFILING_LAST_RUN   = $(shell find "$(PROFILING_RUN_BASE)" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | \
+			sed 's|.*/||' | grep -xE '[0-9]+' | sort -n | tail -1)
+PROFILING_RUN_INDEX := $(or $(GITHUB_RUN_NUMBER),$(shell expr $(or $(PROFILING_LAST_RUN),0) + 1))
 
 #
 #  Image plumbing.
@@ -192,10 +204,7 @@ test.multi-server.${1}.${2}: $$(TEST_MULTI_SERVER_RENDERED.${1}.${2}) ${4}/start
 		if [ "$(PROFILING_RESULT_MODE)" = "dev" ]; then \
 			PROFILING_RESULT_PATH="$(PROFILING_RESULT_ROOT)/${1}/${2}"; \
 		else \
-			RUN_BASE="$(PROFILING_RESULT_ROOT)/$(GIT_BRANCH)/$(GIT_COMMIT)"; \
-			EXISTING=$$$$( find "$$$$RUN_BASE" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ' ); \
-			RUN_INDEX=$$$$((EXISTING + 1)); \
-			PROFILING_RESULT_PATH="$$$$RUN_BASE/$$$$RUN_INDEX/${1}/${2}"; \
+			PROFILING_RESULT_PATH="$(PROFILING_RUN_BASE)/$(PROFILING_RUN_INDEX)/${1}/${2}"; \
 		fi; \
 		mkdir -p "$$$$PROFILING_RESULT_PATH"; \
 		echo "PROFILING_RESULT_PATH: $$$$PROFILING_RESULT_PATH"; \


### PR DESCRIPTION
This change ensures all profiling test results are generated and saved in a directory structure that uses a single run index per make invocation.  

Without this change, when tests run in parallel (-j), results from one invocation could scatter across several indexes.  This is because the previous implementation computed the index inside each test's recipe. 

The index is now calculated once at makefile parse time and before any tests are run, calculated from the workflow run number in CI, highest existing plus one locally.

There's also a minor edit in the README to fix the directory structure of the profiling results.