### PR TITLE
fix worker reply size fallback

### DIFF
--- a/src/lib/io/worker.c
+++ b/src/lib/io/worker.c
@@ -490,7 +490,7 @@ static void worker_nak(fr_worker_t *worker, fr_channel_data_t *cd, fr_time_t now
 	fr_assert(ms != NULL);
 
 	size = listen->app_io->default_reply_size;
-	if (!size) size = listen->app_io->default_message_size;
+	if (!size) size = listen->default_message_size;
 
 	/*
 	 *	Allocate a default message size.
@@ -652,7 +652,7 @@ static void worker_send_reply(fr_worker_t *worker, request_t *request, bool send
 
 	if (send_reply) {
 		size = request->async->listen->app_io->default_reply_size;
-		if (!size) size = request->async->listen->app_io->default_message_size;
+		if (!size) size = request->async->listen->default_message_size;
 	}
 
 	/*

--- a/src/tests/util/worker_test.c
+++ b/src/tests/util/worker_test.c
@@ -194,7 +194,7 @@ static void master_process(void)
 	fr_channel_event_t	ce;
 	pthread_attr_t		attr;
 	fr_schedule_worker_t	*sw;
-	fr_listen_t		listen = { .app_io = &app_io };
+	fr_listen_t		listen = { .app_io = &app_io, .default_message_size = 4096 };
 	struct kevent		events[MAX_KEVENTS];
 
 	MEM(ctx = talloc_init_const("master"));


### PR DESCRIPTION
The check for missing app_io.default_message_size resulted in trying to fallback to the same app_io.default_message_size (yielding the same result). Instead, the message size set by fr_master_io_listen() should be used. Consequences were incorrectly sized reply message buffers when the config max_packet_size differs from the protocol's compiled-in default

network.c was updated in e7cc943f05 to read default_message_size from fr_listen_t, but worker.c was not.

Also updated worker test to initialize listen.default_message_size, mimicking how fr_master_io_listen() sets it in production.