### PR TITLE
docs-v4: Fixed table options syntax so that the first rowder  renders…

### DIFF
--- a/doc/antora/modules/concepts/pages/session/radius_session_msg.adoc
+++ b/doc/antora/modules/concepts/pages/session/radius_session_msg.adoc
@@ -21,7 +21,7 @@ RADIUS server use may be difficult.
 Basic RADIUS attribute types are defined in http://tools.ietf.org/html/rfc2865[RFC 2865]. Since the original implementation and standardisation, additional attribute types have been also defined.
 
 .RADIUS Attribute Types
-[options="headers, autowidth"]
+[options="header, autowidth"]
 |===
 | *Type*                | *Format*                       | *Description*
 | integer               | Value between 0 - 4294967295   | Unsigned 32-bit integer.

--- a/doc/antora/modules/reference/pages/xlat/all.adoc
+++ b/doc/antora/modules/reference/pages/xlat/all.adoc
@@ -2,7 +2,7 @@
 
 
 .File Handling Functions
-[options="headers, autowidth]
+[options="header, autowidth"]
 |===
 | *Function*				            | *Description*
 | xref:reference:xlat/file/escape.adoc[escape]	    | Returns an escaped or safe version of the input string.
@@ -16,7 +16,7 @@
 == Miscellaneous Functions
 
 .Miscellaneous Functions
-[options="headers, autowidth]
+[options="header, autowidth"]
 |===
 | *Function*				            | *Description*
 | xref:xlat/misc/config.adoc[Server Configuration]  | Examine configuration items.
@@ -29,7 +29,7 @@
 == Pair Manipulation
 
 .Pair Manipulation
-[options="headers, autowidth]
+[options="header, autowidth"]
 |===
 | *Function*					| *Description*
 | xref:xlat/interpreter.adoc#debug_xlat[debug]  | Print attributes to the debug output.

--- a/doc/antora/modules/reference/pages/xlat/file/index.adoc
+++ b/doc/antora/modules/reference/pages/xlat/file/index.adoc
@@ -7,7 +7,7 @@ The filenames can be taken from untrusted sources, in which cases special charac
 For example, the "unsafe" string `user@freeradius.org/..` will turn into the filename `user@freeradius.org_2f..`.  This operation renders the filename "safe" for operations on the local file system.  It is not possible for unsafe data to create unexpected files, or to perform directory traversal attacks.
 
 .File Handling Functions
-[options="headers, autowidth]
+[options="header, autowidth"]
 |===
 | *Function*				                | *Description*
 | xref:xlat/file/cat.adoc[cat]				| Returns the contents of a file.

--- a/doc/antora/modules/reference/pages/xlat/misc/index.adoc
+++ b/doc/antora/modules/reference/pages/xlat/misc/index.adoc
@@ -5,7 +5,7 @@ of built-in expansions.  These expansions act largely as functions
 which operate on inputs, and produce an output.
 
 .Builtin Functions
-[options="headers, autowidth]
+[options="header, autowidth"]
 |===
 | *Function*				            | *Description*
 | xref:xlat/misc/config.adoc[Server Configuration]  | Examine configuration items

--- a/doc/antora/modules/reference/pages/xlat/pairs/index.adoc
+++ b/doc/antora/modules/reference/pages/xlat/pairs/index.adoc
@@ -3,7 +3,7 @@
 These functions manipulate attribute-value pairs.
 
 .Pair Manipulation
-[options="headers, autowidth]
+[options="header, autowidth"]
 |===
 | *Function*					| *Description*
 | xref:xlat/interpreter.adoc#debug_xlat[debug]  | Print attributes to the debug output.


### PR DESCRIPTION
… correctly with text/colour-fill.