### PR TITLE
multi-server: interim test env update for gperftools profiling

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -203,37 +203,40 @@ jobs:
     uses: ./.github/workflows/docker-freeradius-images-refresh.yml
     secrets: inherit
 
-  ci:
-    needs: [docker_ci_images_refresh, ci_prev_run]
-    if: ${{ !cancelled() && needs.docker_ci_images_refresh.result != 'failure'
-            && needs.ci_prev_run.outputs.should_skip != 'true' }}
-    name: CI
-    uses: ./.github/workflows/ci.yml
-    secrets: inherit
+  #
+  #  Disabled on this branch so only the multi-server profiling leg runs.
+  #
+#   ci:
+#     needs: [docker_ci_images_refresh, ci_prev_run]
+#     if: ${{ !cancelled() && needs.docker_ci_images_refresh.result != 'failure'
+#             && needs.ci_prev_run.outputs.should_skip != 'true' }}
+#     name: CI
+#     uses: ./.github/workflows/ci.yml
+#     secrets: inherit
 
-  ci-deb:
-    needs: [docker_ci_images_refresh, ci_prev_run]
-    if: ${{ !cancelled() && needs.docker_ci_images_refresh.result != 'failure'
-            && needs.ci_prev_run.outputs.should_skip != 'true' }}
-    name: CI DEB
-    uses: ./.github/workflows/ci-deb.yml
-    secrets: inherit
+#   ci-deb:
+#     needs: [docker_ci_images_refresh, ci_prev_run]
+#     if: ${{ !cancelled() && needs.docker_ci_images_refresh.result != 'failure'
+#             && needs.ci_prev_run.outputs.should_skip != 'true' }}
+#     name: CI DEB
+#     uses: ./.github/workflows/ci-deb.yml
+#     secrets: inherit
 
-  ci-rpm:
-    needs: [docker_ci_images_refresh, ci_prev_run]
-    if: ${{ !cancelled() && needs.docker_ci_images_refresh.result != 'failure'
-            && needs.ci_prev_run.outputs.should_skip != 'true' }}
-    name: CI RPM
-    uses: ./.github/workflows/ci-rpm.yml
-    secrets: inherit
+#   ci-rpm:
+#     needs: [docker_ci_images_refresh, ci_prev_run]
+#     if: ${{ !cancelled() && needs.docker_ci_images_refresh.result != 'failure'
+#             && needs.ci_prev_run.outputs.should_skip != 'true' }}
+#     name: CI RPM
+#     uses: ./.github/workflows/ci-rpm.yml
+#     secrets: inherit
 
-  ci-sanitizers:
-    needs: [docker_ci_images_refresh, ci_prev_run]
-    if: ${{ !cancelled() && needs.docker_ci_images_refresh.result != 'failure'
-            && needs.ci_prev_run.outputs.should_skip != 'true' }}
-    name: CI-Sanitizers
-    uses: ./.github/workflows/ci-sanitizers.yml
-    secrets: inherit
+#   ci-sanitizers:
+#     needs: [docker_ci_images_refresh, ci_prev_run]
+#     if: ${{ !cancelled() && needs.docker_ci_images_refresh.result != 'failure'
+#             && needs.ci_prev_run.outputs.should_skip != 'true' }}
+#     name: CI-Sanitizers
+#     uses: ./.github/workflows/ci-sanitizers.yml
+#     secrets: inherit
 
   #
   #  `ci-freebsd` and `ci-macos` run on every commit but are absent
@@ -241,21 +244,21 @@ jobs:
   #  on virtual machines and read no docker images, so neither leg waits
   #  for a refresh.
   #
-  ci-freebsd:
-    needs: [ci_prev_run]
-    if: ${{ !cancelled()
-            && needs.ci_prev_run.outputs.should_skip != 'true' }}
-    name: CI FreeBSD
-    uses: ./.github/workflows/ci-freebsd.yml
-    secrets: inherit
+#   ci-freebsd:
+#     needs: [ci_prev_run]
+#     if: ${{ !cancelled()
+#             && needs.ci_prev_run.outputs.should_skip != 'true' }}
+#     name: CI FreeBSD
+#     uses: ./.github/workflows/ci-freebsd.yml
+#     secrets: inherit
 
-  ci-macos:
-    needs: [ci_prev_run]
-    if: ${{ !cancelled()
-            && needs.ci_prev_run.outputs.should_skip != 'true' }}
-    name: CI macOS
-    uses: ./.github/workflows/ci-macos.yml
-    secrets: inherit
+#   ci-macos:
+#     needs: [ci_prev_run]
+#     if: ${{ !cancelled()
+#             && needs.ci_prev_run.outputs.should_skip != 'true' }}
+#     name: CI macOS
+#     uses: ./.github/workflows/ci-macos.yml
+#     secrets: inherit
 
   #
   #  `docker_freeradius_images_refresh` skips whenever `docker_ci_images_refresh` skips or fails,
@@ -272,37 +275,37 @@ jobs:
     uses: ./.github/workflows/ci-multi-server-tests.yml
     secrets: inherit
 
-  docker-crossbuild:
-    name: Docker crossbuild images
-    needs: [docker_ci_images_refresh, docker_freeradius_images_refresh, ci]
-    if: ${{ !cancelled() && needs.docker_ci_images_refresh.result != 'failure'
-            && needs.docker_freeradius_images_refresh.result != 'failure'
-            && needs.ci.result == 'success' && github.repository_owner == 'FreeRADIUS' }}
-    uses: ./.github/workflows/docker-crossbuild.yml
-    secrets: inherit
+#   docker-crossbuild:
+#     name: Docker crossbuild images
+#     needs: [docker_ci_images_refresh, docker_freeradius_images_refresh, ci]
+#     if: ${{ !cancelled() && needs.docker_ci_images_refresh.result != 'failure'
+#             && needs.docker_freeradius_images_refresh.result != 'failure'
+#             && needs.ci.result == 'success' && github.repository_owner == 'FreeRADIUS' }}
+#     uses: ./.github/workflows/docker-crossbuild.yml
+#     secrets: inherit
 
-  docker-service:
-    name: Docker service images
-    needs: [docker_ci_images_refresh, docker_freeradius_images_refresh, ci]
-    if: ${{ !cancelled() && needs.docker_ci_images_refresh.result != 'failure'
-            && needs.docker_freeradius_images_refresh.result != 'failure'
-            && needs.ci.result == 'success' && github.repository_owner == 'FreeRADIUS' }}
-    uses: ./.github/workflows/docker-service.yml
-    secrets: inherit
+#   docker-service:
+#     name: Docker service images
+#     needs: [docker_ci_images_refresh, docker_freeradius_images_refresh, ci]
+#     if: ${{ !cancelled() && needs.docker_ci_images_refresh.result != 'failure'
+#             && needs.docker_freeradius_images_refresh.result != 'failure'
+#             && needs.ci.result == 'success' && github.repository_owner == 'FreeRADIUS' }}
+#     uses: ./.github/workflows/docker-service.yml
+#     secrets: inherit
 
   #
   #  `docs` only runs when the commit changes a file that the
   #  documentation build reads.  `docs` is absent from the `needs` list of the `merge` job,
   #  because a failed documentation build should not hold up a merge.
   #
-  docs:
-    name: Documentation
-    needs: [common_vars, docker_ci_images_refresh, ci_prev_run]
-    if: ${{ !cancelled() && needs.docker_ci_images_refresh.result != 'failure'
-            && needs.ci_prev_run.outputs.should_skip != 'true'
-            && needs.common_vars.outputs.docs_changed == 'true' }}
-    uses: ./.github/workflows/documentation.yml
-    secrets: inherit
+#   docs:
+#     name: Documentation
+#     needs: [common_vars, docker_ci_images_refresh, ci_prev_run]
+#     if: ${{ !cancelled() && needs.docker_ci_images_refresh.result != 'failure'
+#             && needs.ci_prev_run.outputs.should_skip != 'true'
+#             && needs.common_vars.outputs.docs_changed == 'true' }}
+#     uses: ./.github/workflows/documentation.yml
+#     secrets: inherit
 
   #
   #  `merge` runs when every gating leg passed.  The `needs` list holds only
@@ -322,15 +325,15 @@ jobs:
   #  force pushes.  The reworded commit carries the tree that just
   #  passed, so every leg skips.
   #
-  merge:
-    name: Merge
-    needs: [ci_prev_run, ci, ci-deb, ci-rpm, ci-sanitizers]
-    if: ${{ !cancelled()
-            && (needs.ci_prev_run.outputs.should_skip == 'true'
-                || (needs.ci.result == 'success'
-                    && needs.ci-deb.result == 'success'
-                    && needs.ci-rpm.result == 'success'
-                    && needs.ci-sanitizers.result == 'success')) }}
-    uses: ./.github/workflows/merge-upstream.yml
-    secrets:
-      GH_APP_PRIVATE_KEY_CI_MERGE: ${{ secrets.GH_APP_PRIVATE_KEY_CI_MERGE }}
+#   merge:
+#     name: Merge
+#     needs: [ci_prev_run, ci, ci-deb, ci-rpm, ci-sanitizers]
+#     if: ${{ !cancelled()
+#             && (needs.ci_prev_run.outputs.should_skip == 'true'
+#                 || (needs.ci.result == 'success'
+#                     && needs.ci-deb.result == 'success'
+#                     && needs.ci-rpm.result == 'success'
+#                     && needs.ci-sanitizers.result == 'success')) }}
+#     uses: ./.github/workflows/merge-upstream.yml
+#     secrets:
+#       GH_APP_PRIVATE_KEY_CI_MERGE: ${{ secrets.GH_APP_PRIVATE_KEY_CI_MERGE }}

--- a/src/tests/multi-server/README.md
+++ b/src/tests/multi-server/README.md
@@ -34,30 +34,49 @@ make test.multi-server
 make test.multi-server.ci
 ```
 
-### Profiling pass (same suites, valgrind/callgrind wrapper)
+### Profiling pass (same suites, under a profiler)
 
 ```bash
 make test.multi-server.profiling       # all suites
 make test.multi-server.profiling.ci    # CI subset
 ```
 
-Profiling results land under
-`prof-results/<suite>/<test>/<branch>/<commit>/<run-index>/`. Set
-`PROFILING_RESULT_MODE=dev` to use a flat per-suite layout that overwrites
-each run.
+The profiling pass writes results under
+`prof-results/<branch>/<commit>/<run-index>/<suite>/<test>/`. Set
+`PROFILING_RESULT_MODE=dev` to use a flat `prof-results/<suite>/<test>/`
+layout that each run overwrites.
 
-Profiling runs use valgrind by default. Set `TOOL` to pick another
-profiler, or give a space-separated list to run each profiler in turn
-into the same result directory:
+Profiling runs use every known profiler by default, valgrind then
+gperftools, each writing into the same result directory. Set `TOOL` to one
+name to run a single profiler:
 
 ```bash
-make test.multi-server.accept.short_ci MODE=profiling TOOL=valgrind
-make test.multi-server.profiling.ci TOOL="valgrind gperftools"
+make test.multi-server.profiling.ci                                # both profilers
+make test.multi-server.accept.short_ci MODE=profiling TOOL=gperftools
+make test.multi-server.profiling.ci TOOL=valgrind
 ```
 
-Every run gets its own `logs/<run>/` and `listener/<run>/` subdirectory
-under the test output dir, where `<run>` is the profiler name, or `service`
-in service mode.
+Every run writes into a `logs/<run>/` and a `listener/<run>/` subdirectory
+under the test output dir. `<run>` is the profiler name, or `service` in
+service mode.
+
+The profilers write these files into the result directory:
+
+| valgrind (callgrind)      | gperftools                             | contents                         |
+|---------------------------|----------------------------------------|----------------------------------|
+| `valgrind_profiling.log`  | `gperftools_profiling.log`             | the capture script's own log     |
+| `freeradius_valgrind.log` | `freeradius_gperftools.log`            | server stdout/stderr             |
+| `callgrind.out.<pid>`     | `freeradius_gperftools.prof.<pid>.<n>` | raw profile                      |
+|                           | `pprof.out.<pid>.pb.gz`                | merged profile, symbols resolved |
+| `callgrind_report.txt`    | `pprof_report.txt`                     | text report                      |
+| `valgrind-exit-status`    | `gperftools-exit-status`               | 0 when the capture completed     |
+
+The gperftools capture runs the server single-threaded (`-s`). The capture
+samples CPU time between the ready line of the server and the completion
+line of proto_load, so the profile holds the load phase only. The capture
+needs `pprof` in the profiling image. Without `pprof`, the capture keeps the
+raw dumps and writes a non-zero exit status. The header of
+`scripts/profiling/start_gperftools_profiling.sh` documents the capture.
 
 ### A specific test
 
@@ -98,18 +117,28 @@ Build outputs go to `build/tests/multi-server/<suite>/<test>/`.
 
 ### Service vs profiling mode
 
-Compose envs reference `${FREERADIUS_IMAGE}` and read `${PROFILING:-no}`.
-The per-test recipe in `all.mk` sets both based on the `MODE` makefile
-variable, exporting the SHA-tagged image name directly:
+The compose files reference `${FREERADIUS_IMAGE}` and read `${PROFILING:-no}`.
+`scripts/run_test.sh` sets both variables from the `MODE` makefile variable,
+and exports the SHA-tagged image name directly:
 
 - `MODE=service` (default) selects `freeradius4-service/<image>:<sha>`,
-  the test template `exec`s the server directly.
-- `MODE=profiling` selects `freeradius4-profiling/<image>:<sha>`, sets
-  `PROFILING=yes` and `PROFILING_TOOL=<tool>`, and the test template sources
-  `start_<tool>_profiling.sh` instead so the run is captured by the profiler.
-  The makefile copies `scripts/profiling/start_<tool>_profiling.sh` into the
-  test output dir for every known tool, in every mode, and fails early when
-  one is missing.
+  and `start_freeradius.sh` starts the server directly with `exec`.
+- `MODE=profiling` selects `freeradius4-profiling/<image>:<sha>`, and sets
+  `PROFILING=yes` and `PROFILING_TOOL=<tool>`. `start_freeradius.sh` then
+  starts `start_<tool>_profiling.sh` with `exec`, so the profiler captures
+  the run.
+
+The test templates of the profiling suites only export the `TEST_LOADGEN_*`
+variables from the params file and `exec start_freeradius.sh`.
+`start_freeradius.sh` holds the request count arithmetic and the mode
+dispatch. The makefile copies `scripts/start_freeradius.sh` and every
+`scripts/profiling/start_<tool>_profiling.sh` into `<test output
+dir>/scripts/` in every mode. The compose files bind mount the scripts into
+`/usr/local/bin`. A tool without a script fails the build early.
+
+The per-test recipe itself is `scripts/run_test.sh`. `all.mk` resolves the
+make-side settings into the environment of `scripts/run_test.sh` (see the
+script header), so a developer can repeat one test by hand without make.
 
 The profiling image is the standard `freeradius4-profiling/<image>:<sha>`
 output, built by `scripts/docker/m4/profiling.deb.m4` /

--- a/src/tests/multi-server/README.md
+++ b/src/tests/multi-server/README.md
@@ -46,6 +46,19 @@ Profiling results land under
 `PROFILING_RESULT_MODE=dev` to use a flat per-suite layout that overwrites
 each run.
 
+Profiling runs use valgrind by default. Set `TOOL` to pick another
+profiler, or give a space-separated list to run each profiler in turn
+into the same result directory:
+
+```bash
+make test.multi-server.accept.short_ci MODE=profiling TOOL=valgrind
+make test.multi-server.profiling.ci TOOL="valgrind gperftools"
+```
+
+Every run gets its own `logs/<run>/` and `listener/<run>/` subdirectory
+under the test output dir, where `<run>` is the profiler name, or `service`
+in service mode.
+
 ### A specific test
 
 ```bash
@@ -92,8 +105,11 @@ variable, exporting the SHA-tagged image name directly:
 - `MODE=service` (default) selects `freeradius4-service/<image>:<sha>`,
   the test template `exec`s the server directly.
 - `MODE=profiling` selects `freeradius4-profiling/<image>:<sha>`, sets
-  `PROFILING=yes`, and the test template sources `start_valgrind_profiling.sh`
-  instead so the run is captured by callgrind.
+  `PROFILING=yes` and `PROFILING_TOOL=<tool>`, and the test template sources
+  `start_<tool>_profiling.sh` instead so the run is captured by the profiler.
+  The makefile copies `scripts/profiling/start_<tool>_profiling.sh` into the
+  test output dir for every known tool, in every mode, and fails early when
+  one is missing.
 
 The profiling image is the standard `freeradius4-profiling/<image>:<sha>`
 output, built by `scripts/docker/m4/profiling.deb.m4` /

--- a/src/tests/multi-server/all.mk
+++ b/src/tests/multi-server/all.mk
@@ -3,25 +3,31 @@
 #
 # Makefile arguments:
 # - TEST_MULTI_SERVER_DEBUG=<0-2>   debug level for multi-server test framework
-# - TEST_MULTI_SERVER_VERBOSE=<0-4>  verbosity level
+# - TEST_MULTI_SERVER_VERBOSE=<0-4> verbosity level
 # - MODE=<service|profiling>        which FreeRADIUS image to drive the tests
 #                                   with. Default `service`. `profiling` swaps in
 #                                   freeradius4-profiling/<image>:<sha>, sets PROFILING=yes
 #                                   so the test template runs the server under
-#                                   valgrind/callgrind, and writes results to
-#                                   PROFILING_RESULT_PATH.
-# - PROFILING_RESULT_MODE=<ci|dev>      Profiling output layout (only meaningful when
+#                                   the profiler selected by TOOL, and writes
+#                                   results to PROFILING_RESULT_PATH.
+# - PROFILING_RESULT_MODE=<ci|dev>  Profiling output layout (only meaningful when
 #                                   MODE=profiling). Default `ci`.
 #                                     ci:  PROFILING_RESULT_ROOT/<suite>/<test>/<branch>/<commit>/<run-index>
 #                                     dev: PROFILING_RESULT_ROOT/<suite>/<test>  (flat)
+# - TOOL=<valgrind|gperftools>      Profiler to run under MODE=profiling. Default `valgrind`.
+#                                     valgrind:               only profiles with valgrind
+#                                     gperftools:             only profiles with gperftools
+#                                     "valgrind gperftools":  runs each test once per tool, in that order
 #
 # Usage:
-#   make -f src/tests/multi-server/all.mk test.multi-server                       # all suites, service image
-#   make -f src/tests/multi-server/all.mk test.multi-server.ci                    # CI subset, service image
-#   make -f src/tests/multi-server/all.mk test.multi-server.profiling             # all suites, profiling image
-#   make -f src/tests/multi-server/all.mk test.multi-server.profiling.ci          # CI subset, profiling image
-#   make -f src/tests/multi-server/all.mk test.multi-server.accept.short_ci       # single test
-#   make -f src/tests/multi-server/all.mk clean.test.multi-server                 # clean logs
+#   make -f src/tests/multi-server/all.mk test.multi-server                                          # all suites, service image
+#   make -f src/tests/multi-server/all.mk test.multi-server.ci                                       # CI subset, service image
+#   make -f src/tests/multi-server/all.mk test.multi-server.profiling                                # all suites, profiling image
+#   make -f src/tests/multi-server/all.mk test.multi-server.profiling.ci                             # CI subset, profiling image
+#   make -f src/tests/multi-server/all.mk test.multi-server.profiling.ci TOOL=gperftools             # CI subset, gperftools instead of valgrind
+#   make -f src/tests/multi-server/all.mk test.multi-server.profiling.ci TOOL="valgrind gperftools"  # CI subset, both profilers in turn
+#   make -f src/tests/multi-server/all.mk test.multi-server.accept.short_ci                          # single test
+#   make -f src/tests/multi-server/all.mk clean.test.multi-server                                    # clean logs
 #
 
 SHELL := /bin/bash
@@ -45,6 +51,36 @@ GIT_BRANCH         := $(or $(shell git -C $(top_srcdir) rev-parse --abbrev-ref H
 GIT_COMMIT         := $(or $(shell git -C $(top_srcdir) rev-parse --short HEAD 2>/dev/null),unknown-commit)
 PROFILING_RESULT_ROOT  := $(abspath $(top_srcdir)/prof-results)
 PROFILING_RESULT_MODE  ?= ci
+
+MODE ?= service
+
+#
+#  Known profilers. TOOL selects which of them a profiling run uses and
+#  defaults to valgrind alone; a space-separated list runs each in the
+#  order given. Each name must have a
+#  scripts/profiling/start_<tool>_profiling.sh and a matching branch in
+#  the test template.
+#
+PROFILING_TOOLS := valgrind gperftools
+TOOL            ?= valgrind
+
+ifneq "$(filter-out $(PROFILING_TOOLS),$(TOOL))" ""
+$(error TOOL must be one of: $(PROFILING_TOOLS) (got "$(TOOL)"))
+endif
+
+#
+#  One radenv invocation per entry, sequentially, per test target. Service
+#  mode is a single run; profiling mode is one run per profiler named in
+#  TOOL.  Also verify that TOOL has not been set to be an empty string.
+#
+ifeq "$(MODE)" "profiling"
+  ifeq "$(strip $(TOOL))" ""
+    $(error MODE=profiling needs TOOL set to one or more of the following options: $(PROFILING_TOOLS))
+  endif
+  TEST_MULTI_SERVER_RUNS := $(TOOL)
+else
+  TEST_MULTI_SERVER_RUNS := service
+endif
 
 #
 #  Image plumbing.
@@ -158,11 +194,14 @@ $(OUTPUT)/${1}/${2}/$(notdir $(patsubst %.j2,%,${4})): ${4} ${3} $(TEST_MULTI_SE
 endef
 
 #
-#  Profiling helper script. Always copied into each test's output dir
-#  so the compose bind-mount resolves regardless of MODE; the script
-#  is only sourced when PROFILING=yes is exported into the container.
+#  Profiling helper scripts, one per known tool, copied into each test's
+#  output dir regardless of MODE or TOOL so the compose bind-mounts always
+#  resolve to files. The scripts are only sourced when PROFILING=yes is
+#  exported into the container. A known tool without a script fails the
+#  build early with "No rule to make target .../start_<tool>_profiling.sh".
 #
-PROFILING_SCRIPT_SRC := $(DIR)/scripts/profiling/start_valgrind_profiling.sh
+PROFILING_SCRIPT_DIR   := $(DIR)/scripts/profiling
+PROFILING_SCRIPT_NAMES := $(foreach t,$(PROFILING_TOOLS),start_$(t)_profiling.sh)
 
 #
 #  TEST_MULTI_SERVER_INSTANCE - define render + run targets for a single test.
@@ -182,17 +221,25 @@ TEST_MULTI_SERVER_RENDERED.${1}.${2}     := $$(patsubst $$(DIR)/tests/${1}/%.j2,
 
 $$(foreach j,$$(TEST_MULTI_SERVER_JINJA_FILES.${1}.${2}),$$(eval $$(call TEST_MULTI_SERVER_RENDER,${1},${2},${3},$$j)))
 
-${4}/start_valgrind_profiling.sh: $$(PROFILING_SCRIPT_SRC)
+TEST_MULTI_SERVER_SCRIPTS.${1}.${2}      := $$(addprefix ${4}/,$$(PROFILING_SCRIPT_NAMES))
+
+$$(TEST_MULTI_SERVER_SCRIPTS.${1}.${2}): ${4}/%: $$(PROFILING_SCRIPT_DIR)/%
 	$${Q}mkdir -p $$(@D)
 	$${Q}cp $$< $$@
 
 .PHONY: render.test.multi-server.${1}.${2}
-render.test.multi-server.${1}.${2}: $$(TEST_MULTI_SERVER_RENDERED.${1}.${2}) ${4}/start_valgrind_profiling.sh
+render.test.multi-server.${1}.${2}: $$(TEST_MULTI_SERVER_RENDERED.${1}.${2}) $$(TEST_MULTI_SERVER_SCRIPTS.${1}.${2})
 
+#
+#  Image, PROFILING flag and result path are fixed once per test target;
+#  the run loop then drives radenv once per entry in TEST_MULTI_SERVER_RUNS
+#  so every profiler writes into the same PROFILING_RESULT_PATH. Logs and
+#  listener files sit in a per-run subdirectory. The first failing run
+#  stops the loop.
+#
 .PHONY: test.multi-server.${1}.${2}
-test.multi-server.${1}.${2}: $$(TEST_MULTI_SERVER_RENDERED.${1}.${2}) ${4}/start_valgrind_profiling.sh
-	${Q}mkdir -p "${4}/logs" "${4}/listener"
-	${Q}echo "MULTI-SERVER-TEST test.multi-server.${1}.${2} (MODE=$(MODE))"
+test.multi-server.${1}.${2}: $$(TEST_MULTI_SERVER_RENDERED.${1}.${2}) $$(TEST_MULTI_SERVER_SCRIPTS.${1}.${2})
+	${Q}echo "MULTI-SERVER-TEST test.multi-server.${1}.${2} (MODE=$(MODE) RUNS=$(TEST_MULTI_SERVER_RUNS))"
 	${Q}if [ "$(MODE)" = "profiling" ]; then \
 		FREERADIUS_IMAGE=$(FREERADIUS_PROFILING_IMAGE); \
 		PROFILING=yes; \
@@ -211,37 +258,45 @@ test.multi-server.${1}.${2}: $$(TEST_MULTI_SERVER_RENDERED.${1}.${2}) ${4}/start
 		PROFILING=no; \
 		PROFILING_RESULT_PATH=/tmp/prof-results-unused; \
 	fi; \
-	DATA_PATH="${4}" \
-	TOP_SRCDIR="$(top_srcdir)" \
-	FREERADIUS_IMAGE="$$$$FREERADIUS_IMAGE" \
-	PROFILING="$$$$PROFILING" \
-	PROFILING_RESULT_PATH="$$$$PROFILING_RESULT_PATH" \
-	$(TEST_MULTI_SERVER_FRAMEWORK_DIR)/.venv/bin/radenv $(TEST_MULTI_SERVER_FLAGS) \
-	    --project-name "${1}-${2}-$(MODE)" \
-	    --compose "${4}/environment.yml" \
-	    --test "${4}/template.yml" \
-	    --use-files \
-	    --listener-dir "${4}/listener" \
-	    --log-dir "${4}/logs" \
-	    --output "${4}/logs/result.log" \
-	    > "${4}/logs/stdout.log" 2> "${4}/logs/stderr.log" || \
-	{ \
-	    echo "FAILED: test.multi-server.${1}.${2} (MODE=$(MODE))"; \
-	    for f in ${4}/logs/* ${4}/listener/*; do \
-	        [ -f "$$$$f" ] || continue; \
-	        echo ""; \
-	        echo "=== $$$$f ==="; \
-	        case "$$$$f" in \
-	            */listener/*) \
-	                echo "-- line-type counts --"; \
-	                awk '{print $$$$1}' "$$$$f" | sort | uniq -c; \
-	                echo "-- last 200 lines --"; \
-	                ;; \
-	        esac; \
-	        tail -200 "$$$$f"; \
-	    done; \
-	    exit 1; \
-	}
+	for RUN in $(TEST_MULTI_SERVER_RUNS); do \
+	    if [ "$$$$PROFILING" = "yes" ]; then PROFILING_TOOL="$$$$RUN"; else PROFILING_TOOL=""; fi; \
+	    LOG_DIR="${4}/logs/$$$$RUN"; \
+	    LISTENER_DIR="${4}/listener/$$$$RUN"; \
+	    mkdir -p "$$$$LOG_DIR" "$$$$LISTENER_DIR"; \
+	    echo "MULTI-SERVER-TEST test.multi-server.${1}.${2} run=$$$$RUN"; \
+	    DATA_PATH="${4}" \
+	    TOP_SRCDIR="$(top_srcdir)" \
+	    FREERADIUS_IMAGE="$$$$FREERADIUS_IMAGE" \
+	    PROFILING="$$$$PROFILING" \
+	    PROFILING_TOOL="$$$$PROFILING_TOOL" \
+	    PROFILING_RESULT_PATH="$$$$PROFILING_RESULT_PATH" \
+	    $(TEST_MULTI_SERVER_FRAMEWORK_DIR)/.venv/bin/radenv $(TEST_MULTI_SERVER_FLAGS) \
+	        --project-name "${1}-${2}-$(MODE)" \
+	        --compose "${4}/environment.yml" \
+	        --test "${4}/template.yml" \
+	        --use-files \
+	        --listener-dir "$$$$LISTENER_DIR" \
+	        --log-dir "$$$$LOG_DIR" \
+	        --output "$$$$LOG_DIR/result.log" \
+	        > "$$$$LOG_DIR/stdout.log" 2> "$$$$LOG_DIR/stderr.log" || \
+	    { \
+	        echo "FAILED: test.multi-server.${1}.${2} (MODE=$(MODE) run=$$$$RUN)"; \
+	        for f in "$$$$LOG_DIR"/* "$$$$LISTENER_DIR"/*; do \
+	            [ -f "$$$$f" ] || continue; \
+	            echo ""; \
+	            echo "=== $$$$f ==="; \
+	            case "$$$$f" in \
+	                */listener/*) \
+	                    echo "-- line-type counts --"; \
+	                    awk '{print $$$$1}' "$$$$f" | sort | uniq -c; \
+	                    echo "-- last 200 lines --"; \
+	                    ;; \
+	            esac; \
+	            tail -200 "$$$$f"; \
+	        done; \
+	        exit 1; \
+	    }; \
+	done
 endef
 
 #
@@ -264,8 +319,6 @@ endef
 #  Discover suites and generate targets
 #
 ######################################################################
-
-MODE ?= service
 
 #
 #  A suite is any subdirectory containing a template.yml.j2 file.

--- a/src/tests/multi-server/all.mk
+++ b/src/tests/multi-server/all.mk
@@ -4,28 +4,34 @@
 # Makefile arguments:
 # - TEST_MULTI_SERVER_DEBUG=<0-2>   debug level for multi-server test framework
 # - TEST_MULTI_SERVER_VERBOSE=<0-4> verbosity level
-# - MODE=<service|profiling>        which FreeRADIUS image to drive the tests
-#                                   with. Default `service`. `profiling` swaps in
-#                                   freeradius4-profiling/<image>:<sha>, sets PROFILING=yes
-#                                   so the test template runs the server under
-#                                   the profiler selected by TOOL, and writes
-#                                   results to PROFILING_RESULT_PATH.
+# - MODE=<service|profiling>        which FreeRADIUS image runs the tests.
+#                                   Default `service`. `profiling` selects
+#                                   freeradius4-profiling/<image>:<sha> and sets
+#                                   PROFILING=yes, so start_freeradius.sh runs the
+#                                   server under the profiler that TOOL selects.
+#                                   The profiler writes results to
+#                                   PROFILING_RESULT_PATH.
 # - PROFILING_RESULT_MODE=<ci|dev>  Profiling output layout (only meaningful when
 #                                   MODE=profiling). Default `ci`.
-#                                     ci:  PROFILING_RESULT_ROOT/<suite>/<test>/<branch>/<commit>/<run-index>
+#                                     ci:  PROFILING_RESULT_ROOT/<branch>/<commit>/<run-index>/<suite>/<test>
 #                                     dev: PROFILING_RESULT_ROOT/<suite>/<test>  (flat)
-# - TOOL=<valgrind|gperftools>      Profiler to run under MODE=profiling. Default `valgrind`.
+# - TOOL=<valgrind|gperftools>      Profiler(s) to run under MODE=profiling. Default: every
+#                                   known profiler, `valgrind gperftools`, in that order.
 #                                     valgrind:               only profiles with valgrind
 #                                     gperftools:             only profiles with gperftools
-#                                     "valgrind gperftools":  runs each test once per tool, in that order
+#                                     `valgrind gperftools`:  runs each test once per tool, in that order
+#
+# scripts/run_test.sh is the per-test recipe. scripts/start_freeradius.sh is
+# the container entry point, and exec's
+# scripts/profiling/start_<tool>_profiling.sh in profiling mode.
 #
 # Usage:
 #   make -f src/tests/multi-server/all.mk test.multi-server                                          # all suites, service image
 #   make -f src/tests/multi-server/all.mk test.multi-server.ci                                       # CI subset, service image
-#   make -f src/tests/multi-server/all.mk test.multi-server.profiling                                # all suites, profiling image
-#   make -f src/tests/multi-server/all.mk test.multi-server.profiling.ci                             # CI subset, profiling image
-#   make -f src/tests/multi-server/all.mk test.multi-server.profiling.ci TOOL=gperftools             # CI subset, gperftools instead of valgrind
-#   make -f src/tests/multi-server/all.mk test.multi-server.profiling.ci TOOL="valgrind gperftools"  # CI subset, both profilers in turn
+#   make -f src/tests/multi-server/all.mk test.multi-server.profiling                                # all suites, profiling image, every profiler in turn
+#   make -f src/tests/multi-server/all.mk test.multi-server.profiling.ci                             # CI subset, profiling image, every profiler in turn
+#   make -f src/tests/multi-server/all.mk test.multi-server.profiling.ci TOOL=gperftools             # CI subset, gperftools only
+#   make -f src/tests/multi-server/all.mk test.multi-server.profiling.ci TOOL=valgrind               # CI subset, valgrind only
 #   make -f src/tests/multi-server/all.mk test.multi-server.accept.short_ci                          # single test
 #   make -f src/tests/multi-server/all.mk clean.test.multi-server                                    # clean logs
 #
@@ -55,14 +61,13 @@ PROFILING_RESULT_MODE  ?= ci
 MODE ?= service
 
 #
-#  Known profilers. TOOL selects which of them a profiling run uses and
-#  defaults to valgrind alone; a space-separated list runs each in the
-#  order given. Each name must have a
-#  scripts/profiling/start_<tool>_profiling.sh and a matching branch in
-#  the test template.
+#  Known profilers. TOOL selects the profilers that a profiling run uses,
+#  and defaults to all of them. A space-separated TOOL list runs the test
+#  once per profiler, in the order given. Each name in PROFILING_TOOLS
+#  must have a scripts/profiling/start_<tool>_profiling.sh.
 #
 PROFILING_TOOLS := valgrind gperftools
-TOOL            ?= valgrind
+TOOL            ?= $(PROFILING_TOOLS)
 
 ifneq "$(filter-out $(PROFILING_TOOLS),$(TOOL))" ""
 $(error TOOL must be one of: $(PROFILING_TOOLS) (got "$(TOOL)"))
@@ -194,21 +199,26 @@ $(OUTPUT)/${1}/${2}/$(notdir $(patsubst %.j2,%,${4})): ${4} ${3} $(TEST_MULTI_SE
 endef
 
 #
-#  Profiling helper scripts, one per known tool, copied into each test's
-#  output dir regardless of MODE or TOOL so the compose bind-mounts always
-#  resolve to files. The scripts are only sourced when PROFILING=yes is
-#  exported into the container. A known tool without a script fails the
-#  build early with "No rule to make target .../start_<tool>_profiling.sh".
+#  Scripts that the freeradius container runs. start_freeradius.sh is the
+#  entry point that the test templates exec. start_freeradius.sh exec's
+#  start_<tool>_profiling.sh when PROFILING=yes. make copies every script
+#  into each test's output dir in every mode, because the compose files
+#  (environments/*.yml.j2) bind mount every script, and compose turns a
+#  missing bind source into an empty directory instead of an error. A tool in
+#  PROFILING_TOOLS without a script fails the build early with
+#  "No rule to make target .../start_<tool>_profiling.sh".
 #
-PROFILING_SCRIPT_DIR   := $(DIR)/scripts/profiling
-PROFILING_SCRIPT_NAMES := $(foreach t,$(PROFILING_TOOLS),start_$(t)_profiling.sh)
+TEST_MULTI_SERVER_SCRIPT_DIR   := $(DIR)/scripts
+TEST_MULTI_SERVER_SCRIPT_NAMES := start_freeradius.sh $(foreach t,$(PROFILING_TOOLS),start_$(t)_profiling.sh)
 
 #
 #  TEST_MULTI_SERVER_INSTANCE - define render + run targets for a single test.
 #
-#  Discovers all .j2 files in the suite directory, generates a render rule
-#  for each, and creates a test target that depends on all rendered outputs.
-#  Switches image / valgrind wiring based on MODE.
+#  The macro discovers all .j2 files in the suite directory, generates a
+#  render rule for each, and creates a test target that depends on all
+#  rendered outputs and on the container scripts. The test target runs
+#  scripts/run_test.sh, which selects the image and the profiling settings
+#  from MODE.
 #
 #  ${1} = suite dir name
 #  ${2} = test name
@@ -221,9 +231,13 @@ TEST_MULTI_SERVER_RENDERED.${1}.${2}     := $$(patsubst $$(DIR)/tests/${1}/%.j2,
 
 $$(foreach j,$$(TEST_MULTI_SERVER_JINJA_FILES.${1}.${2}),$$(eval $$(call TEST_MULTI_SERVER_RENDER,${1},${2},${3},$$j)))
 
-TEST_MULTI_SERVER_SCRIPTS.${1}.${2}      := $$(addprefix ${4}/,$$(PROFILING_SCRIPT_NAMES))
+TEST_MULTI_SERVER_SCRIPTS.${1}.${2}      := $$(addprefix ${4}/scripts/,$$(TEST_MULTI_SERVER_SCRIPT_NAMES))
 
-$$(TEST_MULTI_SERVER_SCRIPTS.${1}.${2}): ${4}/%: $$(PROFILING_SCRIPT_DIR)/%
+${4}/scripts/start_freeradius.sh: $$(TEST_MULTI_SERVER_SCRIPT_DIR)/start_freeradius.sh
+	$${Q}mkdir -p $$(@D)
+	$${Q}cp $$< $$@
+
+${4}/scripts/start_%_profiling.sh: $$(TEST_MULTI_SERVER_SCRIPT_DIR)/profiling/start_%_profiling.sh
 	$${Q}mkdir -p $$(@D)
 	$${Q}cp $$< $$@
 
@@ -231,72 +245,25 @@ $$(TEST_MULTI_SERVER_SCRIPTS.${1}.${2}): ${4}/%: $$(PROFILING_SCRIPT_DIR)/%
 render.test.multi-server.${1}.${2}: $$(TEST_MULTI_SERVER_RENDERED.${1}.${2}) $$(TEST_MULTI_SERVER_SCRIPTS.${1}.${2})
 
 #
-#  Image, PROFILING flag and result path are fixed once per test target;
-#  the run loop then drives radenv once per entry in TEST_MULTI_SERVER_RUNS
-#  so every profiler writes into the same PROFILING_RESULT_PATH. Logs and
-#  listener files sit in a per-run subdirectory. The first failing run
-#  stops the loop.
+#  scripts/run_test.sh is the recipe. make only resolves the make-side
+#  settings into the environment of the script. Every run in
+#  TEST_MULTI_SERVER_RUNS writes into the same PROFILING_RESULT_PATH, and
+#  writes logs and listener files into a per-run subdirectory.
 #
 .PHONY: test.multi-server.${1}.${2}
 test.multi-server.${1}.${2}: $$(TEST_MULTI_SERVER_RENDERED.${1}.${2}) $$(TEST_MULTI_SERVER_SCRIPTS.${1}.${2})
-	${Q}echo "MULTI-SERVER-TEST test.multi-server.${1}.${2} (MODE=$(MODE) RUNS=$(TEST_MULTI_SERVER_RUNS))"
-	${Q}if [ "$(MODE)" = "profiling" ]; then \
-		FREERADIUS_IMAGE=$(FREERADIUS_PROFILING_IMAGE); \
-		PROFILING=yes; \
-		if [ "$(PROFILING_RESULT_MODE)" = "dev" ]; then \
-			PROFILING_RESULT_PATH="$(PROFILING_RESULT_ROOT)/${1}/${2}"; \
-		else \
-			RUN_BASE="$(PROFILING_RESULT_ROOT)/$(GIT_BRANCH)/$(GIT_COMMIT)"; \
-			EXISTING=$$$$( find "$$$$RUN_BASE" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ' ); \
-			RUN_INDEX=$$$$((EXISTING + 1)); \
-			PROFILING_RESULT_PATH="$$$$RUN_BASE/$$$$RUN_INDEX/${1}/${2}"; \
-		fi; \
-		mkdir -p "$$$$PROFILING_RESULT_PATH"; \
-		echo "PROFILING_RESULT_PATH: $$$$PROFILING_RESULT_PATH"; \
-	else \
-		FREERADIUS_IMAGE=$(FREERADIUS_SERVICE_IMAGE); \
-		PROFILING=no; \
-		PROFILING_RESULT_PATH=/tmp/prof-results-unused; \
-	fi; \
-	for RUN in $(TEST_MULTI_SERVER_RUNS); do \
-	    if [ "$$$$PROFILING" = "yes" ]; then PROFILING_TOOL="$$$$RUN"; else PROFILING_TOOL=""; fi; \
-	    LOG_DIR="${4}/logs/$$$$RUN"; \
-	    LISTENER_DIR="${4}/listener/$$$$RUN"; \
-	    mkdir -p "$$$$LOG_DIR" "$$$$LISTENER_DIR"; \
-	    echo "MULTI-SERVER-TEST test.multi-server.${1}.${2} run=$$$$RUN"; \
-	    DATA_PATH="${4}" \
-	    TOP_SRCDIR="$(top_srcdir)" \
-	    FREERADIUS_IMAGE="$$$$FREERADIUS_IMAGE" \
-	    PROFILING="$$$$PROFILING" \
-	    PROFILING_TOOL="$$$$PROFILING_TOOL" \
-	    PROFILING_RESULT_PATH="$$$$PROFILING_RESULT_PATH" \
-	    $(TEST_MULTI_SERVER_FRAMEWORK_DIR)/.venv/bin/radenv $(TEST_MULTI_SERVER_FLAGS) \
-	        --project-name "${1}-${2}-$(MODE)" \
-	        --compose "${4}/environment.yml" \
-	        --test "${4}/template.yml" \
-	        --use-files \
-	        --listener-dir "$$$$LISTENER_DIR" \
-	        --log-dir "$$$$LOG_DIR" \
-	        --output "$$$$LOG_DIR/result.log" \
-	        > "$$$$LOG_DIR/stdout.log" 2> "$$$$LOG_DIR/stderr.log" || \
-	    { \
-	        echo "FAILED: test.multi-server.${1}.${2} (MODE=$(MODE) run=$$$$RUN)"; \
-	        for f in "$$$$LOG_DIR"/* "$$$$LISTENER_DIR"/*; do \
-	            [ -f "$$$$f" ] || continue; \
-	            echo ""; \
-	            echo "=== $$$$f ==="; \
-	            case "$$$$f" in \
-	                */listener/*) \
-	                    echo "-- line-type counts --"; \
-	                    awk '{print $$$$1}' "$$$$f" | sort | uniq -c; \
-	                    echo "-- last 200 lines --"; \
-	                    ;; \
-	            esac; \
-	            tail -200 "$$$$f"; \
-	        done; \
-	        exit 1; \
-	    }; \
-	done
+	${Q}MODE="$(MODE)" \
+	RUNS="$(TEST_MULTI_SERVER_RUNS)" \
+	FREERADIUS_SERVICE_IMAGE="$(FREERADIUS_SERVICE_IMAGE)" \
+	FREERADIUS_PROFILING_IMAGE="$(FREERADIUS_PROFILING_IMAGE)" \
+	PROFILING_RESULT_ROOT="$(PROFILING_RESULT_ROOT)" \
+	PROFILING_RESULT_MODE="$(PROFILING_RESULT_MODE)" \
+	GIT_BRANCH="$(GIT_BRANCH)" \
+	GIT_COMMIT="$(GIT_COMMIT)" \
+	TOP_SRCDIR="$(top_srcdir)" \
+	RADENV="$(TEST_MULTI_SERVER_FRAMEWORK_DIR)/.venv/bin/radenv" \
+	RADENV_FLAGS="$(TEST_MULTI_SERVER_FLAGS)" \
+	$(DIR)/scripts/run_test.sh "${1}" "${2}" "${4}"
 endef
 
 #

--- a/src/tests/multi-server/environments/accept.yml.j2
+++ b/src/tests/multi-server/environments/accept.yml.j2
@@ -6,7 +6,7 @@
 #   Same compose serves both service and profiling modes. In profiling
 #   mode the make recipe sets FREERADIUS_IMAGE=freeradius4-profiling/<image>:<sha>
 #   and PROFILING=yes; the test template branches on $PROFILING and
-#   either exec's freeradius directly or sources the valgrind wrapper.
+#   either exec's freeradius directly or sources the wrapper for $PROFILING_TOOL.
 # ---------------------------------------------------------------
 x-common-config: &id001
   cap_add:
@@ -20,6 +20,7 @@ services:
     image: ${FREERADIUS_IMAGE}
     environment:
       PROFILING: ${PROFILING:-no}
+      PROFILING_TOOL: ${PROFILING_TOOL:-}
     volumes:
     # freeradius server config
     - ${DATA_PATH}/freeradius/accept/radiusd.conf:/etc/freeradius/radiusd.conf
@@ -29,6 +30,7 @@ services:
     - ${DATA_PATH}/freeradius/common/proto-load/stats/load-generator-stats.csv:/etc/freeradius/stats/load-generator-stats.csv
     # Profiling wrapper (no-op in service mode)
     - ${DATA_PATH}/start_valgrind_profiling.sh:/etc/freeradius/start_valgrind_profiling.sh
+    - ${DATA_PATH}/start_gperftools_profiling.sh:/etc/freeradius/start_gperftools_profiling.sh
     # Profiling results directory; defaults to /tmp/prof-results in service mode (unused)
     - ${PROFILING_RESULT_PATH:-/tmp/prof-results}/:/etc/prof-results/
     # Listener directory

--- a/src/tests/multi-server/environments/accept.yml.j2
+++ b/src/tests/multi-server/environments/accept.yml.j2
@@ -3,10 +3,10 @@
 #
 #   load-generator (proto_load, in-process) -> FreeRADIUS (Access-Accept)
 #
-#   Same compose serves both service and profiling modes. In profiling
-#   mode the make recipe sets FREERADIUS_IMAGE=freeradius4-profiling/<image>:<sha>
-#   and PROFILING=yes; the test template branches on $PROFILING and
-#   either exec's freeradius directly or sources the wrapper for $PROFILING_TOOL.
+#   This compose file serves both service and profiling modes. In profiling
+#   mode scripts/run_test.sh sets FREERADIUS_IMAGE=freeradius4-profiling/<image>:<sha>
+#   and PROFILING=yes. The test template exec's start_freeradius.sh, which
+#   starts the server directly or under the profiler named by $PROFILING_TOOL.
 # ---------------------------------------------------------------
 x-common-config: &id001
   cap_add:
@@ -28,10 +28,13 @@ services:
     - ${DATA_PATH}/freeradius/common/proto-load/proto_load_config.env:/etc/freeradius/proto_load_config.env
     - ${DATA_PATH}/freeradius/common/proto-load/load-generator-packets/:/etc/freeradius/load-generator-packets/
     - ${DATA_PATH}/freeradius/common/proto-load/stats/load-generator-stats.csv:/etc/freeradius/stats/load-generator-stats.csv
-    # Profiling wrapper (no-op in service mode)
-    - ${DATA_PATH}/start_valgrind_profiling.sh:/etc/freeradius/start_valgrind_profiling.sh
-    - ${DATA_PATH}/start_gperftools_profiling.sh:/etc/freeradius/start_gperftools_profiling.sh
-    # Profiling results directory; defaults to /tmp/prof-results in service mode (unused)
+    # Container entry point and the per-profiler capture scripts. Service
+    # mode never runs the capture scripts, but compose turns a missing bind
+    # source into an empty directory, so every script must exist in every mode.
+    - ${DATA_PATH}/scripts/start_freeradius.sh:/usr/local/bin/start_freeradius.sh
+    - ${DATA_PATH}/scripts/start_valgrind_profiling.sh:/usr/local/bin/start_valgrind_profiling.sh
+    - ${DATA_PATH}/scripts/start_gperftools_profiling.sh:/usr/local/bin/start_gperftools_profiling.sh
+    # Profiling results directory, defaults to /tmp/prof-results in service mode (unused)
     - ${PROFILING_RESULT_PATH:-/tmp/prof-results}/:/etc/prof-results/
     # Listener directory
     - ${LISTENER_DIR}/:/var/run/multi-server/

--- a/src/tests/multi-server/environments/ldap.yml.j2
+++ b/src/tests/multi-server/environments/ldap.yml.j2
@@ -40,6 +40,7 @@ services:
     image: ${FREERADIUS_IMAGE}
     environment:
       PROFILING: ${PROFILING:-no}
+      PROFILING_TOOL: ${PROFILING_TOOL:-}
     depends_on:
       openldap:
         condition: service_healthy
@@ -52,6 +53,7 @@ services:
     - ${DATA_PATH}/freeradius/common/proto-load/stats/load-generator-stats.csv:/etc/freeradius/stats/load-generator-stats.csv
     # Profiling wrapper (no-op in service mode)
     - ${DATA_PATH}/start_valgrind_profiling.sh:/etc/freeradius/start_valgrind_profiling.sh
+    - ${DATA_PATH}/start_gperftools_profiling.sh:/etc/freeradius/start_gperftools_profiling.sh
     # Profiling results directory; defaults to /tmp/prof-results in service mode (unused)
     - ${PROFILING_RESULT_PATH:-/tmp/prof-results}/:/etc/prof-results/
     # Listener directory

--- a/src/tests/multi-server/environments/ldap.yml.j2
+++ b/src/tests/multi-server/environments/ldap.yml.j2
@@ -3,8 +3,8 @@
 #
 #   load-generator (proto_load, in-process) -> FreeRADIUS -> openldap
 #
-#   Same compose serves both service and profiling modes; see
-#   environments/accept.yml.j2 for the FREERADIUS_IMAGE / PROFILING
+#   This compose file serves both service and profiling modes.
+#   environments/accept.yml.j2 documents the FREERADIUS_IMAGE / PROFILING
 #   convention.
 # ---------------------------------------------------------------
 x-common-config: &id001
@@ -51,10 +51,13 @@ services:
     - ${DATA_PATH}/freeradius/common/proto-load/proto_load_config.env:/etc/freeradius/proto_load_config.env
     - ${DATA_PATH}/freeradius/common/proto-load/load-generator-packets/:/etc/freeradius/load-generator-packets/
     - ${DATA_PATH}/freeradius/common/proto-load/stats/load-generator-stats.csv:/etc/freeradius/stats/load-generator-stats.csv
-    # Profiling wrapper (no-op in service mode)
-    - ${DATA_PATH}/start_valgrind_profiling.sh:/etc/freeradius/start_valgrind_profiling.sh
-    - ${DATA_PATH}/start_gperftools_profiling.sh:/etc/freeradius/start_gperftools_profiling.sh
-    # Profiling results directory; defaults to /tmp/prof-results in service mode (unused)
+    # Container entry point and the per-profiler capture scripts. Service
+    # mode never runs the capture scripts, but compose turns a missing bind
+    # source into an empty directory, so every script must exist in every mode.
+    - ${DATA_PATH}/scripts/start_freeradius.sh:/usr/local/bin/start_freeradius.sh
+    - ${DATA_PATH}/scripts/start_valgrind_profiling.sh:/usr/local/bin/start_valgrind_profiling.sh
+    - ${DATA_PATH}/scripts/start_gperftools_profiling.sh:/usr/local/bin/start_gperftools_profiling.sh
+    # Profiling results directory, defaults to /tmp/prof-results in service mode (unused)
     - ${PROFILING_RESULT_PATH:-/tmp/prof-results}/:/etc/prof-results/
     # Listener directory
     - ${LISTENER_DIR}/:/var/run/multi-server/

--- a/src/tests/multi-server/environments/mysql.yml.j2
+++ b/src/tests/multi-server/environments/mysql.yml.j2
@@ -3,8 +3,8 @@
 #
 #   load-generator (proto_load, in-process) -> FreeRADIUS -> mariadb
 #
-#   Same compose serves both service and profiling modes; see
-#   environments/accept.yml.j2 for the FREERADIUS_IMAGE / PROFILING
+#   This compose file serves both service and profiling modes.
+#   environments/accept.yml.j2 documents the FREERADIUS_IMAGE / PROFILING
 #   convention.
 # ---------------------------------------------------------------
 x-common-config: &id001
@@ -53,10 +53,13 @@ services:
     - ${DATA_PATH}/freeradius/common/proto-load/proto_load_config.env:/etc/freeradius/proto_load_config.env
     - ${DATA_PATH}/freeradius/common/proto-load/load-generator-packets/:/etc/freeradius/load-generator-packets/
     - ${DATA_PATH}/freeradius/common/proto-load/stats/load-generator-stats.csv:/etc/freeradius/stats/load-generator-stats.csv
-    # Profiling wrapper (no-op in service mode)
-    - ${DATA_PATH}/start_valgrind_profiling.sh:/etc/freeradius/start_valgrind_profiling.sh
-    - ${DATA_PATH}/start_gperftools_profiling.sh:/etc/freeradius/start_gperftools_profiling.sh
-    # Profiling results directory; defaults to /tmp/prof-results in service mode (unused)
+    # Container entry point and the per-profiler capture scripts. Service
+    # mode never runs the capture scripts, but compose turns a missing bind
+    # source into an empty directory, so every script must exist in every mode.
+    - ${DATA_PATH}/scripts/start_freeradius.sh:/usr/local/bin/start_freeradius.sh
+    - ${DATA_PATH}/scripts/start_valgrind_profiling.sh:/usr/local/bin/start_valgrind_profiling.sh
+    - ${DATA_PATH}/scripts/start_gperftools_profiling.sh:/usr/local/bin/start_gperftools_profiling.sh
+    # Profiling results directory, defaults to /tmp/prof-results in service mode (unused)
     - ${PROFILING_RESULT_PATH:-/tmp/prof-results}/:/etc/prof-results/
     # Listener directory
     - ${LISTENER_DIR}/:/var/run/multi-server/

--- a/src/tests/multi-server/environments/mysql.yml.j2
+++ b/src/tests/multi-server/environments/mysql.yml.j2
@@ -42,6 +42,7 @@ services:
     image: ${FREERADIUS_IMAGE}
     environment:
       PROFILING: ${PROFILING:-no}
+      PROFILING_TOOL: ${PROFILING_TOOL:-}
     depends_on:
       mariadb:
         condition: service_healthy
@@ -54,6 +55,7 @@ services:
     - ${DATA_PATH}/freeradius/common/proto-load/stats/load-generator-stats.csv:/etc/freeradius/stats/load-generator-stats.csv
     # Profiling wrapper (no-op in service mode)
     - ${DATA_PATH}/start_valgrind_profiling.sh:/etc/freeradius/start_valgrind_profiling.sh
+    - ${DATA_PATH}/start_gperftools_profiling.sh:/etc/freeradius/start_gperftools_profiling.sh
     # Profiling results directory; defaults to /tmp/prof-results in service mode (unused)
     - ${PROFILING_RESULT_PATH:-/tmp/prof-results}/:/etc/prof-results/
     # Listener directory

--- a/src/tests/multi-server/environments/pap-auth.yml.j2
+++ b/src/tests/multi-server/environments/pap-auth.yml.j2
@@ -3,8 +3,8 @@
 #
 #   load-generator (proto_load, in-process) -> FreeRADIUS (files+pap)
 #
-#   Same compose serves both service and profiling modes; see
-#   environments/accept.yml.j2 for the FREERADIUS_IMAGE / PROFILING
+#   This compose file serves both service and profiling modes.
+#   environments/accept.yml.j2 documents the FREERADIUS_IMAGE / PROFILING
 #   convention.
 # ---------------------------------------------------------------
 x-common-config: &id001
@@ -29,10 +29,13 @@ services:
     - ${DATA_PATH}/freeradius/common/proto-load/proto_load_config.env:/etc/freeradius/proto_load_config.env
     - ${DATA_PATH}/freeradius/common/proto-load/load-generator-packets/:/etc/freeradius/load-generator-packets/
     - ${DATA_PATH}/freeradius/common/proto-load/stats/load-generator-stats.csv:/etc/freeradius/stats/load-generator-stats.csv
-    # Profiling wrapper (no-op in service mode)
-    - ${DATA_PATH}/start_valgrind_profiling.sh:/etc/freeradius/start_valgrind_profiling.sh
-    - ${DATA_PATH}/start_gperftools_profiling.sh:/etc/freeradius/start_gperftools_profiling.sh
-    # Profiling results directory; defaults to /tmp/prof-results in service mode (unused)
+    # Container entry point and the per-profiler capture scripts. Service
+    # mode never runs the capture scripts, but compose turns a missing bind
+    # source into an empty directory, so every script must exist in every mode.
+    - ${DATA_PATH}/scripts/start_freeradius.sh:/usr/local/bin/start_freeradius.sh
+    - ${DATA_PATH}/scripts/start_valgrind_profiling.sh:/usr/local/bin/start_valgrind_profiling.sh
+    - ${DATA_PATH}/scripts/start_gperftools_profiling.sh:/usr/local/bin/start_gperftools_profiling.sh
+    # Profiling results directory, defaults to /tmp/prof-results in service mode (unused)
     - ${PROFILING_RESULT_PATH:-/tmp/prof-results}/:/etc/prof-results/
     # Listener directory
     - ${LISTENER_DIR}/:/var/run/multi-server/

--- a/src/tests/multi-server/environments/pap-auth.yml.j2
+++ b/src/tests/multi-server/environments/pap-auth.yml.j2
@@ -19,6 +19,7 @@ services:
     image: ${FREERADIUS_IMAGE}
     environment:
       PROFILING: ${PROFILING:-no}
+      PROFILING_TOOL: ${PROFILING_TOOL:-}
     volumes:
     # freeradius server config
     - ${DATA_PATH}/freeradius/pap-auth/radiusd.conf:/etc/freeradius/radiusd.conf
@@ -30,6 +31,7 @@ services:
     - ${DATA_PATH}/freeradius/common/proto-load/stats/load-generator-stats.csv:/etc/freeradius/stats/load-generator-stats.csv
     # Profiling wrapper (no-op in service mode)
     - ${DATA_PATH}/start_valgrind_profiling.sh:/etc/freeradius/start_valgrind_profiling.sh
+    - ${DATA_PATH}/start_gperftools_profiling.sh:/etc/freeradius/start_gperftools_profiling.sh
     # Profiling results directory; defaults to /tmp/prof-results in service mode (unused)
     - ${PROFILING_RESULT_PATH:-/tmp/prof-results}/:/etc/prof-results/
     # Listener directory

--- a/src/tests/multi-server/scripts/profiling/README.md
+++ b/src/tests/multi-server/scripts/profiling/README.md
@@ -28,3 +28,23 @@ for f in <path-to-prof-results>/callgrind.out.1004-{04..12}; do
     | dot -Tsvg -o "callgraph_thread${thread}.svg"
 done
 ```
+
+## gperftools results
+
+`start_gperftools_profiling.sh` converts the raw dumps in the container. To
+repeat the conversion by hand, run these commands from a container that
+holds the same build:
+
+```
+export PPROF_BINARY_PATH=/usr/lib
+pprof -text  /usr/sbin/radiusd freeradius_gperftools.prof.<pid>.*  > pprof_report.txt
+pprof -proto /usr/sbin/radiusd freeradius_gperftools.prof.<pid>.*  > pprof.out.<pid>.pb.gz
+```
+
+The `.pb.gz` file holds the resolved symbols, so pprof can read the
+`.pb.gz` file on any host without the build:
+
+```
+pprof -text pprof.out.<pid>.pb.gz
+pprof -http=:8080 pprof.out.<pid>.pb.gz
+```

--- a/src/tests/multi-server/scripts/profiling/start_gperftools_profiling.sh
+++ b/src/tests/multi-server/scripts/profiling/start_gperftools_profiling.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Skeleton for the gperftools capture.
+
+rm -f /etc/prof-results/gperftools_profiling.log
+
+exec > /etc/prof-results/gperftools_profiling.log 2>&1
+
+echo "INFO: gperftools profiling has not been performed, capture has not been implemented ($(date))"
+
+exit 0

--- a/src/tests/multi-server/scripts/profiling/start_gperftools_profiling.sh
+++ b/src/tests/multi-server/scripts/profiling/start_gperftools_profiling.sh
@@ -1,11 +1,217 @@
 #!/bin/bash
+#
+#  gperftools profiling script for the multi-server profiling tests.
+#
+#  This script turns sampling on using SIGUSR2 and CPUPROFILESIGNAL when the server
+#  is ready and turns it off when proto_load has finished sending packets.
+#
+#  Server startup and shutdown are not profiled with --instr-atstart=no
+#
+#  Results, all under /etc/prof-results:
+#    gperftools_profiling.log             this script's log
+#    freeradius_gperftools.log            server stdout/stderr
+#    freeradius_gperftools.prof.<pid>.<n> raw gperftools dump, one per on/off cycle
+#    pprof.out.<pid>.pb.gz                merged profile, symbols resolved
+#    pprof_report.txt                     pprof -text report, for reading by hand
+#    gperftools-exit-status               0 for a complete, converted capture.
+#                                         2 load did not complete or no profile dump
+#                                         3 pprof missing, failed, or no symbols
+#
+set -u
 
-# Skeleton for the gperftools capture.
+RESULTS=/etc/prof-results
 
-rm -f /etc/prof-results/gperftools_profiling.log
+rm -f "$RESULTS"/gperftools_profiling.log "$RESULTS"/freeradius_gperftools.log \
+      "$RESULTS"/freeradius_gperftools.prof.* "$RESULTS"/pprof.out.* \
+      "$RESULTS"/pprof_report.txt "$RESULTS"/gperftools-exit-status
 
-exec > /etc/prof-results/gperftools_profiling.log 2>&1
+exec > "$RESULTS/gperftools_profiling.log" 2>&1
 
-echo "INFO: gperftools profiling has not been performed, capture has not been implemented ($(date))"
+#  finish() writes the status file on every exit path, so an absent file means
+#  that the script exited before reaching finish, not that the run passed.
+STATUS=2
+finish() {
+  echo "$STATUS" > "$RESULTS/gperftools-exit-status"
+  echo "INFO: gperftools capture finished at $(date) with status $STATUS"
+  exit "$STATUS"
+}
 
-exit 0
+echo "proto_load configuration environment variables:"
+env | grep '^TEST_LOADGEN_' | sort
+echo ""
+
+#  This script closes the profile before shutdown, so the server must outlive
+#  the load. With on_complete=exit, proto_load stops the server the moment the
+#  load completes, and the shutdown races the SIGUSR2 that closes the profile.
+if [ "${TEST_LOADGEN_COMPLETE:-}" != "stop" ]; then
+  echo "INFO: overriding on_complete '${TEST_LOADGEN_COMPLETE:-}' with 'stop', this script closes the profile before shutting the server down"
+  export TEST_LOADGEN_COMPLETE=stop
+fi
+
+#  LOAD_TIMEOUT bounds the load phase. The bound is the time to send every
+#  request at start_pps plus a margin for replies not yet received. The
+#  completion line normally arrives at the send time of the ramp.
+LOAD_TIMEOUT=$(( TEST_LOADGEN_MAX_REQUESTS / TEST_LOADGEN_START_PPS + 60 ))
+
+#  Start the server with the profiler loaded but not sampling.
+#
+#  CPUPROFILE            dump path. gperftools appends .<n> per on/off cycle.
+#                        <pid> is the server's own pid, matching callgrind.out.<pid>:
+#                        the inner bash expands $$ to its pid and exec's the
+#                        server without forking, so both share that pid.
+#  CPUPROFILESIGNAL      sampling starts and stops on this signal, and does
+#                        not start at launch (12 = SIGUSR2, which radiusd does
+#                        not handle)
+#  CPUPROFILE_FREQUENCY  samples per CPU-second. A 6000-packet run costs well
+#                        under a second of CPU, so the 100 Hz default would
+#                        leave tens of samples for the whole profile.
+#
+#  The command does not pipe through tee, because $! must be the server pid
+#  and the readiness and completion checks read the log file.
+
+cd "$RESULTS" || { echo "ERROR: cannot cd to $RESULTS"; finish; }
+bash -c 'exec env \
+  CPUPROFILE="/etc/prof-results/freeradius_gperftools.prof.$$" \
+  CPUPROFILESIGNAL=12 \
+  CPUPROFILE_FREQUENCY=1000 \
+  freeradius -s -l stdout -S resources.talloc_skip_cleanup=yes' \
+  > "$RESULTS/freeradius_gperftools.log" 2>&1 &
+FR_PID=$!
+echo "INFO: freeradius started, pid ${FR_PID}"
+
+#  Wait for the server to report ready. Exit if the server exits first.
+STARTUP_TIMEOUT=120
+STARTUP_ELAPSED=0
+until grep -q "Ready to process requests" "$RESULTS/freeradius_gperftools.log"; do
+  if ! kill -0 "$FR_PID" 2>/dev/null; then
+    wait "$FR_PID"; STATUS=$?
+    echo "ERROR: freeradius exited with status $STATUS before becoming ready, see freeradius_gperftools.log"
+    finish
+  fi
+  sleep 1
+  STARTUP_ELAPSED=$(( STARTUP_ELAPSED + 1 ))
+  if [ "$STARTUP_ELAPSED" -ge "$STARTUP_TIMEOUT" ]; then
+    echo "ERROR: aborting, freeradius did not become ready within ${STARTUP_TIMEOUT}s"
+    kill -SIGKILL "$FR_PID" 2>/dev/null
+    finish
+  fi
+done
+echo "INFO: freeradius ready after ${STARTUP_ELAPSED}s"
+
+#  Turn sampling on.
+echo "INFO: enabling gperftools sampling (SIGUSR2)"
+kill -SIGUSR2 "$FR_PID"
+
+#  Wait for proto_load to report completion. With on_complete=stop, proto_load
+#  logs the completion line only after sending every request and receiving
+#  every reply, so the counts on the completion line are the totals of the run.
+LOAD_ELAPSED=0
+until grep -q "Load test for .* complete - sent" "$RESULTS/freeradius_gperftools.log"; do
+  if ! kill -0 "$FR_PID" 2>/dev/null; then
+    wait "$FR_PID"; STATUS=$?
+    echo "ERROR: freeradius exited with status $STATUS during the load phase, see freeradius_gperftools.log"
+    finish
+  fi
+  sleep 1
+  LOAD_ELAPSED=$(( LOAD_ELAPSED + 1 ))
+  if [ "$LOAD_ELAPSED" -ge "$LOAD_TIMEOUT" ]; then
+    echo "ERROR: killing freeradius, proto_load did not report completion within ${LOAD_TIMEOUT}s. Capture is partial and will not be published"
+    kill -SIGKILL "$FR_PID" 2>/dev/null
+    finish
+  fi
+done
+grep "Load test for .* complete - sent" "$RESULTS/freeradius_gperftools.log"
+echo "INFO: load complete after ${LOAD_ELAPSED}s (max_requests ${TEST_LOADGEN_MAX_REQUESTS})"
+
+#  Turn sampling off. gperftools writes the dump from the signal handler, so
+#  the file appears as soon as the server handles the signal.
+echo "INFO: disabling gperftools sampling (SIGUSR2)"
+kill -SIGUSR2 "$FR_PID"
+DUMP_WAIT=0
+until ls "$RESULTS"/freeradius_gperftools.prof."$FR_PID".* >/dev/null 2>&1; do
+  sleep 1
+  DUMP_WAIT=$(( DUMP_WAIT + 1 ))
+  if [ "$DUMP_WAIT" -ge 30 ]; then
+    echo "ERROR: continuing without a profile dump, none appeared within ${DUMP_WAIT}s of stopping the profiler"
+    break
+  fi
+done
+ls -l "$RESULTS"/freeradius_gperftools.prof."$FR_PID".* 2>/dev/null
+
+#  Shut the server down gracefully with SIGINT (equivalent to Ctrl+C). The
+#  profile is already on disk, so a hang during shutdown costs the run a
+#  clean exit status but not the profile.
+echo "INFO: sending SIGINT to freeradius ${FR_PID} for graceful shutdown"
+kill -SIGINT "$FR_PID"
+SHUTDOWN_TIMEOUT=60
+SHUTDOWN_ELAPSED=0
+while kill -0 "$FR_PID" 2>/dev/null; do
+  sleep 1
+  SHUTDOWN_ELAPSED=$(( SHUTDOWN_ELAPSED + 1 ))
+  if [ "$SHUTDOWN_ELAPSED" -ge "$SHUTDOWN_TIMEOUT" ]; then
+    echo "WARNING: sending SIGKILL, freeradius did not exit within ${SHUTDOWN_TIMEOUT}s after SIGINT"
+    kill -SIGKILL "$FR_PID" 2>/dev/null
+    break
+  fi
+done
+FR_STATUS=0
+wait "$FR_PID" 2>/dev/null || FR_STATUS=$?
+echo "INFO: freeradius exited with status ${FR_STATUS} after ${SHUTDOWN_ELAPSED}s"
+
+if [ "$FR_STATUS" -ne 0 ]; then
+  if [ "$FR_STATUS" -gt 128 ]; then
+    echo "ERROR: signal $((FR_STATUS - 128)) killed freeradius during shutdown, see freeradius_gperftools.log"
+  else
+    echo "ERROR: freeradius exited ${FR_STATUS} during shutdown, see freeradius_gperftools.log"
+  fi
+  echo "ERROR: these results will not be published"
+fi
+
+if ! ls "$RESULTS"/freeradius_gperftools.prof."$FR_PID".* >/dev/null 2>&1; then
+  echo "ERROR: exiting, gperftools did not write a profile dump"
+  STATUS=2
+  finish
+fi
+
+#  Convert in the container while the build that the addresses belong to still
+#  exists. pprof takes the main binary as the first argument. pprof finds the
+#  shared objects through the mappings recorded in the dump, and falls back to
+#  PPROF_BINARY_PATH (libfreeradius-*.so and rlm_*.so both install into
+#  /usr/lib).
+if ! command -v pprof >/dev/null 2>&1; then
+  echo "ERROR: keeping raw dumps only, pprof is not installed in this image. No pprof.out.*.pb.gz or pprof_report.txt"
+  STATUS=3
+  finish
+fi
+export PPROF_BINARY_PATH=/usr/lib
+RADIUSD_BIN=$(readlink -f "$(command -v freeradius)")
+
+echo "INFO: merging dumps into pprof.out.${FR_PID}.pb.gz"
+if ! pprof -proto "$RADIUSD_BIN" "$RESULTS"/freeradius_gperftools.prof."$FR_PID".* > "$RESULTS/pprof.out.${FR_PID}.pb.gz"; then
+  echo "ERROR: pprof -proto failed"
+  rm -f "$RESULTS/pprof.out.${FR_PID}.pb.gz"
+  STATUS=3
+  finish
+fi
+
+#  -nodefraction=0 keeps every function in the table, for parity with
+#  callgrind_report.txt, which lists every function. The default drops rows
+#  under 0.5% of the total.
+echo "INFO: writing pprof_report.txt"
+if ! pprof -text -nodefraction=0 "$RADIUSD_BIN" "$RESULTS"/freeradius_gperftools.prof."$FR_PID".* > "$RESULTS/pprof_report.txt"; then
+  echo "ERROR: pprof -text failed"
+  STATUS=3
+  finish
+fi
+head -6 "$RESULTS/pprof_report.txt"
+
+#  A report without a FreeRADIUS symbol means that symbolization failed, and
+#  the reader cannot attribute the numbers in the report to any function.
+if ! grep -qE '\b(fr_|unlang_|main\b)' "$RESULTS/pprof_report.txt"; then
+  echo "ERROR: pprof did not resolve any FreeRADIUS function name in pprof_report.txt"
+  STATUS=3
+  finish
+fi
+
+STATUS=$FR_STATUS
+finish

--- a/src/tests/multi-server/scripts/profiling/start_valgrind_profiling.sh
+++ b/src/tests/multi-server/scripts/profiling/start_valgrind_profiling.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# To be run inside the profiling container
+# Valgrind profiling script to be run inside the profiling container
 
 # Clear any stale marker from a previous run
 rm -f /etc/prof-results/.profiling_complete
-rm -f /etc/prof-results/valgrind_profiling.log
+rm -f /etc/prof-results/valgrind_profiling.log /etc/prof-results/freeradius_valgrind.log
 
 exec > /etc/prof-results/valgrind_profiling.log 2>&1
 
@@ -32,7 +32,7 @@ SEND_DURATION=$(( TEST_LOADGEN_MAX_REQUESTS / TEST_LOADGEN_START_PPS ))
 
 # Start freeradius under valgrind with instrumentation off.
 #
-# valgrind logs to --log-file; freeradius stdout/stderr go to freeradius.log.
+# valgrind logs to --log-file; freeradius stdout/stderr go to freeradius_valgrind.log.
 # No `| tee`: the fallback kill paths below need $! to be the valgrind PID,
 # not tee's.
 #
@@ -60,13 +60,13 @@ valgrind \
   --keep-debuginfo=yes \
   --instr-atstart=no \
   freeradius -f -l stdout -S resources.talloc_skip_cleanup=yes \
-  > /etc/prof-results/freeradius.log 2>&1 &
+  > /etc/prof-results/freeradius_valgrind.log 2>&1 &
 VALGRIND_PID=$!
 
 # Wait for server ready (bail out if freeradius fails to start under valgrind)
 STARTUP_TIMEOUT=300
 STARTUP_ELAPSED=0
-until grep -q "Ready to process requests" /etc/prof-results/freeradius.log; do
+until grep -q "Ready to process requests" /etc/prof-results/freeradius_valgrind.log; do
   sleep 1
   STARTUP_ELAPSED=$(( STARTUP_ELAPSED + 1 ))
   if [ ${STARTUP_ELAPSED} -ge ${STARTUP_TIMEOUT} ]; then
@@ -116,21 +116,17 @@ echo "INFO: disabling callgrind instrumentation"
 CTRL_OUT=$(callgrind_control --instr=off 2>/dev/null || true)
 printf '%s\n' "$CTRL_OUT"
 
-# Wait for valgrind to finish writing callgrind output. Record how it exited:
-# a run valgrind killed produces truncated callgrind output whose numbers are
-# not comparable with a clean run, so the status has to survive to the publish
-# step, which reads this file and refuses to upload an unclean run. The status
-# is recorded for clean runs too, so an absent file means "the wrapper did not
-# get this far" rather than "the run was fine".
+# Record how valgrind exited. A killed valgrind leaves truncated callgrind
+# output, so the publish step reads this file and refuses a non-zero run.
+# Clean runs write 0 too: an absent file means the wrapper never got here.
 echo "INFO: waiting for valgrind to exit"
 VALGRIND_STATUS=0
 wait ${VALGRIND_PID} 2>/dev/null || VALGRIND_STATUS=$?
 echo "${VALGRIND_STATUS}" > /etc/prof-results/valgrind-exit-status
 
 if [ "${VALGRIND_STATUS}" -ne 0 ]; then
-  #  Over 128 means a signal. 139 is SIGSEGV, which is how valgrind exiting on
-  #  its 8 MB brk segment ceiling presents; valgrind.log names the real reason
-  #  on the line above its backtrace.
+  # >128: killed by signal (128 + signal number)
+  #  139: SIGSEGV. not a real crash; see valgrind.log above its backtrace.
   if [ "${VALGRIND_STATUS}" -gt 128 ]; then
     echo "ERROR: valgrind was killed by signal $((VALGRIND_STATUS - 128)); profiling data is truncated" >&2
   else

--- a/src/tests/multi-server/scripts/run_test.sh
+++ b/src/tests/multi-server/scripts/run_test.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+#
+#  Run one multi-server test: start radenv once per run name, and dump the
+#  logs of a failing run. The test.multi-server.<suite>.<test> target in
+#  all.mk resolves the make-side settings into the environment below and
+#  calls this script, so a developer can repeat a single test by hand
+#  without make.
+#
+#  Usage: run_test.sh <suite> <test> <output-dir>
+#
+#  Environment, all set by all.mk:
+#    MODE                        service | profiling
+#    RUNS                        space-separated run names: 'service', or the
+#                                profilers named by TOOL in profiling mode
+#    FREERADIUS_SERVICE_IMAGE    image for MODE=service
+#    FREERADIUS_PROFILING_IMAGE  image for MODE=profiling
+#    PROFILING_RESULT_ROOT       prof-results directory
+#    PROFILING_RESULT_MODE       ci | dev result layout, see all.mk
+#    GIT_BRANCH, GIT_COMMIT      path components of the ci layout
+#    TOP_SRCDIR                  repository root, passed through to compose
+#    RADENV                      the radenv binary
+#    RADENV_FLAGS                extra radenv arguments (TEST_MULTI_SERVER_FLAGS)
+#
+set -u
+
+if [ $# -ne 3 ]; then
+  echo "Usage: ${0##*/} <suite> <test> <output-dir>" >&2
+  exit 2
+fi
+SUITE=$1
+TEST=$2
+OUTDIR=$3
+TARGET="test.multi-server.${SUITE}.${TEST}"
+
+echo "MULTI-SERVER-TEST ${TARGET} (MODE=${MODE} RUNS=${RUNS})"
+
+#  This script fixes the image, the PROFILING flag, and the result path once
+#  per test. Every profiler in RUNS writes into the same PROFILING_RESULT_PATH.
+#  The result directory holds the files of every profiler for one test, and
+#  each capture script uses distinct file names, so the files do not collide.
+if [ "$MODE" = "profiling" ]; then
+  FREERADIUS_IMAGE=$FREERADIUS_PROFILING_IMAGE
+  PROFILING=yes
+  if [ "$PROFILING_RESULT_MODE" = "dev" ]; then
+    PROFILING_RESULT_PATH="${PROFILING_RESULT_ROOT}/${SUITE}/${TEST}"
+  else
+    RUN_BASE="${PROFILING_RESULT_ROOT}/${GIT_BRANCH}/${GIT_COMMIT}"
+    EXISTING=$(find "$RUN_BASE" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+    PROFILING_RESULT_PATH="${RUN_BASE}/$(( EXISTING + 1 ))/${SUITE}/${TEST}"
+  fi
+  mkdir -p "$PROFILING_RESULT_PATH"
+  echo "PROFILING_RESULT_PATH: ${PROFILING_RESULT_PATH}"
+else
+  FREERADIUS_IMAGE=$FREERADIUS_SERVICE_IMAGE
+  PROFILING=no
+  #  The compose files bind mount the results directory in every mode, so
+  #  service mode needs a placeholder path.
+  PROFILING_RESULT_PATH=/tmp/prof-results-unused
+fi
+
+#  Print every log and listener file of a failed run, so a CI failure is
+#  readable from the job log alone.
+dump_logs() {
+  local f
+  for f in "$1"/* "$2"/*; do
+    [ -f "$f" ] || continue
+    echo ""
+    echo "=== $f ==="
+    case "$f" in
+      */listener/*)
+        echo "-- line-type counts --"
+        awk '{print $1}' "$f" | sort | uniq -c
+        echo "-- last 200 lines --"
+        ;;
+    esac
+    tail -200 "$f"
+  done
+}
+
+#  The loop starts radenv once per run name, one run at a time. Each run
+#  writes logs and listener files to a per-run subdirectory. The first
+#  failing run stops the loop.
+for RUN in $RUNS; do
+  if [ "$PROFILING" = "yes" ]; then PROFILING_TOOL=$RUN; else PROFILING_TOOL=""; fi
+  LOG_DIR="${OUTDIR}/logs/${RUN}"
+  LISTENER_DIR="${OUTDIR}/listener/${RUN}"
+  mkdir -p "$LOG_DIR" "$LISTENER_DIR"
+  echo "MULTI-SERVER-TEST ${TARGET} run=${RUN}"
+
+  # shellcheck disable=SC2086  # RADENV_FLAGS is a list of arguments
+  if ! DATA_PATH="$OUTDIR" \
+       TOP_SRCDIR="$TOP_SRCDIR" \
+       FREERADIUS_IMAGE="$FREERADIUS_IMAGE" \
+       PROFILING="$PROFILING" \
+       PROFILING_TOOL="$PROFILING_TOOL" \
+       PROFILING_RESULT_PATH="$PROFILING_RESULT_PATH" \
+       "$RADENV" ${RADENV_FLAGS:-} \
+         --project-name "${SUITE}-${TEST}-${MODE}" \
+         --compose "${OUTDIR}/environment.yml" \
+         --test "${OUTDIR}/template.yml" \
+         --use-files \
+         --listener-dir "$LISTENER_DIR" \
+         --log-dir "$LOG_DIR" \
+         --output "${LOG_DIR}/result.log" \
+         > "${LOG_DIR}/stdout.log" 2> "${LOG_DIR}/stderr.log"; then
+    echo "FAILED: ${TARGET} (MODE=${MODE} run=${RUN})"
+    dump_logs "$LOG_DIR" "$LISTENER_DIR"
+    exit 1
+  fi
+done

--- a/src/tests/multi-server/scripts/start_freeradius.sh
+++ b/src/tests/multi-server/scripts/start_freeradius.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+#  Container entry point for the multi-server suites that profile FreeRADIUS
+#  The test template exports the TEST_LOADGEN_* variables and runs this script.
+#  The script finishes the proto_load configuration and starts the server:
+#
+#    PROFILING=no   (service mode)    exec freeradius directly
+#    PROFILING=yes  (profiling mode)  exec start_${PROFILING_TOOL}_profiling.sh
+#
+set -u
+
+#  TEST_LOADGEN_MAX_REQUESTS is the total request count. Each pps
+#  step from start_pps up to and including max_pps sends TEST_LOADGEN_DURATION
+#  seconds of packets.
+TEST_LOADGEN_MAX_REQUESTS=0
+for ((pps=TEST_LOADGEN_START_PPS; pps<=TEST_LOADGEN_MAX_PPS; pps+=TEST_LOADGEN_STEP)); do
+  TEST_LOADGEN_MAX_REQUESTS=$((TEST_LOADGEN_MAX_REQUESTS + TEST_LOADGEN_DURATION * pps))
+done
+export TEST_LOADGEN_MAX_REQUESTS
+
+echo "Starting freeradius with the following load-generator configuration:"
+env | grep '^TEST_LOADGEN_' | sort | sed 's/^/  /'
+
+if [ "${PROFILING:-no}" != "yes" ]; then
+  exec freeradius -f -l stdout -S resources.talloc_skip_cleanup=yes
+fi
+
+PROFILING_SCRIPT="/usr/local/bin/start_${PROFILING_TOOL:-}_profiling.sh"
+if [ -z "${PROFILING_TOOL:-}" ] || [ ! -r "$PROFILING_SCRIPT" ]; then
+  echo "ERROR: not starting freeradius, PROFILING=yes but PROFILING_TOOL='${PROFILING_TOOL:-}' has no profiling script at $PROFILING_SCRIPT" >&2
+  exit 1
+fi
+
+echo "Profiling with $PROFILING_TOOL ($PROFILING_SCRIPT)"
+exec bash "$PROFILING_SCRIPT"

--- a/src/tests/multi-server/tests/accept/template.yml.j2
+++ b/src/tests/multi-server/tests/accept/template.yml.j2
@@ -10,36 +10,15 @@ states:
         - execute_command:
             command: |
               #
-              # proto_load configuration via environment variables
+              # proto_load configuration via TEST_LOADGEN_* environment variables.
+              # start_freeradius.sh derives TEST_LOADGEN_MAX_REQUESTS from the
+              # TEST_LOADGEN_* variables and starts the server, under the profiler
+              # named by PROFILING_TOOL when PROFILING=yes.
               #
               {%- for key, value in loadgen.items() %}
               export TEST_LOADGEN_{{ key | upper }}="{{ value }}"
               {%- endfor %}
-              TEST_LOADGEN_MAX_REQUESTS=0
-              for ((pps=$TEST_LOADGEN_START_PPS; pps<=$TEST_LOADGEN_MAX_PPS; pps+=$TEST_LOADGEN_STEP)); do
-                TEST_LOADGEN_MAX_REQUESTS=$((TEST_LOADGEN_MAX_REQUESTS + TEST_LOADGEN_DURATION * pps))
-              done
-              export TEST_LOADGEN_MAX_REQUESTS
-              #
-              # Starting load-generator server which will generate traffic based on env configuration
-              # from above.
-              #
-              printf "Starting load-generator with the following configuration:\n"
-              {%- for key, value in loadgen.items() %}
-              printf "  {{ key | upper }}:%s\n" "$TEST_LOADGEN_{{ key | upper }}"
-              {%- endfor %}
-              printf "  MAX_REQUESTS:     %s\n" "$TEST_LOADGEN_MAX_REQUESTS"
-
-              if [ "$PROFILING" = "yes" ]; then
-                START_SCRIPT="/etc/freeradius/start_$PROFILING_TOOL"_profiling.sh
-                if [ ! -r "$START_SCRIPT" ]; then
-                  echo "Profiling start script not found: $START_SCRIPT"
-                  exit 1
-                fi
-                source "$START_SCRIPT"
-              else
-                exec freeradius -f -l stdout -S resources.talloc_skip_cleanup=yes
-              fi
+              exec start_freeradius.sh
 
             detach: true
     verify:

--- a/src/tests/multi-server/tests/accept/template.yml.j2
+++ b/src/tests/multi-server/tests/accept/template.yml.j2
@@ -31,7 +31,12 @@ states:
               printf "  MAX_REQUESTS:     %s\n" "$TEST_LOADGEN_MAX_REQUESTS"
 
               if [ "$PROFILING" = "yes" ]; then
-                source /etc/freeradius/start_valgrind_profiling.sh
+                START_SCRIPT="/etc/freeradius/start_$PROFILING_TOOL"_profiling.sh
+                if [ ! -r "$START_SCRIPT" ]; then
+                  echo "Profiling start script not found: $START_SCRIPT"
+                  exit 1
+                fi
+                source "$START_SCRIPT"
               else
                 exec freeradius -f -l stdout -S resources.talloc_skip_cleanup=yes
               fi

--- a/src/tests/multi-server/tests/ldap/template.yml.j2
+++ b/src/tests/multi-server/tests/ldap/template.yml.j2
@@ -34,7 +34,12 @@ states:
               printf "  MAX_REQUESTS:     %s\n" "$TEST_LOADGEN_MAX_REQUESTS"
 
               if [ "$PROFILING" = "yes" ]; then
-                source /etc/freeradius/start_valgrind_profiling.sh
+                START_SCRIPT="/etc/freeradius/start_$PROFILING_TOOL"_profiling.sh
+                if [ ! -r "$START_SCRIPT" ]; then
+                  echo "Profiling start script not found: $START_SCRIPT"
+                  exit 1
+                fi
+                source "$START_SCRIPT"
               else
                 exec freeradius -f -l stdout -S resources.talloc_skip_cleanup=yes
               fi

--- a/src/tests/multi-server/tests/ldap/template.yml.j2
+++ b/src/tests/multi-server/tests/ldap/template.yml.j2
@@ -9,40 +9,16 @@ states:
         actions:
         - execute_command:
             command: |
-              # Create an empty stats file for proto_load to write to.
-              touch /etc/freeradius/load-generator-stats.csv
-
               #
-              # proto_load configuration via environment variables
+              # proto_load configuration via TEST_LOADGEN_* environment variables.
+              # start_freeradius.sh derives TEST_LOADGEN_MAX_REQUESTS from the
+              # TEST_LOADGEN_* variables and starts the server, under the profiler
+              # named by PROFILING_TOOL when PROFILING=yes.
               #
               {%- for key, value in loadgen.items() %}
               export TEST_LOADGEN_{{ key | upper }}="{{ value }}"
               {%- endfor %}
-              TEST_LOADGEN_MAX_REQUESTS=0
-              for ((pps=$TEST_LOADGEN_START_PPS; pps<=$TEST_LOADGEN_MAX_PPS; pps+=$TEST_LOADGEN_STEP)); do
-                TEST_LOADGEN_MAX_REQUESTS=$((TEST_LOADGEN_MAX_REQUESTS + TEST_LOADGEN_DURATION * pps))
-              done
-              export TEST_LOADGEN_MAX_REQUESTS
-              #
-              # Starting load-generator server which will generate traffic based on env configuration
-              # from above.
-              #
-              printf "Starting load-generator with the following configuration:\n"
-              {%- for key, value in loadgen.items() %}
-              printf "  {{ key | upper }}:%s\n" "$TEST_LOADGEN_{{ key | upper }}"
-              {%- endfor %}
-              printf "  MAX_REQUESTS:     %s\n" "$TEST_LOADGEN_MAX_REQUESTS"
-
-              if [ "$PROFILING" = "yes" ]; then
-                START_SCRIPT="/etc/freeradius/start_$PROFILING_TOOL"_profiling.sh
-                if [ ! -r "$START_SCRIPT" ]; then
-                  echo "Profiling start script not found: $START_SCRIPT"
-                  exit 1
-                fi
-                source "$START_SCRIPT"
-              else
-                exec freeradius -f -l stdout -S resources.talloc_skip_cleanup=yes
-              fi
+              exec start_freeradius.sh
 
             detach: true
     verify:

--- a/src/tests/multi-server/tests/mysql/template.yml.j2
+++ b/src/tests/multi-server/tests/mysql/template.yml.j2
@@ -10,36 +10,15 @@ states:
         - execute_command:
             command: |
               #
-              # proto_load configuration via environment variables
+              # proto_load configuration via TEST_LOADGEN_* environment variables.
+              # start_freeradius.sh derives TEST_LOADGEN_MAX_REQUESTS from the
+              # TEST_LOADGEN_* variables and starts the server, under the profiler
+              # named by PROFILING_TOOL when PROFILING=yes.
               #
               {%- for key, value in loadgen.items() %}
               export TEST_LOADGEN_{{ key | upper }}="{{ value }}"
               {%- endfor %}
-              TEST_LOADGEN_MAX_REQUESTS=0
-              for ((pps=$TEST_LOADGEN_START_PPS; pps<=$TEST_LOADGEN_MAX_PPS; pps+=$TEST_LOADGEN_STEP)); do
-                TEST_LOADGEN_MAX_REQUESTS=$((TEST_LOADGEN_MAX_REQUESTS + TEST_LOADGEN_DURATION * pps))
-              done
-              export TEST_LOADGEN_MAX_REQUESTS
-              #
-              # Starting load-generator server which will generate traffic based on env configuration
-              # from above.
-              #
-              printf "Starting load-generator with the following configuration:\n"
-              {%- for key, value in loadgen.items() %}
-              printf "  {{ key | upper }}:%s\n" "$TEST_LOADGEN_{{ key | upper }}"
-              {%- endfor %}
-              printf "  MAX_REQUESTS:     %s\n" "$TEST_LOADGEN_MAX_REQUESTS"
-
-              if [ "$PROFILING" = "yes" ]; then
-                START_SCRIPT="/etc/freeradius/start_$PROFILING_TOOL"_profiling.sh
-                if [ ! -r "$START_SCRIPT" ]; then
-                  echo "Profiling start script not found: $START_SCRIPT"
-                  exit 1
-                fi
-                source "$START_SCRIPT"
-              else
-                exec freeradius -f -l stdout -S resources.talloc_skip_cleanup=yes
-              fi
+              exec start_freeradius.sh
 
             detach: true
     verify:

--- a/src/tests/multi-server/tests/mysql/template.yml.j2
+++ b/src/tests/multi-server/tests/mysql/template.yml.j2
@@ -31,7 +31,12 @@ states:
               printf "  MAX_REQUESTS:     %s\n" "$TEST_LOADGEN_MAX_REQUESTS"
 
               if [ "$PROFILING" = "yes" ]; then
-                source /etc/freeradius/start_valgrind_profiling.sh
+                START_SCRIPT="/etc/freeradius/start_$PROFILING_TOOL"_profiling.sh
+                if [ ! -r "$START_SCRIPT" ]; then
+                  echo "Profiling start script not found: $START_SCRIPT"
+                  exit 1
+                fi
+                source "$START_SCRIPT"
               else
                 exec freeradius -f -l stdout -S resources.talloc_skip_cleanup=yes
               fi

--- a/src/tests/multi-server/tests/pap-auth/template.yml.j2
+++ b/src/tests/multi-server/tests/pap-auth/template.yml.j2
@@ -10,36 +10,15 @@ states:
         - execute_command:
             command: |
               #
-              # proto_load configuration via environment variables
+              # proto_load configuration via TEST_LOADGEN_* environment variables.
+              # start_freeradius.sh derives TEST_LOADGEN_MAX_REQUESTS from the
+              # TEST_LOADGEN_* variables and starts the server, under the profiler
+              # named by PROFILING_TOOL when PROFILING=yes.
               #
               {%- for key, value in loadgen.items() %}
               export TEST_LOADGEN_{{ key | upper }}="{{ value }}"
               {%- endfor %}
-              TEST_LOADGEN_MAX_REQUESTS=0
-              for ((pps=$TEST_LOADGEN_START_PPS; pps<=$TEST_LOADGEN_MAX_PPS; pps+=$TEST_LOADGEN_STEP)); do
-                TEST_LOADGEN_MAX_REQUESTS=$((TEST_LOADGEN_MAX_REQUESTS + TEST_LOADGEN_DURATION * pps))
-              done
-              export TEST_LOADGEN_MAX_REQUESTS
-              #
-              # Starting load-generator server which will generate traffic based on env configuration
-              # from above.
-              #
-              printf "Starting load-generator with the following configuration:\n"
-              {%- for key, value in loadgen.items() %}
-              printf "  {{ key | upper }}:%s\n" "$TEST_LOADGEN_{{ key | upper }}"
-              {%- endfor %}
-              printf "  MAX_REQUESTS:     %s\n" "$TEST_LOADGEN_MAX_REQUESTS"
-
-              if [ "$PROFILING" = "yes" ]; then
-                START_SCRIPT="/etc/freeradius/start_$PROFILING_TOOL"_profiling.sh
-                if [ ! -r "$START_SCRIPT" ]; then
-                  echo "Profiling start script not found: $START_SCRIPT"
-                  exit 1
-                fi
-                source "$START_SCRIPT"
-              else
-                exec freeradius -f -l stdout -S resources.talloc_skip_cleanup=yes
-              fi
+              exec start_freeradius.sh
 
             detach: true
     verify:

--- a/src/tests/multi-server/tests/pap-auth/template.yml.j2
+++ b/src/tests/multi-server/tests/pap-auth/template.yml.j2
@@ -31,7 +31,12 @@ states:
               printf "  MAX_REQUESTS:     %s\n" "$TEST_LOADGEN_MAX_REQUESTS"
 
               if [ "$PROFILING" = "yes" ]; then
-                source /etc/freeradius/start_valgrind_profiling.sh
+                START_SCRIPT="/etc/freeradius/start_$PROFILING_TOOL"_profiling.sh
+                if [ ! -r "$START_SCRIPT" ]; then
+                  echo "Profiling start script not found: $START_SCRIPT"
+                  exit 1
+                fi
+                source "$START_SCRIPT"
               else
                 exec freeradius -f -l stdout -S resources.talloc_skip_cleanup=yes
               fi


### PR DESCRIPTION
This PR produces gperftools profiling results along side the existing valgrind/callgrind results.  The multi-server tests that currently supports this are the accept, pap-auth, ldap and mysql profiling tests.

These changes focus on setting up the multi-server test environment, configs and test templates which sets us up nicely to profile FreeRADIUS with valgrind and gperftools once start_gperftools_profiling.sh has been fully implemented (in the next update).

Update highlights:

- New TOOL makefile env variable set to "valgrind" by default and allowing user to set it to valgrind or gperftools
- accept, pap-auth, ldap and mysql testcase templates updated to call start_valgrind_profiling.sh or start_gperftools_profiling.sh based on PROFILING_TOOL env variable passed into the container
- multi-server test dockerfile environments updated to pass in PROFILING_TOOL as a new env variable
- new start_gperftools_profiling.sh script which takes care of starting and stopping gperftools profiling during the test
- new start_freeradius.sh script that the testcase templates now runs, based on the tool profiling, start_valgrind_profiling.sh or start_gperftools_profiling.sh is then run
- Every run now writes to logs and listener subdirectories named after the profiler
  - Example: 
    - build/tests/multi-server/accept/short_ci/logs/valgrind/result.log
    - build/tests/multi-server/accept/short_ci/logs/gperftools/result.log 
- README updated based on latest changes

Verification:

Locally verified proper generation of profiling results using valgrind and gperftools for the accept, pap-auth, ldap and mysql multi-server tests.  All four profiling tests generated the callgrind.out.*, callgrind_report.txt, proof_report.txt and proof.out.*.bp.gz compressed gperftools results.