### PR TITLE
lib: fix integer64 to signed range check

### DIFF
--- a/src/lib/value.c
+++ b/src/lib/value.c
@@ -1289,7 +1289,7 @@ ssize_t value_data_cast(TALLOC_CTX *ctx, value_data_t *dst,
 			break;
 
 		case PW_TYPE_INTEGER64:
-			if (src->integer > INT_MAX) {
+			if (src->integer64 > INT_MAX) {
 				fr_strerror_printf("Invalid cast: From integer64 to signed.  integer64 value %" PRIu64
 						   " is larger than max signed int and would overflow", src->integer64);
 				return -1;

--- a/src/tests/all.mk
+++ b/src/tests/all.mk
@@ -1,4 +1,4 @@
-SUBMAKEFILES := rbmonkey.mk unit/all.mk map/all.mk xlat/all.mk keywords/all.mk auth/all.mk modules/all.mk sql_nas_table/all.mk
+SUBMAKEFILES := rbmonkey.mk value_cast.mk unit/all.mk map/all.mk xlat/all.mk keywords/all.mk auth/all.mk modules/all.mk sql_nas_table/all.mk
 PORT := 12340
 SECRET := testing123
 DICT_PATH := $(top_srcdir)/share

--- a/src/tests/value_cast.c
+++ b/src/tests/value_cast.c
@@ -1,0 +1,52 @@
+#include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <freeradius-devel/libradius.h>
+
+static int check_integer64_to_signed(uint64_t value, int expected, bool success)
+{
+	value_data_t src = { .integer64 = value };
+	value_data_t dst = { .sinteger = -1 };
+	ssize_t rcode;
+
+	rcode = value_data_cast(NULL, &dst, PW_TYPE_SIGNED, NULL,
+				PW_TYPE_INTEGER64, NULL,
+				&src, sizeof(src.integer64));
+
+	if (success) {
+		if (rcode != (ssize_t)sizeof(dst.sinteger)) return -1;
+		if (dst.sinteger != expected) return -1;
+		return 0;
+	}
+
+	if (rcode >= 0) return -1;
+
+	/*
+	 * Failed casts must not modify the destination.
+	 */
+	if (dst.sinteger != -1) return -1;
+
+	return 0;
+}
+
+int main(void)
+{
+	if (check_integer64_to_signed(INT_MAX, INT_MAX, true) < 0) {
+		return EXIT_FAILURE;
+	}
+
+	if (check_integer64_to_signed((uint64_t)INT_MAX + 1, 0, false) < 0) {
+		return EXIT_FAILURE;
+	}
+
+	if (check_integer64_to_signed(UINT64_C(1) << 32, 0, false) < 0) {
+		return EXIT_FAILURE;
+	}
+
+	if (check_integer64_to_signed(UINT64_MAX, 0, false) < 0) {
+		return EXIT_FAILURE;
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/src/tests/value_cast.mk
+++ b/src/tests/value_cast.mk
@@ -1,0 +1,13 @@
+TARGET := value_cast
+
+SOURCES := value_cast.c
+
+TGT_PREREQS := libfreeradius-radius.a
+TGT_LDLIBS := $(LIBS)
+TGT_INSTALLDIR :=
+
+.PHONY: tests.value_cast
+tests.value_cast: $(BUILD_DIR)/bin/value_cast
+	${Q}$(JLIBTOOL) --quiet --mode=execute $<
+
+tests.unit: tests.value_cast


### PR DESCRIPTION
## Summary

Fix the range check when casting `PW_TYPE_INTEGER64` to
`PW_TYPE_SIGNED`.

The code checked `src->integer`, but subsequently converted
`src->integer64`. Values larger than `INT_MAX` could therefore bypass
the intended range check.

## Fix

Check `src->integer64` against `INT_MAX`.

## Tests

Added regression tests covering:

- `INT_MAX`
- `INT_MAX + 1`
- `1ULL << 32`
- `UINT64_MAX`

The test fails with the old range check and passes with this change.
