### PR TITLE
print.c: sync list of tokens from token.h

### DIFF
--- a/src/lib/print.c
+++ b/src/lib/print.c
@@ -632,6 +632,7 @@ static char const *vp_tokens[] = {
 	"=*",
 	"!*",
 	"==",
+	"^=",
 	"#",
 	"<BARE-WORD>",
 	"<\"STRING\">",


### PR DESCRIPTION
Commit 92f79fea7e included the prepend operator `^=`, but forgot to include it in the list of tokens present in print.c, which needs to be in sync with token.h, as stated in its comment. This error may cause an incorrect operator string when using indices from 23-27 in the list, and an out-of-bounds read when the index is 28.