### PR TITLE
Coverity CID 1700533 - Handle fr_hash_table_delete return

### DIFF
--- a/src/modules/rlm_linelog/file.c
+++ b/src/modules/rlm_linelog/file.c
@@ -96,7 +96,13 @@ void file_batching_xlat_handle_signal(xlat_ctx_t const *xctx, request_t *request
 
 static int _file_free(rlm_linelog_file_t *file)
 {
-	(void) fr_hash_table_delete(file->thread_inst->file_table, file);
+	int ret;
+
+	ret = fr_hash_table_delete(file->thread_inst->file_table, file);
+
+	fr_fatal_assert_msg(ret >= 0, "Failed removing \"%s\" from file_table: %s", file->filename, fr_strerror());
+
+	fr_cond_assert_msg(ret == 0, "file_table delete for \"%s\" returned \"not found\"", file->filename);
 
 	return 0;
 }


### PR DESCRIPTION
Possible returns for fr_hash_table_delete and how we handle them (and reasoning):
- `-1` means the comparator errored mid-search, so `file` may still be linked into the table. This really shouldn't happen, especially since it is just a strcmp, but if it does happen then this is fatal since there is no safe recovery available here to prevent a potential use-after-free.
- `0` the delete was fine. We don't need to do anything else.
- `1` the entry was not found, meaning `file` wasn't in the `file_table`. This shouldn't happen given the insert always precedes talloc_set_destructor(), and nothing is dangling, so we are safe to free. We log it (and panic in debug builds) even though nothing acts on the result, since we don't want to silently miss this case in a future code change.