### PR TITLE
Handle cf_section_dup allocation failure

### DIFF
--- a/src/main/conffile.c
+++ b/src/main/conffile.c
@@ -821,6 +821,7 @@ CONF_SECTION *cf_section_dup(CONF_SECTION *parent, CONF_SECTION const *cs,
 	CONF_ITEM *ci;
 
 	new = cf_section_alloc(parent, name1, name2);
+	if (!new) return NULL;
 
 	if (copy_meta) {
 		new->template = cs->template;

--- a/src/tests/api/all.mk
+++ b/src/tests/api/all.mk
@@ -1,9 +1,9 @@
 #
 #  Unit tests for the library APIs, using acutest.
 #
-SUBMAKEFILES := value_tests.mk pair_tests.mk
+SUBMAKEFILES := value_tests.mk pair_tests.mk conffile_tests.mk
 
-API_TESTS := value_tests pair_tests
+API_TESTS := value_tests pair_tests conffile_tests
 
 .PHONY: tests.api
 tests.api: $(addprefix $(BUILD_DIR)/tests/api/,$(API_TESTS))

--- a/src/tests/api/conffile_tests.c
+++ b/src/tests/api/conffile_tests.c
@@ -1,0 +1,45 @@
+/*
+ * Tests for configuration file APIs.
+ */
+
+#include <sys/wait.h>
+
+#include <freeradius-devel/radiusd.h>
+
+#include "acutest_common_init.h"
+
+#ifdef HAVE_PTHREAD_H
+pid_t rad_fork(void)
+{
+	return fork();
+}
+
+pid_t rad_waitpid(pid_t pid, int *status)
+{
+	return waitpid(pid, status, 0);
+}
+#endif
+
+static void test_section_dup_alloc_failure(void)
+{
+	CONF_SECTION *src;
+	CONF_SECTION *dup;
+
+	src = cf_section_alloc(NULL, "source", NULL);
+	TEST_ASSERT(src != NULL);
+	if (!src) return;
+
+	/*
+	 * cf_section_alloc() rejects a NULL primary section name.
+	 * cf_section_dup() should propagate that allocation failure.
+	 */
+	dup = cf_section_dup(NULL, src, NULL, NULL, false);
+	TEST_CHECK(dup == NULL);
+
+	talloc_free(src);
+}
+
+TEST_LIST = {
+	{ "section_dup_alloc_failure", test_section_dup_alloc_failure },
+	TEST_TERMINATOR
+};

--- a/src/tests/api/conffile_tests.mk
+++ b/src/tests/api/conffile_tests.mk
@@ -1,0 +1,6 @@
+TARGET		:= conffile_tests
+SOURCES		:= conffile_tests.c
+
+TGT_PREREQS	:= libfreeradius-server.a libfreeradius-radius.a
+TGT_LDLIBS	:= $(LIBS)
+TGT_INSTALLDIR	:=


### PR DESCRIPTION
## Summary

Handle allocation failure in `cf_section_dup()`.

`cf_section_dup()` did not check the result of `cf_section_alloc()` before
dereferencing the returned pointer. If allocation failed, this could result
in a NULL pointer dereference.

## Fix

Check the result of `cf_section_alloc()` and return `NULL` when allocation
fails.

## Tests

Added an API regression test which calls `cf_section_dup()` with a NULL
primary section name, causing `cf_section_alloc()` to return `NULL`.

Before the fix, the test fails due to the NULL pointer dereference.

After the fix:

```text
make tests.api
```
passes.