### PR TITLE
Fix IPv6 Ascend filter port decoding

### DIFF
--- a/src/lib/filters.c
+++ b/src/lib/filters.c
@@ -1372,18 +1372,18 @@ void print_abinary(char *out, size_t outlen, uint8_t const *data, size_t len, in
 		p += i;
 		outlen -= i;
 
-		if (filter->u.ip.srcPortComp > RAD_NO_COMPARE) {
+		if (filter->u.ipv6.srcPortComp > RAD_NO_COMPARE) {
 			i = snprintf(p, outlen, " srcport %s %d",
 				     fr_int2str(filterCompare, filter->u.ipv6.srcPortComp, "??"),
-				     ntohs(filter->u.ip.srcport));
+				     ntohs(filter->u.ipv6.srcport));
 			p += i;
 			outlen -= i;
 		}
 
-		if (filter->u.ip.dstPortComp > RAD_NO_COMPARE) {
+		if (filter->u.ipv6.dstPortComp > RAD_NO_COMPARE) {
 			i = snprintf(p, outlen, " dstport %s %d",
 				     fr_int2str(filterCompare, filter->u.ipv6.dstPortComp, "??"),
-				     ntohs(filter->u.ip.dstport));
+				     ntohs(filter->u.ipv6.dstport));
 			p += i;
 			outlen -= i;
 		}

--- a/src/tests/unit/ascend.txt
+++ b/src/tests/unit/ascend.txt
@@ -3,3 +3,8 @@
 #
 encode Ascend-Data-Filter = "ip in drop tcp dstport > 1023"
 data 1a 28 00 00 02 11 f2 22 01 00 01 00 00 00 00 00 00 00 00 00 00 00 06 00 00 00 03 ff 00 03 00 00 00 00 00 00 00 00 00 00
+#
+#  IPv6 source and destination ports
+#
+decode 1a 38 00 00 02 11 f2 32 03 00 01 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 06 00 03 ff 00 35 03 04 00 00
+data Ascend-Data-Filter = "?? in drop tcp srcport > 1023 dstport != 53"


### PR DESCRIPTION
## Summary

Fix IPv6 Ascend Data Filter decoding to read source and destination port fields from the IPv6 filter structure.

The IPv6 decoding path was checking `srcPortComp` and `dstPortComp`, and reading the corresponding port values, through `filter->u.ip` instead of `filter->u.ipv6`.

As a result, IPv6 filters containing source or destination port conditions could be printed without those conditions.

## Fix

Use the IPv6 union member for:

* `srcPortComp`
* `srcport`
* `dstPortComp`
* `dstport`

## Tests

Added an Ascend Data Filter regression test with both source and destination IPv6 port conditions.

Before the fix the test fails with:

```text
got      : Ascend-Data-Filter = "?? in drop tcp"
expected : Ascend-Data-Filter = "?? in drop tcp srcport > 1023 dstport != 53"
```

With the fix, `make tests.unit` passes.
